### PR TITLE
feat(omnibox): hide on click outside bounds

### DIFF
--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bnema/dumber/internal/ui/layout"
 	"github.com/jwijenbergh/puregotk/v4/gdk"
 	"github.com/jwijenbergh/puregotk/v4/glib"
+	"github.com/jwijenbergh/puregotk/v4/graphene"
 	"github.com/jwijenbergh/puregotk/v4/gtk"
 	"github.com/jwijenbergh/puregotk/v4/pango"
 )
@@ -130,6 +131,10 @@ type Omnibox struct {
 
 	// Callback retention: keep GTK signal callbacks reachable by Go GC.
 	retainedCallbacks []interface{}
+
+	// Click outside handler
+	clickOutsideController *gtk.GestureClick
+	clickOutsideCb         func(gtk.GestureClick, int, float64, float64)
 }
 
 // OmniboxConfig holds configuration for creating an Omnibox.
@@ -199,6 +204,86 @@ func (o *Omnibox) SetParentOverlay(overlay layout.OverlayWidget) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.parentOverlay = overlay
+	o.setupClickOutsideHandler()
+}
+
+// setupClickOutsideHandler attaches a click gesture to the parent overlay
+// that hides the omnibox when clicking outside its bounds.
+func (o *Omnibox) setupClickOutsideHandler() {
+	if o.parentOverlay == nil {
+		return
+	}
+
+	log := logging.FromContext(o.ctx)
+
+	// Create gesture click controller
+	o.clickOutsideController = gtk.NewGestureClick()
+	if o.clickOutsideController == nil {
+		log.Error().Msg("failed to create click outside controller")
+		return
+	}
+
+	// Listen to primary button only
+	o.clickOutsideController.SetButton(1) // GDK_BUTTON_PRIMARY
+
+	// Set capture phase so we see clicks before they reach the omnibox
+	o.clickOutsideController.SetPropagationPhase(gtk.PhaseCaptureValue)
+
+	// Connect pressed handler
+	o.clickOutsideCb = func(_ gtk.GestureClick, _ int, x, y float64) {
+		o.handleClickOutside(x, y)
+	}
+	o.clickOutsideController.ConnectPressed(&o.clickOutsideCb)
+
+	// Add controller to parent overlay
+	gtkWidget := o.parentOverlay.GtkWidget()
+	if gtkWidget != nil {
+		gtkWidget.AddController(&o.clickOutsideController.EventController)
+	}
+
+	log.Debug().Msg("click outside handler attached to parent overlay")
+}
+
+// handleClickOutside checks if a click is outside the omnibox bounds and hides if so.
+func (o *Omnibox) handleClickOutside(clickX, clickY float64) {
+	o.mu.RLock()
+	visible := o.visible
+	o.mu.RUnlock()
+
+	if !visible || o.outerBox == nil || o.parentOverlay == nil {
+		return
+	}
+
+	// Get omnibox position relative to parent overlay using graphene points
+	srcPoint := &graphene.Point{X: 0, Y: 0}
+	outPoint := &graphene.Point{}
+	ok := o.outerBox.ComputePoint(o.parentOverlay.GtkWidget(), srcPoint, outPoint)
+	if !ok {
+		return
+	}
+
+	boxX := float64(outPoint.X)
+	boxY := float64(outPoint.Y)
+
+	// Get omnibox dimensions
+	boxWidth := float64(o.outerBox.GetAllocatedWidth())
+	boxHeight := float64(o.outerBox.GetAllocatedHeight())
+
+	// Check if click is inside omnibox bounds
+	isInside := clickX >= boxX && clickX <= boxX+boxWidth &&
+		clickY >= boxY && clickY <= boxY+boxHeight
+
+	if !isInside {
+		logging.FromContext(o.ctx).Debug().
+			Float64("clickX", clickX).
+			Float64("clickY", clickY).
+			Float64("boxX", boxX).
+			Float64("boxY", boxY).
+			Float64("boxWidth", boxWidth).
+			Float64("boxHeight", boxHeight).
+			Msg("click outside omnibox, hiding")
+		o.Hide(o.ctx)
+	}
 }
 
 // WidgetAsLayout returns the omnibox's outer widget as a layout.Widget.
@@ -2063,6 +2148,8 @@ func (o *Omnibox) Destroy() {
 
 	o.parentOverlay = nil
 	o.retainedCallbacks = nil
+	o.clickOutsideController = nil
+	o.clickOutsideCb = nil
 
 	if o.outerBox != nil {
 		o.outerBox.Unparent()


### PR DESCRIPTION
## Summary
- Add click-outside-to-hide functionality for the omnibox
- Clicking anywhere on the pane/webview area outside the omnibox now dismisses it

## Test plan
- [ ] Open omnibox with Ctrl+L
- [ ] Click inside omnibox (entry, list, buttons) - should NOT hide
- [ ] Click outside omnibox (webview area) - should hide
- [ ] Verify Escape key still works
- [ ] Verify Ctrl+L toggle still works

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds click-outside-to-hide functionality to the omnibox component, allowing users to dismiss the omnibox by clicking anywhere outside its bounds on the webview area.

**Changes:**
- Added `graphene` import for coordinate transformation using `ComputePoint()`
- Created gesture click controller attached to parent overlay in capture phase
- Implemented bounds checking using omnibox position and dimensions
- Added proper cleanup in `Destroy()` method
- Used read lock pattern to check visibility before processing clicks

**Implementation Quality:**
- Correctly uses GTK4 capture phase to intercept clicks before they reach child widgets
- Properly checks visibility state before processing clicks to avoid unnecessary work
- Uses `ComputePoint()` for accurate coordinate transformation between widget coordinate spaces
- Includes appropriate debug logging for troubleshooting
- Follows existing code patterns for callback retention and memory management

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues identified
- The implementation is clean, follows GTK4 best practices, includes proper resource cleanup, uses appropriate locking patterns, and correctly handles coordinate transformations. The change is well-scoped and doesn't introduce side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/ui/component/omnibox.go | Implemented click-outside-to-hide functionality with proper bounds checking and GTK4 gesture handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ParentOverlay
    participant GestureClick
    participant Omnibox
    
    User->>Omnibox: Opens omnibox (Ctrl+L)
    Note over Omnibox: Omnibox becomes visible
    
    User->>ParentOverlay: Clicks on webview area
    ParentOverlay->>GestureClick: Pressed event (capture phase)
    GestureClick->>Omnibox: handleClickOutside(x, y)
    
    alt Click is outside omnibox bounds
        Omnibox->>Omnibox: ComputePoint() to get omnibox position
        Omnibox->>Omnibox: Check if click coordinates outside bounds
        Omnibox->>Omnibox: Hide()
        Note over Omnibox: Omnibox closes
    else Click is inside omnibox bounds
        Note over Omnibox: No action, omnibox stays open
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->