### PR TITLE
fix(aur): update package path for new tarball structure

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -102,21 +102,15 @@ jobs:
             ')' \
             "provides=('dumber-browser' 'dumber')" \
             "conflicts=('dumber-browser' 'dumber-browser-git')" \
-            'source=("${pkgname}-${pkgver}.tar.gz::https://github.com/bnema/dumber/releases/download/v${pkgver}/dumber_linux_x86_64.tar.gz"' \
-            '        "dev.bnema.Dumber.desktop::https://raw.githubusercontent.com/bnema/dumber/v${pkgver}/dev.bnema.Dumber.desktop"' \
-            '        "logo-512.png::https://raw.githubusercontent.com/bnema/dumber/v${pkgver}/assets/logo-512.png"' \
-            '        "LICENSE::https://raw.githubusercontent.com/bnema/dumber/v${pkgver}/LICENSE")' \
-            "sha256sums=('${SHA256}'" \
-            "            'SKIP'" \
-            "            'SKIP'" \
-            "            'SKIP')" \
+            'source=("${pkgname}-${pkgver}.tar.gz::https://github.com/bnema/dumber/releases/download/v${pkgver}/dumber_linux_x86_64.tar.gz")' \
+            "sha256sums=('${SHA256}')" \
             '' \
             'package() {' \
-            '    cd "${srcdir}"' \
+            '    cd "${srcdir}/dumber_${pkgver}"' \
             '    install -Dm755 dumber "${pkgdir}/usr/bin/dumber"' \
-            '    install -Dm644 "${srcdir}/dev.bnema.Dumber.desktop" "${pkgdir}/usr/share/applications/dev.bnema.Dumber.desktop"' \
-            '    install -Dm644 "${srcdir}/logo-512.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/dev.bnema.Dumber.png"' \
-            '    install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"' \
+            '    install -Dm644 dev.bnema.Dumber.desktop "${pkgdir}/usr/share/applications/dev.bnema.Dumber.desktop"' \
+            '    install -Dm644 logo-512.png "${pkgdir}/usr/share/icons/hicolor/512x512/apps/dev.bnema.Dumber.png"' \
+            '    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"' \
             '}' \
             > pkgbuild/dumber-browser-bin/PKGBUILD
           

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,10 @@ archives:
       - LICENSE
       - README.md
       - CHANGELOG.md
+      - dev.bnema.Dumber.desktop
+      - src: assets/logo-512.png
+        dst: .
+        strip_parent: true
 
 checksum:
   name_template: 'checksums.txt'

--- a/aur/dumber-browser-bin/.SRCINFO
+++ b/aur/dumber-browser-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dumber-browser-bin
 	pkgdesc = A minimal keyboard-driven browser for tiling WMs
-	pkgver = 0.23.1
+	pkgver = 0.23.2
 	pkgrel = 1
 	url = https://github.com/bnema/dumber
 	arch = x86_64
@@ -24,13 +24,7 @@ pkgbase = dumber-browser-bin
 	provides = dumber
 	conflicts = dumber-browser
 	conflicts = dumber-browser-git
-	source = dumber-browser-bin-0.23.1.tar.gz::https://github.com/bnema/dumber/releases/download/v0.23.1/dumber_linux_x86_64.tar.gz
-	source = dev.bnema.Dumber.desktop::https://raw.githubusercontent.com/bnema/dumber/v0.23.1/dev.bnema.Dumber.desktop
-	source = logo-512.png::https://raw.githubusercontent.com/bnema/dumber/v0.23.1/assets/logo-512.png
-	source = LICENSE::https://raw.githubusercontent.com/bnema/dumber/v0.23.1/LICENSE
-	sha256sums = c8230e3a5258333fed401439b08c6ef7b0681dd14f4e97a7e837dfc2c4cc83a0
-	sha256sums = SKIP
-	sha256sums = SKIP
-	sha256sums = SKIP
+	source = dumber-browser-bin-0.23.2.tar.gz::https://github.com/bnema/dumber/releases/download/v0.23.2/dumber_linux_x86_64.tar.gz
+	sha256sums = ffd085d0a4204ae61ec83d9f0a060a07703b398a0e5095cae3516dfc98a43c45
 
 pkgname = dumber-browser-bin

--- a/aur/dumber-browser-bin/PKGBUILD
+++ b/aur/dumber-browser-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: bnema <b at bnema dot dev>
 pkgname=dumber-browser-bin
-pkgver=0.23.1
+pkgver=0.23.2
 pkgrel=1
 pkgdesc="A minimal keyboard-driven browser for tiling WMs"
 arch=('x86_64')
@@ -24,19 +24,13 @@ optdepends=(
 )
 provides=('dumber-browser' 'dumber')
 conflicts=('dumber-browser' 'dumber-browser-git')
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/bnema/dumber/releases/download/v${pkgver}/dumber_linux_x86_64.tar.gz"
-        "dev.bnema.Dumber.desktop::https://raw.githubusercontent.com/bnema/dumber/v${pkgver}/dev.bnema.Dumber.desktop"
-        "logo-512.png::https://raw.githubusercontent.com/bnema/dumber/v${pkgver}/assets/logo-512.png"
-        "LICENSE::https://raw.githubusercontent.com/bnema/dumber/v${pkgver}/LICENSE")
-sha256sums=('c8230e3a5258333fed401439b08c6ef7b0681dd14f4e97a7e837dfc2c4cc83a0'
-            'SKIP'
-            'SKIP'
-            'SKIP')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/bnema/dumber/releases/download/v${pkgver}/dumber_linux_x86_64.tar.gz")
+sha256sums=('ffd085d0a4204ae61ec83d9f0a060a07703b398a0e5095cae3516dfc98a43c45')
 
 package() {
-    cd "${srcdir}"
+    cd "${srcdir}/dumber_${pkgver}"
     install -Dm755 dumber "${pkgdir}/usr/bin/dumber"
-    install -Dm644 "${srcdir}/dev.bnema.Dumber.desktop" "${pkgdir}/usr/share/applications/dev.bnema.Dumber.desktop"
-    install -Dm644 "${srcdir}/logo-512.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/dev.bnema.Dumber.png"
-    install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 dev.bnema.Dumber.desktop "${pkgdir}/usr/share/applications/dev.bnema.Dumber.desktop"
+    install -Dm644 logo-512.png "${pkgdir}/usr/share/icons/hicolor/512x512/apps/dev.bnema.Dumber.png"
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }


### PR DESCRIPTION
## Summary
- Fix AUR package build failure caused by tarball structure change
- Binary is now at `dumber_${version}/dumber` instead of `./dumber`
- Remove separate LICENSE download since it's included in tarball