### PR TITLE
fix(ci): remove GPG signing from flatpak build

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -107,17 +107,11 @@ jobs:
           echo "Generated manifest:"
           cat dev.bnema.Dumber.yml
 
-      - name: Import GPG key
-        run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
-          gpg --list-secret-keys --keyid-format=long
-
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: dumber.flatpak
           manifest-path: dev.bnema.Dumber.yml
           cache-key: flatpak-builder-${{ steps.version.outputs.version }}
-          gpg-sign: ${{ secrets.GPG_KEY_ID }}
 
       - name: Upload Flatpak to Release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary

Remove GPG signing from Flatpak build workflow. GPG signing in CI fails with pinentry errors (`No pinentry`) and is not required for distributing Flatpak bundles via GitHub releases.

GPG signing is primarily needed for Flathub repository submissions, not for standalone `.flatpak` bundles.

Fixes the v0.23.1 release build failure.