### PR TITLE
fix(omnibox): delay ghost text until input

### DIFF
--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -30,6 +30,7 @@ const (
 	defaultOmniboxPlaceholder = "Search history or enter URL… (! lists bangs)"
 	ghostPositionRetryMs      = 16
 	ghostPositionMaxAttempts  = 5
+	minGhostInputLength       = 1
 )
 
 // ViewMode distinguishes history search from favorites display.
@@ -1084,12 +1085,18 @@ func (o *Omnibox) updateGhostFromSelectionWithInput(entryText string) {
 	idx := o.selectedIndex
 	mode := o.viewMode
 	bangMode := o.bangMode
+	hasNavigated := o.hasNavigated
 	suggestions := o.suggestions
 	favorites := o.favorites
 	o.mu.RUnlock()
 
 	// No ghost text in bang mode
 	if bangMode {
+		o.clearGhostTextIfInput(entryText)
+		return
+	}
+
+	if utf8.RuneCountInString(entryText) < minGhostInputLength && !hasNavigated {
 		o.clearGhostTextIfInput(entryText)
 		return
 	}


### PR DESCRIPTION
## Summary
- require at least one typed character before showing ghost text unless the user navigates
- keep arrow navigation ghost suggestions while restoring empty-input tab behavior
- centralize the guard with a small input length constant

## Testing
- make test
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete suggestion behavior for short text inputs. Suggestions will now be withheld until the user either enters more characters or navigates using arrow keys, reducing unnecessary autocomplete prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->