### PR TITLE
test(desktop): make session spawner env capture atomic

### DIFF
--- a/internal/infrastructure/desktop/adapter_test.go
+++ b/internal/infrastructure/desktop/adapter_test.go
@@ -28,13 +28,42 @@ func (e testSessionSpawnEnvironment) SessionRootCachePath(sessionID entity.Sessi
 
 func TestMain(m *testing.M) {
 	if envFile := os.Getenv(testCaptureEnvFile); envFile != "" && len(os.Args) >= 2 && os.Args[1] == "browse" {
-		if err := os.WriteFile(envFile, []byte(strings.Join(os.Environ(), "\n")), 0o644); err != nil {
+		if err := writeFileAtomically(envFile, []byte(strings.Join(os.Environ(), "\n")), 0o644); err != nil {
 			os.Exit(2)
 		}
 		os.Exit(0)
 	}
 
 	os.Exit(m.Run())
+}
+
+func writeFileAtomically(path string, data []byte, perm os.FileMode) error {
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Chmod(perm); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func TestSanitizedChildEnv_RemovesLayerShellPreloadOnly(t *testing.T) {


### PR DESCRIPTION
## Summary
- make the test child env capture write atomically in `internal/infrastructure/desktop/adapter_test.go`
- remove the race where the parent could read a partially-written env file
- stabilize the flaky session spawner test seen on `main` CI

## Root cause
The test harness wrote the captured child environment directly to the target file with `os.WriteFile(...)`. The parent test polled for file existence and could read the file before the write had fully completed, intermittently missing `DUMBER_RESTORE_SESSION`.

## Validation
- `go test ./internal/infrastructure/desktop -v`
- `go test ./internal/infrastructure/desktop -run 'TestSessionSpawner_SpawnWithSession_(PassesRestoreSessionAndEngineOverride|OmitsEngineOverrideWhenNotConfigured)' -count=200`
- `go test -race ./internal/infrastructure/desktop -run 'TestSessionSpawner_SpawnWithSession_(PassesRestoreSessionAndEngineOverride|OmitsEngineOverrideWhenNotConfigured)'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved atomic file writing reliability in test infrastructure for safer environment file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->