### PR TITLE
feat(update): add auto-update system with GitHub release checking

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,14 +33,14 @@ archives:
   - id: default
     name_template: >-
       {{ .ProjectName }}_
-      {{- .Version }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: "{{ .ProjectName }}_{{ .Version }}"
     format_overrides:
       - goos: linux
-        format: tar.gz
+        formats: ['tar.gz']
     files:
       - LICENSE
       - README.md
@@ -109,9 +109,16 @@ release:
 
     ### Linux (x86_64/amd64)
     ```bash
-    wget https://github.com/bnema/dumber/releases/download/{{.Tag}}/dumber_{{.Version}}_linux_x86_64.tar.gz
-    tar -xzf dumber_{{.Version}}_linux_x86_64.tar.gz
-    sudo install -m 755 dumber /usr/local/bin/
+    # Download latest release
+    wget https://github.com/bnema/dumber/releases/latest/download/dumber_linux_x86_64.tar.gz
+
+    # Extract and install to ~/.local/bin (enables auto-updates)
+    tar -xzf dumber_linux_x86_64.tar.gz
+    mkdir -p ~/.local/bin
+    install -m 755 dumber_*/dumber ~/.local/bin/
+
+    # Ensure ~/.local/bin is in your PATH (add to ~/.bashrc or ~/.zshrc if needed)
+    # export PATH="$HOME/.local/bin:$PATH"
     ```
 
     ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Auto-update system**: Automatic update checking and self-updating binary replacement following clean architecture.
+  - **Update check on startup**: Async check against GitHub releases API (configurable via `update.enable_on_startup`, default: true).
+  - **Toast notifications**: Non-intrusive auto-dismiss notifications for update availability.
+  - **Auto-download**: Optional background download with binary staging (configurable via `update.auto_download`, default: false).
+  - **Binary self-update**: Atomic binary replacement on clean exit with `.old` backup. Only works if binary is user-writable (e.g., `~/.local/bin/`).
+  - **CLI update check**: `dumber about` now displays update availability.
+  - **Version-less release archives**: Goreleaser now produces `dumber_linux_x86_64.tar.gz` (version in directory inside) enabling stable GitHub `/releases/latest/download/` URLs.
 - **Session management & resurrection**: Zellij-inspired session management system allowing users to save, list, and restore browser sessions.
   - **Automatic session snapshots**: Debounced state saving (configurable interval, default 5s) captures tabs, panes, splits, stacks, URLs, titles, and zoom levels.
   - **Session Manager modal**: Access via `Ctrl+O → s/w` or `Ctrl+Shift+S` to browse and restore sessions with inline preview of tabs and panes.

--- a/internal/application/port/updater.go
+++ b/internal/application/port/updater.go
@@ -1,0 +1,51 @@
+// Package port defines interfaces for external dependencies.
+package port
+
+import (
+	"context"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+// UpdateChecker checks for available updates from a remote source.
+type UpdateChecker interface {
+	// CheckForUpdate compares the current version with the latest available release.
+	// Returns update info including whether a newer version is available.
+	CheckForUpdate(ctx context.Context, currentVersion string) (*entity.UpdateInfo, error)
+}
+
+// UpdateDownloader downloads and extracts update archives.
+type UpdateDownloader interface {
+	// Download fetches the update archive to the specified destination directory.
+	// Returns the path to the downloaded archive file.
+	Download(ctx context.Context, downloadURL string, destDir string) (archivePath string, err error)
+
+	// Extract extracts the binary from the downloaded archive.
+	// Returns the path to the extracted binary.
+	Extract(ctx context.Context, archivePath string, destDir string) (binaryPath string, err error)
+}
+
+// UpdateApplier stages and applies updates.
+type UpdateApplier interface {
+	// CanSelfUpdate checks if the current binary is writable by the current user.
+	// Returns true if auto-update is possible, false if user lacks write permission.
+	CanSelfUpdate(ctx context.Context) bool
+
+	// GetBinaryPath returns the path to the currently running binary.
+	GetBinaryPath() (string, error)
+
+	// StageUpdate prepares the new binary to be applied on exit.
+	// The staged update will be applied when ApplyOnExit is called.
+	StageUpdate(ctx context.Context, newBinaryPath string) error
+
+	// HasStagedUpdate checks if there is an update staged and ready to apply.
+	HasStagedUpdate(ctx context.Context) bool
+
+	// ApplyOnExit replaces the current binary with the staged update.
+	// This should be called during graceful shutdown.
+	// Returns the path to the backup of the old binary.
+	ApplyOnExit(ctx context.Context) (backupPath string, err error)
+
+	// ClearStagedUpdate removes any staged update without applying it.
+	ClearStagedUpdate(ctx context.Context) error
+}

--- a/internal/application/usecase/apply_update.go
+++ b/internal/application/usecase/apply_update.go
@@ -1,0 +1,150 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/logging"
+)
+
+const (
+	// File permission for directories.
+	updateDirPerm = 0o755
+)
+
+// ApplyUpdateInput holds the input for the apply update use case.
+type ApplyUpdateInput struct {
+	// DownloadURL is the URL to download the update from.
+	DownloadURL string
+}
+
+// ApplyUpdateOutput holds the result of the update application.
+type ApplyUpdateOutput struct {
+	// Status is the current update status.
+	Status entity.UpdateStatus
+	// Message is a human-readable status message.
+	Message string
+	// StagedPath is the path to the staged binary (if status is Ready).
+	StagedPath string
+}
+
+// ApplyUpdateUseCase downloads and stages updates for application on exit.
+type ApplyUpdateUseCase struct {
+	downloader port.UpdateDownloader
+	applier    port.UpdateApplier
+	cacheDir   string
+}
+
+// NewApplyUpdateUseCase creates a new apply update use case.
+func NewApplyUpdateUseCase(
+	downloader port.UpdateDownloader,
+	applier port.UpdateApplier,
+	cacheDir string,
+) *ApplyUpdateUseCase {
+	return &ApplyUpdateUseCase{
+		downloader: downloader,
+		applier:    applier,
+		cacheDir:   cacheDir,
+	}
+}
+
+// Execute downloads and stages the update for application on exit.
+func (uc *ApplyUpdateUseCase) Execute(ctx context.Context, input ApplyUpdateInput) (*ApplyUpdateOutput, error) {
+	log := logging.FromContext(ctx)
+
+	// Check if we can self-update.
+	if !uc.applier.CanSelfUpdate(ctx) {
+		return &ApplyUpdateOutput{
+			Status:  entity.UpdateStatusFailed,
+			Message: "Cannot auto-update: binary is not writable",
+		}, nil
+	}
+
+	// Create download directory.
+	downloadDir := uc.cacheDir + "/updates"
+	if err := os.MkdirAll(downloadDir, updateDirPerm); err != nil {
+		return nil, fmt.Errorf("failed to create download directory: %w", err)
+	}
+
+	log.Info().Str("url", input.DownloadURL).Msg("downloading update")
+
+	// Download the archive.
+	archivePath, err := uc.downloader.Download(ctx, input.DownloadURL, downloadDir)
+	if err != nil {
+		return &ApplyUpdateOutput{
+			Status:  entity.UpdateStatusFailed,
+			Message: fmt.Sprintf("Download failed: %v", err),
+		}, nil
+	}
+
+	log.Info().Str("archive", archivePath).Msg("extracting update")
+
+	// Extract the binary.
+	binaryPath, err := uc.downloader.Extract(ctx, archivePath, downloadDir)
+	if err != nil {
+		_ = os.Remove(archivePath)
+		return &ApplyUpdateOutput{
+			Status:  entity.UpdateStatusFailed,
+			Message: fmt.Sprintf("Extraction failed: %v", err),
+		}, nil
+	}
+
+	log.Info().Str("binary", binaryPath).Msg("staging update")
+
+	// Stage the update.
+	if err := uc.applier.StageUpdate(ctx, binaryPath); err != nil {
+		_ = os.Remove(archivePath)
+		_ = os.Remove(binaryPath)
+		return &ApplyUpdateOutput{
+			Status:  entity.UpdateStatusFailed,
+			Message: fmt.Sprintf("Staging failed: %v", err),
+		}, nil
+	}
+
+	// Clean up download artifacts.
+	_ = os.Remove(archivePath)
+	_ = os.Remove(binaryPath)
+
+	log.Info().Msg("update staged successfully, will apply on exit")
+
+	return &ApplyUpdateOutput{
+		Status:  entity.UpdateStatusReady,
+		Message: "Update ready - will apply on exit",
+	}, nil
+}
+
+// FinalizeOnExit applies the staged update during shutdown.
+// This should be called from the app's shutdown handler.
+func (uc *ApplyUpdateUseCase) FinalizeOnExit(ctx context.Context) error {
+	log := logging.FromContext(ctx)
+
+	if !uc.applier.HasStagedUpdate(ctx) {
+		log.Debug().Msg("no staged update to apply")
+		return nil
+	}
+
+	backupPath, err := uc.applier.ApplyOnExit(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to apply update on exit")
+		return err
+	}
+
+	log.Info().
+		Str("backup", backupPath).
+		Msg("update applied successfully")
+
+	return nil
+}
+
+// HasPendingUpdate checks if there's an update waiting to be applied on exit.
+func (uc *ApplyUpdateUseCase) HasPendingUpdate(ctx context.Context) bool {
+	return uc.applier.HasStagedUpdate(ctx)
+}
+
+// ClearPendingUpdate removes any staged update.
+func (uc *ApplyUpdateUseCase) ClearPendingUpdate(ctx context.Context) error {
+	return uc.applier.ClearStagedUpdate(ctx)
+}

--- a/internal/application/usecase/check_update.go
+++ b/internal/application/usecase/check_update.go
@@ -1,0 +1,80 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/build"
+	"github.com/bnema/dumber/internal/logging"
+)
+
+// CheckUpdateInput holds the input for the check update use case.
+type CheckUpdateInput struct{}
+
+// CheckUpdateOutput holds the result of the update check.
+type CheckUpdateOutput struct {
+	// UpdateAvailable is true if a newer version exists.
+	UpdateAvailable bool
+	// CanAutoUpdate is true if the binary is writable and auto-update is possible.
+	CanAutoUpdate bool
+	// CurrentVersion is the version of the running binary.
+	CurrentVersion string
+	// LatestVersion is the latest available version.
+	LatestVersion string
+	// ReleaseURL is the URL to the GitHub release page.
+	ReleaseURL string
+	// DownloadURL is the direct download URL for the archive.
+	DownloadURL string
+}
+
+// CheckUpdateUseCase checks for available updates.
+type CheckUpdateUseCase struct {
+	checker   port.UpdateChecker
+	applier   port.UpdateApplier
+	buildInfo build.Info
+}
+
+// NewCheckUpdateUseCase creates a new check update use case.
+func NewCheckUpdateUseCase(
+	checker port.UpdateChecker,
+	applier port.UpdateApplier,
+	buildInfo build.Info,
+) *CheckUpdateUseCase {
+	return &CheckUpdateUseCase{
+		checker:   checker,
+		applier:   applier,
+		buildInfo: buildInfo,
+	}
+}
+
+// Execute checks for available updates.
+func (uc *CheckUpdateUseCase) Execute(ctx context.Context, _ CheckUpdateInput) (*CheckUpdateOutput, error) {
+	log := logging.FromContext(ctx)
+
+	info, err := uc.checker.CheckForUpdate(ctx, uc.buildInfo.Version)
+	if err != nil {
+		log.Warn().Err(err).Msg("update check failed")
+		return nil, err
+	}
+
+	canAutoUpdate := false
+	if info.IsNewer {
+		canAutoUpdate = uc.applier.CanSelfUpdate(ctx)
+	}
+
+	log.Debug().
+		Str("current", uc.buildInfo.Version).
+		Str("latest", info.LatestVersion).
+		Bool("update_available", info.IsNewer).
+		Bool("can_auto_update", canAutoUpdate).
+		Msg("update check completed")
+
+	return &CheckUpdateOutput{
+		UpdateAvailable: info.IsNewer,
+		CanAutoUpdate:   canAutoUpdate,
+		CurrentVersion:  info.CurrentVersion,
+		LatestVersion:   info.LatestVersion,
+		ReleaseURL:      info.ReleaseURL,
+		DownloadURL:     info.DownloadURL,
+	}, nil
+}

