### PR TITLE
fix(webkit): skip TerminateWebProcess for related popup WebViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
   - New config: `workspace.switch_to_tab_on_move` (default: true).
 
 ### Fixed
+- **OAuth popup login**: Fixed parent page going blank after OAuth popup closes (e.g., Google login on claude.ai, notion.com). Related WebViews share a web process with their parent; destroying the popup was terminating the shared process, killing the parent. Now skips `TerminateWebProcess()` for popup WebViews.
 - Startup: defer WebView pool prewarm until after initial tab creation to reduce cold-start navigation latency.
 - README CLI examples: updated to match current commands/flags (`purge --force` only, `logs` usage, `sessions list --limit`, removed deprecated `--dmenu` root flag).
 


### PR DESCRIPTION
## Summary
- Fix parent page going blank after OAuth popup closes (e.g., Google login on claude.ai, notion.com)

## Root Cause
Related WebViews (created via `NewWebViewWithRelatedView` for popups) share a web process with their parent. When destroying a popup, we were calling `TerminateWebProcess()` which killed the shared process, causing the parent WebView to go blank.

## Solution
- Add `isRelated` field to track popup WebViews
- Skip `TerminateWebProcess()` for related views in `Destroy()`
- The parent process will be terminated when the parent WebView is destroyed