### PR TITLE
fix: popups not working in split panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.1] - 2026-01-25
+
+### Fixed
+- **Popups not working in split panes**: Fixed `window.open()` and `target="_blank"` links not functioning in split panes. Popup handling was not being set up for WebViews created via `EnsureWebView`.
+
+### Changed
+- **WebView callback setup refactoring**: Consolidated duplicate callback setup code into single `setupWebViewCallbacks` function. `EnsureWebView` now delegates to this function instead of inline setup. Made `setupPopupHandling` private since no external callers remain.
+
 ## [0.26.0] - 2026-01-24
 
 ### Added

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -129,7 +129,6 @@ func New(deps *Dependencies) (*App, error) {
 	if err := deps.Validate(); err != nil {
 		return nil, err
 	}
-
 	ctx, cancel := context.WithCancelCause(deps.Ctx)
 
 	app := &App{
@@ -1798,11 +1797,7 @@ func (a *App) attachPopupToTab(ctx context.Context, tabID entity.TabID, pane *en
 				log.Warn().Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
 			}
 		}
-
-		// Setup popup handling for nested popups
-		a.contentCoord.SetupPopupHandling(ctx, pane.ID, wv)
 	}
-
 	log.Debug().
 		Str("tab_id", string(tabID)).
 		Str("pane_id", string(pane.ID)).


### PR DESCRIPTION
## Summary
- Fixed `window.open()` and `target="_blank"` links not functioning in split panes
- Consolidated duplicate WebView callback setup code into single `setupWebViewCallbacks` function
- Made `setupPopupHandling` private since no external callers remain

## Test plan
- [ ] Open a link with `target="_blank"` from a split pane
- [ ] Test `window.open()` from JavaScript in a split pane
- [ ] Middle-click a link in a split pane to open in new pane
- [ ] Test nested popups (popup from within a popup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed popups not working in split panes; window.open() and target="_blank" links now function correctly in all split pane configurations
  * Improved popup web view handling initialization to ensure proper configuration on creation

* **Chores**
  * Refactored internal callback setup logic to reduce code duplication and improve maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->