### PR TITLE
refactor(cef): integrate purego-cef v0.10.1

### DIFF
--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -126,8 +126,18 @@ func main() {
 	// engine can also be selected via config.
 	if isCEFSubprocess(os.Args) {
 		runtime.LockOSThread()
-		cef.MaybeExitSubprocessWithApp(infracef.NewSubprocessApp())
-		os.Exit(1)
+		executed, exitCode, err := cef.ExecuteSubprocessWithApp(infracef.NewSubprocessApp())
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "cef: ExecuteSubprocessWithApp: %v\n", err)
+			os.Exit(1)
+		}
+		if executed {
+			os.Exit(exitCode)
+		}
+		// If Chromium-style helper args were present but purego-cef declined to
+		// handle them as a subprocess, drop them before normal startup so Cobra
+		// and the GUI bootstrap do not choke on unknown --type/... flags.
+		os.Args = os.Args[:1]
 	}
 
 	enableCrashForensics()

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -120,10 +120,10 @@ func configureBrowserLaunchRelay(cfg *config.Config) {
 func main() {
 	// CEF subprocess handling: when CEF re-launches this binary with
 	// --type=renderer/gpu/etc, we must call ExecuteProcess before anything
-	// else (Cobra, config, arg stripping). We detect subprocesses by the
-	// presence of a --type flag in os.Args rather than checking the engine
-	// env var, because subprocesses may not inherit the environment and the
-	// engine can also be selected via config.
+	// else (Cobra, config, arg stripping). We only treat a leading Chromium
+	// helper-process --type flag as a subprocess marker rather than scanning
+	// the full argv, so normal user commands like `dumber browse --type=foo`
+	// are not misclassified.
 	if isCEFSubprocess(os.Args) {
 		runtime.LockOSThread()
 		executed, exitCode, err := cef.ExecuteSubprocessWithApp(infracef.NewSubprocessApp())
@@ -134,6 +134,7 @@ func main() {
 		if executed {
 			os.Exit(exitCode)
 		}
+		runtime.UnlockOSThread()
 		// If Chromium-style helper args were present but purego-cef declined to
 		// handle them as a subprocess, drop them before normal startup so Cobra
 		// and the GUI bootstrap do not choke on unknown --type/... flags.
@@ -739,25 +740,23 @@ func createUseCases(repos *repositories, cfg *config.Config) *useCases {
 	}
 }
 
-// isCEFSubprocess returns true if args contains a --type flag, indicating
-// this process was spawned by CEF as a renderer, GPU, or utility subprocess.
+// isCEFSubprocess returns true when argv begins with a Chromium helper-process
+// --type flag, indicating this process was spawned by CEF as a renderer, GPU,
+// or utility subprocess.
 func isCEFSubprocess(args []string) bool {
-	for i, arg := range args {
-		if strings.HasPrefix(arg, "--type=") {
-			value := strings.TrimPrefix(arg, "--type=")
-			if value != "" && !strings.HasPrefix(value, "-") {
-				return true
-			}
-			continue
-		}
-		if arg == "--type" && i+1 < len(args) {
-			next := args[i+1]
-			if next != "" && !strings.HasPrefix(next, "-") {
-				return true
-			}
-		}
+	if len(args) < 2 {
+		return false
 	}
-	return false
+
+	if strings.HasPrefix(args[1], "--type=") {
+		value := strings.TrimPrefix(args[1], "--type=")
+		return value != "" && !strings.HasPrefix(value, "-")
+	}
+
+	return args[1] == "--type" &&
+		len(args) > 2 &&
+		args[2] != "" &&
+		!strings.HasPrefix(args[2], "-")
 }
 
 func buildUIDependencies(

--- a/cmd/dumber/main_test.go
+++ b/cmd/dumber/main_test.go
@@ -108,6 +108,21 @@ func TestIsCEFSubprocess(t *testing.T) {
 			args: []string{"dumber", "--unexpected"},
 			want: false,
 		},
+		{
+			name: "type flag after user command",
+			args: []string{"dumber", "browse", "--type=renderer"},
+			want: false,
+		},
+		{
+			name: "type flag not in second argv slot",
+			args: []string{"dumber", "browse", "https://example.com", "--type", "renderer"},
+			want: false,
+		},
+		{
+			name: "equals form with dash-prefixed value",
+			args: []string{"dumber", "--type=--renderer"},
+			want: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/bnema/purego v0.11.0-bnema.2
-	github.com/bnema/purego-cef v0.9.1
+	github.com/bnema/purego-cef v0.10.0
 	github.com/bnema/purego-ffmpeg v0.3.1
 	github.com/bnema/purego-pipewire v0.1.2
 	github.com/bnema/purego-sqlite v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/bnema/purego v0.11.0-bnema.2
-	github.com/bnema/purego-cef v0.10.0
+	github.com/bnema/purego-cef v0.10.1
 	github.com/bnema/purego-ffmpeg v0.3.1
 	github.com/bnema/purego-pipewire v0.1.2
 	github.com/bnema/purego-sqlite v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/bnema/purego v0.11.0-bnema.2 h1:7pzcdOJ8bGtLrCz6V582oyleP6css1ICQoGgj+/Ve4o=
 github.com/bnema/purego v0.11.0-bnema.2/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
-github.com/bnema/purego-cef v0.9.0 h1:pFTxOa0nvoDkXsqIzUWCjzPTCaQwPnJaXqZk0kMt1ts=
-github.com/bnema/purego-cef v0.9.0/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
-github.com/bnema/purego-cef v0.9.1 h1:yP5wkw6+9PPV6THDzn3d2p+nn6ED3J6IxG4x/JfikJE=
-github.com/bnema/purego-cef v0.9.1/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
+github.com/bnema/purego-cef v0.10.0 h1:9uztAhPIEO99rAu/SWf7ghooPLCODZOvRJ/vQBjxB7c=
+github.com/bnema/purego-cef v0.10.0/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
 github.com/bnema/purego-ffmpeg v0.3.1 h1:BWqRQvRXH3Lu7atem71Ai//fOYdNwuFofVF7uz/0XF0=
 github.com/bnema/purego-ffmpeg v0.3.1/go.mod h1:0/PCk5gYU0Dl1taBgiJd8ttR7A3SFSJXeNJBljeqFGc=
 github.com/bnema/purego-pipewire v0.1.2 h1:U057iOlpQatwlis6nfrZQJVrT3aGDFdagRLUz+ll7Ik=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/bnema/purego v0.11.0-bnema.2 h1:7pzcdOJ8bGtLrCz6V582oyleP6css1ICQoGgj
 github.com/bnema/purego v0.11.0-bnema.2/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.10.0 h1:9uztAhPIEO99rAu/SWf7ghooPLCODZOvRJ/vQBjxB7c=
 github.com/bnema/purego-cef v0.10.0/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
+github.com/bnema/purego-cef v0.10.1 h1:+kQur8Zrl3IWV2no9HPLdTPV1gwHF7lhFfm6sJ/AUok=
+github.com/bnema/purego-cef v0.10.1/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
 github.com/bnema/purego-ffmpeg v0.3.1 h1:BWqRQvRXH3Lu7atem71Ai//fOYdNwuFofVF7uz/0XF0=
 github.com/bnema/purego-ffmpeg v0.3.1/go.mod h1:0/PCk5gYU0Dl1taBgiJd8ttR7A3SFSJXeNJBljeqFGc=
 github.com/bnema/purego-pipewire v0.1.2 h1:U057iOlpQatwlis6nfrZQJVrT3aGDFdagRLUz+ll7Ik=

--- a/internal/infrastructure/cef/app.go
+++ b/internal/infrastructure/cef/app.go
@@ -222,7 +222,7 @@ func (h *dumberBPH) OnAlreadyRunningAppRelaunch(commandLine purecef.CommandLine,
 
 	return 0
 }
-func (h *dumberBPH) GetDefaultClient() purecef.Client                               { return nil }
+func (h *dumberBPH) GetDefaultClient() purecef.RawClient                            { return nil }
 func (h *dumberBPH) GetDefaultRequestContextHandler() purecef.RequestContextHandler { return nil }
 
 // OnScheduleMessagePumpWork is a no-op — multi-threaded message loop drives

--- a/internal/infrastructure/cef/app_test.go
+++ b/internal/infrastructure/cef/app_test.go
@@ -31,19 +31,19 @@ func (c relaunchCommandLineStub) Copy() purecef.CommandLine          { return c 
 func (c relaunchCommandLineStub) InitFromArgv(int32, unsafe.Pointer) {}
 func (c relaunchCommandLineStub) InitFromString(string)              {}
 func (c relaunchCommandLineStub) Reset()                             {}
-func (c relaunchCommandLineStub) GetArgv(uintptr)                    {}
+func (c relaunchCommandLineStub) GetArgv(purecef.StringList)         {}
 func (c relaunchCommandLineStub) GetCommandLineString() string       { return c.commandLineString }
 func (c relaunchCommandLineStub) GetProgram() string                 { return "dumber" }
 func (c relaunchCommandLineStub) SetProgram(string)                  {}
 func (c relaunchCommandLineStub) HasSwitches() bool                  { return false }
 func (c relaunchCommandLineStub) HasSwitch(string) bool              { return false }
 func (c relaunchCommandLineStub) GetSwitchValue(string) string       { return "" }
-func (c relaunchCommandLineStub) GetSwitches(uintptr)                {}
+func (c relaunchCommandLineStub) GetSwitches(purecef.StringMap)      {}
 func (c relaunchCommandLineStub) AppendSwitch(string)                {}
 func (c relaunchCommandLineStub) AppendSwitchWithValue(string, string) {
 }
-func (c relaunchCommandLineStub) HasArguments() bool   { return true }
-func (c relaunchCommandLineStub) GetArguments(uintptr) {}
+func (c relaunchCommandLineStub) HasArguments() bool              { return true }
+func (c relaunchCommandLineStub) GetArguments(purecef.StringList) {}
 func (c relaunchCommandLineStub) AppendArgument(string) {
 }
 func (c relaunchCommandLineStub) PrependWrapper(string) {}

--- a/internal/infrastructure/cef/context_menu_adapter_test.go
+++ b/internal/infrastructure/cef/context_menu_adapter_test.go
@@ -35,11 +35,11 @@ func (p stubContextMenuParams) GetMediaType() purecef.ContextMenuMediaType { ret
 func (p stubContextMenuParams) GetMediaStateFlags() purecef.ContextMenuMediaStateFlags {
 	return 0
 }
-func (p stubContextMenuParams) GetSelectionText() string               { return p.selection }
-func (p stubContextMenuParams) GetMisspelledWord() string              { return "" }
-func (p stubContextMenuParams) GetDictionarySuggestions(uintptr) int32 { return 0 }
-func (p stubContextMenuParams) IsEditable() bool                       { return p.editable }
-func (p stubContextMenuParams) IsSpellCheckEnabled() bool              { return false }
+func (p stubContextMenuParams) GetSelectionText() string                          { return p.selection }
+func (p stubContextMenuParams) GetMisspelledWord() string                         { return "" }
+func (p stubContextMenuParams) GetDictionarySuggestions(purecef.StringList) int32 { return 0 }
+func (p stubContextMenuParams) IsEditable() bool                                  { return p.editable }
+func (p stubContextMenuParams) IsSpellCheckEnabled() bool                         { return false }
 func (p stubContextMenuParams) GetEditStateFlags() purecef.ContextMenuEditStateFlags {
 	return 0
 }

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -144,11 +144,10 @@ func prepareCEFSettings(
 	if bootstrapLogFile, err := prepareCEFInitTraceFile(paths.LogFile, cfg.LogFile); err != nil {
 		logger.Warn().Err(err).Msg("cef: failed to prepare init trace file")
 	} else if bootstrapLogFile != "" {
-		settings.InitTraceFile = bootstrapLogFile
-		logger.Info().
+		logger.Warn().
 			Str("bootstrap_log_file", bootstrapLogFile).
 			Str("env_var", puregoCEFInitTraceEnvVar).
-			Msg("cef: init bootstrap diagnostics enabled")
+			Msg("cef: init bootstrap diagnostics requested, but current purego-cef no longer consumes this trace file")
 	}
 	if cfg.LogSeverity != 0 {
 		settings.LogSeverity = cfg.LogSeverity

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -141,13 +141,12 @@ func prepareCEFSettings(
 	} else {
 		settings.LogFile = runtimeLogFile
 	}
-	if bootstrapLogFile, err := prepareCEFInitTraceFile(paths.LogFile, cfg.LogFile); err != nil {
-		logger.Warn().Err(err).Msg("cef: failed to prepare init trace file")
-	} else if bootstrapLogFile != "" {
-		logger.Warn().
-			Str("bootstrap_log_file", bootstrapLogFile).
-			Str("env_var", puregoCEFInitTraceEnvVar).
-			Msg("cef: init bootstrap diagnostics requested, but current purego-cef no longer consumes this trace file")
+	if puregoCEFInitTraceEnabled() {
+		warn := logger.Warn().Str("env_var", puregoCEFInitTraceEnvVar)
+		if bootstrapLogFile := resolveCEFInitTraceFile(paths.LogFile, cfg.LogFile); bootstrapLogFile != "" {
+			warn = warn.Str("bootstrap_log_file", bootstrapLogFile)
+		}
+		warn.Msg("cef: init bootstrap diagnostics requested, but current purego-cef no longer consumes this trace file")
 	}
 	if cfg.LogSeverity != 0 {
 		settings.LogSeverity = cfg.LogSeverity
@@ -472,31 +471,12 @@ func openFileNoFollow(path string, flags int, perm os.FileMode) (*os.File, error
 	return os.NewFile(uintptr(fd), path), nil
 }
 
-func prepareCEFInitTraceFile(defaultLogFile, logFile string) (string, error) {
-	if !puregoCEFInitTraceEnabled() {
-		return "", nil
-	}
-
+func resolveCEFInitTraceFile(defaultLogFile, logFile string) string {
 	runtimeLogFile := resolveLogFile(defaultLogFile, logFile)
 	if runtimeLogFile == "" {
-		return "", nil
+		return ""
 	}
-	bootstrapLogFile := strings.TrimSuffix(runtimeLogFile, filepath.Ext(runtimeLogFile)) + ".bootstrap.log"
-	if err := os.MkdirAll(filepath.Dir(bootstrapLogFile), dirPerm); err != nil {
-		return "", fmt.Errorf("mkdir %s: %w", filepath.Dir(bootstrapLogFile), err)
-	}
-	file, err := openRegularLogFile(bootstrapLogFile)
-	if err != nil {
-		return "", fmt.Errorf("reset %s: %w", bootstrapLogFile, err)
-	}
-	defer func() { _ = file.Close() }()
-	if err := file.Truncate(0); err != nil {
-		return "", fmt.Errorf("reset %s: %w", bootstrapLogFile, err)
-	}
-	if err := file.Chmod(filePerm); err != nil {
-		return "", fmt.Errorf("chmod %s: %w", bootstrapLogFile, err)
-	}
-	return bootstrapLogFile, nil
+	return strings.TrimSuffix(runtimeLogFile, filepath.Ext(runtimeLogFile)) + ".bootstrap.log"
 }
 
 func resolveLogFile(defaultLogFile, logFile string) string {

--- a/internal/infrastructure/cef/engine_init_test.go
+++ b/internal/infrastructure/cef/engine_init_test.go
@@ -1,6 +1,7 @@
 package cef
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -59,13 +60,8 @@ func TestPrepareCEFSettings_AllowsNoThirdPartyCookiePolicy(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPrepareCEFInitTraceFile_DisabledByDefault(t *testing.T) {
-	t.Setenv(puregoCEFInitTraceEnvVar, "")
-	profile := testCEFDevProfile(t)
-
-	path, err := prepareCEFInitTraceFile(profile.CEFLogFile(), "")
-	require.NoError(t, err)
-	require.Empty(t, path)
+func TestResolveCEFInitTraceFile_EmptyWithoutLogPath(t *testing.T) {
+	require.Empty(t, resolveCEFInitTraceFile("", ""))
 }
 
 func TestPrepareCEFLogFile_CreatesPrivateDirectoryAndFile(t *testing.T) {
@@ -124,71 +120,41 @@ func TestPrepareCEFLogFile_RejectsDirectoryPath(t *testing.T) {
 	require.Empty(t, path)
 }
 
-func TestPrepareCEFInitTraceFile_EnabledViaExplicitLogFile(t *testing.T) {
-	t.Setenv(puregoCEFInitTraceEnvVar, "1")
+func TestResolveCEFInitTraceFile_UsesExplicitLogFile(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "custom", "cef_runtime.log")
 
-	path, err := prepareCEFInitTraceFile("", logFile)
-	require.NoError(t, err)
+	path := resolveCEFInitTraceFile("", logFile)
 	require.Equal(t, filepath.Join(filepath.Dir(logFile), "cef_runtime.bootstrap.log"), path)
-	require.FileExists(t, path)
-
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(filePerm), info.Mode().Perm())
-
-	dirInfo, err := os.Stat(filepath.Dir(path))
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(dirPerm), dirInfo.Mode().Perm())
 }
 
-func TestPrepareCEFInitTraceFile_TruncatesExistingFile(t *testing.T) {
-	t.Setenv(puregoCEFInitTraceEnvVar, "1")
-	logFile := filepath.Join(t.TempDir(), "custom", "cef_runtime.log")
-	bootstrapLogFile := filepath.Join(filepath.Dir(logFile), "cef_runtime.bootstrap.log")
-	require.NoError(t, os.MkdirAll(filepath.Dir(bootstrapLogFile), dirPerm))
-	require.NoError(t, os.WriteFile(bootstrapLogFile, []byte("existing"), 0o644))
-
-	path, err := prepareCEFInitTraceFile("", logFile)
-	require.NoError(t, err)
-	require.Equal(t, bootstrapLogFile, path)
-
-	content, readErr := os.ReadFile(path)
-	require.NoError(t, readErr)
-	require.Empty(t, content)
-
-	info, statErr := os.Stat(path)
-	require.NoError(t, statErr)
-	require.Equal(t, os.FileMode(filePerm), info.Mode().Perm())
-}
-
-func TestPrepareCEFInitTraceFile_RejectsSymlink(t *testing.T) {
-	t.Setenv(puregoCEFInitTraceEnvVar, "1")
-	target := filepath.Join(t.TempDir(), "target.bootstrap.log")
-	require.NoError(t, os.WriteFile(target, []byte("existing"), 0o644))
-
-	logFile := filepath.Join(t.TempDir(), "custom", "cef_runtime.log")
-	bootstrapLogFile := filepath.Join(filepath.Dir(logFile), "cef_runtime.bootstrap.log")
-	require.NoError(t, os.MkdirAll(filepath.Dir(bootstrapLogFile), dirPerm))
-	require.NoError(t, os.Symlink(target, bootstrapLogFile))
-
-	path, err := prepareCEFInitTraceFile("", logFile)
-	require.ErrorContains(t, err, "must not be a symlink")
-	require.Empty(t, path)
-
-	targetInfo, statErr := os.Stat(target)
-	require.NoError(t, statErr)
-	require.Equal(t, os.FileMode(0o644), targetInfo.Mode().Perm())
-}
-
-func TestPrepareCEFInitTraceFile_UsesResolvedProfileLogDirByDefault(t *testing.T) {
-	t.Setenv(puregoCEFInitTraceEnvVar, "1")
+func TestResolveCEFInitTraceFile_UsesResolvedProfileLogDirByDefault(t *testing.T) {
 	profile := testCEFDevProfile(t)
 
-	path, err := prepareCEFInitTraceFile(profile.CEFLogFile(), "")
-	require.NoError(t, err)
+	path := resolveCEFInitTraceFile(profile.CEFLogFile(), "")
 	require.Equal(t, filepath.Join(profile.EnginePaths.LogDir, "cef_runtime.bootstrap.log"), path)
-	require.FileExists(t, path)
+}
+
+func TestPrepareCEFSettings_IgnoresInitTraceRequestWithoutTouchingFilesystem(t *testing.T) {
+	t.Setenv(puregoCEFInitTraceEnvVar, "1")
+	profile := testCEFDevProfile(t)
+	bootstrapLogFile := resolveCEFInitTraceFile(profile.CEFLogFile(), "")
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+
+	settings, err := prepareCEFSettings(
+		port.EngineOptions{},
+		RuntimePaths{StateRoot: profile.CEFUserDataDir(), LogFile: profile.CEFLogFile()},
+		RuntimeConfig{},
+		&logger,
+	)
+	require.NoError(t, err)
+	require.Equal(t, profile.CEFLogFile(), settings.LogFile)
+
+	_, statErr := os.Stat(bootstrapLogFile)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+	require.Contains(t, logs.String(), puregoCEFInitTraceEnvVar)
+	require.Contains(t, logs.String(), bootstrapLogFile)
 }
 
 // TestCreateAudioOutputFactory_CreatesUsableFactory verifies that the audio

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -156,7 +156,7 @@ func (f *WebViewFactory) Create(ctx context.Context) (port.WebView, error) {
 }
 
 func (f *WebViewFactory) configureInitialBrowserCreation(
-	ctx context.Context, wv *WebView, pipeline *renderPipeline, client purecef.Client,
+	ctx context.Context, wv *WebView, pipeline *renderPipeline, client purecef.RawClient,
 	windowInfo *purecef.WindowInfo, settings *purecef.BrowserSettings,
 ) {
 	wv.pendingCreate = &pendingBrowserCreate{

--- a/internal/infrastructure/cef/scheme_handler.go
+++ b/internal/infrastructure/cef/scheme_handler.go
@@ -555,9 +555,11 @@ func (h *dumbSchemeHandler) newAPIJSONResourceHandler(status int, v any) purecef
 }
 
 // Open handles the request immediately (synchronous).
-func (rh *staticResourceHandler) Open(_ purecef.Request, handleRequest unsafe.Pointer, _ purecef.Callback) int32 {
+func (rh *staticResourceHandler) Open(_ purecef.Request, handleRequest *int32, _ purecef.Callback) int32 {
 	// Set handleRequest = true (1) to indicate we handle it immediately.
-	*(*int32)(handleRequest) = 1
+	if handleRequest != nil {
+		*handleRequest = 1
+	}
 	return 1
 }
 
@@ -569,7 +571,7 @@ func (rh *staticResourceHandler) ProcessRequest(_ purecef.Request, _ purecef.Cal
 // GetResponseHeaders sets status code, MIME type, and content length.
 // CEF's SetMimeType expects the MIME type without charset parameters;
 // the charset must be set separately via SetCharset.
-func (rh *staticResourceHandler) GetResponseHeaders(response purecef.Response, responseLength unsafe.Pointer, _ uintptr) {
+func (rh *staticResourceHandler) GetResponseHeaders(response purecef.Response, responseLength *int64, _ uintptr) {
 	response.SetStatus(int32(rh.statusCode))
 	if text := http.StatusText(rh.statusCode); text != "" {
 		response.SetStatusText(text)
@@ -582,18 +584,20 @@ func (rh *staticResourceHandler) GetResponseHeaders(response purecef.Response, r
 	for name, value := range rh.headers {
 		response.SetHeaderByName(name, value, 1)
 	}
-	*(*int64)(responseLength) = int64(len(rh.data))
+	if responseLength != nil {
+		*responseLength = int64(len(rh.data))
+	}
 }
 
 // Skip is not used for static content.
-func (rh *staticResourceHandler) Skip(_ int64, _ unsafe.Pointer, _ purecef.ResourceSkipCallback) int32 {
+func (rh *staticResourceHandler) Skip(_ int64, _ *int64, _ purecef.ResourceSkipCallback) int32 {
 	return 0
 }
 
 // Read copies data into the output buffer.
 func (rh *staticResourceHandler) Read(
 	dataOut unsafe.Pointer, bytesToRead int32,
-	bytesRead unsafe.Pointer, _ purecef.ResourceReadCallback,
+	bytesRead *int32, _ purecef.ResourceReadCallback,
 ) int32 {
 	if rh.offset >= len(rh.data) {
 		return 0
@@ -610,12 +614,14 @@ func (rh *staticResourceHandler) Read(
 	copy(dst, rh.data[rh.offset:rh.offset+toRead])
 	rh.offset += toRead
 
-	*(*int32)(bytesRead) = int32(toRead)
+	if bytesRead != nil {
+		*bytesRead = int32(toRead)
+	}
 	return 1
 }
 
 // ReadResponse is deprecated; Read is used instead.
-func (rh *staticResourceHandler) ReadResponse(_ unsafe.Pointer, _ int32, _ unsafe.Pointer, _ purecef.Callback) int32 {
+func (rh *staticResourceHandler) ReadResponse(_ unsafe.Pointer, _ int32, _ *int32, _ purecef.Callback) int32 {
 	return 0
 }
 

--- a/internal/infrastructure/cef/scheme_handler_test.go
+++ b/internal/infrastructure/cef/scheme_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"testing"
-	"unsafe"
 
 	purecef "github.com/bnema/purego-cef/cef"
 	cefmocks "github.com/bnema/purego-cef/cef/mocks"
@@ -103,7 +102,7 @@ func TestSchemeHandler_APIClipboardSetPathWritesClipboardPayload(t *testing.T) {
 	require.NotNil(t, handler)
 
 	var responseLength int64
-	handler.GetResponseHeaders(response, unsafe.Pointer(&responseLength), 0)
+	handler.GetResponseHeaders(response, &responseLength, 0)
 	require.Positive(t, responseLength)
 	require.Equal(t, "copied from js", copied)
 }
@@ -129,7 +128,7 @@ func TestSchemeHandler_APIFocusSyncRejectsRequestsWithoutTrustedBridgeHeader(t *
 	require.NotNil(t, handler)
 
 	var responseLength int64
-	handler.GetResponseHeaders(response, unsafe.Pointer(&responseLength), 0)
+	handler.GetResponseHeaders(response, &responseLength, 0)
 	require.Positive(t, responseLength)
 }
 
@@ -164,7 +163,7 @@ func TestSchemeHandler_APIFocusSyncInvokesEditableFocusCallback(t *testing.T) {
 	require.NotNil(t, handler)
 
 	var responseLength int64
-	handler.GetResponseHeaders(response, unsafe.Pointer(&responseLength), 0)
+	handler.GetResponseHeaders(response, &responseLength, 0)
 	require.Positive(t, responseLength)
 	require.Same(t, browser, focused)
 }
@@ -203,7 +202,7 @@ func TestSchemeHandler_Create_ConceptualAPIRequestBypassesRedirect(t *testing.T)
 	require.NotNil(t, handler)
 
 	var responseLength int64
-	handler.GetResponseHeaders(response, unsafe.Pointer(&responseLength), 0)
+	handler.GetResponseHeaders(response, &responseLength, 0)
 	require.Positive(t, responseLength)
 	require.Equal(t, "copied from create", copied)
 }
@@ -232,7 +231,7 @@ func TestSchemeHandler_APIClipboardSetRejectsInvalidBridgeNonce(t *testing.T) {
 	require.NotNil(t, handler)
 
 	var responseLength int64
-	handler.GetResponseHeaders(response, unsafe.Pointer(&responseLength), 0)
+	handler.GetResponseHeaders(response, &responseLength, 0)
 	require.Positive(t, responseLength)
 }
 
@@ -256,6 +255,6 @@ func TestSchemeHandler_APIOptionsReturnsCORSPreflightHeaders(t *testing.T) {
 	require.NotNil(t, handler)
 
 	var responseLength int64
-	handler.GetResponseHeaders(response, unsafe.Pointer(&responseLength), 0)
+	handler.GetResponseHeaders(response, &responseLength, 0)
 	require.Zero(t, responseLength)
 }

--- a/internal/infrastructure/cef/testutil_test.go
+++ b/internal/infrastructure/cef/testutil_test.go
@@ -1,8 +1,6 @@
 package cef
 
 import (
-	"unsafe"
-
 	purecef "github.com/bnema/purego-cef/cef"
 )
 
@@ -76,10 +74,10 @@ func (stubMenuModel) SetAcceleratorAt(_ int, _, _, _, _ int32) int32 {
 }
 func (stubMenuModel) RemoveAccelerator(_ int32) int32 { panic("unexpected call") }
 func (stubMenuModel) RemoveAcceleratorAt(_ int) int32 { panic("unexpected call") }
-func (stubMenuModel) GetAccelerator(_ int32, _, _, _, _ unsafe.Pointer) int32 {
+func (stubMenuModel) GetAccelerator(_ int32, _, _, _, _ *int32) int32 {
 	panic("unexpected call")
 }
-func (stubMenuModel) GetAcceleratorAt(_ int, _, _, _, _ unsafe.Pointer) int32 {
+func (stubMenuModel) GetAcceleratorAt(_ int, _, _, _, _ *int32) int32 {
 	panic("unexpected call")
 }
 func (stubMenuModel) SetColor(_ int32, _ purecef.MenuColorType, _ uintptr) int32 {

--- a/internal/infrastructure/cef/transcoding_handler.go
+++ b/internal/infrastructure/cef/transcoding_handler.go
@@ -47,10 +47,12 @@ type transcodingResourceHandler struct {
 // Open starts the transcode session asynchronously. CEF will call
 // GetResponseHeaders and Read once the callback fires.
 func (rh *transcodingResourceHandler) Open(
-	_ purecef.Request, handleRequest unsafe.Pointer, callback purecef.Callback,
+	_ purecef.Request, handleRequest *int32, callback purecef.Callback,
 ) int32 {
 	// Signal async handling: set handleRequest = 0.
-	*(*int32)(handleRequest) = 0
+	if handleRequest != nil {
+		*handleRequest = 0
+	}
 
 	log := rh.logger()
 	sourceURL := logging.TruncateURL(rh.sourceURL, maxTranscodingURLLength)
@@ -84,7 +86,7 @@ func (rh *transcodingResourceHandler) Open(
 
 // GetResponseHeaders sets the streaming response metadata.
 func (rh *transcodingResourceHandler) GetResponseHeaders(
-	response purecef.Response, responseLength unsafe.Pointer, _ uintptr,
+	response purecef.Response, responseLength *int64, _ uintptr,
 ) {
 	response.SetStatus(httpStatusOK)
 	response.SetStatusText("OK")
@@ -96,13 +98,15 @@ func (rh *transcodingResourceHandler) GetResponseHeaders(
 	response.SetHeaderByName("Access-Control-Allow-Origin", "*", 1)
 	response.SetHeaderByName("Cache-Control", "no-store", 1)
 	// Streaming — unknown length.
-	*(*int64)(responseLength) = -1
+	if responseLength != nil {
+		*responseLength = -1
+	}
 }
 
 // Read copies transcoded data from the session into the CEF output buffer.
 func (rh *transcodingResourceHandler) Read(
 	dataOut unsafe.Pointer, bytesToRead int32,
-	bytesRead unsafe.Pointer, _ purecef.ResourceReadCallback,
+	bytesRead *int32, _ purecef.ResourceReadCallback,
 ) int32 {
 	if rh.session == nil {
 		return 0
@@ -118,7 +122,9 @@ func (rh *transcodingResourceHandler) Read(
 				Int("first_chunk_bytes", n).
 				Msg("cef: transcoding resource stream produced first bytes")
 		}
-		*(*int32)(bytesRead) = int32(n)
+		if bytesRead != nil {
+			*bytesRead = int32(n)
+		}
 		return 1
 	}
 	if err != nil {
@@ -166,12 +172,12 @@ func (rh *transcodingResourceHandler) ProcessRequest(_ purecef.Request, _ purece
 }
 
 // ReadResponse is deprecated; Read is used instead.
-func (rh *transcodingResourceHandler) ReadResponse(_ unsafe.Pointer, _ int32, _ unsafe.Pointer, _ purecef.Callback) int32 {
+func (rh *transcodingResourceHandler) ReadResponse(_ unsafe.Pointer, _ int32, _ *int32, _ purecef.Callback) int32 {
 	return 0
 }
 
 // Skip is not used for streaming content.
-func (rh *transcodingResourceHandler) Skip(_ int64, _ unsafe.Pointer, _ purecef.ResourceSkipCallback) int32 {
+func (rh *transcodingResourceHandler) Skip(_ int64, _ *int64, _ purecef.ResourceSkipCallback) int32 {
 	return 0
 }
 
@@ -360,7 +366,7 @@ func (h *transcodingRequestHandler) OnResourceLoadComplete(
 ) {
 }
 
-func (h *transcodingRequestHandler) OnProtocolExecution(_ purecef.Browser, _ purecef.Frame, _ purecef.Request, _ unsafe.Pointer) {
+func (h *transcodingRequestHandler) OnProtocolExecution(_ purecef.Browser, _ purecef.Frame, _ purecef.Request, _ *int32) {
 }
 
 func buildRequestInfo(request purecef.Request) requestInfo {

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -68,7 +68,7 @@ type WebView struct {
 	engine           *Engine
 	browser          purecef.Browser
 	host             purecef.BrowserHost
-	client           purecef.Client // prevent GC from collecting the client before CEF AddRef's it
+	client           purecef.RawClient // prevent GC from collecting the client before CEF AddRef's it
 	pipeline         *renderPipeline
 	input            *inputBridge
 	handlers         *handlerSet
@@ -140,7 +140,7 @@ type WebView struct {
 // deferred until the GL area has a non-zero size.
 type pendingBrowserCreate struct {
 	windowInfo *purecef.WindowInfo
-	client     purecef.Client
+	client     purecef.RawClient
 	settings   *purecef.BrowserSettings
 }
 

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -29,16 +29,16 @@ type handlerSet struct {
 
 // Compile-time interface checks.
 var (
-	_ purecef.SafeClient          = (*handlerSet)(nil)
-	_ purecef.RenderHandler       = (*handlerSet)(nil)
-	_ purecef.DisplayHandler      = (*handlerSet)(nil)
-	_ purecef.LoadHandler         = (*handlerSet)(nil)
-	_ purecef.SafeLifeSpanHandler = (*handlerSet)(nil)
-	_ purecef.RequestHandler      = (*handlerSet)(nil)
-	_ purecef.AudioHandler        = (*handlerSet)(nil)
-	_ purecef.ContextMenuHandler  = (*handlerSet)(nil)
-	_ purecef.DownloadHandler     = (*handlerSet)(nil)
-	_ purecef.FindHandler         = (*handlerSet)(nil)
+	_ purecef.Client             = (*handlerSet)(nil)
+	_ purecef.RenderHandler      = (*handlerSet)(nil)
+	_ purecef.DisplayHandler     = (*handlerSet)(nil)
+	_ purecef.LoadHandler        = (*handlerSet)(nil)
+	_ purecef.LifeSpanHandler    = (*handlerSet)(nil)
+	_ purecef.RequestHandler     = (*handlerSet)(nil)
+	_ purecef.AudioHandler       = (*handlerSet)(nil)
+	_ purecef.ContextMenuHandler = (*handlerSet)(nil)
+	_ purecef.DownloadHandler    = (*handlerSet)(nil)
+	_ purecef.FindHandler        = (*handlerSet)(nil)
 )
 
 // ===========================================================================
@@ -69,7 +69,7 @@ func (h *handlerSet) GetFrameHandler() purecef.FrameHandler           { return n
 func (h *handlerSet) GetPermissionHandler() purecef.PermissionHandler { return nil }
 func (h *handlerSet) GetJsdialogHandler() purecef.JsdialogHandler     { return nil }
 func (h *handlerSet) GetKeyboardHandler() purecef.KeyboardHandler     { return nil }
-func (h *handlerSet) GetLifeSpanHandler() purecef.SafeLifeSpanHandler { return h }
+func (h *handlerSet) GetLifeSpanHandler() purecef.LifeSpanHandler     { return h }
 func (h *handlerSet) GetLoadHandler() purecef.LoadHandler             { return h }
 func (h *handlerSet) GetPrintHandler() purecef.PrintHandler           { return nil }
 func (h *handlerSet) GetRenderHandler() purecef.RenderHandler         { return h }
@@ -424,7 +424,7 @@ func (h *handlerSet) OnTitleChange(_ purecef.Browser, title string) {
 	h.wv.updateTitle(title)
 }
 
-func (h *handlerSet) OnFaviconUrlchange(_ purecef.Browser, _ uintptr) {}
+func (h *handlerSet) OnFaviconUrlchange(_ purecef.Browser, _ purecef.StringList) {}
 
 // OnFullscreenModeChange toggles the fullscreen atomic and fires callbacks.
 func (h *handlerSet) OnFullscreenModeChange(_ purecef.Browser, fullscreen int32) {
@@ -656,7 +656,7 @@ func (h *handlerSet) OnLoadError(_ purecef.Browser, _ purecef.Frame, _ purecef.E
 func (h *handlerSet) OnBeforePopup(
 	_ purecef.Browser, _ purecef.Frame, _ int32, targetURL, targetFrameName string,
 	_ purecef.WindowOpenDisposition, userGesture int32, _ *purecef.PopupFeatures,
-	_ *purecef.WindowInfo, _ *purecef.Client, _ *purecef.BrowserSettings,
+	_ *purecef.WindowInfo, _ *purecef.RawClientWriteSlot, _ *purecef.BrowserSettings,
 	_ *purecef.DictionaryValue, _ *bool,
 ) bool {
 	if targetURL == "" {
@@ -685,7 +685,7 @@ func (h *handlerSet) OnBeforePopup(
 func (h *handlerSet) OnBeforePopupAborted(_ purecef.Browser, _ int32) {}
 
 func (h *handlerSet) OnBeforeDevToolsPopup(
-	_ purecef.Browser, _ *purecef.WindowInfo, _ *purecef.Client,
+	_ purecef.Browser, _ *purecef.WindowInfo, _ *purecef.RawClientWriteSlot,
 	_ *purecef.BrowserSettings, _ *purecef.DictionaryValue, _ *bool,
 ) {
 }

--- a/internal/infrastructure/cef/webview_handlers_test.go
+++ b/internal/infrastructure/cef/webview_handlers_test.go
@@ -314,26 +314,29 @@ func (n stubEditableDomnode) IsElement() bool                                   
 func (n stubEditableDomnode) IsEditable() bool                                      { return n.editable }
 func (n stubEditableDomnode) IsFormControlElement() bool                            { return false }
 func (n stubEditableDomnode) GetFormControlElementType() purecef.DomFormControlType { return 0 }
-func (n stubEditableDomnode) IsSame(that purecef.Domnode) bool                      { return n == that }
-func (n stubEditableDomnode) GetName() string                                       { return "" }
-func (n stubEditableDomnode) GetValue() string                                      { return "" }
-func (n stubEditableDomnode) SetValue(string) int32                                 { return 0 }
-func (n stubEditableDomnode) GetAsMarkup() string                                   { return "" }
-func (n stubEditableDomnode) GetDocument() purecef.Domdocument                      { return nil }
-func (n stubEditableDomnode) GetParent() purecef.Domnode                            { return nil }
-func (n stubEditableDomnode) GetPreviousSibling() purecef.Domnode                   { return nil }
-func (n stubEditableDomnode) GetNextSibling() purecef.Domnode                       { return nil }
-func (n stubEditableDomnode) HasChildren() bool                                     { return false }
-func (n stubEditableDomnode) GetFirstChild() purecef.Domnode                        { return nil }
-func (n stubEditableDomnode) GetLastChild() purecef.Domnode                         { return nil }
-func (n stubEditableDomnode) GetElementTagName() string                             { return "" }
-func (n stubEditableDomnode) HasElementAttributes() bool                            { return false }
-func (n stubEditableDomnode) HasElementAttribute(string) bool                       { return false }
-func (n stubEditableDomnode) GetElementAttribute(string) string                     { return "" }
-func (n stubEditableDomnode) GetElementAttributes(uintptr)                          {}
-func (n stubEditableDomnode) SetElementAttribute(string, string) int32              { return 0 }
-func (n stubEditableDomnode) GetElementInnerText() string                           { return "" }
-func (n stubEditableDomnode) GetElementBounds() uintptr                             { return 0 }
+func (n stubEditableDomnode) IsSame(that purecef.Domnode) bool {
+	other, ok := that.(stubEditableDomnode)
+	return ok && n == other
+}
+func (n stubEditableDomnode) GetName() string                          { return "" }
+func (n stubEditableDomnode) GetValue() string                         { return "" }
+func (n stubEditableDomnode) SetValue(string) int32                    { return 0 }
+func (n stubEditableDomnode) GetAsMarkup() string                      { return "" }
+func (n stubEditableDomnode) GetDocument() purecef.Domdocument         { return nil }
+func (n stubEditableDomnode) GetParent() purecef.Domnode               { return nil }
+func (n stubEditableDomnode) GetPreviousSibling() purecef.Domnode      { return nil }
+func (n stubEditableDomnode) GetNextSibling() purecef.Domnode          { return nil }
+func (n stubEditableDomnode) HasChildren() bool                        { return false }
+func (n stubEditableDomnode) GetFirstChild() purecef.Domnode           { return nil }
+func (n stubEditableDomnode) GetLastChild() purecef.Domnode            { return nil }
+func (n stubEditableDomnode) GetElementTagName() string                { return "" }
+func (n stubEditableDomnode) HasElementAttributes() bool               { return false }
+func (n stubEditableDomnode) HasElementAttribute(string) bool          { return false }
+func (n stubEditableDomnode) GetElementAttribute(string) string        { return "" }
+func (n stubEditableDomnode) GetElementAttributes(purecef.StringMap)   {}
+func (n stubEditableDomnode) SetElementAttribute(string, string) int32 { return 0 }
+func (n stubEditableDomnode) GetElementInnerText() string              { return "" }
+func (n stubEditableDomnode) GetElementBounds() uintptr                { return 0 }
 
 func TestGetViewRectUsesDIPCoordinates(t *testing.T) {
 	rect := &purecef.Rect{}


### PR DESCRIPTION
## Summary

Integrate `github.com/bnema/purego-cef` `v0.10.1` into Dumber.

This updates Dumber to the new purego-cef public API shape, including the safe/raw split cleanup introduced in `v0.10.0`, and picks up the `v0.10.1` subprocess regression fix.

## What changed

- bump `github.com/bnema/purego-cef` to `v0.10.1`
- migrate subprocess startup to `cef.ExecuteSubprocessWithApp(...)`
- adapt CEF client/lifespan plumbing to the new `Client` / `LifeSpanHandler` / `RawClient` API shape
- update resource handler and request handler signatures for the newer typed pointer parameters
- update local CEF test stubs for `StringList`-based generated APIs and related typed callback signatures
- keep the Dumber CEF integration compiling and tested against the current purego-cef release

## Testing

- `make lint`
- `make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CEF library dependency version.

* **Bug Fixes**
  * Improved subprocess detection and execution handling, with clearer error exit behavior and safer startup when helper args are present.

* **Refactor**
  * Replaced unsafe out-parameter usage with typed pointers and added nil-safety checks.
  * Adjusted internal CEF client/interface usage and reduced file-touch behavior for init-trace handling (now logs resolution instead of creating files).

* **Tests**
  * Updated and added tests to reflect interface and behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->