### PR TITLE
feat(config): defaults for new panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Configurable new-pane defaults**: New `defaults.new_pane_url` (default: `about:blank`, supports `dumb://`) and `defaults.auto_open_omnibox_on_new_pane` (default: false).
 - **Zellij-style pane resize mode**: New modal resize mode (`Ctrl+N`) to adjust split sizes with keyboard (`h/j/k/l` or arrow keys, `+/-` smart resize). Shows a per-pane border indicator and keeps the timeout alive while you resize.
 - **Mouse-driven pane resizing**: Drag split dividers with the mouse; split ratios are persisted in session snapshots (rounded to 2 decimals) and restored on resurrection.
 - **Dynamic window title**: Window title now displays the active pane's page title in format `<Page Title> - Dumber`. Updates when switching tabs/panes or navigating. Truncated at 255 characters.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -121,6 +121,20 @@ initial_behavior = "recent"  # Show recent history when omnibox opens
 # initial_behavior = "none"          # Show no initial suggestions
 ```
 
+## Defaults
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `defaults.new_pane_url` | string | `"about:blank"` | URL loaded for new panes/tabs (supports `http(s)://`, `dumb://`, `file://`, `about:`) |
+| `defaults.auto_open_omnibox_on_new_pane` | bool | `false` | Automatically open the omnibox after creating a new pane |
+
+**Example:**
+```toml
+[defaults]
+new_pane_url = "dumb://home"
+auto_open_omnibox_on_new_pane = false
+```
+
 ## Logging
 
 | Key | Type | Default | Valid Values | Description |

--- a/internal/application/usecase/manage_panes.go
+++ b/internal/application/usecase/manage_panes.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/bnema/dumber/internal/domain/entity"
+	domainurl "github.com/bnema/dumber/internal/domain/url"
 	"github.com/bnema/dumber/internal/logging"
 )
 
