### PR TITLE
fix(ci): add concurrency to AUR workflow

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -11,7 +11,7 @@ on:
       - completed
 
 concurrency:
-  group: aur-publish
+  group: aur-publish-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `concurrency` group to AUR workflow to auto-cancel duplicate runs
- Prevents race conditions when multiple Flatpak workflows complete in quick succession

This fixes the issue where re-pushing a tag triggered two Flatpak runs, each spawning an AUR publish workflow.