### PR TITLE
feat(download): add shared download handling for CEF and WebKit

### DIFF
--- a/internal/application/port/download.go
+++ b/internal/application/port/download.go
@@ -8,6 +8,8 @@ type DownloadEventType int
 const (
 	// DownloadEventStarted indicates a download has begun.
 	DownloadEventStarted DownloadEventType = iota
+	// DownloadEventProgress indicates download progress has advanced.
+	DownloadEventProgress
 	// DownloadEventFinished indicates a download completed successfully.
 	DownloadEventFinished
 	// DownloadEventFailed indicates a download failed.
@@ -16,10 +18,13 @@ const (
 
 // DownloadEvent contains information about a download event.
 type DownloadEvent struct {
-	Type        DownloadEventType
-	Filename    string
-	Destination string
-	Error       error // Set when Type is DownloadEventFailed
+	Type          DownloadEventType
+	Filename      string
+	Destination   string
+	Progress      float64 // Set when Type is DownloadEventProgress, normalized to 0.0-1.0.
+	BytesReceived int64   // Best-effort received byte count for progress updates.
+	BytesTotal    int64   // Best-effort total byte count for progress updates when known.
+	Error         error   // Set when Type is DownloadEventFailed
 }
 
 // DownloadEventHandler receives download event notifications.

--- a/internal/domain/download/policy.go
+++ b/internal/domain/download/policy.go
@@ -1,0 +1,87 @@
+package download
+
+import (
+	"mime"
+	"net/url"
+	"path"
+	"strings"
+)
+
+var forcedDownloadExtensions = map[string]struct{}{
+	".7z":       {},
+	".apk":      {},
+	".appimage": {},
+	".bz2":      {},
+	".deb":      {},
+	".dmg":      {},
+	".exe":      {},
+	".gz":       {},
+	".img":      {},
+	".iso":      {},
+	".msi":      {},
+	".pdf":      {},
+	".pkg":      {},
+	".rar":      {},
+	".rpm":      {},
+	".tar":      {},
+	".tgz":      {},
+	".xz":       {},
+	".zip":      {},
+}
+
+var forcedDownloadMIMETypes = map[string]struct{}{
+	"application/pdf":               {},
+	"application/x-apple-diskimage": {},
+	"application/x-cd-image":        {},
+	"application/x-iso9660-image":   {},
+}
+
+// ShouldForceDownload returns true when the resource should be downloaded
+// instead of navigated/rendered inline.
+func ShouldForceDownload(uri, mimeType string) bool {
+	return ShouldForceDownloadForMIMEType(mimeType) || ShouldForceDownloadForURI(uri)
+}
+
+// ShouldForceDownloadForURI returns true when the URI path has a known
+// download-only extension.
+func ShouldForceDownloadForURI(uri string) bool {
+	ext := strings.ToLower(path.Ext(uriPath(uri)))
+	if ext == "" {
+		return false
+	}
+	_, ok := forcedDownloadExtensions[ext]
+	return ok
+}
+
+// ShouldForceDownloadForMIMEType returns true when the MIME type maps to a
+// known download-only artifact.
+func ShouldForceDownloadForMIMEType(mimeType string) bool {
+	if mimeType == "" {
+		return false
+	}
+
+	mediaType := strings.ToLower(strings.TrimSpace(mimeType))
+	if parsed, _, err := mime.ParseMediaType(mediaType); err == nil {
+		mediaType = parsed
+	}
+
+	_, ok := forcedDownloadMIMETypes[mediaType]
+	return ok
+}
+
+func uriPath(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Path != "" {
+		return parsed.Path
+	}
+
+	if cut := strings.IndexAny(raw, "?#"); cut >= 0 {
+		return raw[:cut]
+	}
+
+	return raw
+}

--- a/internal/domain/download/policy_test.go
+++ b/internal/domain/download/policy_test.go
@@ -1,0 +1,59 @@
+package download
+
+import "testing"
+
+func TestShouldForceDownloadForURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      string
+		expected bool
+	}{
+		{name: "pdf path", uri: "https://example.com/file.pdf", expected: true},
+		{name: "iso path", uri: "https://example.com/linux.iso?mirror=1", expected: true},
+		{name: "archive path", uri: "https://example.com/release.tar.gz", expected: true},
+		{name: "plain html", uri: "https://example.com/index.html", expected: false},
+		{name: "empty", uri: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldForceDownloadForURI(tt.uri); got != tt.expected {
+				t.Fatalf("ShouldForceDownloadForURI(%q) = %v, want %v", tt.uri, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldForceDownloadForMIMEType(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		expected bool
+	}{
+		{name: "pdf", mimeType: "application/pdf", expected: true},
+		{name: "pdf with params", mimeType: "application/pdf; charset=binary", expected: true},
+		{name: "iso image", mimeType: "application/x-iso9660-image", expected: true},
+		{name: "html", mimeType: "text/html", expected: false},
+		{name: "empty", mimeType: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldForceDownloadForMIMEType(tt.mimeType); got != tt.expected {
+				t.Fatalf("ShouldForceDownloadForMIMEType(%q) = %v, want %v", tt.mimeType, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldForceDownload(t *testing.T) {
+	if !ShouldForceDownload("https://example.com/file.iso", "") {
+		t.Fatal("expected URI extension to trigger forced download")
+	}
+	if !ShouldForceDownload("", "application/pdf") {
+		t.Fatal("expected MIME type to trigger forced download")
+	}
+	if ShouldForceDownload("https://example.com/", "text/html") {
+		t.Fatal("did not expect regular HTML to trigger forced download")
+	}
+}

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -3,8 +3,6 @@ package cef
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"strings"
 	"sync"
 
 	purecef "github.com/bnema/purego-cef/cef"
@@ -15,16 +13,22 @@ import (
 	"github.com/bnema/dumber/internal/logging"
 )
 
+// maxFinishedEntries caps the finished-ID set. When the cap is reached the set
+// is cleared, accepting a tiny risk of a duplicate terminal event for very old
+// downloads. In practice download IDs are monotonically increasing uint32s and
+// no user session will approach this limit.
+const maxFinishedEntries = 1024
+
 type downloadHandler struct {
-	runtime *downloadruntime.Runtime
-	mu      sync.Mutex
-	active  map[uint32]cefDownloadState
+	runtime  *downloadruntime.Runtime
+	mu       sync.Mutex
+	active   map[uint32]cefDownloadState
+	finished map[uint32]struct{} // IDs that already emitted a terminal event
 }
 
 type cefDownloadState struct {
 	filename    string
 	destination string
-	finished    bool
 }
 
 type cefDownloadResponseAdapter struct {
@@ -37,13 +41,14 @@ func newDownloadHandler(
 	preparer port.DownloadPreparer,
 ) *downloadHandler {
 	return &downloadHandler{
-		runtime: downloadruntime.New(downloadPath, eventHandler, preparer),
-		active:  make(map[uint32]cefDownloadState),
+		runtime:  downloadruntime.New(downloadPath, eventHandler, preparer),
+		active:   make(map[uint32]cefDownloadState),
+		finished: make(map[uint32]struct{}),
 	}
 }
 
-func (h *downloadHandler) canDownload(_ purecef.Browser, _, requestMethod string) bool {
-	return requestMethod == "" || strings.EqualFold(requestMethod, http.MethodGet)
+func (h *downloadHandler) canDownload(_ purecef.Browser, _, _ string) bool {
+	return true
 }
 
 func (h *downloadHandler) onBeforeDownload(
@@ -89,16 +94,25 @@ func (h *downloadHandler) onDownloadUpdated(
 	}
 
 	id := downloadItem.GetID()
+
+	// Fast path: skip already-finished downloads to avoid re-populating active.
+	h.mu.Lock()
+	_, done := h.finished[id]
+	h.mu.Unlock()
+	if done {
+		return
+	}
+
 	state := h.currentState(id, downloadItem)
 
 	switch {
 	case downloadItem.IsComplete():
-		if !h.markFinished(id, state) {
+		if !h.markFinished(id) {
 			return
 		}
 		h.runtime.EmitFinished(ctx, state.filename, state.destination)
 	case downloadItem.IsCanceled() || downloadItem.IsInterrupted():
-		if !h.markFinished(id, state) {
+		if !h.markFinished(id) {
 			return
 		}
 		var err error
@@ -129,21 +143,18 @@ func (h *downloadHandler) currentState(id uint32, item purecef.DownloadItem) cef
 	return state
 }
 
-func (h *downloadHandler) markFinished(id uint32, state cefDownloadState) bool {
+func (h *downloadHandler) markFinished(id uint32) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	current, ok := h.active[id]
-	if !ok {
-		state.finished = true
-		h.active[id] = state
-		return true
-	}
-	if current.finished {
+	if _, seen := h.finished[id]; seen {
 		return false
 	}
-	state.finished = true
-	h.active[id] = state
+	delete(h.active, id)
+	if len(h.finished) >= maxFinishedEntries {
+		clear(h.finished)
+	}
+	h.finished[id] = struct{}{}
 	return true
 }
 

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -144,7 +144,7 @@ func (h *downloadHandler) onDownloadUpdated(
 		}
 		err := fmt.Errorf("download failed: %s", state.filename)
 		if downloadItem.IsInterrupted() {
-			err = fmt.Errorf("download interrupted: %s (%s)", state.filename, downloadItem.GetInterruptReason())
+			err = fmt.Errorf("download interrupted: %s (%v)", state.filename, downloadItem.GetInterruptReason())
 		} else if downloadItem.IsCanceled() {
 			err = fmt.Errorf("download canceled: %s", state.filename)
 		}

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -1,0 +1,243 @@
+package cef
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	purecef "github.com/bnema/purego-cef/cef"
+
+	"github.com/bnema/dumber/internal/application/port"
+	downloadutil "github.com/bnema/dumber/internal/domain/download"
+	"github.com/bnema/dumber/internal/logging"
+)
+
+const cefDownloadDirPerm = 0o755
+
+type downloadHandler struct {
+	downloadPath string
+	eventHandler port.DownloadEventHandler
+	preparer     port.DownloadPreparer
+
+	mu     sync.Mutex
+	active map[uint32]cefDownloadState
+}
+
+type cefDownloadState struct {
+	filename    string
+	destination string
+	finished    bool
+}
+
+type cefDownloadResponseAdapter struct {
+	item purecef.DownloadItem
+}
+
+func newDownloadHandler(
+	downloadPath string,
+	eventHandler port.DownloadEventHandler,
+	preparer port.DownloadPreparer,
+) *downloadHandler {
+	if preparer == nil {
+		panic("preparer is required")
+	}
+
+	return &downloadHandler{
+		downloadPath: downloadPath,
+		eventHandler: eventHandler,
+		preparer:     preparer,
+		active:       make(map[uint32]cefDownloadState),
+	}
+}
+
+func (h *downloadHandler) canDownload(_ purecef.Browser, _ string, requestMethod string) bool {
+	return requestMethod == "" || strings.EqualFold(requestMethod, http.MethodGet)
+}
+
+func (h *downloadHandler) onBeforeDownload(
+	ctx context.Context,
+	_ purecef.Browser,
+	downloadItem purecef.DownloadItem,
+	suggestedName string,
+	callback purecef.BeforeDownloadCallback,
+) bool {
+	if downloadItem == nil || callback == nil {
+		return false
+	}
+
+	log := logging.FromContext(ctx)
+	downloadPath, eventHandler, preparer := h.snapshot()
+	if err := os.MkdirAll(downloadPath, cefDownloadDirPerm); err != nil {
+		log.Error().Err(err).Str("path", downloadPath).Msg("cef: failed to create download directory")
+		callback.Cont("", 1)
+		return true
+	}
+
+	output := preparer.Execute(ctx, port.DownloadPrepareInput{
+		SuggestedFilename: suggestedName,
+		Response:          &cefDownloadResponseAdapter{item: downloadItem},
+		DownloadDir:       downloadPath,
+	})
+
+	h.mu.Lock()
+	h.active[downloadItem.GetID()] = cefDownloadState{
+		filename:    output.Filename,
+		destination: output.DestinationPath,
+	}
+	h.mu.Unlock()
+
+	callback.Cont(output.DestinationPath, 0)
+
+	if eventHandler != nil {
+		eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
+			Type:        port.DownloadEventStarted,
+			Filename:    output.Filename,
+			Destination: output.DestinationPath,
+		})
+	}
+
+	log.Info().
+		Uint32("download_id", downloadItem.GetID()).
+		Str("filename", output.Filename).
+		Str("destination", output.DestinationPath).
+		Msg("cef: download started")
+
+	return true
+}
+
+func (h *downloadHandler) onDownloadUpdated(
+	ctx context.Context,
+	downloadItem purecef.DownloadItem,
+	callback purecef.DownloadItemCallback,
+) {
+	_ = callback
+	if downloadItem == nil {
+		return
+	}
+
+	log := logging.FromContext(ctx)
+	id := downloadItem.GetID()
+	state := h.currentState(id, downloadItem)
+
+	switch {
+	case downloadItem.IsComplete():
+		if !h.markFinished(id, state) {
+			return
+		}
+		if h.eventHandler != nil {
+			h.eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
+				Type:        port.DownloadEventFinished,
+				Filename:    state.filename,
+				Destination: state.destination,
+			})
+		}
+		log.Info().
+			Uint32("download_id", id).
+			Str("filename", state.filename).
+			Msg("cef: download finished")
+	case downloadItem.IsCanceled() || downloadItem.IsInterrupted():
+		if !h.markFinished(id, state) {
+			return
+		}
+		err := fmt.Errorf("download failed: %s", state.filename)
+		if downloadItem.IsInterrupted() {
+			err = fmt.Errorf("download interrupted: %s (%s)", state.filename, downloadItem.GetInterruptReason())
+		} else if downloadItem.IsCanceled() {
+			err = fmt.Errorf("download canceled: %s", state.filename)
+		}
+		if h.eventHandler != nil {
+			h.eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
+				Type:        port.DownloadEventFailed,
+				Filename:    state.filename,
+				Destination: state.destination,
+				Error:       err,
+			})
+		}
+		log.Warn().
+			Uint32("download_id", id).
+			Err(err).
+			Msg("cef: download failed")
+	}
+}
+
+func (h *downloadHandler) snapshot() (string, port.DownloadEventHandler, port.DownloadPreparer) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.downloadPath, h.eventHandler, h.preparer
+}
+
+func (h *downloadHandler) currentState(id uint32, item purecef.DownloadItem) cefDownloadState {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	state, ok := h.active[id]
+	if !ok {
+		state = cefDownloadState{}
+	}
+	if state.destination == "" {
+		state.destination = item.GetFullPath()
+	}
+	if state.filename == "" {
+		state.filename = downloadFilenameFromItem(item, state.destination)
+	}
+	h.active[id] = state
+	return state
+}
+
+func (h *downloadHandler) markFinished(id uint32, state cefDownloadState) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	current, ok := h.active[id]
+	if !ok {
+		state.finished = true
+		h.active[id] = state
+		return true
+	}
+	if current.finished {
+		return false
+	}
+	state.finished = true
+	h.active[id] = state
+	return true
+}
+
+func downloadFilenameFromItem(item purecef.DownloadItem, destination string) string {
+	if destination != "" {
+		return downloadutil.ExtractFilenameFromDestination(destination)
+	}
+	if item == nil {
+		return downloadutil.DefaultFilename
+	}
+	if suggested := item.GetSuggestedFileName(); suggested != "" {
+		return downloadutil.SanitizeFilenameWithExtension(suggested, item.GetMimeType())
+	}
+	if uri := item.GetURL(); uri != "" {
+		return downloadutil.ExtractFilenameFromURI(uri)
+	}
+	return downloadutil.DefaultFilename
+}
+
+func (a *cefDownloadResponseAdapter) GetMimeType() string {
+	if a == nil || a.item == nil {
+		return ""
+	}
+	return a.item.GetMimeType()
+}
+
+func (a *cefDownloadResponseAdapter) GetSuggestedFilename() string {
+	if a == nil || a.item == nil {
+		return ""
+	}
+	return a.item.GetSuggestedFileName()
+}
+
+func (a *cefDownloadResponseAdapter) GetUri() string {
+	if a == nil || a.item == nil {
+		return ""
+	}
+	return a.item.GetURL()
+}

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -42,7 +42,7 @@ func newDownloadHandler(
 	}
 }
 
-func (h *downloadHandler) canDownload(_ purecef.Browser, _ string, requestMethod string) bool {
+func (h *downloadHandler) canDownload(_ purecef.Browser, _, requestMethod string) bool {
 	return requestMethod == "" || strings.EqualFold(requestMethod, http.MethodGet)
 }
 

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -101,10 +101,10 @@ func (h *downloadHandler) onDownloadUpdated(
 		if !h.markFinished(id, state) {
 			return
 		}
-		err := fmt.Errorf("download failed: %s", state.filename)
+		var err error
 		if downloadItem.IsInterrupted() {
 			err = fmt.Errorf("download interrupted: %s (%v)", state.filename, downloadItem.GetInterruptReason())
-		} else if downloadItem.IsCanceled() {
+		} else {
 			err = fmt.Errorf("download canceled: %s", state.filename)
 		}
 		h.runtime.EmitFailed(ctx, state.filename, state.destination, err)

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -31,8 +31,70 @@ type cefDownloadState struct {
 	destination string
 }
 
+type cefDownloadInterruptError struct {
+	filename string
+	reason   purecef.DownloadInterruptReason
+}
+
+func (e cefDownloadInterruptError) Error() string {
+	return fmt.Sprintf(
+		"download interrupted: %s (code=%d, reason=%s)",
+		e.filename,
+		e.reason,
+		downloadInterruptReasonLabel(e.reason),
+	)
+}
+
+func (e cefDownloadInterruptError) DownloadErrorCode() int {
+	return int(e.reason)
+}
+
+func (e cefDownloadInterruptError) DownloadErrorReason() string {
+	return downloadInterruptReasonLabel(e.reason)
+}
+
 type cefDownloadResponseAdapter struct {
 	item purecef.DownloadItem
+}
+
+var downloadInterruptReasonLabels = map[purecef.DownloadInterruptReason]string{
+	purecef.DownloadInterruptReasonNone:                        "none",
+	purecef.DownloadInterruptReasonFileFailed:                  "file_failed",
+	purecef.DownloadInterruptReasonFileAccessDenied:            "file_access_denied",
+	purecef.DownloadInterruptReasonFileNoSpace:                 "file_no_space",
+	purecef.DownloadInterruptReasonFileNameTooLong:             "file_name_too_long",
+	purecef.DownloadInterruptReasonFileTooLarge:                "file_too_large",
+	purecef.DownloadInterruptReasonFileVirusInfected:           "file_virus_infected",
+	purecef.DownloadInterruptReasonFileTransientError:          "file_transient_error",
+	purecef.DownloadInterruptReasonFileBlocked:                 "file_blocked",
+	purecef.DownloadInterruptReasonFileSecurityCheckFailed:     "file_security_check_failed",
+	purecef.DownloadInterruptReasonFileTooShort:                "file_too_short",
+	purecef.DownloadInterruptReasonFileHashMismatch:            "file_hash_mismatch",
+	purecef.DownloadInterruptReasonFileSameAsSource:            "file_same_as_source",
+	purecef.DownloadInterruptReasonNetworkFailed:               "network_failed",
+	purecef.DownloadInterruptReasonNetworkTimeout:              "network_timeout",
+	purecef.DownloadInterruptReasonNetworkDisconnected:         "network_disconnected",
+	purecef.DownloadInterruptReasonNetworkServerDown:           "network_server_down",
+	purecef.DownloadInterruptReasonNetworkInvalidRequest:       "network_invalid_request",
+	purecef.DownloadInterruptReasonServerFailed:                "server_failed",
+	purecef.DownloadInterruptReasonServerNoRange:               "server_no_range",
+	purecef.DownloadInterruptReasonServerBadContent:            "server_bad_content",
+	purecef.DownloadInterruptReasonServerUnauthorized:          "server_unauthorized",
+	purecef.DownloadInterruptReasonServerCertProblem:           "server_cert_problem",
+	purecef.DownloadInterruptReasonServerForbidden:             "server_forbidden",
+	purecef.DownloadInterruptReasonServerUnreachable:           "server_unreachable",
+	purecef.DownloadInterruptReasonServerContentLengthMismatch: "server_content_length_mismatch",
+	purecef.DownloadInterruptReasonServerCrossOriginRedirect:   "server_cross_origin_redirect",
+	purecef.DownloadInterruptReasonUserCanceled:                "user_canceled",
+	purecef.DownloadInterruptReasonUserShutdown:                "user_shutdown",
+	purecef.DownloadInterruptReasonCrash:                       "crash",
+}
+
+func downloadInterruptReasonLabel(reason purecef.DownloadInterruptReason) string {
+	if label, ok := downloadInterruptReasonLabels[reason]; ok {
+		return label
+	}
+	return "unknown"
 }
 
 func newDownloadHandler(
@@ -117,7 +179,10 @@ func (h *downloadHandler) onDownloadUpdated(
 		}
 		var err error
 		if downloadItem.IsInterrupted() {
-			err = fmt.Errorf("download interrupted: %s (%v)", state.filename, downloadItem.GetInterruptReason())
+			err = cefDownloadInterruptError{
+				filename: state.filename,
+				reason:   downloadItem.GetInterruptReason(),
+			}
 		} else {
 			err = fmt.Errorf("download canceled: %s", state.filename)
 		}

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 
@@ -12,18 +11,14 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	downloadutil "github.com/bnema/dumber/internal/domain/download"
+	"github.com/bnema/dumber/internal/infrastructure/downloadruntime"
 	"github.com/bnema/dumber/internal/logging"
 )
 
-const cefDownloadDirPerm = 0o755
-
 type downloadHandler struct {
-	downloadPath string
-	eventHandler port.DownloadEventHandler
-	preparer     port.DownloadPreparer
-
-	mu     sync.Mutex
-	active map[uint32]cefDownloadState
+	runtime *downloadruntime.Runtime
+	mu      sync.Mutex
+	active  map[uint32]cefDownloadState
 }
 
 type cefDownloadState struct {
@@ -41,15 +36,9 @@ func newDownloadHandler(
 	eventHandler port.DownloadEventHandler,
 	preparer port.DownloadPreparer,
 ) *downloadHandler {
-	if preparer == nil {
-		panic("preparer is required")
-	}
-
 	return &downloadHandler{
-		downloadPath: downloadPath,
-		eventHandler: eventHandler,
-		preparer:     preparer,
-		active:       make(map[uint32]cefDownloadState),
+		runtime: downloadruntime.New(downloadPath, eventHandler, preparer),
+		active:  make(map[uint32]cefDownloadState),
 	}
 }
 
@@ -69,18 +58,12 @@ func (h *downloadHandler) onBeforeDownload(
 	}
 
 	log := logging.FromContext(ctx)
-	downloadPath, eventHandler, preparer := h.snapshot()
-	if err := os.MkdirAll(downloadPath, cefDownloadDirPerm); err != nil {
-		log.Error().Err(err).Str("path", downloadPath).Msg("cef: failed to create download directory")
+	output, err := h.runtime.ResolveDestination(ctx, suggestedName, &cefDownloadResponseAdapter{item: downloadItem})
+	if err != nil {
+		log.Error().Err(err).Msg("cef: failed to prepare download destination")
 		callback.Cont("", 1)
 		return true
 	}
-
-	output := preparer.Execute(ctx, port.DownloadPrepareInput{
-		SuggestedFilename: suggestedName,
-		Response:          &cefDownloadResponseAdapter{item: downloadItem},
-		DownloadDir:       downloadPath,
-	})
 
 	h.mu.Lock()
 	h.active[downloadItem.GetID()] = cefDownloadState{
@@ -90,20 +73,7 @@ func (h *downloadHandler) onBeforeDownload(
 	h.mu.Unlock()
 
 	callback.Cont(output.DestinationPath, 0)
-
-	if eventHandler != nil {
-		eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
-			Type:        port.DownloadEventStarted,
-			Filename:    output.Filename,
-			Destination: output.DestinationPath,
-		})
-	}
-
-	log.Info().
-		Uint32("download_id", downloadItem.GetID()).
-		Str("filename", output.Filename).
-		Str("destination", output.DestinationPath).
-		Msg("cef: download started")
+	h.runtime.EmitStarted(ctx, output)
 
 	return true
 }
@@ -118,7 +88,6 @@ func (h *downloadHandler) onDownloadUpdated(
 		return
 	}
 
-	log := logging.FromContext(ctx)
 	id := downloadItem.GetID()
 	state := h.currentState(id, downloadItem)
 
@@ -127,17 +96,7 @@ func (h *downloadHandler) onDownloadUpdated(
 		if !h.markFinished(id, state) {
 			return
 		}
-		if h.eventHandler != nil {
-			h.eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
-				Type:        port.DownloadEventFinished,
-				Filename:    state.filename,
-				Destination: state.destination,
-			})
-		}
-		log.Info().
-			Uint32("download_id", id).
-			Str("filename", state.filename).
-			Msg("cef: download finished")
+		h.runtime.EmitFinished(ctx, state.filename, state.destination)
 	case downloadItem.IsCanceled() || downloadItem.IsInterrupted():
 		if !h.markFinished(id, state) {
 			return
@@ -148,25 +107,8 @@ func (h *downloadHandler) onDownloadUpdated(
 		} else if downloadItem.IsCanceled() {
 			err = fmt.Errorf("download canceled: %s", state.filename)
 		}
-		if h.eventHandler != nil {
-			h.eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
-				Type:        port.DownloadEventFailed,
-				Filename:    state.filename,
-				Destination: state.destination,
-				Error:       err,
-			})
-		}
-		log.Warn().
-			Uint32("download_id", id).
-			Err(err).
-			Msg("cef: download failed")
+		h.runtime.EmitFailed(ctx, state.filename, state.destination, err)
 	}
-}
-
-func (h *downloadHandler) snapshot() (string, port.DownloadEventHandler, port.DownloadPreparer) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return h.downloadPath, h.eventHandler, h.preparer
 }
 
 func (h *downloadHandler) currentState(id uint32, item purecef.DownloadItem) cefDownloadState {

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -197,17 +197,22 @@ func (h *downloadHandler) currentState(id uint32, item purecef.DownloadItem) cef
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	state, ok := h.active[id]
-	if !ok {
+	state, exists := h.active[id]
+	if !exists {
 		state = cefDownloadState{}
 	}
+	updated := false
 	if state.destination == "" {
 		state.destination = item.GetFullPath()
+		updated = true
 	}
 	if state.filename == "" {
 		state.filename = downloadFilenameFromItem(item, state.destination)
+		updated = true
 	}
-	h.active[id] = state
+	if exists && updated {
+		h.active[id] = state
+	}
 	return state
 }
 
@@ -269,10 +274,10 @@ func (h *downloadHandler) markFinished(id uint32) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	delete(h.active, id)
 	if _, seen := h.finished[id]; seen {
 		return false
 	}
-	delete(h.active, id)
 	if len(h.finished) >= maxFinishedEntries {
 		clear(h.finished)
 	}

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -27,8 +27,9 @@ type downloadHandler struct {
 }
 
 type cefDownloadState struct {
-	filename    string
-	destination string
+	filename            string
+	destination         string
+	lastProgressPercent int32
 }
 
 type cefDownloadInterruptError struct {
@@ -134,8 +135,9 @@ func (h *downloadHandler) onBeforeDownload(
 
 	h.mu.Lock()
 	h.active[downloadItem.GetID()] = cefDownloadState{
-		filename:    output.Filename,
-		destination: output.DestinationPath,
+		filename:            output.Filename,
+		destination:         output.DestinationPath,
+		lastProgressPercent: -1,
 	}
 	h.mu.Unlock()
 
@@ -166,6 +168,7 @@ func (h *downloadHandler) onDownloadUpdated(
 	}
 
 	state := h.currentState(id, downloadItem)
+	h.emitProgressIfNeeded(ctx, id, downloadItem, state)
 
 	switch {
 	case downloadItem.IsComplete():
@@ -206,6 +209,60 @@ func (h *downloadHandler) currentState(id uint32, item purecef.DownloadItem) cef
 	}
 	h.active[id] = state
 	return state
+}
+
+func (h *downloadHandler) emitProgressIfNeeded(
+	ctx context.Context,
+	id uint32,
+	item purecef.DownloadItem,
+	state cefDownloadState,
+) {
+	percent, ok := downloadProgressPercentFromItem(item)
+	if !ok {
+		return
+	}
+
+	h.mu.Lock()
+	current, exists := h.active[id]
+	if !exists {
+		current = state
+	}
+	if current.lastProgressPercent == percent {
+		h.mu.Unlock()
+		return
+	}
+	current.lastProgressPercent = percent
+	h.active[id] = current
+	h.mu.Unlock()
+
+	h.runtime.EmitProgress(
+		ctx,
+		current.filename,
+		current.destination,
+		float64(percent)/100,
+		item.GetReceivedBytes(),
+		item.GetTotalBytes(),
+	)
+}
+
+func downloadProgressPercentFromItem(item purecef.DownloadItem) (int32, bool) {
+	if item == nil || item.IsComplete() || item.IsCanceled() || item.IsInterrupted() {
+		return 0, false
+	}
+
+	percent := item.GetPercentComplete()
+	if percent < 0 {
+		total := item.GetTotalBytes()
+		received := item.GetReceivedBytes()
+		if total <= 0 || received <= 0 {
+			return 0, false
+		}
+		percent = int32((received * 100) / total)
+	}
+	if percent <= 0 || percent >= 100 {
+		return 0, false
+	}
+	return percent, true
 }
 
 func (h *downloadHandler) markFinished(id uint32) bool {

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -12,15 +12,18 @@ import (
 )
 
 type stubDownloadItem struct {
-	id          uint32
-	url         string
-	suggested   string
-	mimeType    string
-	fullPath    string
-	complete    bool
-	canceled    bool
-	interrupted bool
-	reason      purecef.DownloadInterruptReason
+	id              uint32
+	url             string
+	suggested       string
+	mimeType        string
+	fullPath        string
+	complete        bool
+	canceled        bool
+	interrupted     bool
+	reason          purecef.DownloadInterruptReason
+	percentComplete int32
+	totalBytes      int64
+	receivedBytes   int64
 }
 
 func (s stubDownloadItem) IsValid() bool       { return true }
@@ -32,9 +35,9 @@ func (s stubDownloadItem) GetInterruptReason() purecef.DownloadInterruptReason {
 	return s.reason
 }
 func (s stubDownloadItem) GetCurrentSpeed() int64        { return 0 }
-func (s stubDownloadItem) GetPercentComplete() int32     { return 0 }
-func (s stubDownloadItem) GetTotalBytes() int64          { return 0 }
-func (s stubDownloadItem) GetReceivedBytes() int64       { return 0 }
+func (s stubDownloadItem) GetPercentComplete() int32     { return s.percentComplete }
+func (s stubDownloadItem) GetTotalBytes() int64          { return s.totalBytes }
+func (s stubDownloadItem) GetReceivedBytes() int64       { return s.receivedBytes }
 func (s stubDownloadItem) GetStartTime() uintptr         { return 0 }
 func (s stubDownloadItem) GetEndTime() uintptr           { return 0 }
 func (s stubDownloadItem) GetFullPath() string           { return s.fullPath }
@@ -120,7 +123,7 @@ func TestMarkFinished_SuppressesDuplicatesAfterCleanup(t *testing.T) {
 
 	// Simulate a download that was tracked through onBeforeDownload.
 	handler.mu.Lock()
-	handler.active[42] = cefDownloadState{filename: "test.bin", destination: "/tmp/test.bin"}
+	handler.active[42] = cefDownloadState{filename: "test.bin", destination: "/tmp/test.bin", lastProgressPercent: -1}
 	handler.mu.Unlock()
 
 	require.True(t, handler.markFinished(42), "first terminal event should succeed")
@@ -131,6 +134,41 @@ func TestMarkFinished_SuppressesDuplicatesAfterCleanup(t *testing.T) {
 	_, inActive := handler.active[42]
 	handler.mu.Unlock()
 	require.False(t, inActive)
+}
+
+func TestCEFDownloadHandlerEmitsProgressOncePerPercent(t *testing.T) {
+	ctx := context.Background()
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+	events := &captureDownloadEvents{}
+	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	callback := &stubBeforeDownloadCallback{}
+
+	item := stubDownloadItem{
+		id:        11,
+		url:       "https://example.com/archive.zip",
+		suggested: "archive.zip",
+		mimeType:  "application/zip",
+	}
+
+	require.True(t, handler.onBeforeDownload(ctx, nil, item, item.suggested, callback))
+
+	item.fullPath = callback.path
+	item.percentComplete = 12
+	item.receivedBytes = 12
+	item.totalBytes = 100
+	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, item, nil)
+
+	item.percentComplete = 13
+	item.receivedBytes = 13
+	handler.onDownloadUpdated(ctx, item, nil)
+
+	require.Len(t, events.events, 3)
+	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
+	require.Equal(t, port.DownloadEventProgress, events.events[1].Type)
+	require.InEpsilon(t, 0.12, events.events[1].Progress, 0.0001)
+	require.Equal(t, port.DownloadEventProgress, events.events[2].Type)
+	require.InEpsilon(t, 0.13, events.events[2].Progress, 0.0001)
 }
 
 func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -21,28 +21,28 @@ type stubDownloadItem struct {
 	canceled  bool
 }
 
-func (s stubDownloadItem) IsValid() bool                            { return true }
-func (s stubDownloadItem) IsInProgress() bool                       { return !s.complete && !s.canceled }
-func (s stubDownloadItem) IsComplete() bool                         { return s.complete }
-func (s stubDownloadItem) IsCanceled() bool                         { return s.canceled }
-func (s stubDownloadItem) IsInterrupted() bool                      { return false }
+func (s stubDownloadItem) IsValid() bool       { return true }
+func (s stubDownloadItem) IsInProgress() bool  { return !s.complete && !s.canceled }
+func (s stubDownloadItem) IsComplete() bool    { return s.complete }
+func (s stubDownloadItem) IsCanceled() bool    { return s.canceled }
+func (s stubDownloadItem) IsInterrupted() bool { return false }
 func (s stubDownloadItem) GetInterruptReason() purecef.DownloadInterruptReason {
 	return 0
 }
-func (s stubDownloadItem) GetCurrentSpeed() int64                { return 0 }
-func (s stubDownloadItem) GetPercentComplete() int32             { return 0 }
-func (s stubDownloadItem) GetTotalBytes() int64                  { return 0 }
-func (s stubDownloadItem) GetReceivedBytes() int64               { return 0 }
-func (s stubDownloadItem) GetStartTime() uintptr                 { return 0 }
-func (s stubDownloadItem) GetEndTime() uintptr                   { return 0 }
-func (s stubDownloadItem) GetFullPath() string                   { return s.fullPath }
-func (s stubDownloadItem) GetID() uint32                         { return s.id }
-func (s stubDownloadItem) GetURL() string                        { return s.url }
-func (s stubDownloadItem) GetOriginalURL() string                { return s.url }
-func (s stubDownloadItem) GetSuggestedFileName() string          { return s.suggested }
-func (s stubDownloadItem) GetContentDisposition() string         { return "" }
-func (s stubDownloadItem) GetMimeType() string                   { return s.mimeType }
-func (s stubDownloadItem) IsPaused() bool                        { return false }
+func (s stubDownloadItem) GetCurrentSpeed() int64        { return 0 }
+func (s stubDownloadItem) GetPercentComplete() int32     { return 0 }
+func (s stubDownloadItem) GetTotalBytes() int64          { return 0 }
+func (s stubDownloadItem) GetReceivedBytes() int64       { return 0 }
+func (s stubDownloadItem) GetStartTime() uintptr         { return 0 }
+func (s stubDownloadItem) GetEndTime() uintptr           { return 0 }
+func (s stubDownloadItem) GetFullPath() string           { return s.fullPath }
+func (s stubDownloadItem) GetID() uint32                 { return s.id }
+func (s stubDownloadItem) GetURL() string                { return s.url }
+func (s stubDownloadItem) GetOriginalURL() string        { return s.url }
+func (s stubDownloadItem) GetSuggestedFileName() string  { return s.suggested }
+func (s stubDownloadItem) GetContentDisposition() string { return "" }
+func (s stubDownloadItem) GetMimeType() string           { return s.mimeType }
+func (s stubDownloadItem) IsPaused() bool                { return false }
 
 type stubBeforeDownloadCallback struct {
 	path       string

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -12,22 +12,24 @@ import (
 )
 
 type stubDownloadItem struct {
-	id        uint32
-	url       string
-	suggested string
-	mimeType  string
-	fullPath  string
-	complete  bool
-	canceled  bool
+	id          uint32
+	url         string
+	suggested   string
+	mimeType    string
+	fullPath    string
+	complete    bool
+	canceled    bool
+	interrupted bool
+	reason      purecef.DownloadInterruptReason
 }
 
 func (s stubDownloadItem) IsValid() bool       { return true }
-func (s stubDownloadItem) IsInProgress() bool  { return !s.complete && !s.canceled }
+func (s stubDownloadItem) IsInProgress() bool  { return !s.complete && !s.canceled && !s.interrupted }
 func (s stubDownloadItem) IsComplete() bool    { return s.complete }
 func (s stubDownloadItem) IsCanceled() bool    { return s.canceled }
-func (s stubDownloadItem) IsInterrupted() bool { return false }
+func (s stubDownloadItem) IsInterrupted() bool { return s.interrupted }
 func (s stubDownloadItem) GetInterruptReason() purecef.DownloadInterruptReason {
-	return 0
+	return s.reason
 }
 func (s stubDownloadItem) GetCurrentSpeed() int64        { return 0 }
 func (s stubDownloadItem) GetPercentComplete() int32     { return 0 }
@@ -129,4 +131,31 @@ func TestMarkFinished_SuppressesDuplicatesAfterCleanup(t *testing.T) {
 	_, inActive := handler.active[42]
 	handler.mu.Unlock()
 	require.False(t, inActive)
+}
+
+func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
+	ctx := context.Background()
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+	events := &captureDownloadEvents{}
+	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	callback := &stubBeforeDownloadCallback{}
+
+	item := stubDownloadItem{
+		id:        9,
+		url:       "https://example.com/ubuntu.iso",
+		suggested: "ubuntu.iso",
+		mimeType:  "application/x-iso9660-image",
+	}
+
+	require.True(t, handler.onBeforeDownload(ctx, nil, item, item.suggested, callback))
+
+	item.fullPath = callback.path
+	item.interrupted = true
+	item.reason = purecef.DownloadInterruptReasonServerBadContent
+	handler.onDownloadUpdated(ctx, item, nil)
+
+	require.Len(t, events.events, 2)
+	require.Error(t, events.events[1].Error)
+	require.ErrorContains(t, events.events[1].Error, "code=33")
+	require.ErrorContains(t, events.events[1].Error, "reason=server_bad_content")
 }

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -2,6 +2,7 @@ package cef
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	purecef "github.com/bnema/purego-cef/cef"
@@ -127,6 +128,12 @@ func TestMarkFinished_SuppressesDuplicatesAfterCleanup(t *testing.T) {
 	handler.mu.Unlock()
 
 	require.True(t, handler.markFinished(42), "first terminal event should succeed")
+
+	// Simulate a concurrent update re-populating active before a duplicate terminal update.
+	handler.mu.Lock()
+	handler.active[42] = cefDownloadState{filename: "test.bin", destination: "/tmp/test.bin", lastProgressPercent: -1}
+	handler.mu.Unlock()
+
 	require.False(t, handler.markFinished(42), "second terminal event should be suppressed")
 
 	// Active map should not contain the entry.
@@ -194,6 +201,7 @@ func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
 
 	require.Len(t, events.events, 2)
 	require.Error(t, events.events[1].Error)
-	require.ErrorContains(t, events.events[1].Error, "code=33")
+	expectedCode := fmt.Sprintf("code=%d", purecef.DownloadInterruptReasonServerBadContent)
+	require.ErrorContains(t, events.events[1].Error, expectedCode)
 	require.ErrorContains(t, events.events[1].Error, "reason=server_bad_content")
 }

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -86,6 +86,7 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 	item.complete = true
 	item.fullPath = callback.path
 	handler.onDownloadUpdated(ctx, item, nil)
+	// Repeated completion updates should not emit duplicate finished events.
 	handler.onDownloadUpdated(ctx, item, nil)
 
 	require.Len(t, events.events, 2)

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -1,0 +1,94 @@
+package cef
+
+import (
+	"context"
+	"testing"
+
+	purecef "github.com/bnema/purego-cef/cef"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/application/usecase"
+)
+
+type stubDownloadItem struct {
+	id        uint32
+	url       string
+	suggested string
+	mimeType  string
+	fullPath  string
+	complete  bool
+	canceled  bool
+}
+
+func (s stubDownloadItem) IsValid() bool                            { return true }
+func (s stubDownloadItem) IsInProgress() bool                       { return !s.complete && !s.canceled }
+func (s stubDownloadItem) IsComplete() bool                         { return s.complete }
+func (s stubDownloadItem) IsCanceled() bool                         { return s.canceled }
+func (s stubDownloadItem) IsInterrupted() bool                      { return false }
+func (s stubDownloadItem) GetInterruptReason() purecef.DownloadInterruptReason {
+	return 0
+}
+func (s stubDownloadItem) GetCurrentSpeed() int64                { return 0 }
+func (s stubDownloadItem) GetPercentComplete() int32             { return 0 }
+func (s stubDownloadItem) GetTotalBytes() int64                  { return 0 }
+func (s stubDownloadItem) GetReceivedBytes() int64               { return 0 }
+func (s stubDownloadItem) GetStartTime() uintptr                 { return 0 }
+func (s stubDownloadItem) GetEndTime() uintptr                   { return 0 }
+func (s stubDownloadItem) GetFullPath() string                   { return s.fullPath }
+func (s stubDownloadItem) GetID() uint32                         { return s.id }
+func (s stubDownloadItem) GetURL() string                        { return s.url }
+func (s stubDownloadItem) GetOriginalURL() string                { return s.url }
+func (s stubDownloadItem) GetSuggestedFileName() string          { return s.suggested }
+func (s stubDownloadItem) GetContentDisposition() string         { return "" }
+func (s stubDownloadItem) GetMimeType() string                   { return s.mimeType }
+func (s stubDownloadItem) IsPaused() bool                        { return false }
+
+type stubBeforeDownloadCallback struct {
+	path       string
+	showDialog int32
+}
+
+func (s *stubBeforeDownloadCallback) Cont(downloadPath string, showDialog int32) {
+	s.path = downloadPath
+	s.showDialog = showDialog
+}
+
+type captureDownloadEvents struct {
+	events []port.DownloadEvent
+}
+
+func (c *captureDownloadEvents) OnDownloadEvent(_ context.Context, event port.DownloadEvent) {
+	c.events = append(c.events, event)
+}
+
+func TestCEFDownloadHandlerLifecycle(t *testing.T) {
+	ctx := context.Background()
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+	events := &captureDownloadEvents{}
+	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	callback := &stubBeforeDownloadCallback{}
+
+	item := stubDownloadItem{
+		id:        7,
+		url:       "https://example.com/image.iso",
+		suggested: "image.iso",
+		mimeType:  "application/x-iso9660-image",
+	}
+
+	ok := handler.onBeforeDownload(ctx, nil, item, item.suggested, callback)
+
+	require.True(t, ok)
+	require.Equal(t, "/tmp/downloads/image.iso", callback.path)
+	require.Len(t, events.events, 1)
+	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
+
+	item.complete = true
+	item.fullPath = callback.path
+	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, item, nil)
+
+	require.Len(t, events.events, 2)
+	require.Equal(t, port.DownloadEventFinished, events.events[1].Type)
+	require.Equal(t, "image.iso", events.events[1].Filename)
+}

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -92,4 +92,41 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 	require.Len(t, events.events, 2)
 	require.Equal(t, port.DownloadEventFinished, events.events[1].Type)
 	require.Equal(t, "image.iso", events.events[1].Filename)
+
+	// Active map should be cleaned up after terminal event.
+	handler.mu.Lock()
+	_, inActive := handler.active[7]
+	_, inFinished := handler.finished[7]
+	handler.mu.Unlock()
+	require.False(t, inActive, "completed download should be removed from active map")
+	require.True(t, inFinished, "completed download should be in finished set")
+}
+
+func TestCanDownload_AllowsAllMethods(t *testing.T) {
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+	handler := newDownloadHandler("/tmp/downloads", nil, preparer)
+
+	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", "GET"))
+	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", "POST"))
+	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", "PUT"))
+	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", ""))
+}
+
+func TestMarkFinished_SuppressesDuplicatesAfterCleanup(t *testing.T) {
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+	handler := newDownloadHandler("/tmp/downloads", nil, preparer)
+
+	// Simulate a download that was tracked through onBeforeDownload.
+	handler.mu.Lock()
+	handler.active[42] = cefDownloadState{filename: "test.bin", destination: "/tmp/test.bin"}
+	handler.mu.Unlock()
+
+	require.True(t, handler.markFinished(42), "first terminal event should succeed")
+	require.False(t, handler.markFinished(42), "second terminal event should be suppressed")
+
+	// Active map should not contain the entry.
+	handler.mu.Lock()
+	_, inActive := handler.active[42]
+	handler.mu.Unlock()
+	require.False(t, inActive)
 }

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -3,6 +3,7 @@ package cef
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	purecef "github.com/bnema/purego-cef/cef"
@@ -72,7 +73,8 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 	ctx := context.Background()
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
 	events := &captureDownloadEvents{}
-	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	downloadDir := t.TempDir()
+	handler := newDownloadHandler(downloadDir, events, preparer)
 	callback := &stubBeforeDownloadCallback{}
 
 	item := stubDownloadItem{
@@ -85,7 +87,7 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 	ok := handler.onBeforeDownload(ctx, nil, item, item.suggested, callback)
 
 	require.True(t, ok)
-	require.Equal(t, "/tmp/downloads/image.iso", callback.path)
+	require.Equal(t, filepath.Join(downloadDir, "image.iso"), callback.path)
 	require.Len(t, events.events, 1)
 	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
 

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -42,6 +42,8 @@ type Engine struct {
 	onClipboardCopied                func(textLen int)
 	resolver                         port.ImageDataResolver
 	mediaClassifier                  MediaClassifier
+	downloadMu                       sync.RWMutex
+	downloadHandler                  *downloadHandler
 	alreadyRunningAppRelaunchMu      sync.RWMutex
 	alreadyRunningAppRelaunchHandler func(string)
 
@@ -256,14 +258,17 @@ func (e *Engine) RegisterAccentHandlers(ctx context.Context, handler port.Accent
 	return e.registerAccentHandlers(ctx, e.messageRouter, handler)
 }
 
-// ConfigureDownloads sets up download handling (Phase 1 stub).
+// ConfigureDownloads sets up download handling for all CEF webviews.
 func (e *Engine) ConfigureDownloads(
 	_ context.Context,
-	_ string,
-	_ port.DownloadEventHandler,
-	_ port.DownloadPreparer,
+	downloadPath string,
+	eventHandler port.DownloadEventHandler,
+	preparer port.DownloadPreparer,
 ) error {
-	return ErrDownloadsUnsupported
+	e.downloadMu.Lock()
+	e.downloadHandler = newDownloadHandler(downloadPath, eventHandler, preparer)
+	e.downloadMu.Unlock()
+	return nil
 }
 
 // OnToolkitReady is called after the UI toolkit has initialized.
@@ -445,6 +450,15 @@ func (e *Engine) validateBridgeRequest(browser purecef.Browser, bridgeNonce stri
 		return true
 	})
 	return valid
+}
+
+func (e *Engine) currentDownloadHandler() *downloadHandler {
+	if e == nil {
+		return nil
+	}
+	e.downloadMu.RLock()
+	defer e.downloadMu.RUnlock()
+	return e.downloadHandler
 }
 
 func (e *Engine) logTranscoderStartupState() {

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -3,6 +3,7 @@ package cef
 import (
 	"context"
 	"crypto/subtle"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -265,6 +266,9 @@ func (e *Engine) ConfigureDownloads(
 	eventHandler port.DownloadEventHandler,
 	preparer port.DownloadPreparer,
 ) error {
+	if preparer == nil {
+		return fmt.Errorf("cef: download preparer is required")
+	}
 	e.downloadMu.Lock()
 	e.downloadHandler = newDownloadHandler(downloadPath, eventHandler, preparer)
 	e.downloadMu.Unlock()

--- a/internal/infrastructure/cef/engine_contract_test.go
+++ b/internal/infrastructure/cef/engine_contract_test.go
@@ -19,6 +19,16 @@ func TestEngineConfigureDownloads_StoresHandler(t *testing.T) {
 	require.NotNil(t, eng.currentDownloadHandler())
 }
 
+func TestEngineConfigureDownloads_NilPreparer(t *testing.T) {
+	eng := &Engine{}
+
+	err := eng.ConfigureDownloads(context.Background(), "/tmp", nil, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "preparer is required")
+	require.Nil(t, eng.currentDownloadHandler())
+}
+
 func TestWebViewFactoryCreateRelated_ReturnsUnsupported(t *testing.T) {
 	factory := &WebViewFactory{}
 	wv, err := factory.CreateRelated(context.Background(), port.WebViewID(42))

--- a/internal/infrastructure/cef/engine_contract_test.go
+++ b/internal/infrastructure/cef/engine_contract_test.go
@@ -5,13 +5,18 @@ import (
 	"testing"
 
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/stretchr/testify/require"
 )
 
-func TestEngineConfigureDownloads_ReturnsUnsupported(t *testing.T) {
+func TestEngineConfigureDownloads_StoresHandler(t *testing.T) {
 	eng := &Engine{}
-	err := eng.ConfigureDownloads(context.Background(), "/tmp", nil, nil)
-	require.ErrorIs(t, err, ErrDownloadsUnsupported)
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+
+	err := eng.ConfigureDownloads(context.Background(), "/tmp", nil, preparer)
+
+	require.NoError(t, err)
+	require.NotNil(t, eng.currentDownloadHandler())
 }
 
 func TestWebViewFactoryCreateRelated_ReturnsUnsupported(t *testing.T) {

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -7,6 +7,7 @@ import (
 	purecef "github.com/bnema/purego-cef/cef"
 
 	"github.com/bnema/dumber/internal/application/port"
+	downloadutil "github.com/bnema/dumber/internal/domain/download"
 	"github.com/bnema/dumber/internal/infrastructure/transcoder"
 	"github.com/bnema/dumber/internal/logging"
 )
@@ -36,6 +37,7 @@ var (
 	_ purecef.RequestHandler      = (*handlerSet)(nil)
 	_ purecef.AudioHandler        = (*handlerSet)(nil)
 	_ purecef.ContextMenuHandler  = (*handlerSet)(nil)
+	_ purecef.DownloadHandler     = (*handlerSet)(nil)
 	_ purecef.FindHandler         = (*handlerSet)(nil)
 )
 
@@ -54,19 +56,24 @@ func (h *handlerSet) GetCommandHandler() purecef.CommandHandler         { return
 func (h *handlerSet) GetContextMenuHandler() purecef.ContextMenuHandler { return h }
 func (h *handlerSet) GetDialogHandler() purecef.DialogHandler           { return nil }
 func (h *handlerSet) GetDisplayHandler() purecef.DisplayHandler         { return h }
-func (h *handlerSet) GetDownloadHandler() purecef.DownloadHandler       { return nil }
-func (h *handlerSet) GetDragHandler() purecef.DragHandler               { return nil }
-func (h *handlerSet) GetFindHandler() purecef.FindHandler               { return h }
-func (h *handlerSet) GetFocusHandler() purecef.FocusHandler             { return nil }
-func (h *handlerSet) GetFrameHandler() purecef.FrameHandler             { return nil }
-func (h *handlerSet) GetPermissionHandler() purecef.PermissionHandler   { return nil }
-func (h *handlerSet) GetJsdialogHandler() purecef.JsdialogHandler       { return nil }
-func (h *handlerSet) GetKeyboardHandler() purecef.KeyboardHandler       { return nil }
-func (h *handlerSet) GetLifeSpanHandler() purecef.SafeLifeSpanHandler   { return h }
-func (h *handlerSet) GetLoadHandler() purecef.LoadHandler               { return h }
-func (h *handlerSet) GetPrintHandler() purecef.PrintHandler             { return nil }
-func (h *handlerSet) GetRenderHandler() purecef.RenderHandler           { return h }
-func (h *handlerSet) GetRequestHandler() purecef.RequestHandler         { return h }
+func (h *handlerSet) GetDownloadHandler() purecef.DownloadHandler {
+	if h.downloadHandler() != nil {
+		return h
+	}
+	return nil
+}
+func (h *handlerSet) GetDragHandler() purecef.DragHandler             { return nil }
+func (h *handlerSet) GetFindHandler() purecef.FindHandler             { return h }
+func (h *handlerSet) GetFocusHandler() purecef.FocusHandler           { return nil }
+func (h *handlerSet) GetFrameHandler() purecef.FrameHandler           { return nil }
+func (h *handlerSet) GetPermissionHandler() purecef.PermissionHandler { return nil }
+func (h *handlerSet) GetJsdialogHandler() purecef.JsdialogHandler     { return nil }
+func (h *handlerSet) GetKeyboardHandler() purecef.KeyboardHandler     { return nil }
+func (h *handlerSet) GetLifeSpanHandler() purecef.SafeLifeSpanHandler { return h }
+func (h *handlerSet) GetLoadHandler() purecef.LoadHandler             { return h }
+func (h *handlerSet) GetPrintHandler() purecef.PrintHandler           { return nil }
+func (h *handlerSet) GetRenderHandler() purecef.RenderHandler         { return h }
+func (h *handlerSet) GetRequestHandler() purecef.RequestHandler       { return h }
 
 func (h *handlerSet) OnProcessMessageReceived(
 	browser purecef.Browser,
@@ -779,8 +786,79 @@ func (h *handlerSet) OnBeforeClose(_ purecef.Browser) {
 // RequestHandler (11 methods)
 // ===========================================================================
 
-func (h *handlerSet) OnBeforeBrowse(_ purecef.Browser, _ purecef.Frame, _ purecef.Request, _, _ int32) bool {
-	return false
+func (h *handlerSet) OnBeforeBrowse(browser purecef.Browser, frame purecef.Frame, request purecef.Request, _, _ int32) bool {
+	if frame == nil || !frame.IsMain() || request == nil {
+		return false
+	}
+
+	handler := h.downloadHandler()
+	if handler == nil || !strings.EqualFold(request.GetMethod(), "GET") {
+		return false
+	}
+
+	url := request.GetURL()
+	if !downloadutil.ShouldForceDownloadForURI(url) || browser == nil {
+		return false
+	}
+
+	host := browser.GetHost()
+	if host == nil {
+		return false
+	}
+
+	logging.FromContext(h.currentContext()).Debug().
+		Str("url", logging.TruncateURL(url, maxTranscodingURLLength)).
+		Msg("cef: forcing download for navigation")
+
+	host.StartDownload(url)
+	return true
+}
+
+func (h *handlerSet) CanDownload(browser purecef.Browser, url string, requestMethod string) bool {
+	handler := h.downloadHandler()
+	if handler == nil {
+		return false
+	}
+	return handler.canDownload(browser, url, requestMethod)
+}
+
+func (h *handlerSet) OnBeforeDownload(
+	browser purecef.Browser,
+	downloadItem purecef.DownloadItem,
+	suggestedName string,
+	callback purecef.BeforeDownloadCallback,
+) bool {
+	handler := h.downloadHandler()
+	if handler == nil {
+		return false
+	}
+	return handler.onBeforeDownload(h.currentContext(), browser, downloadItem, suggestedName, callback)
+}
+
+func (h *handlerSet) OnDownloadUpdated(
+	_ purecef.Browser,
+	downloadItem purecef.DownloadItem,
+	callback purecef.DownloadItemCallback,
+) {
+	handler := h.downloadHandler()
+	if handler == nil {
+		return
+	}
+	handler.onDownloadUpdated(h.currentContext(), downloadItem, callback)
+}
+
+func (h *handlerSet) downloadHandler() *downloadHandler {
+	if h == nil || h.wv == nil || h.wv.engine == nil {
+		return nil
+	}
+	return h.wv.engine.currentDownloadHandler()
+}
+
+func (h *handlerSet) currentContext() context.Context {
+	if h == nil || h.wv == nil || h.wv.ctx == nil {
+		return context.Background()
+	}
+	return h.wv.ctx
 }
 
 func (h *handlerSet) OnOpenUrlfromTab(

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -814,7 +814,7 @@ func (h *handlerSet) OnBeforeBrowse(browser purecef.Browser, frame purecef.Frame
 	return true
 }
 
-func (h *handlerSet) CanDownload(browser purecef.Browser, url string, requestMethod string) bool {
+func (h *handlerSet) CanDownload(browser purecef.Browser, url, requestMethod string) bool {
 	handler := h.downloadHandler()
 	if handler == nil {
 		return false

--- a/internal/infrastructure/cef/webview_handlers_test.go
+++ b/internal/infrastructure/cef/webview_handlers_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bnema/dumber/internal/application/usecase"
 	purecef "github.com/bnema/purego-cef/cef"
 	cefmocks "github.com/bnema/purego-cef/cef/mocks"
-	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/internal/infrastructure/cef/webview_handlers_test.go
+++ b/internal/infrastructure/cef/webview_handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	purecef "github.com/bnema/purego-cef/cef"
 	cefmocks "github.com/bnema/purego-cef/cef/mocks"
+	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -372,6 +373,20 @@ func TestOptionalHandlersAreAlwaysEnabled(t *testing.T) {
 	// AudioHandler is always enabled (required for media decoding).
 	require.Same(t, h, h.GetAudioHandler())
 	require.Same(t, h, h.GetContextMenuHandler())
+}
+
+func TestGetDownloadHandler_EnabledWhenEngineConfigured(t *testing.T) {
+	eng := &Engine{}
+	require.NoError(t, eng.ConfigureDownloads(context.Background(), "/tmp/downloads", nil, usecase.NewPrepareDownloadUseCase(nil)))
+
+	h := &handlerSet{
+		wv: &WebView{
+			ctx:    context.Background(),
+			engine: eng,
+		},
+	}
+
+	require.Same(t, h, h.GetDownloadHandler())
 }
 
 func TestOnPaint_DropsStaleMainViewPaint(t *testing.T) {

--- a/internal/infrastructure/cef/webview_handlers_test.go
+++ b/internal/infrastructure/cef/webview_handlers_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bnema/dumber/internal/application/usecase"
 	purecef "github.com/bnema/purego-cef/cef"
 	cefmocks "github.com/bnema/purego-cef/cef/mocks"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +21,12 @@ type clipboardOrchestratorRecorder struct {
 	mu             sync.Mutex
 	selection      dto.SelectionClipboardInput
 	selectionCalls int
+}
+
+type stubDownloadPreparer struct{}
+
+func (stubDownloadPreparer) Execute(context.Context, port.DownloadPrepareInput) *port.DownloadPrepareOutput {
+	return &port.DownloadPrepareOutput{}
 }
 
 type controlledSelectionTimer struct {
@@ -377,7 +382,7 @@ func TestOptionalHandlersAreAlwaysEnabled(t *testing.T) {
 
 func TestGetDownloadHandler_EnabledWhenEngineConfigured(t *testing.T) {
 	eng := &Engine{}
-	require.NoError(t, eng.ConfigureDownloads(context.Background(), "/tmp/downloads", nil, usecase.NewPrepareDownloadUseCase(nil)))
+	require.NoError(t, eng.ConfigureDownloads(context.Background(), "/tmp/downloads", nil, stubDownloadPreparer{}))
 
 	h := &handlerSet{
 		wv: &WebView{

--- a/internal/infrastructure/downloadruntime/runtime.go
+++ b/internal/infrastructure/downloadruntime/runtime.go
@@ -1,0 +1,123 @@
+package downloadruntime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/logging"
+)
+
+const dirPerm = 0o755
+
+// Runtime shares common download preparation and event emission logic across engines.
+type Runtime struct {
+	mu           sync.RWMutex
+	downloadPath string
+	eventHandler port.DownloadEventHandler
+	preparer     port.DownloadPreparer
+}
+
+func New(downloadPath string, eventHandler port.DownloadEventHandler, preparer port.DownloadPreparer) *Runtime {
+	if preparer == nil {
+		panic("preparer is required")
+	}
+
+	return &Runtime{
+		downloadPath: downloadPath,
+		eventHandler: eventHandler,
+		preparer:     preparer,
+	}
+}
+
+func (r *Runtime) SetDownloadPath(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.downloadPath = path
+}
+
+func (r *Runtime) ResolveDestination(
+	ctx context.Context,
+	suggestedFilename string,
+	response port.DownloadResponse,
+) (*port.DownloadPrepareOutput, error) {
+	r.mu.RLock()
+	downloadPath := r.downloadPath
+	preparer := r.preparer
+	r.mu.RUnlock()
+
+	if err := os.MkdirAll(downloadPath, dirPerm); err != nil {
+		return nil, fmt.Errorf("failed to create download directory %q: %w", downloadPath, err)
+	}
+
+	return preparer.Execute(ctx, port.DownloadPrepareInput{
+		SuggestedFilename: suggestedFilename,
+		Response:          response,
+		DownloadDir:       downloadPath,
+	}), nil
+}
+
+func (r *Runtime) EmitStarted(ctx context.Context, output *port.DownloadPrepareOutput) {
+	if output == nil {
+		return
+	}
+
+	r.mu.RLock()
+	eventHandler := r.eventHandler
+	r.mu.RUnlock()
+
+	if eventHandler != nil {
+		eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
+			Type:        port.DownloadEventStarted,
+			Filename:    output.Filename,
+			Destination: output.DestinationPath,
+		})
+	}
+
+	logging.FromContext(ctx).Info().
+		Str("filename", output.Filename).
+		Str("destination", output.DestinationPath).
+		Msg("download started")
+}
+
+func (r *Runtime) EmitFinished(ctx context.Context, filename, destination string) {
+	r.mu.RLock()
+	eventHandler := r.eventHandler
+	r.mu.RUnlock()
+
+	if eventHandler != nil {
+		eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
+			Type:        port.DownloadEventFinished,
+			Filename:    filename,
+			Destination: destination,
+		})
+	}
+
+	logging.FromContext(ctx).Info().
+		Str("filename", filename).
+		Str("destination", destination).
+		Msg("download finished")
+}
+
+func (r *Runtime) EmitFailed(ctx context.Context, filename, destination string, err error) {
+	r.mu.RLock()
+	eventHandler := r.eventHandler
+	r.mu.RUnlock()
+
+	if eventHandler != nil {
+		eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
+			Type:        port.DownloadEventFailed,
+			Filename:    filename,
+			Destination: destination,
+			Error:       err,
+		})
+	}
+
+	logging.FromContext(ctx).Warn().
+		Err(err).
+		Str("filename", filename).
+		Str("destination", destination).
+		Msg("download failed")
+}

--- a/internal/infrastructure/downloadruntime/runtime.go
+++ b/internal/infrastructure/downloadruntime/runtime.go
@@ -90,6 +90,28 @@ func (r *Runtime) EmitStarted(ctx context.Context, output *port.DownloadPrepareO
 		Msg("download started")
 }
 
+func (r *Runtime) EmitProgress(
+	ctx context.Context,
+	filename, destination string,
+	progress float64,
+	bytesReceived, bytesTotal int64,
+) {
+	r.mu.RLock()
+	eventHandler := r.eventHandler
+	r.mu.RUnlock()
+
+	if eventHandler != nil {
+		eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
+			Type:          port.DownloadEventProgress,
+			Filename:      filename,
+			Destination:   destination,
+			Progress:      progress,
+			BytesReceived: bytesReceived,
+			BytesTotal:    bytesTotal,
+		})
+	}
+}
+
 func (r *Runtime) EmitFinished(ctx context.Context, filename, destination string) {
 	r.mu.RLock()
 	eventHandler := r.eventHandler

--- a/internal/infrastructure/downloadruntime/runtime.go
+++ b/internal/infrastructure/downloadruntime/runtime.go
@@ -20,11 +20,9 @@ type Runtime struct {
 	preparer     port.DownloadPreparer
 }
 
+// New creates a Runtime. The caller must ensure preparer is non-nil;
+// ConfigureDownloads validates this before reaching here.
 func New(downloadPath string, eventHandler port.DownloadEventHandler, preparer port.DownloadPreparer) *Runtime {
-	if preparer == nil {
-		panic("preparer is required")
-	}
-
 	return &Runtime{
 		downloadPath: downloadPath,
 		eventHandler: eventHandler,

--- a/internal/infrastructure/downloadruntime/runtime.go
+++ b/internal/infrastructure/downloadruntime/runtime.go
@@ -12,6 +12,11 @@ import (
 
 const dirPerm = 0o755
 
+type codedDownloadError interface {
+	DownloadErrorCode() int
+	DownloadErrorReason() string
+}
+
 // Runtime shares common download preparation and event emission logic across engines.
 type Runtime struct {
 	mu           sync.RWMutex
@@ -118,9 +123,14 @@ func (r *Runtime) EmitFailed(ctx context.Context, filename, destination string, 
 		})
 	}
 
-	logging.FromContext(ctx).Warn().
+	log := logging.FromContext(ctx).Warn().
 		Err(err).
 		Str("filename", filename).
-		Str("destination", destination).
-		Msg("download failed")
+		Str("destination", destination)
+	if codedErr, ok := err.(codedDownloadError); ok {
+		log = log.
+			Int("error_code", codedErr.DownloadErrorCode()).
+			Str("error_reason", codedErr.DownloadErrorReason())
+	}
+	log.Msg("download failed")
 }

--- a/internal/infrastructure/downloadruntime/runtime.go
+++ b/internal/infrastructure/downloadruntime/runtime.go
@@ -52,11 +52,16 @@ func (r *Runtime) ResolveDestination(
 		return nil, fmt.Errorf("failed to create download directory %q: %w", downloadPath, err)
 	}
 
-	return preparer.Execute(ctx, port.DownloadPrepareInput{
+	output := preparer.Execute(ctx, port.DownloadPrepareInput{
 		SuggestedFilename: suggestedFilename,
 		Response:          response,
 		DownloadDir:       downloadPath,
-	}), nil
+	})
+	if output == nil {
+		return nil, fmt.Errorf("failed to prepare download destination for %q", suggestedFilename)
+	}
+
+	return output, nil
 }
 
 func (r *Runtime) EmitStarted(ctx context.Context, output *port.DownloadPrepareOutput) {

--- a/internal/infrastructure/downloadruntime/runtime.go
+++ b/internal/infrastructure/downloadruntime/runtime.go
@@ -2,6 +2,7 @@ package downloadruntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -50,6 +51,10 @@ func (r *Runtime) ResolveDestination(
 	downloadPath := r.downloadPath
 	preparer := r.preparer
 	r.mu.RUnlock()
+
+	if preparer == nil {
+		return nil, fmt.Errorf("download preparer is required")
+	}
 
 	if err := os.MkdirAll(downloadPath, dirPerm); err != nil {
 		return nil, fmt.Errorf("failed to create download directory %q: %w", downloadPath, err)
@@ -149,7 +154,8 @@ func (r *Runtime) EmitFailed(ctx context.Context, filename, destination string, 
 		Err(err).
 		Str("filename", filename).
 		Str("destination", destination)
-	if codedErr, ok := err.(codedDownloadError); ok {
+	var codedErr codedDownloadError
+	if errors.As(err, &codedErr) {
 		log = log.
 			Int("error_code", codedErr.DownloadErrorCode()).
 			Str("error_reason", codedErr.DownloadErrorReason())

--- a/internal/infrastructure/downloadruntime/runtime_test.go
+++ b/internal/infrastructure/downloadruntime/runtime_test.go
@@ -37,11 +37,16 @@ func TestRuntimeResolveDestinationAndEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "artifact.pdf", output.Filename)
 	runtime.EmitStarted(ctx, output)
+	runtime.EmitProgress(ctx, output.Filename, output.DestinationPath, 0.42, 42, 100)
 	runtime.EmitFinished(ctx, output.Filename, output.DestinationPath)
 
-	require.Len(t, events.events, 2)
+	require.Len(t, events.events, 3)
 	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
-	require.Equal(t, port.DownloadEventFinished, events.events[1].Type)
+	require.Equal(t, port.DownloadEventProgress, events.events[1].Type)
+	require.InEpsilon(t, 0.42, events.events[1].Progress, 0.0001)
+	require.EqualValues(t, 42, events.events[1].BytesReceived)
+	require.EqualValues(t, 100, events.events[1].BytesTotal)
+	require.Equal(t, port.DownloadEventFinished, events.events[2].Type)
 }
 
 func TestNewRuntime_NilPreparer_NoPanic(t *testing.T) {

--- a/internal/infrastructure/downloadruntime/runtime_test.go
+++ b/internal/infrastructure/downloadruntime/runtime_test.go
@@ -30,7 +30,7 @@ func (c *captureEvents) OnDownloadEvent(_ context.Context, event port.DownloadEv
 func TestRuntimeResolveDestinationAndEvents(t *testing.T) {
 	ctx := context.Background()
 	events := &captureEvents{}
-	runtime := New("/tmp/downloads", events, usecase.NewPrepareDownloadUseCase(nil))
+	runtime := New(t.TempDir(), events, usecase.NewPrepareDownloadUseCase(nil))
 
 	output, err := runtime.ResolveDestination(ctx, "artifact", stubResponse{mimeType: "application/pdf"})
 
@@ -53,4 +53,14 @@ func TestNewRuntime_NilPreparer_NoPanic(t *testing.T) {
 	require.NotPanics(t, func() {
 		_ = New("/tmp/downloads", nil, nil)
 	})
+}
+
+func TestRuntimeResolveDestination_NilPreparerReturnsError(t *testing.T) {
+	runtime := New(t.TempDir(), nil, nil)
+
+	output, err := runtime.ResolveDestination(context.Background(), "artifact", stubResponse{})
+
+	require.Nil(t, output)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "download preparer is required")
 }

--- a/internal/infrastructure/downloadruntime/runtime_test.go
+++ b/internal/infrastructure/downloadruntime/runtime_test.go
@@ -43,3 +43,9 @@ func TestRuntimeResolveDestinationAndEvents(t *testing.T) {
 	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
 	require.Equal(t, port.DownloadEventFinished, events.events[1].Type)
 }
+
+func TestNewRuntime_NilPreparer_NoPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		_ = New("/tmp/downloads", nil, nil)
+	})
+}

--- a/internal/infrastructure/downloadruntime/runtime_test.go
+++ b/internal/infrastructure/downloadruntime/runtime_test.go
@@ -15,9 +15,9 @@ type stubResponse struct {
 	uri      string
 }
 
-func (s stubResponse) GetMimeType() string          { return s.mimeType }
-func (s stubResponse) GetSuggestedFilename() string { return "" }
-func (s stubResponse) GetUri() string               { return s.uri }
+func (s stubResponse) GetMimeType() string        { return s.mimeType }
+func (stubResponse) GetSuggestedFilename() string { return "" }
+func (s stubResponse) GetUri() string             { return s.uri }
 
 type captureEvents struct {
 	events []port.DownloadEvent

--- a/internal/infrastructure/downloadruntime/runtime_test.go
+++ b/internal/infrastructure/downloadruntime/runtime_test.go
@@ -1,0 +1,45 @@
+package downloadruntime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/application/usecase"
+)
+
+type stubResponse struct {
+	mimeType string
+	uri      string
+}
+
+func (s stubResponse) GetMimeType() string          { return s.mimeType }
+func (s stubResponse) GetSuggestedFilename() string { return "" }
+func (s stubResponse) GetUri() string               { return s.uri }
+
+type captureEvents struct {
+	events []port.DownloadEvent
+}
+
+func (c *captureEvents) OnDownloadEvent(_ context.Context, event port.DownloadEvent) {
+	c.events = append(c.events, event)
+}
+
+func TestRuntimeResolveDestinationAndEvents(t *testing.T) {
+	ctx := context.Background()
+	events := &captureEvents{}
+	runtime := New("/tmp/downloads", events, usecase.NewPrepareDownloadUseCase(nil))
+
+	output, err := runtime.ResolveDestination(ctx, "artifact", stubResponse{mimeType: "application/pdf"})
+
+	require.NoError(t, err)
+	require.Equal(t, "artifact.pdf", output.Filename)
+	runtime.EmitStarted(ctx, output)
+	runtime.EmitFinished(ctx, output.Filename, output.DestinationPath)
+
+	require.Len(t, events.events, 2)
+	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
+	require.Equal(t, port.DownloadEventFinished, events.events[1].Type)
+}

--- a/internal/infrastructure/webkit/download_handler.go
+++ b/internal/infrastructure/webkit/download_handler.go
@@ -3,27 +3,20 @@ package webkit
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/bnema/dumber/internal/application/port"
 	downloadutil "github.com/bnema/dumber/internal/domain/download"
+	"github.com/bnema/dumber/internal/infrastructure/downloadruntime"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/glib"
 	"github.com/bnema/puregotk/v4/webkit"
 )
 
-const (
-	// dirPerm is the permission mode for creating download directories.
-	dirPerm = 0755
-)
-
 // DownloadHandler manages WebKit downloads and notifies the UI layer.
 type DownloadHandler struct {
-	downloadPath string
-	eventHandler port.DownloadEventHandler
-	preparer     port.DownloadPreparer
-	mu           sync.RWMutex
+	runtime *downloadruntime.Runtime
+	mu      sync.RWMutex
 }
 
 // NewDownloadHandler creates a new download handler.
@@ -37,9 +30,7 @@ func NewDownloadHandler(
 		panic("preparer is required")
 	}
 	return &DownloadHandler{
-		downloadPath: downloadPath,
-		eventHandler: handler,
-		preparer:     preparer,
+		runtime: downloadruntime.New(downloadPath, handler, preparer),
 	}
 }
 
@@ -55,9 +46,7 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 	log := logging.FromContext(ctx)
 
 	h.mu.RLock()
-	downloadPath := h.downloadPath
-	eventHandler := h.eventHandler
-	preparer := h.preparer
+	runtime := h.runtime
 	h.mu.RUnlock()
 
 	// Track download state in a dedicated struct to ensure proper isolation.
@@ -67,25 +56,17 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 	// Handle decide-destination signal to set download path.
 	//nolint:unparam // bool return is required by WebKit's signal signature (false = handled synchronously)
 	decideDestCb := func(d webkit.Download, suggestedFilename string) bool {
-		// Ensure download directory exists.
-		if err := os.MkdirAll(downloadPath, dirPerm); err != nil {
-			log.Error().Err(err).Str("path", downloadPath).Msg("failed to create download directory")
-			d.Cancel()
-			return false
-		}
-
-		// Wrap WebKit response as port.DownloadResponse
 		var response port.DownloadResponse
 		if resp := d.GetResponse(); resp != nil {
 			response = &uriResponseAdapter{resp: resp}
 		}
 
-		// Use DownloadPreparer to resolve filename
-		output := preparer.Execute(ctx, port.DownloadPrepareInput{
-			SuggestedFilename: suggestedFilename,
-			Response:          response,
-			DownloadDir:       downloadPath,
-		})
+		output, err := runtime.ResolveDestination(ctx, suggestedFilename, response)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to prepare download destination")
+			d.Cancel()
+			return false
+		}
 
 		log.Debug().
 			Str("suggested", suggestedFilename).
@@ -96,19 +77,7 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 		// WebKit expects an absolute file path for the destination.
 		d.SetDestination(output.DestinationPath)
 
-		// Notify: download started.
-		if eventHandler != nil {
-			eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
-				Type:        port.DownloadEventStarted,
-				Filename:    output.Filename,
-				Destination: output.DestinationPath,
-			})
-		}
-
-		log.Info().
-			Str("filename", output.Filename).
-			Str("destination", output.DestinationPath).
-			Msg("download started")
+		runtime.EmitStarted(ctx, output)
 
 		return false // false = we handled it synchronously
 	}
@@ -126,16 +95,7 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 		// Create error for the failed download.
 		downloadErr := fmt.Errorf("download failed: %s: %s", filename, gerr.MessageGo())
 
-		if eventHandler != nil {
-			eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
-				Type:        port.DownloadEventFailed,
-				Filename:    filename,
-				Destination: dest,
-				Error:       downloadErr,
-			})
-		}
-
-		log.Warn().Str("filename", filename).Msg("download failed")
+		runtime.EmitFailed(ctx, filename, dest, downloadErr)
 	}
 	download.ConnectFailed(&failedCb)
 
@@ -153,15 +113,7 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 		dest := d.GetDestination()
 		filename := downloadutil.ExtractFilenameFromDestination(dest)
 
-		if eventHandler != nil {
-			eventHandler.OnDownloadEvent(ctx, port.DownloadEvent{
-				Type:        port.DownloadEventFinished,
-				Filename:    filename,
-				Destination: dest,
-			})
-		}
-
-		log.Info().Str("filename", filename).Msg("download finished")
+		runtime.EmitFinished(ctx, filename, dest)
 	}
 	download.ConnectFinished(&finishedCb)
 }
@@ -170,7 +122,7 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 func (h *DownloadHandler) SetDownloadPath(path string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.downloadPath = path
+	h.runtime.SetDownloadPath(path)
 }
 
 // uriResponseAdapter wraps webkit.URIResponse to implement port.DownloadResponse.

--- a/internal/infrastructure/webkit/download_handler.go
+++ b/internal/infrastructure/webkit/download_handler.go
@@ -20,15 +20,12 @@ type DownloadHandler struct {
 }
 
 // NewDownloadHandler creates a new download handler.
-// Panics if preparer is nil (fail fast on misconfiguration).
+// The caller (ConfigureDownloads) must validate that preparer is non-nil.
 func NewDownloadHandler(
 	downloadPath string,
 	handler port.DownloadEventHandler,
 	preparer port.DownloadPreparer,
 ) *DownloadHandler {
-	if preparer == nil {
-		panic("preparer is required")
-	}
 	return &DownloadHandler{
 		runtime: downloadruntime.New(downloadPath, handler, preparer),
 	}

--- a/internal/infrastructure/webkit/download_handler.go
+++ b/internal/infrastructure/webkit/download_handler.go
@@ -34,13 +34,18 @@ func NewDownloadHandler(
 // downloadState tracks the state of a single download to prevent duplicate notifications.
 // This is allocated per-download to ensure proper isolation between concurrent downloads.
 type downloadState struct {
-	failed bool
-	mu     sync.Mutex
+	failed              bool
+	filename            string
+	destination         string
+	lastProgressPercent int
+	mu                  sync.Mutex
 }
 
 // HandleDownload sets up signal handlers for a new download.
 func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.Download) {
-	log := logging.FromContext(ctx)
+	if download == nil {
+		return
+	}
 
 	h.mu.RLock()
 	runtime := h.runtime
@@ -48,11 +53,29 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 
 	// Track download state in a dedicated struct to ensure proper isolation.
 	// Each download gets its own state to prevent interference between concurrent downloads.
-	state := &downloadState{}
+	state := &downloadState{lastProgressPercent: -1}
 
-	// Handle decide-destination signal to set download path.
-	//nolint:unparam // bool return is required by WebKit's signal signature (false = handled synchronously)
-	decideDestCb := func(d webkit.Download, suggestedFilename string) bool {
+	decideDestCb := makeDecideDestinationCallback(ctx, runtime, state)
+	download.ConnectDecideDestination(&decideDestCb)
+
+	progressCb := makeProgressCallback(ctx, runtime, state)
+	download.ConnectReceivedData(&progressCb)
+
+	failedCb := makeFailedCallback(ctx, runtime, state)
+	download.ConnectFailed(&failedCb)
+
+	finishedCb := makeFinishedCallback(ctx, runtime, state)
+	download.ConnectFinished(&finishedCb)
+}
+
+func makeDecideDestinationCallback(
+	ctx context.Context,
+	runtime *downloadruntime.Runtime,
+	state *downloadState,
+) func(webkit.Download, string) bool {
+	log := logging.FromContext(ctx)
+
+	return func(d webkit.Download, suggestedFilename string) bool {
 		var response port.DownloadResponse
 		if resp := d.GetResponse(); resp != nil {
 			response = &uriResponseAdapter{resp: resp}
@@ -71,48 +94,103 @@ func (h *DownloadHandler) HandleDownload(ctx context.Context, download *webkit.D
 			Str("destPath", output.DestinationPath).
 			Msg("setting download destination")
 
-		// WebKit expects an absolute file path for the destination.
 		d.SetDestination(output.DestinationPath)
 
+		state.mu.Lock()
+		state.filename = output.Filename
+		state.destination = output.DestinationPath
+		state.lastProgressPercent = -1
+		state.mu.Unlock()
+
 		runtime.EmitStarted(ctx, output)
-
-		return false // false = we handled it synchronously
+		emitWebKitDownloadProgress(ctx, runtime, state, d)
+		return false
 	}
-	download.ConnectDecideDestination(&decideDestCb)
+}
 
-	// Handle failed signal.
-	failedCb := func(d webkit.Download, gerr *glib.Error) {
+func makeProgressCallback(
+	ctx context.Context,
+	runtime *downloadruntime.Runtime,
+	state *downloadState,
+) func(webkit.Download, uint64) {
+	return func(d webkit.Download, _ uint64) {
+		emitWebKitDownloadProgress(ctx, runtime, state, d)
+	}
+}
+
+func makeFailedCallback(
+	ctx context.Context,
+	runtime *downloadruntime.Runtime,
+	state *downloadState,
+) func(webkit.Download, *glib.Error) {
+	return func(d webkit.Download, gerr *glib.Error) {
 		state.mu.Lock()
 		state.failed = true
 		state.mu.Unlock()
 
 		dest := d.GetDestination()
 		filename := downloadutil.ExtractFilenameFromDestination(dest)
-
-		// Create error for the failed download.
 		downloadErr := fmt.Errorf("download failed: %s: %s", filename, gerr.MessageGo())
-
 		runtime.EmitFailed(ctx, filename, dest, downloadErr)
 	}
-	download.ConnectFailed(&failedCb)
+}
 
-	// Handle finished signal.
-	finishedCb := func(d webkit.Download) {
+func makeFinishedCallback(
+	ctx context.Context,
+	runtime *downloadruntime.Runtime,
+	state *downloadState,
+) func(webkit.Download) {
+	return func(d webkit.Download) {
 		state.mu.Lock()
 		failed := state.failed
 		state.mu.Unlock()
-
-		// Don't send finished event if we already sent a failed event.
 		if failed {
 			return
 		}
 
 		dest := d.GetDestination()
 		filename := downloadutil.ExtractFilenameFromDestination(dest)
-
 		runtime.EmitFinished(ctx, filename, dest)
 	}
-	download.ConnectFinished(&finishedCb)
+}
+
+func emitWebKitDownloadProgress(
+	ctx context.Context,
+	runtime *downloadruntime.Runtime,
+	state *downloadState,
+	d webkit.Download,
+) {
+	state.mu.Lock()
+	if state.failed {
+		state.mu.Unlock()
+		return
+	}
+	filename := state.filename
+	destination := state.destination
+	lastPercent := state.lastProgressPercent
+	state.mu.Unlock()
+	if filename == "" || destination == "" {
+		return
+	}
+
+	progress := d.GetEstimatedProgress()
+	if progress <= 0 || progress >= 1 {
+		return
+	}
+	percent := int(progress * 100)
+	if percent <= lastPercent {
+		return
+	}
+
+	state.mu.Lock()
+	if state.failed || percent <= state.lastProgressPercent {
+		state.mu.Unlock()
+		return
+	}
+	state.lastProgressPercent = percent
+	state.mu.Unlock()
+
+	runtime.EmitProgress(ctx, filename, destination, progress, int64(d.GetReceivedDataLength()), 0)
 }
 
 // SetDownloadPath updates the download directory.

--- a/internal/infrastructure/webkit/download_handler_test.go
+++ b/internal/infrastructure/webkit/download_handler_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDownloadHandler(t *testing.T) {
@@ -14,15 +15,13 @@ func TestNewDownloadHandler(t *testing.T) {
 		handler := NewDownloadHandler("/tmp/downloads", nil, prepareUC)
 
 		assert.NotNil(t, handler)
-		assert.Equal(t, "/tmp/downloads", handler.downloadPath)
-		assert.Nil(t, handler.eventHandler)
-		assert.NotNil(t, handler.preparer)
+		require.NotNil(t, handler.runtime)
 	})
 
 	t.Run("creates handler with custom path", func(t *testing.T) {
 		handler := NewDownloadHandler("/custom/path", nil, prepareUC)
 
-		assert.Equal(t, "/custom/path", handler.downloadPath)
+		require.NotNil(t, handler.runtime)
 	})
 }
 
@@ -32,7 +31,7 @@ func TestDownloadHandler_SetDownloadPath(t *testing.T) {
 
 	handler.SetDownloadPath("/new/path")
 
-	assert.Equal(t, "/new/path", handler.downloadPath)
+	assert.NotNil(t, handler.runtime)
 }
 
 func TestURIResponseAdapter(t *testing.T) {

--- a/internal/infrastructure/webkit/download_handler_test.go
+++ b/internal/infrastructure/webkit/download_handler_test.go
@@ -1,6 +1,7 @@
 package webkit
 
 import (
+	"context"
 	"testing"
 
 	"github.com/bnema/dumber/internal/application/usecase"
@@ -31,7 +32,10 @@ func TestDownloadHandler_SetDownloadPath(t *testing.T) {
 
 	handler.SetDownloadPath("/new/path")
 
-	assert.NotNil(t, handler.runtime)
+	output, err := handler.runtime.ResolveDestination(context.Background(), "artifact.pdf", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/new/path/artifact.pdf", output.DestinationPath)
 }
 
 func TestURIResponseAdapter(t *testing.T) {

--- a/internal/infrastructure/webkit/download_handler_test.go
+++ b/internal/infrastructure/webkit/download_handler_test.go
@@ -2,6 +2,7 @@ package webkit
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/bnema/dumber/internal/application/usecase"
@@ -30,12 +31,13 @@ func TestDownloadHandler_SetDownloadPath(t *testing.T) {
 	prepareUC := usecase.NewPrepareDownloadUseCase(nil)
 	handler := NewDownloadHandler("/initial/path", nil, prepareUC)
 
-	handler.SetDownloadPath("/new/path")
+	newPath := t.TempDir()
+	handler.SetDownloadPath(newPath)
 
 	output, err := handler.runtime.ResolveDestination(context.Background(), "artifact.pdf", nil)
 
 	require.NoError(t, err)
-	assert.Equal(t, "/new/path/artifact.pdf", output.DestinationPath)
+	assert.Equal(t, filepath.Join(newPath, "artifact.pdf"), output.DestinationPath)
 }
 
 func TestURIResponseAdapter(t *testing.T) {

--- a/internal/infrastructure/webkit/engine.go
+++ b/internal/infrastructure/webkit/engine.go
@@ -120,6 +120,9 @@ func (e *Engine) ConfigureDownloads(
 	if e.wkCtx == nil {
 		return fmt.Errorf("webkit context not initialized")
 	}
+	if preparer == nil {
+		return fmt.Errorf("download preparer is required")
+	}
 	handler := NewDownloadHandler(downloadPath, eventHandler, preparer)
 	e.wkCtx.SetDownloadHandler(ctx, handler)
 	e.downloadPath = downloadPath

--- a/internal/infrastructure/webkit/engine_runtime_test.go
+++ b/internal/infrastructure/webkit/engine_runtime_test.go
@@ -46,6 +46,14 @@ func TestEngine_ConfigureDownloads_NilContext(t *testing.T) {
 	require.Contains(t, err.Error(), "webkit context not initialized")
 }
 
+func TestNewDownloadHandler_NilPreparer_NoPanic(t *testing.T) {
+	// After removing the panic, NewDownloadHandler with nil preparer should
+	// not panic. The caller (ConfigureDownloads) is responsible for validation.
+	require.NotPanics(t, func() {
+		_ = NewDownloadHandler("/tmp", nil, nil)
+	})
+}
+
 func TestEngine_Close_NilPool(t *testing.T) {
 	e := &Engine{}
 	err := e.Close()

--- a/internal/infrastructure/webkit/webview.go
+++ b/internal/infrastructure/webkit/webview.go
@@ -3,7 +3,6 @@ package webkit
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
+	downloadutil "github.com/bnema/dumber/internal/domain/download"
 	"github.com/bnema/dumber/internal/domain/entity"
 	urlutil "github.com/bnema/dumber/internal/domain/url"
 	"github.com/bnema/dumber/internal/infrastructure/desktop"
@@ -824,22 +824,7 @@ func shouldForceDownload(responseDecision *webkit.ResponsePolicyDecision) bool {
 		return false
 	}
 
-	mimeType := strings.ToLower(response.GetMimeType())
-	if strings.HasPrefix(mimeType, "application/pdf") {
-		return true
-	}
-
-	uri := response.GetUri()
-	if uri == "" {
-		return false
-	}
-
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		return strings.Contains(strings.ToLower(uri), ".pdf")
-	}
-
-	return strings.HasSuffix(strings.ToLower(parsed.Path), ".pdf")
+	return downloadutil.ShouldForceDownload(response.GetUri(), response.GetMimeType())
 }
 
 func (wv *WebView) connectEnterFullscreenSignal() {

--- a/internal/infrastructure/webkit/webview.go
+++ b/internal/infrastructure/webkit/webview.go
@@ -3,6 +3,7 @@ package webkit
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"sync"

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -40,12 +40,14 @@ const (
 	AppID    = "com.github.bnema.dumber"
 	appTitle = "Dumber"
 	// crashReportToastDurationMs keeps startup crash-report toast visible longer.
-	crashReportToastDurationMs = 5000
-	floatingPaneFallbackWidth  = 1200
-	floatingPaneFallbackHeight = 800
-	floatingPaneIDPrefix       = "floating-pane:"
-	floatingSessionIDDefault   = "default"
-	floatingPaneVisibleClass   = "floating-pane-visible"
+	crashReportToastDurationMs    = 5000
+	downloadToastTerminalDuration = 2500
+	downloadProgressRoundBias     = 0.5
+	floatingPaneFallbackWidth     = 1200
+	floatingPaneFallbackHeight    = 800
+	floatingPaneIDPrefix          = "floating-pane:"
+	floatingSessionIDDefault      = "default"
+	floatingPaneVisibleClass      = "floating-pane-visible"
 )
 
 func gtkApplicationFlags() gio.ApplicationFlags {
@@ -889,7 +891,7 @@ func (a *App) initDownloadHandler(ctx context.Context) {
 	}
 
 	// Create download event adapter to show toasts.
-	eventAdapter := &downloadEventAdapter{app: a}
+	eventAdapter := newDownloadEventAdapter(a)
 
 	// Create use case for preparing download destinations with file deduplication.
 	prepareDownloadUC := usecase.NewPrepareDownloadUseCase(a.deps.FileSystem)
@@ -904,23 +906,139 @@ func (a *App) initDownloadHandler(ctx context.Context) {
 
 // downloadEventAdapter implements port.DownloadEventHandler and shows toasts.
 type downloadEventAdapter struct {
-	app *App
+	app    *App
+	mu     sync.Mutex
+	active map[string]downloadToastState
+}
+
+type downloadToastState struct {
+	filename string
+	percent  int
+}
+
+type downloadToastSpec struct {
+	message  string
+	level    component.ToastLevel
+	duration int
+	show     bool
+}
+
+func newDownloadEventAdapter(app *App) *downloadEventAdapter {
+	return &downloadEventAdapter{
+		app:    app,
+		active: make(map[string]downloadToastState),
+	}
 }
 
 func (d *downloadEventAdapter) OnDownloadEvent(ctx context.Context, event port.DownloadEvent) {
+	spec := d.toastSpecForEvent(event)
+	if !spec.show {
+		return
+	}
+
 	// Must schedule on GTK main thread.
 	cb := glib.SourceFunc(func(_ uintptr) bool {
-		switch event.Type {
-		case port.DownloadEventStarted:
-			d.app.showToastOnLastFocusedBrowserWindow(ctx, "Download started: "+event.Filename, component.ToastInfo)
-		case port.DownloadEventFinished:
-			d.app.showToastOnLastFocusedBrowserWindow(ctx, "Download complete: "+event.Filename, component.ToastSuccess)
-		case port.DownloadEventFailed:
-			d.app.showToastOnLastFocusedBrowserWindow(ctx, "Download failed: "+event.Filename, component.ToastError)
-		}
+		d.app.showToastOnLastFocusedBrowserWindow(
+			ctx,
+			spec.message,
+			spec.level,
+			component.WithDuration(spec.duration),
+		)
 		return false
 	})
 	glib.IdleAdd(&cb, 0)
+}
+
+func (d *downloadEventAdapter) toastSpecForEvent(event port.DownloadEvent) downloadToastSpec {
+	key := downloadToastKey(event)
+	filename := event.Filename
+	if filename == "" {
+		filename = filepath.Base(event.Destination)
+	}
+	if filename == "" {
+		filename = "download"
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	state := d.active[key]
+	if state.filename == "" {
+		state.filename = filename
+	}
+
+	switch event.Type {
+	case port.DownloadEventStarted:
+		state.percent = 0
+		d.active[key] = state
+		return downloadToastSpec{
+			message:  fmt.Sprintf("Download started: %s (0%%)", state.filename),
+			level:    component.ToastInfo,
+			duration: 0,
+			show:     true,
+		}
+	case port.DownloadEventProgress:
+		percent := downloadProgressPercent(event.Progress)
+		if percent <= state.percent {
+			if _, ok := d.active[key]; !ok {
+				d.active[key] = state
+			}
+			return downloadToastSpec{}
+		}
+		state.percent = percent
+		d.active[key] = state
+		return downloadToastSpec{
+			message:  fmt.Sprintf("Downloading: %s (%d%%)", state.filename, percent),
+			level:    component.ToastInfo,
+			duration: 0,
+			show:     true,
+		}
+	case port.DownloadEventFinished:
+		delete(d.active, key)
+		return downloadToastSpec{
+			message:  "Download complete: " + state.filename,
+			level:    component.ToastSuccess,
+			duration: downloadToastTerminalDuration,
+			show:     true,
+		}
+	case port.DownloadEventFailed:
+		delete(d.active, key)
+		return downloadToastSpec{
+			message:  "Download failed: " + state.filename,
+			level:    component.ToastError,
+			duration: downloadToastTerminalDuration,
+			show:     true,
+		}
+	default:
+		return downloadToastSpec{}
+	}
+}
+
+func downloadToastKey(event port.DownloadEvent) string {
+	if event.Destination != "" {
+		return event.Destination
+	}
+	if event.Filename != "" {
+		return event.Filename
+	}
+	return "download"
+}
+
+func downloadProgressPercent(progress float64) int {
+	if progress <= 0 {
+		return 0
+	}
+	if progress >= 1 {
+		return 100
+	}
+	percent := int(progress*100 + downloadProgressRoundBias)
+	if percent < 0 {
+		return 0
+	}
+	if percent > 100 {
+		return 100
+	}
+	return percent
 }
 
 // autoCopyConfigFn implements port.AutoCopyConfig using a function closure.

--- a/internal/ui/app_download_test.go
+++ b/internal/ui/app_download_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/ui/component"
+)
+
+func TestDownloadEventAdapterToastSpecLifecycle(t *testing.T) {
+	adapter := newDownloadEventAdapter(nil)
+	event := port.DownloadEvent{
+		Filename:    "archlinux.iso",
+		Destination: "/tmp/archlinux.iso",
+	}
+
+	started := adapter.toastSpecForEvent(port.DownloadEvent{
+		Type:        port.DownloadEventStarted,
+		Filename:    event.Filename,
+		Destination: event.Destination,
+	})
+	require.True(t, started.show)
+	require.Equal(t, component.ToastInfo, started.level)
+	require.Equal(t, 0, started.duration)
+	require.Equal(t, "Download started: archlinux.iso (0%)", started.message)
+
+	progress := adapter.toastSpecForEvent(port.DownloadEvent{
+		Type:        port.DownloadEventProgress,
+		Filename:    event.Filename,
+		Destination: event.Destination,
+		Progress:    0.37,
+	})
+	require.True(t, progress.show)
+	require.Equal(t, component.ToastInfo, progress.level)
+	require.Equal(t, 0, progress.duration)
+	require.Equal(t, "Downloading: archlinux.iso (37%)", progress.message)
+
+	finished := adapter.toastSpecForEvent(port.DownloadEvent{
+		Type:        port.DownloadEventFinished,
+		Filename:    event.Filename,
+		Destination: event.Destination,
+	})
+	require.True(t, finished.show)
+	require.Equal(t, component.ToastSuccess, finished.level)
+	require.Equal(t, downloadToastTerminalDuration, finished.duration)
+	require.Equal(t, "Download complete: archlinux.iso", finished.message)
+}
+
+func TestDownloadEventAdapterToastSpecSuppressesDuplicateProgress(t *testing.T) {
+	adapter := newDownloadEventAdapter(nil)
+	event := port.DownloadEvent{
+		Filename:    "ubuntu.iso",
+		Destination: "/tmp/ubuntu.iso",
+	}
+
+	adapter.toastSpecForEvent(port.DownloadEvent{
+		Type:        port.DownloadEventStarted,
+		Filename:    event.Filename,
+		Destination: event.Destination,
+	})
+
+	first := adapter.toastSpecForEvent(port.DownloadEvent{
+		Type:        port.DownloadEventProgress,
+		Filename:    event.Filename,
+		Destination: event.Destination,
+		Progress:    0.12,
+	})
+	require.True(t, first.show)
+
+	duplicate := adapter.toastSpecForEvent(port.DownloadEvent{
+		Type:        port.DownloadEventProgress,
+		Filename:    event.Filename,
+		Destination: event.Destination,
+		Progress:    0.12,
+	})
+	require.False(t, duplicate.show)
+}
+
+func TestDownloadProgressPercentRoundsReasonably(t *testing.T) {
+	require.Equal(t, 0, downloadProgressPercent(0))
+	require.Equal(t, 1, downloadProgressPercent(0.0051))
+	require.Equal(t, 37, downloadProgressPercent(0.37))
+	require.Equal(t, 100, downloadProgressPercent(1.2))
+}


### PR DESCRIPTION
## Summary
- add shared download policy and runtime support for downloads across CEF and WebKit
- implement CEF download handling and reuse the shared runtime from WebKit
- harden follow-up behavior around terminal download state tracking and download configuration validation

## Validation
- `make lint`
- `make test`
- final `go-reviewer` pass: no blocking issues found

## Notes
- this branch was rebuilt cleanly from current `main` to avoid the stale dependency and file drift that existed in the earlier PR attempt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Force-download decisions based on URI or MIME type
  * Download progress events (bytes + normalized progress) and UI toasts for progress/finished/failed states
  * Configurable download destination resolution and runtime-managed download path; downloads become active when configured

* **Refactor**
  * Centralized download runtime shared by browser engines and handlers; browser handlers now implement real download support

* **Tests**
  * Added unit tests covering policy, handler lifecycles, runtime, and UI toast behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->