### PR TITLE
fix: hide visible floating pane on Escape

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -625,6 +625,9 @@ func (a *App) initKeyboardHandler(ctx context.Context) {
 		}
 		return a.kbDispatcher.Dispatch(ctx, action)
 	})
+	a.keyboardHandler.SetOnEscape(func(ctx context.Context) bool {
+		return a.handleGlobalEscape(ctx)
+	})
 	a.keyboardHandler.SetOnModeChange(func(from, to input.Mode) {
 		a.handleModeChange(ctx, from, to)
 	})
@@ -2728,6 +2731,10 @@ func (a *App) closeActiveFloatingPane(ctx context.Context) bool {
 	a.hideFloatingSession(ctx, session)
 	a.syncFloatingFocus()
 	return true
+}
+
+func (a *App) handleGlobalEscape(ctx context.Context) bool {
+	return a.closeActiveFloatingPane(ctx)
 }
 
 func (a *App) closeAndReleaseActiveFloatingPane(ctx context.Context) bool {

--- a/internal/ui/floating_pane_test.go
+++ b/internal/ui/floating_pane_test.go
@@ -312,6 +312,17 @@ func TestFloatingPane_CloseActiveFloatingSession(t *testing.T) {
 	assert.False(t, handled)
 }
 
+func TestFloatingPane_HandleGlobalEscape_HidesVisibleFloatingPane(t *testing.T) {
+	app, _, session := newFloatingPaneTestApp(t)
+
+	require.NoError(t, app.ToggleFloatingPane(context.Background()))
+	require.True(t, session.pane.IsVisible())
+
+	handled := app.handleGlobalEscape(context.Background())
+	assert.True(t, handled)
+	assert.False(t, session.pane.IsVisible())
+}
+
 func TestFloatingPane_OpenFloatingPaneSession_OptionalURL(t *testing.T) {
 	app, _, session := newFloatingPaneTestApp(t)
 


### PR DESCRIPTION
## Summary
- route plain `Esc` through a new keyboard escape hook before normal shortcut dispatch
- wire the app-level escape handler to close the active floating pane when visible
- add a regression test to verify escape hides an open floating pane session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Escape key now closes the currently active floating pane, providing a standard keyboard shortcut for dismissing floating UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->