### PR TITLE
chore(ci): track latest golangci-lint release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: make build-frontend
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b /usr/local/bin v2.9.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b /usr/local/bin latest
       - name: Run golangci-lint
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Summary
- switch the CI golangci-lint installer from a pinned `v2.9.0` tag to `latest`
- keep CI aligned with current upstream golangci-lint releases without manual version bumps
- use the installer mode verified locally to avoid the unsupported `v2` alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration tooling configuration to use the latest version of code linting tools during automated quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->