### PR TITLE
Add CI-triggered AUR publish for dumber-browser-git

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -7,7 +7,6 @@ name: AUR Publish
 on:
   workflow_run:
     workflows: ["CI", "Flatpak"]
-    branches: [main]
     types:
       - completed
 
@@ -26,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Calculate pkgver


### PR DESCRIPTION
## Summary
- Adds automatic AUR publishing for `dumber-browser-git` package after CI passes on main branch
- Users running `yay -Syu` will now see updates available when new commits land on main
- Renamed existing job to `publish-aur-bin` for clarity

## Changes
- Trigger: listens to both `CI` and `Flatpak` workflow completions
- New job `publish-aur-git`: runs when CI succeeds on main, calculates pkgver, publishes to AUR
- Existing job `publish-aur-bin`: unchanged behavior, still waits for Flatpak + 1 hour delay