--- a/internal/domain/entity/update.go
+++ b/internal/domain/entity/update.go
@@ -1,0 +1,60 @@
+// Package entity defines domain entities for dumber.
+package entity
+
+import "time"
+
+// UpdateInfo holds information about an available update.
+type UpdateInfo struct {
+	// CurrentVersion is the version of the running binary.
+	CurrentVersion string
+	// LatestVersion is the latest available version from GitHub.
+	LatestVersion string
+	// IsNewer is true if LatestVersion is newer than CurrentVersion.
+	IsNewer bool
+	// ReleaseURL is the URL to the GitHub release page.
+	ReleaseURL string
+	// DownloadURL is the direct download URL for the binary archive.
+	DownloadURL string
+	// PublishedAt is when the release was published.
+	PublishedAt time.Time
+	// ReleaseNotes contains the release changelog (optional).
+	ReleaseNotes string
+}
+
+// UpdateStatus represents the current state of the update process.
+type UpdateStatus int
+
+const (
+	// UpdateStatusUnknown means update status hasn't been checked yet.
+	UpdateStatusUnknown UpdateStatus = iota
+	// UpdateStatusUpToDate means the current version is the latest.
+	UpdateStatusUpToDate
+	// UpdateStatusAvailable means a newer version is available.
+	UpdateStatusAvailable
+	// UpdateStatusDownloading means the update is being downloaded.
+	UpdateStatusDownloading
+	// UpdateStatusReady means the update is downloaded and staged for exit.
+	UpdateStatusReady
+	// UpdateStatusFailed means the update check or download failed.
+	UpdateStatusFailed
+)
+
+// String returns a human-readable string for the update status.
+func (s UpdateStatus) String() string {
+	switch s {
+	case UpdateStatusUnknown:
+		return "unknown"
+	case UpdateStatusUpToDate:
+		return "up-to-date"
+	case UpdateStatusAvailable:
+		return "available"
+	case UpdateStatusDownloading:
+		return "downloading"
+	case UpdateStatusReady:
+		return "ready"
+	case UpdateStatusFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -241,6 +241,10 @@ func DefaultConfig() *Config {
 			ZoomCacheSize:           defaultZoomCacheSize,
 			WebViewPoolPrewarmCount: defaultWebViewPoolPrewarmCount,
 		},
+		Update: UpdateConfig{
+			EnableOnStartup: true,  // Check for updates on startup by default
+			AutoDownload:    false, // Conservative: don't auto-download by default
+		},
 	}
 }
 

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -315,6 +315,7 @@ func (m *Manager) setDefaults() {
 	m.setMediaDefaults(defaults)
 	m.setRuntimeDefaults(defaults)
 	m.setSessionDefaults(defaults)
+	m.setUpdateDefaults(defaults)
 }
 
 func (m *Manager) setHistoryDefaults(defaults *Config) {
@@ -440,6 +441,11 @@ func (m *Manager) setSessionDefaults(defaults *Config) {
 	m.viper.SetDefault("session.session_mode.activation_shortcut", defaults.Session.SessionMode.ActivationShortcut)
 	m.viper.SetDefault("session.session_mode.timeout_ms", defaults.Session.SessionMode.TimeoutMilliseconds)
 	m.viper.SetDefault("session.session_mode.actions", defaults.Session.SessionMode.Actions)
+}
+
+func (m *Manager) setUpdateDefaults(defaults *Config) {
+	m.viper.SetDefault("update.enable_on_startup", defaults.Update.EnableOnStartup)
+	m.viper.SetDefault("update.auto_download", defaults.Update.AutoDownload)
 }
 
 // New returns a new default configuration instance.

--- a/internal/infrastructure/config/schema.go
+++ b/internal/infrastructure/config/schema.go
@@ -31,6 +31,8 @@ type Config struct {
 	Runtime RuntimeConfig `mapstructure:"runtime" yaml:"runtime" toml:"runtime"`
 	// Performance holds internal performance tuning options (not exposed in UI).
 	Performance PerformanceConfig `mapstructure:"performance" yaml:"performance" toml:"performance"`
+	// Update controls automatic update checking and downloading.
+	Update UpdateConfig `mapstructure:"update" yaml:"update" toml:"update"`
 }
 
 // RenderingMode selects GPU vs CPU rendering.
@@ -278,6 +280,17 @@ type OmniboxConfig struct {
 type DebugConfig struct {
 	// Enable browser developer tools (F12, Inspect Element in context menu)
 	EnableDevTools bool `mapstructure:"enable_devtools" yaml:"enable_devtools" toml:"enable_devtools"`
+}
+
+// UpdateConfig holds automatic update settings.
+type UpdateConfig struct {
+	// EnableOnStartup enables checking for updates when the browser starts.
+	// Default: true
+	EnableOnStartup bool `mapstructure:"enable_on_startup" yaml:"enable_on_startup" toml:"enable_on_startup"`
+	// AutoDownload automatically downloads updates in the background.
+	// When enabled, updates are applied on browser exit.
+	// Default: false
+	AutoDownload bool `mapstructure:"auto_download" yaml:"auto_download" toml:"auto_download"`
 }
 
 // WorkspaceConfig captures layout, pane, and tab behavior preferences.

--- a/internal/infrastructure/updater/applier.go
+++ b/internal/infrastructure/updater/applier.go
@@ -1,0 +1,203 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/logging"
+)
+
+const (
+	// Staging directory name within XDG_STATE_HOME.
+	stagingDirName = "pending-update"
+	// Staged binary filename.
+	stagedBinaryName = "dumber"
+	// Backup suffix for old binary.
+	backupSuffix = ".old"
+	// File permission for directories and executables.
+	applierExecPerm = 0o755
+	// Execute permission bit for owner.
+	execBit = 0o100
+)
+
+// Applier implements UpdateApplier for self-updating the binary.
+type Applier struct {
+	stateDir string
+}
+
+// NewApplier creates a new update applier.
+// stateDir is the XDG state directory (e.g., ~/.local/state/dumber).
+func NewApplier(stateDir string) *Applier {
+	return &Applier{
+		stateDir: stateDir,
+	}
+}
+
+// NewApplierFromXDG creates a new update applier using XDG directories.
+func NewApplierFromXDG() (*Applier, error) {
+	stateDir, err := config.GetStateDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get state directory: %w", err)
+	}
+	return NewApplier(stateDir), nil
+}
+
+// stagingDir returns the path to the staging directory.
+func (a *Applier) stagingDir() string {
+	return filepath.Join(a.stateDir, stagingDirName)
+}
+
+// stagedBinaryPath returns the path to the staged binary.
+func (a *Applier) stagedBinaryPath() string {
+	return filepath.Join(a.stagingDir(), stagedBinaryName)
+}
+
+// CanSelfUpdate checks if the current binary is writable by the current user.
+func (a *Applier) CanSelfUpdate(ctx context.Context) bool {
+	log := logging.FromContext(ctx)
+
+	binaryPath, err := a.GetBinaryPath()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to get binary path")
+		return false
+	}
+
+	// Check if we have write permission on the binary file.
+	err = unix.Access(binaryPath, unix.W_OK)
+	if err != nil {
+		log.Debug().
+			Str("path", binaryPath).
+			Err(err).
+			Msg("binary is not writable, self-update disabled")
+		return false
+	}
+
+	log.Debug().Str("path", binaryPath).Msg("binary is writable, self-update enabled")
+	return true
+}
+
+// GetBinaryPath returns the path to the currently running binary.
+func (*Applier) GetBinaryPath() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	// Resolve any symlinks to get the actual binary path.
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	return resolved, nil
+}
+
+// StageUpdate copies the new binary to the staging directory.
+func (a *Applier) StageUpdate(ctx context.Context, newBinaryPath string) error {
+	log := logging.FromContext(ctx)
+
+	// Create staging directory.
+	stagingDir := a.stagingDir()
+	if err := os.MkdirAll(stagingDir, applierExecPerm); err != nil {
+		return fmt.Errorf("failed to create staging directory: %w", err)
+	}
+
+	// Read the new binary.
+	newBinary, err := os.ReadFile(newBinaryPath)
+	if err != nil {
+		return fmt.Errorf("failed to read new binary: %w", err)
+	}
+
+	// Write to staging location.
+	stagedPath := a.stagedBinaryPath()
+	if err := os.WriteFile(stagedPath, newBinary, applierExecPerm); err != nil {
+		return fmt.Errorf("failed to write staged binary: %w", err)
+	}
+
+	log.Info().
+		Str("staged_path", stagedPath).
+		Int("size", len(newBinary)).
+		Msg("update staged for exit")
+
+	return nil
+}
+
+// HasStagedUpdate checks if there is an update staged and ready to apply.
+func (a *Applier) HasStagedUpdate(_ context.Context) bool {
+	stagedPath := a.stagedBinaryPath()
+	info, err := os.Stat(stagedPath)
+	if err != nil {
+		return false
+	}
+	// Ensure it's a regular file with execute permission.
+	return info.Mode().IsRegular() && info.Mode()&execBit != 0
+}
+
+// ApplyOnExit replaces the current binary with the staged update.
+// This should be called during graceful shutdown.
+func (a *Applier) ApplyOnExit(ctx context.Context) (string, error) {
+	log := logging.FromContext(ctx)
+
+	if !a.HasStagedUpdate(ctx) {
+		return "", fmt.Errorf("no staged update found")
+	}
+
+	binaryPath, err := a.GetBinaryPath()
+	if err != nil {
+		return "", err
+	}
+
+	stagedPath := a.stagedBinaryPath()
+	backupPath := binaryPath + backupSuffix
+
+	log.Info().
+		Str("current", binaryPath).
+		Str("staged", stagedPath).
+		Str("backup", backupPath).
+		Msg("applying staged update")
+
+	// Step 1: Remove old backup if exists.
+	_ = os.Remove(backupPath)
+
+	// Step 2: Rename current binary to backup.
+	if err := os.Rename(binaryPath, backupPath); err != nil {
+		return "", fmt.Errorf("failed to backup current binary: %w", err)
+	}
+
+	// Step 3: Rename staged binary to current.
+	if err := os.Rename(stagedPath, binaryPath); err != nil {
+		// Try to restore backup.
+		if restoreErr := os.Rename(backupPath, binaryPath); restoreErr != nil {
+			log.Error().Err(restoreErr).Msg("failed to restore backup after update failure")
+		}
+		return "", fmt.Errorf("failed to install new binary: %w", err)
+	}
+
+	// Step 4: Clean up staging directory.
+	_ = os.RemoveAll(a.stagingDir())
+
+	log.Info().
+		Str("binary", binaryPath).
+		Str("backup", backupPath).
+		Msg("update applied successfully")
+
+	return backupPath, nil
+}
+
+// ClearStagedUpdate removes any staged update without applying it.
+func (a *Applier) ClearStagedUpdate(ctx context.Context) error {
+	log := logging.FromContext(ctx)
+
+	stagingDir := a.stagingDir()
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return fmt.Errorf("failed to clear staged update: %w", err)
+	}
+
+	log.Debug().Str("path", stagingDir).Msg("cleared staged update")
+	return nil
+}

