### PR TITLE
fix oauth popup auto-close stability in GTK flow

### DIFF
--- a/internal/ui/coordinator/oauth.go
+++ b/internal/ui/coordinator/oauth.go
@@ -105,6 +105,16 @@ func ShouldAutoClose(url string) bool {
 	return IsOAuthCallback(url)
 }
 
+// shouldForceCloseOnSafetyTimeout determines if a popup should be force-closed
+// when the OAuth safety timeout is reached.
+//
+// Safety-timeout force close is disabled for stability. OAuth popups close on
+// callback detection or manual user action.
+func shouldForceCloseOnSafetyTimeout(url string) bool {
+	_ = url
+	return false
+}
+
 // IsOAuthSuccess checks if the callback indicates successful authentication.
 func IsOAuthSuccess(url string) bool {
 	if url == "" {

--- a/internal/ui/coordinator/oauth_test.go
+++ b/internal/ui/coordinator/oauth_test.go
@@ -108,6 +108,18 @@ func TestIsOAuthURL_DetectsOAuthAuthorizeRequest(t *testing.T) {
 	assert.True(t, IsOAuthURL(url))
 }
 
+func TestShouldForceCloseOnSafetyTimeout(t *testing.T) {
+	t.Run("does not force close during in-progress auth challenge", func(t *testing.T) {
+		url := "https://accounts.google.com/v3/signin/challenge/dp?TL=AHU8sQabc"
+		assert.False(t, shouldForceCloseOnSafetyTimeout(url))
+	})
+
+	t.Run("does not force close when callback is reached", func(t *testing.T) {
+		url := "http://localhost:1455/auth/callback?code=abc123&state=xyz"
+		assert.False(t, shouldForceCloseOnSafetyTimeout(url))
+	})
+}
+
 func waitFor(t *testing.T, timeout time.Duration, condition func() bool) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- dispatch OAuth popup close actions to the GTK main loop via `glib.IdleAdd` to avoid cross-thread widget teardown
- tighten OAuth popup classification to avoid false positives (e.g. generic `state=` URLs)
- disable safety-timeout forced popup close so active auth/MFA flows are not interrupted and can only close via callback detection or manual close

## Test Plan
- go test ./internal/ui/coordinator -run TestIsOAuthURL -v
- go test ./internal/ui/coordinator -run TestShouldForceCloseOnSafetyTimeout -v
- go test ./internal/ui/coordinator/...
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authentication popup closing behavior for enhanced safety and responsiveness, preventing potential hangs and delays during sign-in workflows.
  * Enhanced authentication request detection for more accurate identification and handling of legitimate OAuth sign-in requests.
  * Strengthened testing with additional test coverage for OAuth authentication scenarios to ensure consistent reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->