@@ -113,7 +114,7 @@ func (uc *ManagePanesUseCase) Split(ctx context.Context, input SplitPaneInput) (
 		paneID := entity.PaneID(uc.idGenerator())
 		newPane = entity.NewPane(paneID)
 		if input.InitialURL != "" {
-			newPane.URI = input.InitialURL
+			newPane.URI = domainurl.Normalize(input.InitialURL)
 		} else {
 			newPane.URI = "about:blank"
 		}

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -15,6 +15,10 @@ const (
 	// Appearance defaults
 	defaultFontSize = 16 // points
 
+	// Defaults
+	defaultNewPaneURL               = "about:blank"
+	defaultAutoOpenOmniboxOnNewPane = false
+
 	// Omnibox defaults
 	defaultOmniboxInitialBehavior = "recent"
 
@@ -150,6 +154,10 @@ func DefaultConfig() *Config {
 		},
 		DefaultWebpageZoom: 1.2,            // 120% default zoom for better readability
 		DefaultUIScale:     defaultUIScale, // 1.0 = 100%, 2.0 = 200%
+		Defaults: DefaultsConfig{
+			NewPaneURL:               defaultNewPaneURL,
+			AutoOpenOmniboxOnNewPane: defaultAutoOpenOmniboxOnNewPane,
+		},
 		Workspace: WorkspaceConfig{
 			PaneMode: PaneModeConfig{
 				ActivationShortcut:  defaultPaneActivationShortcut,

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -309,6 +309,7 @@ func (m *Manager) setDefaults() {
 	m.setDebugDefaults(defaults)
 	m.setAppearanceDefaults(defaults)
 	m.setRenderingDefaults(defaults)
+	m.setDefaultsDefaults(defaults)
 	m.setWorkspaceDefaults(defaults)
 	m.setContentFilteringDefaults(defaults)
 	m.setOmniboxDefaults(defaults)
@@ -377,6 +378,11 @@ func (m *Manager) setRenderingDefaults(defaults *Config) {
 	m.viper.SetDefault("rendering.debug_frames", defaults.Rendering.DebugFrames)
 	m.viper.SetDefault("default_webpage_zoom", defaults.DefaultWebpageZoom)
 	m.viper.SetDefault("default_ui_scale", defaults.DefaultUIScale)
+}
+
+func (m *Manager) setDefaultsDefaults(defaults *Config) {
+	m.viper.SetDefault("defaults.new_pane_url", defaults.Defaults.NewPaneURL)
+	m.viper.SetDefault("defaults.auto_open_omnibox_on_new_pane", defaults.Defaults.AutoOpenOmniboxOnNewPane)
 }
 
 func (m *Manager) setWorkspaceDefaults(defaults *Config) {

--- a/internal/infrastructure/config/schema.go
+++ b/internal/infrastructure/config/schema.go
@@ -15,6 +15,8 @@ type Config struct {
 	DefaultWebpageZoom float64 `mapstructure:"default_webpage_zoom" yaml:"default_webpage_zoom" toml:"default_webpage_zoom"`
 	// DefaultUIScale sets the default UI scale for GTK widgets (1.0 = 100%, 2.0 = 200%)
 	DefaultUIScale float64 `mapstructure:"default_ui_scale" yaml:"default_ui_scale" toml:"default_ui_scale"`
+	// Defaults controls default behavior like new-pane URL.
+	Defaults DefaultsConfig `mapstructure:"defaults" yaml:"defaults" toml:"defaults"`
 	// Workspace defines workspace, pane, and tab handling behavior.
 	Workspace WorkspaceConfig `mapstructure:"workspace" yaml:"workspace" toml:"workspace"`
 	// Session controls session persistence and restoration.
@@ -33,6 +35,19 @@ type Config struct {
 	Performance PerformanceConfig `mapstructure:"performance" yaml:"performance" toml:"performance"`
 	// Update controls automatic update checking and downloading.
 	Update UpdateConfig `mapstructure:"update" yaml:"update" toml:"update"`
+}
+
+// DefaultsConfig controls default behavior like new-pane URL.
+//
+// These defaults are applied when a new pane/tab is created without an explicit URL.
+// This is not currently exposed in dumb://config UI.
+type DefaultsConfig struct {
+	// NewPaneURL is the URL loaded when creating a new empty pane.
+	// Default: "about:blank"
+	NewPaneURL string `mapstructure:"new_pane_url" yaml:"new_pane_url" toml:"new_pane_url"`
+	// AutoOpenOmniboxOnNewPane opens the omnibox automatically when a new pane is created.
+	// Default: false
+	AutoOpenOmniboxOnNewPane bool `mapstructure:"auto_open_omnibox_on_new_pane" yaml:"auto_open_omnibox_on_new_pane" toml:"auto_open_omnibox_on_new_pane"` //nolint:lll // struct tags must stay on one line
 }
 
 // RenderingMode selects GPU vs CPU rendering.

--- a/internal/ui/dispatcher/keyboard.go
+++ b/internal/ui/dispatcher/keyboard.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/bnema/dumber/internal/domain/entity"
+	domainurl "github.com/bnema/dumber/internal/domain/url"
+	"github.com/bnema/dumber/internal/infrastructure/config"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/dumber/internal/ui/component"
 	"github.com/bnema/dumber/internal/ui/coordinator"
@@ -97,7 +99,11 @@ func (d *KeyboardDispatcher) initActionHandlers() {
 	)
 	d.actionHandlers = map[input.Action]func(ctx context.Context) error{
 		// Tab actions
-		input.ActionNewTab:           func(ctx context.Context) error { _, err := d.tabCoord.Create(ctx, "about:blank"); return err },
+		input.ActionNewTab: func(ctx context.Context) error {
+			cfg := config.Get()
+			_, err := d.tabCoord.Create(ctx, domainurl.Normalize(cfg.Defaults.NewPaneURL))
+			return err
+		},
 		input.ActionCloseTab:         d.tabCoord.Close,
 		input.ActionNextTab:          d.tabCoord.SwitchNext,
 		input.ActionPreviousTab:      d.tabCoord.SwitchPrev,


### PR DESCRIPTION
## Summary
- Add `defaults.new_pane_url` (default `about:blank`, supports `dumb://`) and `defaults.auto_open_omnibox_on_new_pane` (default false).
- Use `defaults.new_pane_url` when creating new panes/tabs; optionally auto-open omnibox after new pane creation.

Fixes #37.

## Notes
- Config validation enforces non-empty URL and allowed schemes: http/https/dumb/file/about.
- Docs updated: `docs/CONFIG.md` and `CHANGELOG.md`.