--- a/internal/infrastructure/updater/github.go
+++ b/internal/infrastructure/updater/github.go
@@ -1,0 +1,309 @@
+// Package updater provides update checking and downloading functionality.
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/logging"
+)
+
+const (
+	// GitHub API endpoint for latest release.
+	githubAPIURL = "https://api.github.com/repos/bnema/dumber/releases/latest"
+
+	// Download URL pattern for the release archive.
+	// Uses version-less filename for stable "latest" download URL.
+	downloadURLTemplate = "https://github.com/bnema/dumber/releases/latest/download/dumber_%s_%s.tar.gz"
+
+	// HTTP client timeout for API requests.
+	apiTimeout = 10 * time.Second
+
+	// HTTP client timeout for downloads.
+	downloadTimeout = 5 * time.Minute
+
+	// File permission for directories and executables.
+	execPerm = 0o755
+
+	// Maximum size for extracted binary (100MB) - prevents decompression bombs.
+	maxBinarySize = 100 * 1024 * 1024
+)
+
+// githubRelease represents the GitHub API response for a release.
+type githubRelease struct {
+	TagName     string    `json:"tag_name"`
+	HTMLURL     string    `json:"html_url"`
+	PublishedAt time.Time `json:"published_at"`
+	Body        string    `json:"body"`
+}
+
+// GitHubChecker implements UpdateChecker using the GitHub API.
+type GitHubChecker struct {
+	client *http.Client
+}
+
+// NewGitHubChecker creates a new GitHub-based update checker.
+func NewGitHubChecker() *GitHubChecker {
+	return &GitHubChecker{
+		client: &http.Client{Timeout: apiTimeout},
+	}
+}
+
+// CheckForUpdate checks if a newer version is available on GitHub.
+func (g *GitHubChecker) CheckForUpdate(ctx context.Context, currentVersion string) (*entity.UpdateInfo, error) {
+	log := logging.FromContext(ctx)
+
+	// Skip check for dev builds.
+	if currentVersion == "" || currentVersion == "dev" {
+		log.Debug().Str("version", currentVersion).Msg("skipping update check for dev build")
+		return &entity.UpdateInfo{
+			CurrentVersion: currentVersion,
+			LatestVersion:  currentVersion,
+			IsNewer:        false,
+		}, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubAPIURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "dumber-browser/"+currentVersion)
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch latest release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github API returned status %d", resp.StatusCode)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to decode release: %w", err)
+	}
+
+	latestVersion := strings.TrimPrefix(release.TagName, "v")
+	currentClean := strings.TrimPrefix(currentVersion, "v")
+
+	isNewer := compareVersions(currentClean, latestVersion) < 0
+
+	// Build download URL based on current architecture.
+	archName := getArchName()
+	downloadURL := fmt.Sprintf(downloadURLTemplate, runtime.GOOS, archName)
+
+	log.Debug().
+		Str("current", currentVersion).
+		Str("latest", latestVersion).
+		Bool("is_newer", isNewer).
+		Msg("update check completed")
+
+	return &entity.UpdateInfo{
+		CurrentVersion: currentVersion,
+		LatestVersion:  latestVersion,
+		IsNewer:        isNewer,
+		ReleaseURL:     release.HTMLURL,
+		DownloadURL:    downloadURL,
+		PublishedAt:    release.PublishedAt,
+		ReleaseNotes:   release.Body,
+	}, nil
+}
+
+// getArchName returns the architecture name used in release assets.
+func getArchName() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x86_64"
+	case "386":
+		return "i386"
+	default:
+		return runtime.GOARCH
+	}
+}
+
+// compareVersions compares two semantic versions.
+// Returns -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2.
+func compareVersions(v1, v2 string) int {
+	// Parse version components.
+	parse := func(v string) (major, minor, patch int) {
+		// Remove any pre-release suffix for comparison.
+		v = regexp.MustCompile(`-.*$`).ReplaceAllString(v, "")
+		parts := strings.Split(v, ".")
+		if len(parts) >= 1 {
+			major, _ = strconv.Atoi(parts[0])
+		}
+		if len(parts) >= 2 {
+			minor, _ = strconv.Atoi(parts[1])
+		}
+		if len(parts) >= 3 {
+			patch, _ = strconv.Atoi(parts[2])
+		}
+		return
+	}
+
+	maj1, min1, pat1 := parse(v1)
+	maj2, min2, pat2 := parse(v2)
+
+	if maj1 != maj2 {
+		if maj1 < maj2 {
+			return -1
+		}
+		return 1
+	}
+	if min1 != min2 {
+		if min1 < min2 {
+			return -1
+		}
+		return 1
+	}
+	if pat1 != pat2 {
+		if pat1 < pat2 {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// GitHubDownloader implements UpdateDownloader for GitHub releases.
+type GitHubDownloader struct {
+	client *http.Client
+}
+
+// NewGitHubDownloader creates a new GitHub release downloader.
+func NewGitHubDownloader() *GitHubDownloader {
+	return &GitHubDownloader{
+		client: &http.Client{Timeout: downloadTimeout},
+	}
+}
+
+// Download fetches the update archive from the given URL.
+func (g *GitHubDownloader) Download(ctx context.Context, downloadURL, destDir string) (string, error) {
+	log := logging.FromContext(ctx)
+
+	// Ensure destination directory exists.
+	if err := os.MkdirAll(destDir, execPerm); err != nil {
+		return "", fmt.Errorf("failed to create download directory: %w", err)
+	}
+
+	// Create the request.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to create download request: %w", err)
+	}
+	req.Header.Set("User-Agent", "dumber-browser")
+
+	log.Debug().Str("url", downloadURL).Msg("downloading update")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	// Extract filename from URL.
+	archivePath := filepath.Join(destDir, "dumber_update.tar.gz")
+
+	// Create the file.
+	file, err := os.Create(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create archive file: %w", err)
+	}
+
+	// Copy the response body to the file.
+	written, err := io.Copy(file, resp.Body)
+	if closeErr := file.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(archivePath)
+		return "", fmt.Errorf("failed to write archive: %w", err)
+	}
+
+	log.Debug().
+		Int64("bytes", written).
+		Str("path", archivePath).
+		Msg("download completed")
+
+	return archivePath, nil
+}
+
+// Extract extracts the dumber binary from the tar.gz archive.
+func (*GitHubDownloader) Extract(ctx context.Context, archivePath, destDir string) (string, error) {
+	log := logging.FromContext(ctx)
+
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open archive: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return "", fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer func() { _ = gzr.Close() }()
+
+	tr := tar.NewReader(gzr)
+
+	var binaryPath string
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to read tar: %w", err)
+		}
+
+		// Look for the dumber binary (inside dumber_VERSION/ directory).
+		if header.Typeflag == tar.TypeReg && strings.HasSuffix(header.Name, "/dumber") {
+			binaryPath = filepath.Join(destDir, "dumber")
+
+			outFile, err := os.OpenFile(binaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, execPerm)
+			if err != nil {
+				return "", fmt.Errorf("failed to create binary file: %w", err)
+			}
+
+			// Limit copy to prevent decompression bombs (G110).
+			written, err := io.CopyN(outFile, tr, maxBinarySize)
+			if closeErr := outFile.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil && !errors.Is(err, io.EOF) {
+				_ = os.Remove(binaryPath)
+				return "", fmt.Errorf("failed to extract binary: %w", err)
+			}
+
+			log.Debug().Int64("bytes", written).Str("path", binaryPath).Msg("extracted binary")
+			break
+		}
+	}
+
+	if binaryPath == "" {
+		return "", fmt.Errorf("dumber binary not found in archive")
+	}
+
+	return binaryPath, nil
+}

