### PR TITLE
fix(webview): reset background to white for external pages to prevent dark bleeding

### DIFF
--- a/internal/infrastructure/webkit/webview.go
+++ b/internal/infrastructure/webkit/webview.go
@@ -905,6 +905,12 @@ func (wv *WebView) SetBackgroundColor(r, g, b, a float32) {
 	wv.inner.SetBackgroundColor(rgba)
 }
 
+// ResetBackgroundToDefault sets WebView background to white (browser default).
+// Used for external pages to prevent dark background from bleeding through.
+func (wv *WebView) ResetBackgroundToDefault() {
+	wv.SetBackgroundColor(1.0, 1.0, 1.0, 1.0)
+}
+
 // Show makes the WebView widget visible.
 // This should be called after the WebView is ready to be displayed.
 func (wv *WebView) Show() {

--- a/internal/ui/coordinator/content.go
+++ b/internal/ui/coordinator/content.go
@@ -24,6 +24,12 @@ import (
 const (
 	aboutBlankURI = "about:blank"
 	logURLMaxLen  = 80
+
+	// Dark theme background color (#0a0a0b) as float32 RGBA values
+	darkBgR = 0.039
+	darkBgG = 0.039
+	darkBgB = 0.043
+	darkBgA = 1.0
 )
 
 // ContentCoordinator manages WebView lifecycle, title tracking, and content attachment.
@@ -934,6 +940,23 @@ func (c *ContentCoordinator) onLoadCommitted(ctx context.Context, paneID entity.
 	url := wv.URI()
 	if url == "" {
 		return
+	}
+
+	// Set appropriate background color based on page type to prevent dark background bleeding.
+	switch {
+	case strings.HasPrefix(url, "dumb://"):
+		// Internal pages: apply themed background
+		theme, ok := c.getCurrentTheme()
+		if ok && theme.prefersDark {
+			wv.SetBackgroundColor(darkBgR, darkBgG, darkBgB, darkBgA)
+		} else {
+			wv.ResetBackgroundToDefault()
+		}
+	case strings.HasPrefix(url, "about:"):
+		// Keep pool background (no action)
+	default:
+		// External pages: white background
+		wv.ResetBackgroundToDefault()
 	}
 
 	// Show the WebView now that content is being painted


### PR DESCRIPTION
## Summary
- Adds `ResetBackgroundToDefault()` method to WebView that sets background to white
- Calls this method in `onLoadCommitted()` for external pages (non `dumb://` and non `about:`)
- Fixes dark background bleeding on external websites like PageSpeed Insights

## Test plan
- [x] Build with `make build`
- [x] Test external light-mode site (pagespeed.web.dev) - no black areas
- [x] Test external dark-mode site (github.com) - white flash acceptable
- [x] Test internal pages (`dumb://settings`, `dumb://home`) - proper dark/light theme
- [x] Test light mode setting - everything works as before