### PR TITLE
feat(cli): add self-update command with --force flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **CLI self-update command**: New `dumber update` command to check for and install updates from the command line.
+  - Interactive spinner animation during check and download phases.
+  - `--force` / `-f` flag to skip version check and reinstall the current version.
+  - Reuses existing auto-update infrastructure (check, download, stage, apply on exit).
+  - Theme-aware styling consistent with other CLI commands.
 - **Move pane to tab**: New pane-mode actions to move the active pane to another tab.
   - `Ctrl+P → m`: Opens a tab picker modal.
   - `Ctrl+P → M`: Moves the active pane to the next tab (creates a new tab if needed).

--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ sudo apt install va-driver-all
   - `dumber browse "!g golang"`        # search via bang shortcut
 - Show version information:
   - `dumber about`                      # version, commit, and build date
+- Check for and install updates:
+  - `dumber update`                     # check and install if available
+  - `dumber update --force`             # force reinstall (skips version check)
 - Launcher integration (dmenu‑style examples with favicon support):
   - rofi:   `dumber dmenu | rofi -dmenu -show-icons -p "🔍 " | dumber dmenu --select`
   - fuzzel: `dumber dmenu | fuzzel --dmenu -p "🔍 " | dumber dmenu --select`

--- a/internal/cli/cmd/update.go
+++ b/internal/cli/cmd/update.go
@@ -1,0 +1,289 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/cli/styles"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/infrastructure/updater"
+)
+
+var updateForce bool
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Check for and install updates",
+	Long: `Check for available updates and download/install them.
+
+Use --force to reinstall even if already up-to-date (skips version check).`,
+	RunE: runUpdate,
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+	updateCmd.Flags().BoolVarP(&updateForce, "force", "f", false, "force reinstall (skips version check)")
+}
+
+// updateState represents the current state of the update process.
+type updateState int
+
+const (
+	stateChecking updateState = iota
+	stateDownloading
+	stateDone
+)
+
+// updateModel is the bubbletea model for the update command.
+type updateModel struct {
+	spinner  spinner.Model
+	renderer *styles.UpdateRenderer
+	state    updateState
+	force    bool
+
+	// Results from check.
+	updateAvailable bool
+	canAutoUpdate   bool
+	currentVersion  string
+	latestVersion   string
+	releaseURL      string
+	downloadURL     string
+
+	// Final result.
+	result       string
+	err          error
+	quitting     bool
+	updateStaged bool // tracks if an update was actually downloaded and staged
+}
+
+// checkResultMsg is sent when the update check completes.
+type checkResultMsg struct {
+	output *usecase.CheckUpdateOutput
+	err    error
+}
+
+// downloadResultMsg is sent when the download completes.
+type downloadResultMsg struct {
+	output *usecase.ApplyUpdateOutput
+	err    error
+}
+
+func newUpdateModel(renderer *styles.UpdateRenderer, accentColor lipgloss.Color, force bool) updateModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(accentColor)
+
+	return updateModel{
+		spinner:  s,
+		renderer: renderer,
+		state:    stateChecking,
+		force:    force,
+	}
+}
+
+func (m updateModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, m.checkForUpdates())
+}
+
+func (m updateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		}
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case checkResultMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			m.state = stateDone
+			return m, tea.Quit
+		}
+
+		m.updateAvailable = msg.output.UpdateAvailable
+		m.canAutoUpdate = msg.output.CanAutoUpdate
+		m.currentVersion = msg.output.CurrentVersion
+		m.latestVersion = msg.output.LatestVersion
+		m.releaseURL = msg.output.ReleaseURL
+		m.downloadURL = msg.output.DownloadURL
+
+		// Handle dev builds when force is used.
+		if m.force && (m.currentVersion == "" || m.currentVersion == "dev") {
+			m.result = m.renderer.RenderDevBuild()
+			m.state = stateDone
+			return m, tea.Quit
+		}
+
+		// Decide next action.
+		switch {
+		case !m.updateAvailable && !m.force:
+			// Already up to date.
+			m.result = m.renderer.RenderUpToDate(m.currentVersion)
+			m.state = stateDone
+			return m, tea.Quit
+
+		case m.updateAvailable && !m.canAutoUpdate:
+			// Update available but can't auto-update.
+			m.result = m.renderer.RenderCannotAutoUpdate(m.currentVersion, m.latestVersion, m.releaseURL)
+			m.state = stateDone
+			return m, tea.Quit
+
+		default:
+			// Proceed with download (either update available or force mode).
+			m.state = stateDownloading
+			return m, m.downloadUpdate()
+		}
+
+	case downloadResultMsg:
+		m.state = stateDone
+		if msg.err != nil {
+			m.err = msg.err
+			return m, tea.Quit
+		}
+
+		if msg.output.Status == entity.UpdateStatusFailed {
+			m.result = m.renderer.RenderError(fmt.Errorf("%s", msg.output.Message))
+		} else {
+			m.result = m.renderer.RenderStaged(m.latestVersion)
+			m.updateStaged = true
+		}
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+func (m updateModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	if m.err != nil {
+		return m.renderer.RenderError(m.err)
+	}
+
+	if m.state == stateDone {
+		return m.result
+	}
+
+	switch m.state {
+	case stateChecking:
+		return m.renderer.RenderChecking(m.spinner.View())
+	case stateDownloading:
+		version := m.latestVersion
+		if m.force && !m.updateAvailable {
+			version = m.currentVersion
+		}
+		return m.renderer.RenderDownloading(m.spinner.View(), version)
+	default:
+		return ""
+	}
+}
+
+func (updateModel) checkForUpdates() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		checker := updater.NewGitHubChecker()
+		applier, err := updater.NewApplierFromXDG()
+		if err != nil {
+			return checkResultMsg{err: fmt.Errorf("failed to create applier: %w", err)}
+		}
+
+		app := GetApp()
+		if app == nil {
+			return checkResultMsg{err: fmt.Errorf("app not initialized")}
+		}
+
+		checkUC := usecase.NewCheckUpdateUseCase(checker, applier, app.BuildInfo)
+		result, err := checkUC.Execute(ctx, usecase.CheckUpdateInput{})
+
+		return checkResultMsg{output: result, err: err}
+	}
+}
+
+func (m updateModel) downloadUpdate() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		downloader := updater.NewGitHubDownloader()
+		applier, err := updater.NewApplierFromXDG()
+		if err != nil {
+			return downloadResultMsg{err: fmt.Errorf("failed to create applier: %w", err)}
+		}
+
+		dirs, err := config.GetXDGDirs()
+		if err != nil {
+			return downloadResultMsg{err: fmt.Errorf("failed to get cache dir: %w", err)}
+		}
+
+		applyUC := usecase.NewApplyUpdateUseCase(downloader, applier, dirs.CacheHome)
+		result, err := applyUC.Execute(ctx, usecase.ApplyUpdateInput{
+			DownloadURL: m.downloadURL,
+		})
+
+		return downloadResultMsg{output: result, err: err}
+	}
+}
+
+func runUpdate(_ *cobra.Command, _ []string) error {
+	app := GetApp()
+	if app == nil {
+		return fmt.Errorf("app not initialized")
+	}
+
+	renderer := styles.NewUpdateRenderer(app.Theme)
+
+	// Create and run the bubbletea program.
+	m := newUpdateModel(renderer, app.Theme.Accent, updateForce)
+	p := tea.NewProgram(m)
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("update failed: %w", err)
+	}
+
+	// Check if the update was staged and we need to finalize on exit.
+	if model, ok := finalModel.(updateModel); ok {
+		if model.updateStaged {
+			// If update was successfully staged, finalize it.
+			if err := finalizeUpdate(); err != nil {
+				fmt.Println(renderer.RenderError(err))
+			}
+		}
+	}
+
+	return nil
+}
+
+// finalizeUpdate applies any staged update.
+func finalizeUpdate() error {
+	ctx := context.Background()
+
+	downloader := updater.NewGitHubDownloader()
+	applier, err := updater.NewApplierFromXDG()
+	if err != nil {
+		return fmt.Errorf("failed to create applier: %w", err)
+	}
+
+	dirs, err := config.GetXDGDirs()
+	if err != nil {
+		return fmt.Errorf("failed to get cache dir: %w", err)
+	}
+
+	applyUC := usecase.NewApplyUpdateUseCase(downloader, applier, dirs.CacheHome)
+	return applyUC.FinalizeOnExit(ctx)
+}

