### PR TITLE
fix: stacked pane close button now properly closes instead of switching pane

### DIFF
--- a/internal/ui/layout/tree_test.go
+++ b/internal/ui/layout/tree_test.go
@@ -19,11 +19,10 @@ func setupStackedLeafMocks(t *testing.T, mockFactory *mocks.MockWidgetFactory) (
 	mockStackBox.EXPECT().SetHexpand(true).Once()
 	mockStackBox.EXPECT().SetVexpand(true).Once()
 
-	mockTitleBar, mockFavicon, mockOverlay, mockSpinner, mockContainer := setupPaneMocks(t, mockFactory, mockStackBox)
+	mockTitleBar, mockFavicon, mockLabel, mockContainer := setupPaneMocks(t, mockFactory, mockStackBox)
 	_ = mockFavicon
-	_ = mockOverlay
-	_ = mockSpinner
-	mockTitleBar.EXPECT().GetParent().Return(nil).Maybe()
+	_ = mockLabel
+	mockTitleBar.EXPECT().SetVisible(false).Once() // Active pane hides its title bar
 	mockContainer.EXPECT().SetVisible(true).Once()
 	mockTitleBar.EXPECT().AddCssClass("active").Once()
 

--- a/internal/ui/theme/css.go
+++ b/internal/ui/theme/css.go
@@ -572,6 +572,7 @@ func generateStackedPaneCSS(p Palette) string {
 	return `/* ===== Stacked Pane Styling ===== */
 
 /* Title bar for inactive panes in a stack */
+/* The title bar is now a Box with GestureClick, not wrapped in a button */
 .stacked-pane-titlebar {
 	background-color: var(--surface-variant);
 	border-bottom: 0.0625em solid var(--border);
@@ -579,25 +580,13 @@ func generateStackedPaneCSS(p Palette) string {
 	min-height: 1.5em;
 }
 
-/* Title bar button wrapper - clickable area */
-button.stacked-pane-title-button {
-	background-color: var(--surface-variant);
-	background-image: none;
-	border: none;
-	border-bottom: 0.0625em solid var(--border);
-	border-radius: 0;
-	padding: 0;
-	margin: 0;
+/* Clickable title bar - hover styling */
+.stacked-pane-titlebar.stacked-pane-title-clickable {
 	transition: background-color 150ms ease-in-out;
 }
 
-button.stacked-pane-title-button:hover {
+.stacked-pane-titlebar.stacked-pane-title-clickable:hover {
 	background-color: shade(var(--surface-variant), 1.15);
-}
-
-button.stacked-pane-title-button:focus {
-	outline: none;
-	box-shadow: none;
 }
 
 /* Title bar content box */
@@ -620,7 +609,8 @@ button.stacked-pane-title-button:focus {
 	font-weight: 400;
 }
 
-button.stacked-pane-title-button:hover .stacked-pane-titlebar label {
+/* Hover effect on title bar label */
+.stacked-pane-titlebar.stacked-pane-title-clickable:hover label {
 	color: var(--accent);
 }
 
@@ -652,7 +642,7 @@ button.stacked-pane-title-button:hover .stacked-pane-titlebar label {
 }
 
 /* Show close button more prominently when hovering title bar */
-button.stacked-pane-title-button:hover .stacked-pane-close-button {
+.stacked-pane-titlebar.stacked-pane-title-clickable:hover .stacked-pane-close-button {
 	opacity: 0.7;
 }
 


### PR DESCRIPTION
## Summary

- Fixed stacked pane close button (X) triggering pane switch instead of closing the pane
- Replaced button-inside-button architecture with GestureClick controller + hit testing
- Updated CSS for the new widget structure

## Problem

When clicking the close button on a stacked pane's title bar, it was switching to that pane instead of closing it. This was caused by the close button being nested inside a wrapper button, causing click events to propagate and trigger both handlers.

## Solution

- Removed the outer `Button` wrapper around the title bar
- Added a `GestureClick` controller directly on the title bar `Box` widget
- Implemented hit testing to detect clicks on the close button area and skip activation in that case
- Updated CSS selectors from `button.stacked-pane-title-button` to `.stacked-pane-titlebar.stacked-pane-title-clickable`

## Testing

- Create a stacked pane (2+ panes in a stack)
- Click on the title bar of an inactive pane → should switch to that pane
- Click on the X button → should close the pane (not switch first)