### PR TITLE
fix(perf): remove memory kill threshold

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -521,13 +521,12 @@ Performance profiles provide preset configurations for WebKitGTK tuning. These s
 | Setting | default | lite | max |
 |---------|---------|------|-----|
 | Skia CPU threads | unset | 2 | `NumCPU()/2` (min 4) |
-| Skia GPU threads | unset | unset | 2 |
-| Web process memory (MB) | unset | 512 | 2048 |
-| Network process memory (MB) | unset | 256 | 512 |
-| Conservative threshold | unset | 0.25 | 0.5 |
-| Strict threshold | unset | 0.4 | 0.7 |
-| Kill threshold | unset | 0.8 | unset (never) |
-| WebView pool prewarm | 4 | 2 | 8 |
+| Skia GPU threads | unset | unset | scales with VRAM |
+| Web process memory (MB) | unset | 768 | unset |
+| Network process memory (MB) | unset | 384 | unset |
+| Conservative threshold | unset | 0.25 | unset |
+| Strict threshold | unset | 0.4 | unset |
+| WebView pool prewarm | 4 | 2 | scales with RAM |
 
 **Example:**
 ```toml
@@ -557,12 +556,10 @@ When `profile = "custom"`, you can configure individual tuning options:
 | `performance.web_process_memory_poll_interval_sec` | float | `0` | Memory check interval (0=WebKit default: 30s) |
 | `performance.web_process_memory_conservative_threshold` | float | `0` | Conservative cleanup threshold (0=unset) |
 | `performance.web_process_memory_strict_threshold` | float | `0` | Strict cleanup threshold (0=unset) |
-| `performance.web_process_memory_kill_threshold` | float | `-1` | Process kill threshold (-1=unset, 0=never kill) |
 | `performance.network_process_memory_limit_mb` | int | `0` | Network process memory limit in MB |
 | `performance.network_process_memory_poll_interval_sec` | float | `0` | Network memory check interval |
 | `performance.network_process_memory_conservative_threshold` | float | `0` | Network conservative threshold |
 | `performance.network_process_memory_strict_threshold` | float | `0` | Network strict threshold |
-| `performance.network_process_memory_kill_threshold` | float | `-1` | Network process kill threshold |
 | `performance.webview_pool_prewarm_count` | int | `4` | WebViews to pre-create at startup |
 | `performance.zoom_cache_size` | int | `256` | Domain zoom levels to cache |
 
@@ -579,7 +576,6 @@ skia_gpu_painting_threads = 2
 web_process_memory_limit_mb = 1024
 web_process_memory_conservative_threshold = 0.4
 web_process_memory_strict_threshold = 0.6
-web_process_memory_kill_threshold = -1  # Never kill
 
 # WebView pool
 webview_pool_prewarm_count = 6

--- a/internal/application/port/webkit_context.go
+++ b/internal/application/port/webkit_context.go
@@ -4,7 +4,7 @@ package port
 import "context"
 
 // MemoryPressureConfig holds memory pressure settings for a WebKit process.
-// Zero values mean "use WebKit defaults" except for KillThreshold where -1 means unset.
+// Zero values mean "use WebKit defaults".
 type MemoryPressureConfig struct {
 	// MemoryLimitMB sets the memory limit in megabytes.
 	// 0 means unset (uses WebKit default: system RAM capped at 3GB).
@@ -21,10 +21,6 @@ type MemoryPressureConfig struct {
 	// StrictThreshold sets threshold for strict memory release.
 	// Must be in (0, 1). 0 means unset (uses WebKit default: 0.5).
 	StrictThreshold float64
-
-	// KillThreshold sets threshold for killing the process.
-	// -1 means unset; 0 means never kill; values > 1 are allowed by WebKit.
-	KillThreshold float64
 }
 
 // IsConfigured returns true if any memory pressure setting is configured.
@@ -35,8 +31,7 @@ func (c *MemoryPressureConfig) IsConfigured() bool {
 	return c.MemoryLimitMB > 0 ||
 		c.PollIntervalSec > 0 ||
 		c.ConservativeThreshold > 0 ||
-		c.StrictThreshold > 0 ||
-		c.KillThreshold >= 0
+		c.StrictThreshold > 0
 }
 
 // WebKitContextOptions configures WebKitContext creation.

--- a/internal/application/port/webkit_context_test.go
+++ b/internal/application/port/webkit_context_test.go
@@ -19,10 +19,8 @@ func TestMemoryPressureConfig_IsConfigured(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "empty config with default kill threshold",
-			config: &port.MemoryPressureConfig{
-				KillThreshold: -1, // explicit unset
-			},
+			name:     "empty config",
+			config:   &port.MemoryPressureConfig{},
 			expected: false,
 		},
 		{
@@ -54,34 +52,12 @@ func TestMemoryPressureConfig_IsConfigured(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "KillThreshold set to 0 (never kill)",
-			config: &port.MemoryPressureConfig{
-				KillThreshold: 0,
-			},
-			expected: true,
-		},
-		{
-			name: "KillThreshold set to positive value",
-			config: &port.MemoryPressureConfig{
-				KillThreshold: 1.5,
-			},
-			expected: true,
-		},
-		{
-			name: "KillThreshold unset (-1)",
-			config: &port.MemoryPressureConfig{
-				KillThreshold: -1,
-			},
-			expected: false,
-		},
-		{
 			name: "all defaults (unset)",
 			config: &port.MemoryPressureConfig{
 				MemoryLimitMB:         0,
 				PollIntervalSec:       0,
 				ConservativeThreshold: 0,
 				StrictThreshold:       0,
-				KillThreshold:         -1,
 			},
 			expected: false,
 		},
@@ -92,7 +68,6 @@ func TestMemoryPressureConfig_IsConfigured(t *testing.T) {
 				PollIntervalSec:       15.0,
 				ConservativeThreshold: 0.25,
 				StrictThreshold:       0.6,
-				KillThreshold:         0.9,
 			},
 			expected: true,
 		},
@@ -118,11 +93,9 @@ func TestWebKitContextOptions_IsWebProcessMemoryConfigured(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "empty WebProcessMemory with default kill threshold",
+			name: "empty WebProcessMemory",
 			opts: port.WebKitContextOptions{
-				WebProcessMemory: &port.MemoryPressureConfig{
-					KillThreshold: -1, // explicit unset
-				},
+				WebProcessMemory: &port.MemoryPressureConfig{},
 			},
 			expected: false,
 		},
@@ -157,11 +130,9 @@ func TestWebKitContextOptions_IsNetworkProcessMemoryConfigured(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "empty NetworkProcessMemory with default kill threshold",
+			name: "empty NetworkProcessMemory",
 			opts: port.WebKitContextOptions{
-				NetworkProcessMemory: &port.MemoryPressureConfig{
-					KillThreshold: -1, // explicit unset
-				},
+				NetworkProcessMemory: &port.MemoryPressureConfig{},
 			},
 			expected: false,
 		},

--- a/internal/bootstrap/webkit_stack.go
+++ b/internal/bootstrap/webkit_stack.go
@@ -79,7 +79,6 @@ func BuildWebKitStack(input WebKitStackInput) WebKitStack {
 			PollIntervalSec:       perfSettings.WebProcessMemoryPollIntervalSec,
 			ConservativeThreshold: perfSettings.WebProcessMemoryConservativeThreshold,
 			StrictThreshold:       perfSettings.WebProcessMemoryStrictThreshold,
-			KillThreshold:         perfSettings.WebProcessMemoryKillThreshold,
 		}
 	}
 
@@ -90,7 +89,6 @@ func BuildWebKitStack(input WebKitStackInput) WebKitStack {
 			PollIntervalSec:       perfSettings.NetworkProcessMemoryPollIntervalSec,
 			ConservativeThreshold: perfSettings.NetworkProcessMemoryConservativeThreshold,
 			StrictThreshold:       perfSettings.NetworkProcessMemoryStrictThreshold,
-			KillThreshold:         perfSettings.NetworkProcessMemoryKillThreshold,
 		}
 	}
 
@@ -165,8 +163,7 @@ func hasWebProcessMemoryConfig(p *config.ResolvedPerformanceSettings) bool {
 	return p.WebProcessMemoryLimitMB > 0 ||
 		p.WebProcessMemoryPollIntervalSec > 0 ||
 		p.WebProcessMemoryConservativeThreshold > 0 ||
-		p.WebProcessMemoryStrictThreshold > 0 ||
-		p.WebProcessMemoryKillThreshold >= 0
+		p.WebProcessMemoryStrictThreshold > 0
 }
 
 // hasNetworkProcessMemoryConfig returns true if any network process memory setting is configured.
@@ -174,8 +171,7 @@ func hasNetworkProcessMemoryConfig(p *config.ResolvedPerformanceSettings) bool {
 	return p.NetworkProcessMemoryLimitMB > 0 ||
 		p.NetworkProcessMemoryPollIntervalSec > 0 ||
 		p.NetworkProcessMemoryConservativeThreshold > 0 ||
-		p.NetworkProcessMemoryStrictThreshold > 0 ||
-		p.NetworkProcessMemoryKillThreshold >= 0
+		p.NetworkProcessMemoryStrictThreshold > 0
 }
 
 // configureRenderingEnvironment sets up the rendering environment before WebKit/GTK initialization.

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -69,9 +69,6 @@ const (
 	// Skia threading defaults (0 = unset, -1 = unset for GPU threads)
 	defaultSkiaCPUPaintingThreads = 0
 	defaultSkiaGPUPaintingThreads = -1 // -1 means unset; 0 would disable GPU tile painting
-
-	// Memory pressure defaults (-1 = unset for kill threshold, 0 = unset for others)
-	defaultMemoryPressureKillThreshold = -1.0
 )
 
 // getDefaultLogDir returns the default log directory, falls back to empty string on error
@@ -302,13 +299,11 @@ func DefaultConfig() *Config {
 			WebProcessMemoryPollIntervalSec:       0,
 			WebProcessMemoryConservativeThreshold: 0,
 			WebProcessMemoryStrictThreshold:       0,
-			WebProcessMemoryKillThreshold:         defaultMemoryPressureKillThreshold,
 			// Network process memory pressure - all unset by default
 			NetworkProcessMemoryLimitMB:               0,
 			NetworkProcessMemoryPollIntervalSec:       0,
 			NetworkProcessMemoryConservativeThreshold: 0,
 			NetworkProcessMemoryStrictThreshold:       0,
-			NetworkProcessMemoryKillThreshold:         defaultMemoryPressureKillThreshold,
 		},
 		Update: UpdateConfig{
 			EnableOnStartup:     true,  // Check for updates on startup by default

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -492,14 +492,12 @@ func (m *Manager) setPerformanceDefaults(defaults *Config) {
 	m.viper.SetDefault("performance.web_process_memory_poll_interval_sec", defaults.Performance.WebProcessMemoryPollIntervalSec)
 	m.viper.SetDefault("performance.web_process_memory_conservative_threshold", defaults.Performance.WebProcessMemoryConservativeThreshold)
 	m.viper.SetDefault("performance.web_process_memory_strict_threshold", defaults.Performance.WebProcessMemoryStrictThreshold)
-	m.viper.SetDefault("performance.web_process_memory_kill_threshold", defaults.Performance.WebProcessMemoryKillThreshold)
 	// Network process memory pressure
 	m.viper.SetDefault("performance.network_process_memory_limit_mb", defaults.Performance.NetworkProcessMemoryLimitMB)
 	m.viper.SetDefault("performance.network_process_memory_poll_interval_sec", defaults.Performance.NetworkProcessMemoryPollIntervalSec)
 	netConservativeThreshold := defaults.Performance.NetworkProcessMemoryConservativeThreshold
 	m.viper.SetDefault("performance.network_process_memory_conservative_threshold", netConservativeThreshold)
 	m.viper.SetDefault("performance.network_process_memory_strict_threshold", defaults.Performance.NetworkProcessMemoryStrictThreshold)
-	m.viper.SetDefault("performance.network_process_memory_kill_threshold", defaults.Performance.NetworkProcessMemoryKillThreshold)
 }
 
 // New returns a new default configuration instance.

--- a/internal/infrastructure/config/profile.go
+++ b/internal/infrastructure/config/profile.go
@@ -65,14 +65,12 @@ type ResolvedPerformanceSettings struct {
 	WebProcessMemoryPollIntervalSec       float64
 	WebProcessMemoryConservativeThreshold float64
 	WebProcessMemoryStrictThreshold       float64
-	WebProcessMemoryKillThreshold         float64
 
 	// Network process memory pressure
 	NetworkProcessMemoryLimitMB               int
 	NetworkProcessMemoryPollIntervalSec       float64
 	NetworkProcessMemoryConservativeThreshold float64
 	NetworkProcessMemoryStrictThreshold       float64
-	NetworkProcessMemoryKillThreshold         float64
 
 	// WebView pool
 	WebViewPoolPrewarmCount int
@@ -108,13 +106,11 @@ func resolveDefaultProfile() ResolvedPerformanceSettings {
 		WebProcessMemoryPollIntervalSec:       0,
 		WebProcessMemoryConservativeThreshold: 0,
 		WebProcessMemoryStrictThreshold:       0,
-		WebProcessMemoryKillThreshold:         -1,
 
 		NetworkProcessMemoryLimitMB:               0,
 		NetworkProcessMemoryPollIntervalSec:       0,
 		NetworkProcessMemoryConservativeThreshold: 0,
 		NetworkProcessMemoryStrictThreshold:       0,
-		NetworkProcessMemoryKillThreshold:         -1,
 
 		WebViewPoolPrewarmCount: 4,
 	}
@@ -134,17 +130,15 @@ func resolveLiteProfile(hw *port.HardwareInfo) ResolvedPerformanceSettings {
 		SkiaGPUPaintingThreads: -1, // unset
 		SkiaEnableCPURendering: false,
 
-		WebProcessMemoryLimitMB:               512,
+		WebProcessMemoryLimitMB:               768,
 		WebProcessMemoryPollIntervalSec:       0, // use WebKit default (30s)
 		WebProcessMemoryConservativeThreshold: 0.25,
 		WebProcessMemoryStrictThreshold:       0.4,
-		WebProcessMemoryKillThreshold:         0.8,
 
-		NetworkProcessMemoryLimitMB:               256,
+		NetworkProcessMemoryLimitMB:               384,
 		NetworkProcessMemoryPollIntervalSec:       0,
 		NetworkProcessMemoryConservativeThreshold: 0.25,
 		NetworkProcessMemoryStrictThreshold:       0.4,
-		NetworkProcessMemoryKillThreshold:         0.8,
 
 		WebViewPoolPrewarmCount: 2,
 	}
@@ -159,9 +153,6 @@ func resolveMaxProfile(hw *port.HardwareInfo) ResolvedPerformanceSettings {
 	// GPU threads: scale based on VRAM
 	gpuThreads := computeMaxGPUThreads(hw)
 
-	// Memory limits: scale based on system RAM
-	webMemMB, netMemMB := computeMaxMemoryLimits(hw)
-
 	// WebView pool: scale based on RAM
 	poolPrewarm := computeMaxPoolPrewarm(hw)
 
@@ -170,17 +161,16 @@ func resolveMaxProfile(hw *port.HardwareInfo) ResolvedPerformanceSettings {
 		SkiaGPUPaintingThreads: gpuThreads,
 		SkiaEnableCPURendering: false,
 
-		WebProcessMemoryLimitMB:               webMemMB,
-		WebProcessMemoryPollIntervalSec:       0, // use WebKit default
-		WebProcessMemoryConservativeThreshold: 0.5,
-		WebProcessMemoryStrictThreshold:       0.7,
-		WebProcessMemoryKillThreshold:         -1, // never kill
+		// Max profile: no memory limits, let WebKit use defaults
+		WebProcessMemoryLimitMB:               0,
+		WebProcessMemoryPollIntervalSec:       0,
+		WebProcessMemoryConservativeThreshold: 0,
+		WebProcessMemoryStrictThreshold:       0,
 
-		NetworkProcessMemoryLimitMB:               netMemMB,
+		NetworkProcessMemoryLimitMB:               0,
 		NetworkProcessMemoryPollIntervalSec:       0,
-		NetworkProcessMemoryConservativeThreshold: 0.5,
-		NetworkProcessMemoryStrictThreshold:       0.7,
-		NetworkProcessMemoryKillThreshold:         -1,
+		NetworkProcessMemoryConservativeThreshold: 0,
+		NetworkProcessMemoryStrictThreshold:       0,
 
 		WebViewPoolPrewarmCount: poolPrewarm,
 	}
@@ -280,13 +270,11 @@ func resolveCustomProfile(cfg *PerformanceConfig) ResolvedPerformanceSettings {
 		WebProcessMemoryPollIntervalSec:       cfg.WebProcessMemoryPollIntervalSec,
 		WebProcessMemoryConservativeThreshold: cfg.WebProcessMemoryConservativeThreshold,
 		WebProcessMemoryStrictThreshold:       cfg.WebProcessMemoryStrictThreshold,
-		WebProcessMemoryKillThreshold:         cfg.WebProcessMemoryKillThreshold,
 
 		NetworkProcessMemoryLimitMB:               cfg.NetworkProcessMemoryLimitMB,
 		NetworkProcessMemoryPollIntervalSec:       cfg.NetworkProcessMemoryPollIntervalSec,
 		NetworkProcessMemoryConservativeThreshold: cfg.NetworkProcessMemoryConservativeThreshold,
 		NetworkProcessMemoryStrictThreshold:       cfg.NetworkProcessMemoryStrictThreshold,
-		NetworkProcessMemoryKillThreshold:         cfg.NetworkProcessMemoryKillThreshold,
 
 		WebViewPoolPrewarmCount: cfg.WebViewPoolPrewarmCount,
 	}
@@ -302,12 +290,10 @@ func HasCustomPerformanceFields(cfg *PerformanceConfig) bool {
 		cfg.WebProcessMemoryPollIntervalSec != 0 ||
 		cfg.WebProcessMemoryConservativeThreshold != 0 ||
 		cfg.WebProcessMemoryStrictThreshold != 0 ||
-		cfg.WebProcessMemoryKillThreshold != -1 ||
 		cfg.NetworkProcessMemoryLimitMB != 0 ||
 		cfg.NetworkProcessMemoryPollIntervalSec != 0 ||
 		cfg.NetworkProcessMemoryConservativeThreshold != 0 ||
-		cfg.NetworkProcessMemoryStrictThreshold != 0 ||
-		cfg.NetworkProcessMemoryKillThreshold != -1
+		cfg.NetworkProcessMemoryStrictThreshold != 0
 }
 
 // IsValidPerformanceProfile returns true if the profile name is recognized.

--- a/internal/infrastructure/config/profile_test.go
+++ b/internal/infrastructure/config/profile_test.go
@@ -55,17 +55,14 @@ func TestResolvePerformanceProfile_Lite_NoHardware(t *testing.T) {
 	if result.SkiaCPUPaintingThreads != 2 {
 		t.Errorf("expected SkiaCPUPaintingThreads=2, got %d", result.SkiaCPUPaintingThreads)
 	}
-	if result.WebProcessMemoryLimitMB != 512 {
-		t.Errorf("expected WebProcessMemoryLimitMB=512, got %d", result.WebProcessMemoryLimitMB)
+	if result.WebProcessMemoryLimitMB != 768 {
+		t.Errorf("expected WebProcessMemoryLimitMB=768, got %d", result.WebProcessMemoryLimitMB)
 	}
-	if result.NetworkProcessMemoryLimitMB != 256 {
-		t.Errorf("expected NetworkProcessMemoryLimitMB=256, got %d", result.NetworkProcessMemoryLimitMB)
+	if result.NetworkProcessMemoryLimitMB != 384 {
+		t.Errorf("expected NetworkProcessMemoryLimitMB=384, got %d", result.NetworkProcessMemoryLimitMB)
 	}
 	if result.WebViewPoolPrewarmCount != 2 {
 		t.Errorf("expected WebViewPoolPrewarmCount=2, got %d", result.WebViewPoolPrewarmCount)
-	}
-	if result.WebProcessMemoryKillThreshold != 0.8 {
-		t.Errorf("expected WebProcessMemoryKillThreshold=0.8, got %f", result.WebProcessMemoryKillThreshold)
 	}
 }
 
@@ -109,15 +106,12 @@ func TestResolvePerformanceProfile_Max_NoHardware(t *testing.T) {
 	if result.SkiaGPUPaintingThreads != 2 {
 		t.Errorf("expected SkiaGPUPaintingThreads=2 (fallback), got %d", result.SkiaGPUPaintingThreads)
 	}
-	// Memory: fallback assumes 16GB system
-	if result.WebProcessMemoryLimitMB != 2048 {
-		t.Errorf("expected WebProcessMemoryLimitMB=2048, got %d", result.WebProcessMemoryLimitMB)
+	// Max profile: no memory limits (unset)
+	if result.WebProcessMemoryLimitMB != 0 {
+		t.Errorf("expected WebProcessMemoryLimitMB=0 (unset), got %d", result.WebProcessMemoryLimitMB)
 	}
 	if result.WebViewPoolPrewarmCount != 8 {
 		t.Errorf("expected WebViewPoolPrewarmCount=8, got %d", result.WebViewPoolPrewarmCount)
-	}
-	if result.WebProcessMemoryKillThreshold != -1 {
-		t.Errorf("expected WebProcessMemoryKillThreshold=-1 (never kill), got %f", result.WebProcessMemoryKillThreshold)
 	}
 }
 
@@ -143,12 +137,12 @@ func TestResolvePerformanceProfile_Max_HighEndSystem(t *testing.T) {
 	if result.SkiaGPUPaintingThreads != 8 {
 		t.Errorf("expected SkiaGPUPaintingThreads=8 for 16GB VRAM, got %d", result.SkiaGPUPaintingThreads)
 	}
-	// Memory: high-end tier (32GB+ RAM)
-	if result.WebProcessMemoryLimitMB != 4096 {
-		t.Errorf("expected WebProcessMemoryLimitMB=4096 for 64GB RAM, got %d", result.WebProcessMemoryLimitMB)
+	// Max profile: no memory limits (unset)
+	if result.WebProcessMemoryLimitMB != 0 {
+		t.Errorf("expected WebProcessMemoryLimitMB=0 (unset) for max profile, got %d", result.WebProcessMemoryLimitMB)
 	}
-	if result.NetworkProcessMemoryLimitMB != 1024 {
-		t.Errorf("expected NetworkProcessMemoryLimitMB=1024 for 64GB RAM, got %d", result.NetworkProcessMemoryLimitMB)
+	if result.NetworkProcessMemoryLimitMB != 0 {
+		t.Errorf("expected NetworkProcessMemoryLimitMB=0 (unset) for max profile, got %d", result.NetworkProcessMemoryLimitMB)
 	}
 	// Pool prewarm: high-end tier
 	if result.WebViewPoolPrewarmCount != 12 {
@@ -178,9 +172,9 @@ func TestResolvePerformanceProfile_Max_MidRangeSystem(t *testing.T) {
 	if result.SkiaGPUPaintingThreads != 6 {
 		t.Errorf("expected SkiaGPUPaintingThreads=6 for 8GB VRAM, got %d", result.SkiaGPUPaintingThreads)
 	}
-	// Memory: mid-range tier (16-32GB RAM)
-	if result.WebProcessMemoryLimitMB != 3072 {
-		t.Errorf("expected WebProcessMemoryLimitMB=3072 for 16GB RAM, got %d", result.WebProcessMemoryLimitMB)
+	// Max profile: no memory limits (unset)
+	if result.WebProcessMemoryLimitMB != 0 {
+		t.Errorf("expected WebProcessMemoryLimitMB=0 (unset) for max profile, got %d", result.WebProcessMemoryLimitMB)
 	}
 	// Pool prewarm: mid-range tier
 	if result.WebViewPoolPrewarmCount != 8 {
@@ -210,9 +204,9 @@ func TestResolvePerformanceProfile_Max_LowEndSystem(t *testing.T) {
 	if result.SkiaGPUPaintingThreads != 2 {
 		t.Errorf("expected SkiaGPUPaintingThreads=2 for 2GB VRAM, got %d", result.SkiaGPUPaintingThreads)
 	}
-	// Memory: low tier (<8GB RAM)
-	if result.WebProcessMemoryLimitMB != 1024 {
-		t.Errorf("expected WebProcessMemoryLimitMB=1024 for 4GB RAM, got %d", result.WebProcessMemoryLimitMB)
+	// Max profile: no memory limits (unset)
+	if result.WebProcessMemoryLimitMB != 0 {
+		t.Errorf("expected WebProcessMemoryLimitMB=0 (unset) for max profile, got %d", result.WebProcessMemoryLimitMB)
 	}
 	// Pool prewarm: low tier
 	if result.WebViewPoolPrewarmCount != 4 {
@@ -267,40 +261,33 @@ func TestHasCustomPerformanceFields(t *testing.T) {
 		{
 			name: "all defaults - no custom fields",
 			cfg: PerformanceConfig{
-				SkiaCPUPaintingThreads:            0,
-				SkiaGPUPaintingThreads:            -1,
-				SkiaEnableCPURendering:            false,
-				WebProcessMemoryKillThreshold:     -1,
-				NetworkProcessMemoryKillThreshold: -1,
+				SkiaCPUPaintingThreads: 0,
+				SkiaGPUPaintingThreads: -1,
+				SkiaEnableCPURendering: false,
 			},
 			expected: false,
 		},
 		{
 			name: "skia cpu threads set",
 			cfg: PerformanceConfig{
-				SkiaCPUPaintingThreads:            4,
-				SkiaGPUPaintingThreads:            -1,
-				WebProcessMemoryKillThreshold:     -1,
-				NetworkProcessMemoryKillThreshold: -1,
+				SkiaCPUPaintingThreads: 4,
+				SkiaGPUPaintingThreads: -1,
 			},
 			expected: true,
 		},
 		{
 			name: "memory limit set",
 			cfg: PerformanceConfig{
-				SkiaGPUPaintingThreads:            -1,
-				WebProcessMemoryLimitMB:           1024,
-				WebProcessMemoryKillThreshold:     -1,
-				NetworkProcessMemoryKillThreshold: -1,
+				SkiaGPUPaintingThreads:  -1,
+				WebProcessMemoryLimitMB: 1024,
 			},
 			expected: true,
 		},
 		{
-			name: "kill threshold changed from -1",
+			name: "conservative threshold set",
 			cfg: PerformanceConfig{
-				SkiaGPUPaintingThreads:            -1,
-				WebProcessMemoryKillThreshold:     0.9,
-				NetworkProcessMemoryKillThreshold: -1,
+				SkiaGPUPaintingThreads:                -1,
+				WebProcessMemoryConservativeThreshold: 0.4,
 			},
 			expected: true,
 		},

--- a/internal/infrastructure/config/schema.go
+++ b/internal/infrastructure/config/schema.go
@@ -242,10 +242,6 @@ type PerformanceConfig struct {
 	// Valid: (0, 1). Default: 0 (unset, uses WebKit default: 0.5)
 	WebProcessMemoryStrictThreshold float64 `mapstructure:"web_process_memory_strict_threshold" yaml:"web_process_memory_strict_threshold" toml:"web_process_memory_strict_threshold"` //nolint:lll // struct tags must stay on one line
 
-	// WebProcessMemoryKillThreshold sets threshold for killing processes.
-	// Default: -1 (unset). Value 0 means never kill.
-	WebProcessMemoryKillThreshold float64 `mapstructure:"web_process_memory_kill_threshold" yaml:"web_process_memory_kill_threshold" toml:"web_process_memory_kill_threshold"` //nolint:lll // struct tags must stay on one line
-
 	// --- Network process memory pressure ---
 	// NetworkProcessMemoryLimitMB sets memory limit in MB for network process.
 	// Default: 0 (unset)
@@ -262,10 +258,6 @@ type PerformanceConfig struct {
 	// NetworkProcessMemoryStrictThreshold sets threshold for strict memory release.
 	// Valid: (0, 1). Default: 0 (unset)
 	NetworkProcessMemoryStrictThreshold float64 `mapstructure:"network_process_memory_strict_threshold" yaml:"network_process_memory_strict_threshold" toml:"network_process_memory_strict_threshold"` //nolint:lll // struct tags must stay on one line
-
-	// NetworkProcessMemoryKillThreshold sets threshold for killing network process.
-	// Default: -1 (unset). Value 0 means never kill.
-	NetworkProcessMemoryKillThreshold float64 `mapstructure:"network_process_memory_kill_threshold" yaml:"network_process_memory_kill_threshold" toml:"network_process_memory_kill_threshold"` //nolint:lll // struct tags must stay on one line
 }
 
 // SearchShortcut represents a search shortcut configuration.

--- a/internal/infrastructure/webkit/context.go
+++ b/internal/infrastructure/webkit/context.go
@@ -85,7 +85,6 @@ func NewWebKitContextWithOptions(ctx context.Context, opts port.WebKitContextOpt
 					Float64("poll_sec", opts.WebProcessMemory.PollIntervalSec).
 					Float64("conservative", opts.WebProcessMemory.ConservativeThreshold).
 					Float64("strict", opts.WebProcessMemory.StrictThreshold).
-					Float64("kill", opts.WebProcessMemory.KillThreshold).
 					Msg("created WebContext with memory pressure settings")
 			}
 		}

--- a/internal/infrastructure/webkit/memory_pressure.go
+++ b/internal/infrastructure/webkit/memory_pressure.go
@@ -41,7 +41,6 @@ func (*MemoryPressureApplier) ApplyNetworkProcessSettings(ctx context.Context, c
 		Float64("poll_sec", cfg.PollIntervalSec).
 		Float64("conservative", cfg.ConservativeThreshold).
 		Float64("strict", cfg.StrictThreshold).
-		Float64("kill", cfg.KillThreshold).
 		Msg("applied network process memory pressure settings")
 
 	return nil
@@ -72,7 +71,6 @@ func (*MemoryPressureApplier) ApplyWebProcessSettings(ctx context.Context, cfg *
 		Float64("poll_sec", cfg.PollIntervalSec).
 		Float64("conservative", cfg.ConservativeThreshold).
 		Float64("strict", cfg.StrictThreshold).
-		Float64("kill", cfg.KillThreshold).
 		Msg("prepared web process memory pressure settings")
 
 	return settings, nil
@@ -110,11 +108,6 @@ func buildMemoryPressureSettings(cfg *port.MemoryPressureConfig) *webkit.MemoryP
 		if conservative < strict {
 			settings.SetConservativeThreshold(conservative)
 		}
-	}
-
-	// Kill threshold: -1 = unset, 0 = never kill, >0 = threshold
-	if cfg.KillThreshold >= 0 {
-		settings.SetKillThreshold(cfg.KillThreshold)
 	}
 
 	return settings

--- a/internal/infrastructure/webkit/scheme_handler.go
+++ b/internal/infrastructure/webkit/scheme_handler.go
@@ -114,7 +114,6 @@ type configResolvedPerformance struct {
 	WebViewPoolPrewarm     int     `json:"webview_pool_prewarm"`
 	ConservativeThreshold  float64 `json:"conservative_threshold"`
 	StrictThreshold        float64 `json:"strict_threshold"`
-	KillThreshold          float64 `json:"kill_threshold"`
 }
 
 type configPayload struct {
@@ -224,7 +223,6 @@ func (h *DumbSchemeHandler) buildConfigResponse(cfg *config.Config) *SchemeRespo
 				WebViewPoolPrewarm:     resolved.WebViewPoolPrewarmCount,
 				ConservativeThreshold:  resolved.WebProcessMemoryConservativeThreshold,
 				StrictThreshold:        resolved.WebProcessMemoryStrictThreshold,
-				KillThreshold:          resolved.WebProcessMemoryKillThreshold,
 			},
 			Hardware: buildHardwarePayload(hw),
 		},

--- a/webui/src/pages/ConfigPage.svelte
+++ b/webui/src/pages/ConfigPage.svelte
@@ -36,7 +36,6 @@
     webview_pool_prewarm: number;
     conservative_threshold: number;
     strict_threshold: number;
-    kill_threshold: number;
   };
 
   type HardwareInfo = {
@@ -595,13 +594,6 @@
                         <span class="font-mono">{config.performance.resolved.webview_pool_prewarm}</span>
                       </div>
                       <p class="text-xs text-muted-foreground">Pre-created WebViews at startup for faster new tab/pane creation.</p>
-                    </div>
-                    <div class="space-y-1">
-                      <div class="flex justify-between">
-                        <span class="font-medium">Memory Kill Threshold</span>
-                        <span class="font-mono">{config.performance.resolved.kill_threshold === -1 ? 'never' : (config.performance.resolved.kill_threshold * 100).toFixed(0) + '%'}</span>
-                      </div>
-                      <p class="text-xs text-muted-foreground">When memory usage exceeds this threshold, WebKit may terminate the process to free memory.</p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Removes the memory kill threshold feature from performance profiles as it was causing immediate webview process termination, especially in lite mode.

## Problem

The memory kill threshold (introduced in PR #65) was too aggressive:
- **Lite profile**: Set memory limit to 512MB with kill threshold at 80% (~410MB)
- Modern websites easily exceed 410MB, causing constant process termination
- This made the browser essentially unusable in lite mode

According to WebKitGTK docs, the kill threshold "sets value as the fraction of the defined memory limit where the process will be killed" - this is a nuclear option that should almost never be used in a browser context.

## Solution

- **Remove `KillThreshold` entirely** from all profiles and config schema
- **Increase lite profile memory limits**: 512MB → 768MB (web), 256MB → 384MB (network)
- **Max profile uses WebKit defaults**: No memory limits for best performance
- **Keep conservative/strict thresholds**: These properly trigger WebKit's garbage collection and cache cleanup

## Changes

- `profile.go`: Remove kill threshold fields, update lite/max profiles
- `schema.go`, `defaults.go`, `loader.go`: Remove config fields
- `webkit_stack.go`, `webkit_context.go`, `memory_pressure.go`: Remove kill threshold handling
- `scheme_handler.go`, `ConfigPage.svelte`: Remove from API and UI
- `CONFIG.md`: Update documentation
- Tests updated accordingly

## Testing

- `go build ./...` - passes
- `go test ./internal/infrastructure/config/... ./internal/application/port/...` - passes
- `make lint` - 0 issues