--- a/internal/cli/styles/icons.go
+++ b/internal/cli/styles/icons.go
@@ -53,4 +53,9 @@ const (
 	IconRestore      = "\uf0e2" // rotate-left (restore)
 	IconExpand       = "\uf065" // expand
 	IconCollapse     = "\uf066" // compress
+
+	// Update / download
+	IconDownload = "\uf019" // download
+	IconUpdate   = "\uf021" // refresh/sync
+	IconRocket   = "\uf135" // rocket (upgrade)
 )

--- a/internal/cli/styles/update.go
+++ b/internal/cli/styles/update.go
@@ -1,0 +1,113 @@
+package styles
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// UpdateRenderer renders update status messages with styled output.
+type UpdateRenderer struct {
+	theme *Theme
+}
+
+// NewUpdateRenderer creates a new update renderer with the given theme.
+func NewUpdateRenderer(theme *Theme) *UpdateRenderer {
+	return &UpdateRenderer{theme: theme}
+}
+
+// RenderChecking renders the "checking for updates" message.
+func (*UpdateRenderer) RenderChecking(spinner string) string {
+	return fmt.Sprintf("\n  %s Checking for updates...\n", spinner)
+}
+
+// RenderUpToDate renders the "already up to date" message.
+func (r *UpdateRenderer) RenderUpToDate(version string) string {
+	iconStyle := lipgloss.NewStyle().Foreground(r.theme.Success)
+	versionStyle := r.theme.Highlight
+
+	return fmt.Sprintf(
+		"\n  %s Already up to date (%s)\n",
+		iconStyle.Render(IconCheck),
+		versionStyle.Render(version),
+	)
+}
+
+// RenderAvailable renders the "update available" message.
+func (r *UpdateRenderer) RenderAvailable(current, latest, releaseURL string) string {
+	iconStyle := lipgloss.NewStyle().Foreground(r.theme.Accent)
+	versionStyle := r.theme.Highlight
+	urlStyle := r.theme.Subtle
+
+	return fmt.Sprintf(
+		"\n  %s Update available: %s %s %s\n     %s\n",
+		iconStyle.Render(IconRocket),
+		versionStyle.Render(current),
+		iconStyle.Render(IconArrow),
+		versionStyle.Render(latest),
+		urlStyle.Render(releaseURL),
+	)
+}
+
+// RenderDownloading renders the "downloading" message with spinner.
+func (r *UpdateRenderer) RenderDownloading(spinner, version string) string {
+	versionStyle := r.theme.Highlight
+
+	return fmt.Sprintf(
+		"\n  %s Downloading %s...\n",
+		spinner,
+		versionStyle.Render(version),
+	)
+}
+
+// RenderStaged renders the "update staged" success message.
+func (r *UpdateRenderer) RenderStaged(version string) string {
+	iconStyle := lipgloss.NewStyle().Foreground(r.theme.Success)
+	versionStyle := r.theme.Highlight
+
+	return fmt.Sprintf(
+		"\n  %s Update %s downloaded and staged\n  %s Will be applied when this command exits\n",
+		iconStyle.Render(IconCheck),
+		versionStyle.Render(version),
+		iconStyle.Render(IconCheck),
+	)
+}
+
+// RenderError renders an error message.
+func (r *UpdateRenderer) RenderError(err error) string {
+	iconStyle := lipgloss.NewStyle().Foreground(r.theme.Error)
+
+	return fmt.Sprintf(
+		"\n  %s Update failed: %v\n",
+		iconStyle.Render(IconX),
+		err,
+	)
+}
+
+// RenderCannotAutoUpdate renders the "cannot auto-update" message.
+func (r *UpdateRenderer) RenderCannotAutoUpdate(current, latest, releaseURL string) string {
+	iconStyle := lipgloss.NewStyle().Foreground(r.theme.Warning)
+	versionStyle := r.theme.Highlight
+	urlStyle := r.theme.Subtle
+
+	return fmt.Sprintf(
+		"\n  %s Update available: %s %s %s\n"+
+			"  %s Cannot auto-update: binary is not writable\n"+
+			"     Download manually: %s\n",
+		iconStyle.Render(IconRocket),
+		versionStyle.Render(current),
+		iconStyle.Render(IconArrow),
+		versionStyle.Render(latest),
+		iconStyle.Render(IconWarning),
+		urlStyle.Render(releaseURL),
+	)
+}
+
+// RenderDevBuild renders the "dev build" skip message.
+func (r *UpdateRenderer) RenderDevBuild() string {
+	iconStyle := lipgloss.NewStyle().Foreground(r.theme.Warning)
+	return fmt.Sprintf(
+		"\n  %s Development build - update check skipped\n",
+		iconStyle.Render(IconInfo),
+	)
+}


### PR DESCRIPTION
## Summary
- Add dedicated `dumber update` CLI command for manual self-update
- Support `--force` / `-f` flag to skip version check and reinstall
- Interactive spinner animation using bubbletea with theme-aware accent color
- Reuses existing auto-update infrastructure (check, download, stage, apply on exit)