--- a/internal/infrastructure/updater/github_test.go
+++ b/internal/infrastructure/updater/github_test.go
@@ -1,0 +1,63 @@
+package updater
+
+import (
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int
+	}{
+		// Equal versions
+		{"equal simple", "1.0.0", "1.0.0", 0},
+		{"equal two parts", "1.0", "1.0", 0},
+		{"equal one part", "1", "1", 0},
+
+		// v1 < v2 (should update)
+		{"major less", "1.0.0", "2.0.0", -1},
+		{"minor less", "1.1.0", "1.2.0", -1},
+		{"patch less", "1.1.1", "1.1.2", -1},
+		{"complex less", "0.20.1", "0.21.0", -1},
+		{"real world less", "0.20.1", "0.20.2", -1},
+
+		// v1 > v2 (no update needed)
+		{"major greater", "2.0.0", "1.0.0", 1},
+		{"minor greater", "1.2.0", "1.1.0", 1},
+		{"patch greater", "1.1.2", "1.1.1", 1},
+
+		// Pre-release versions (suffix stripped)
+		{"prerelease equal", "1.0.0-alpha", "1.0.0", 0},
+		{"prerelease less", "1.0.0-alpha", "1.0.1", -1},
+		{"prerelease greater", "1.0.1-beta", "1.0.0", 1},
+
+		// Partial versions
+		{"partial v1", "1", "1.0.0", 0},
+		{"partial v2", "1.0.0", "1", 0},
+		{"partial less", "1", "2.0.0", -1},
+		{"partial greater", "2", "1.0.0", 1},
+
+		// Edge cases
+		{"zero versions", "0.0.0", "0.0.0", 0},
+		{"zero less", "0.0.0", "0.0.1", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := compareVersions(tt.v1, tt.v2)
+			if result != tt.expected {
+				t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetArchName(t *testing.T) {
+	// This test just ensures the function doesn't panic and returns something.
+	arch := getArchName()
+	if arch == "" {
+		t.Error("getArchName() returned empty string")
+	}
+}

--- a/internal/ui/coordinator/update.go
+++ b/internal/ui/coordinator/update.go
@@ -1,0 +1,172 @@
+package coordinator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jwijenbergh/puregotk/v4/glib"
+
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/logging"
+	"github.com/bnema/dumber/internal/ui/component"
+)
+
+// UpdateCoordinator handles update checking and notification.
+type UpdateCoordinator struct {
+	checkUC  *usecase.CheckUpdateUseCase
+	applyUC  *usecase.ApplyUpdateUseCase
+	toaster  *component.Toaster
+	config   *config.Config
+	status   entity.UpdateStatus
+	lastInfo *usecase.CheckUpdateOutput
+}
+
+// NewUpdateCoordinator creates a new update coordinator.
+func NewUpdateCoordinator(
+	checkUC *usecase.CheckUpdateUseCase,
+	applyUC *usecase.ApplyUpdateUseCase,
+	toaster *component.Toaster,
+	cfg *config.Config,
+) *UpdateCoordinator {
+	return &UpdateCoordinator{
+		checkUC: checkUC,
+		applyUC: applyUC,
+		toaster: toaster,
+		config:  cfg,
+		status:  entity.UpdateStatusUnknown,
+	}
+}
+
+// CheckOnStartup performs an async update check if enabled in config.
+// This should be called during app initialization.
+func (c *UpdateCoordinator) CheckOnStartup(ctx context.Context) {
+	log := logging.FromContext(ctx)
+
+	if !c.config.Update.EnableOnStartup {
+		log.Debug().Msg("update check on startup disabled")
+		return
+	}
+
+	go c.checkAsync(ctx)
+}
+
+// checkAsync performs the update check in a goroutine.
+func (c *UpdateCoordinator) checkAsync(ctx context.Context) {
+	log := logging.FromContext(ctx)
+
+	result, err := c.checkUC.Execute(ctx, usecase.CheckUpdateInput{})
+	if err != nil {
+		log.Warn().Err(err).Msg("background update check failed")
+		c.status = entity.UpdateStatusFailed
+		return
+	}
+
+	c.lastInfo = result
+
+	if !result.UpdateAvailable {
+		c.status = entity.UpdateStatusUpToDate
+		log.Debug().
+			Str("version", result.CurrentVersion).
+			Msg("already on latest version")
+		return
+	}
+
+	c.status = entity.UpdateStatusAvailable
+	log.Info().
+		Str("current", result.CurrentVersion).
+		Str("latest", result.LatestVersion).
+		Bool("can_auto_update", result.CanAutoUpdate).
+		Msg("update available")
+
+	// Show notification on GTK main thread.
+	c.showUpdateNotification(ctx, result)
+
+	// Auto-download if enabled and possible.
+	if c.config.Update.AutoDownload && result.CanAutoUpdate {
+		c.downloadAsync(ctx, result.DownloadURL)
+	}
+}
+
+// showUpdateNotification displays a toast notification about the update.
+func (c *UpdateCoordinator) showUpdateNotification(ctx context.Context, result *usecase.CheckUpdateOutput) {
+	var msg string
+	if result.CanAutoUpdate && c.config.Update.AutoDownload {
+		msg = fmt.Sprintf("Downloading update %s...", result.LatestVersion)
+	} else if result.CanAutoUpdate {
+		msg = fmt.Sprintf("Update %s available", result.LatestVersion)
+	} else {
+		msg = fmt.Sprintf("Update %s available (manual install required)", result.LatestVersion)
+	}
+
+	// Dispatch to GTK main thread.
+	cb := glib.SourceFunc(func(_ uintptr) bool {
+		c.toaster.Show(ctx, msg, component.ToastInfo)
+		return false
+	})
+	glib.IdleAdd(&cb, 0)
+}
+
+// downloadAsync downloads and stages the update in the background.
+func (c *UpdateCoordinator) downloadAsync(ctx context.Context, downloadURL string) {
+	log := logging.FromContext(ctx)
+
+	c.status = entity.UpdateStatusDownloading
+
+	result, err := c.applyUC.Execute(ctx, usecase.ApplyUpdateInput{
+		DownloadURL: downloadURL,
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("update download failed")
+		c.status = entity.UpdateStatusFailed
+		c.showToast(ctx, "Update download failed", component.ToastError)
+		return
+	}
+
+	if result.Status == entity.UpdateStatusReady {
+		c.status = entity.UpdateStatusReady
+		log.Info().Msg("update ready, will apply on exit")
+		c.showToast(ctx, "Update ready - applies on exit", component.ToastSuccess)
+	} else {
+		c.status = entity.UpdateStatusFailed
+		log.Warn().Str("message", result.Message).Msg("update staging failed")
+		c.showToast(ctx, result.Message, component.ToastWarning)
+	}
+}
+
+// showToast dispatches a toast notification to the GTK main thread.
+func (c *UpdateCoordinator) showToast(ctx context.Context, msg string, level component.ToastLevel) {
+	cb := glib.SourceFunc(func(_ uintptr) bool {
+		c.toaster.Show(ctx, msg, level)
+		return false
+	})
+	glib.IdleAdd(&cb, 0)
+}
+
+// FinalizeOnExit applies any staged update during shutdown.
+// This should be called from the app's shutdown handler.
+func (c *UpdateCoordinator) FinalizeOnExit(ctx context.Context) error {
+	if c.applyUC == nil {
+		return nil
+	}
+	return c.applyUC.FinalizeOnExit(ctx)
+}
+
+// Status returns the current update status.
+func (c *UpdateCoordinator) Status() entity.UpdateStatus {
+	return c.status
+}
+
+// LastCheckResult returns the result of the last update check.
+func (c *UpdateCoordinator) LastCheckResult() *usecase.CheckUpdateOutput {
+	return c.lastInfo
+}
+
+// HasPendingUpdate returns true if an update is staged for exit.
+func (c *UpdateCoordinator) HasPendingUpdate(ctx context.Context) bool {
+	if c.applyUC == nil {
+		return false
+	}
+	return c.applyUC.HasPendingUpdate(ctx)
+}

--- a/internal/ui/deps.go
+++ b/internal/ui/deps.go
@@ -61,6 +61,10 @@ type Dependencies struct {
 	SessionRepo      repository.SessionRepository
 	CurrentSessionID entity.SessionID
 	SnapshotUC       *usecase.SnapshotSessionUseCase
+
+	// Update management
+	CheckUpdateUC *usecase.CheckUpdateUseCase
+	ApplyUpdateUC *usecase.ApplyUpdateUseCase
 }
 
 // Validate checks that all required dependencies are set.


### PR DESCRIPTION
## Summary

- Add automatic update checking against GitHub releases API on browser startup
- Implement self-updating binary replacement on clean exit for user-writable installations

## Features

### Update Checking
- Async update check on startup (configurable via `update.enable_on_startup`, default: true)
- Non-intrusive toast notifications for update availability
- CLI update check in `dumber about` command
- Skips dev builds (version == "dev" or empty)

### Auto-Download & Self-Update
- Optional background download (configurable via `update.auto_download`, default: false)
- Binary staging to `~/.local/state/dumber/pending-update/`
- Atomic binary replacement on clean exit with `.old` backup
- Only works if binary is user-writable (checks with `unix.Access()`)

### Goreleaser Changes
- Fixed deprecation: `format` → `formats` (list)
- Version-less archive name: `dumber_linux_x86_64.tar.gz`
- Version in directory inside archive: `dumber_0.21.0/`
- Updated footer with `~/.local/bin/` install instructions
- Enables stable GitHub `/releases/latest/download/` URLs

## Architecture (Clean Architecture)

```
Presentation: coordinator/update.go (toast notifications)
Application:  usecase/check_update.go, apply_update.go
Domain:       entity/update.go (UpdateInfo, UpdateStatus)
Infrastructure: updater/github.go, applier.go (GitHub API, binary ops)
Ports:        port/updater.go (UpdateChecker, UpdateDownloader, UpdateApplier)
```

## Configuration

```toml
[update]
enable_on_startup = true   # Check for updates on startup
auto_download = false      # Auto-download (conservative default)
```

## Testing

- Unit tests for version comparison logic
- `go test ./...` passes
- `make lint` passes (0 issues)
- `goreleaser --snapshot` produces correct archive structure