### PR TITLE
Add count-based session log cleanup

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -123,14 +123,14 @@ auto_open_on_new_pane = false
 
 | Key | Type | Default | Valid Values | Description |
 |-----|------|---------|--------------|-------------|
-| `logging.level` | string | `"info"` | `debug`, `info`, `warn`, `error` | Log level |
-| `logging.format` | string | `"text"` | `text`, `json` | Log format |
-| `logging.max_age` | int | `7` | >= 0 | Days to keep logs |
-| `logging.max_files` | int | `100` | >= 0 | Session log files to keep (`0` disables count cleanup) |
-| `logging.log_dir` | string | `~/.local/state/dumber/logs/` | any | Log directory |
+| `logging.level` | string | `"info"` | `trace`, `debug`, `info`, `warn`, `error`, `fatal` | Log level |
+| `logging.format` | string | `"text"` | `text`, `json`, `console` | Log format |
+| `logging.max_age` | int | `7` | `>= 0` | Days to keep logs |
+| `logging.max_files` | int | `100` | `>= 0` | Session log files to keep (`0` disables count cleanup) |
+| `logging.log_dir` | string | `~/.local/state/dumber/logs` | any path | Log directory |
 | `logging.enable_file_log` | bool | `true` | - | Enable file logging |
 | `logging.capture_console` | bool | `false` | - | Capture browser console to logs |
-| `logging.capture_gtk_webkit_logs` | bool | `false` | - | Capture GTK and WebKit logs for debugging |
+| `logging.capture_gtk_logs` | bool | `false` | - | Capture GTK and WebKit logs for debugging. |
 
 ## Appearance
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -126,6 +126,7 @@ auto_open_on_new_pane = false
 | `logging.level` | string | `"info"` | `debug`, `info`, `warn`, `error` | Log level |
 | `logging.format` | string | `"text"` | `text`, `json` | Log format |
 | `logging.max_age` | int | `7` | >= 0 | Days to keep logs |
+| `logging.max_files` | int | `100` | >= 0 | Session log files to keep (`0` disables count cleanup) |
 | `logging.log_dir` | string | `~/.local/state/dumber/logs/` | any | Log directory |
 | `logging.enable_file_log` | bool | `true` | - | Enable file logging |
 | `logging.capture_console` | bool | `false` | - | Capture browser console to logs |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -23,6 +23,7 @@
 | `logging.level` | string | `info` | `debug`, `info`, `warn`, `error` |
 | `logging.format` | string | `text` | `text`, `json` |
 | `logging.max_age` | int | `7` | >= 0 |
+| `logging.max_files` | int | `100` | >= 0 |
 | `logging.log_dir` | string | `~/.local/state/dumber/logs/` | |
 | `logging.enable_file_log` | bool | `true` | |
 | `logging.capture_console` | bool | `false` | |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,14 +20,14 @@
 | `omnibox.initial_behavior` | string | `recent` | `recent`, `most_visited`, `none` |
 | `omnibox.most_visited_days` | int | `30` | `>= 0` |
 | `omnibox.auto_open_on_new_pane` | bool | `false` | |
-| `logging.level` | string | `info` | `debug`, `info`, `warn`, `error` |
-| `logging.format` | string | `text` | `text`, `json` |
+| `logging.level` | string | `info` | `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
+| `logging.format` | string | `text` | `text`, `json`, `console` |
 | `logging.max_age` | int | `7` | >= 0 |
-| `logging.max_files` | int | `100` | >= 0 |
-| `logging.log_dir` | string | `~/.local/state/dumber/logs/` | |
+| `logging.max_files` | int | `100` | >= 0 (0 disables count cleanup) |
+| `logging.log_dir` | string | `~/.local/state/dumber/logs` | any path |
 | `logging.enable_file_log` | bool | `true` | |
 | `logging.capture_console` | bool | `false` | |
-| `logging.capture_gtk_webkit_logs` | bool | `false` | |
+| `logging.capture_gtk_logs` | bool | `false` | |
 | `appearance.sans_font` | string | `Fira Sans` | |
 | `appearance.serif_font` | string | `Fira Sans` | |
 | `appearance.monospace_font` | string | `Fira Code` | |

--- a/internal/bootstrap/session.go
+++ b/internal/bootstrap/session.go
@@ -348,6 +348,22 @@ func runSessionCleanup(
 
 	// Prune old marker files left by previous versions.
 	sweepLegacyMarkers(cfg.Logging.LogDir, log)
+
+	removedLogs, logCleanupErr := corelogging.CleanupSessionLogFiles(
+		cfg.Logging.LogDir,
+		cfg.Logging.MaxFiles,
+		string(currentSessionID),
+	)
+	if logCleanupErr != nil {
+		if log != nil {
+			log.Warn().Err(logCleanupErr).Msg("background: failed to cleanup session log files")
+		}
+	} else if removedLogs > 0 && log != nil {
+		log.Info().
+			Int("deleted", removedLogs).
+			Int("max_files", cfg.Logging.MaxFiles).
+			Msg("background: cleaned up session log files")
+	}
 }
 
 // sweepLegacyMarkers removes .startup.marker, .shutdown.marker,

--- a/internal/bootstrap/session.go
+++ b/internal/bootstrap/session.go
@@ -102,7 +102,7 @@ func StartBrowserSession(
 		Level:         cfg.Logging.Level,
 		Format:        cfg.Logging.Format,
 		TimeFormat:    corelogging.ConsoleTimeFormat,
-		LogDir:        cfg.Logging.LogDir,
+		LogDir:        logDir,
 		WriteToStderr: true,
 		EnableFileLog: cfg.Logging.EnableFileLog,
 	})
@@ -156,7 +156,7 @@ func StartBrowserSession(
 			}
 
 			// Background cleanup of old sessions.
-			go runSessionCleanup(persistCtx, sessionUC, cleanupUC, cfg, session.ID, log)
+			go runSessionCleanup(persistCtx, sessionUC, cleanupUC, cfg, logDir, session.ID, log)
 		})
 		return persistErr
 	}
@@ -310,6 +310,7 @@ func runSessionCleanup(
 	sessionUC *usecase.ManageSessionUseCase,
 	cleanupUC *usecase.CleanupSessionsUseCase,
 	cfg *config.Config,
+	logDir string,
 	currentSessionID entity.SessionID,
 	log *zerolog.Logger,
 ) {
@@ -347,10 +348,10 @@ func runSessionCleanup(
 	}
 
 	// Prune old marker files left by previous versions.
-	sweepLegacyMarkers(cfg.Logging.LogDir, log)
+	sweepLegacyMarkers(logDir, log)
 
 	removedLogs, logCleanupErr := corelogging.CleanupSessionLogFiles(
-		cfg.Logging.LogDir,
+		logDir,
 		cfg.Logging.MaxFiles,
 		string(currentSessionID),
 	)

--- a/internal/bootstrap/session_test.go
+++ b/internal/bootstrap/session_test.go
@@ -21,6 +21,7 @@ func TestRunSessionCleanup_SkipsCurrentActiveSession(t *testing.T) {
 	sessionUC := usecase.NewManageSessionUseCase(repo, nil)
 	cleanupUC := usecase.NewCleanupSessionsUseCase(repo)
 	cfg := config.DefaultConfig()
+	logDir := t.TempDir()
 
 	now := time.Now().UTC()
 	current := &entity.Session{
@@ -45,7 +46,7 @@ func TestRunSessionCleanup_SkipsCurrentActiveSession(t *testing.T) {
 	repo.EXPECT().DeleteExitedBefore(mock.Anything, mock.MatchedBy(func(time.Time) bool { return true })).Return(int64(0), nil).Once()
 	repo.EXPECT().DeleteOldestExited(mock.Anything, cfg.Session.MaxExitedSessions).Return(int64(0), nil).Once()
 
-	runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, cfg.Logging.LogDir, current.ID, nil)
+	runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, logDir, current.ID, nil)
 }
 
 func TestRunSessionCleanup_NoPanicOnNilSessions(t *testing.T) {
@@ -56,12 +57,13 @@ func TestRunSessionCleanup_NoPanicOnNilSessions(t *testing.T) {
 	sessionUC := usecase.NewManageSessionUseCase(repo, nil)
 	cleanupUC := usecase.NewCleanupSessionsUseCase(repo)
 	cfg := config.DefaultConfig()
+	logDir := t.TempDir()
 
 	repo.EXPECT().GetRecent(mock.Anything, recentSessionsLimit).Return([]*entity.Session{nil}, nil).Once()
 	repo.EXPECT().DeleteExitedBefore(mock.Anything, mock.MatchedBy(func(time.Time) bool { return true })).Return(int64(0), nil).Once()
 	repo.EXPECT().DeleteOldestExited(mock.Anything, cfg.Session.MaxExitedSessions).Return(int64(0), nil).Once()
 
 	require.NotPanics(t, func() {
-		runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, cfg.Logging.LogDir, entity.SessionID("current"), nil)
+		runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, logDir, entity.SessionID("current"), nil)
 	})
 }

--- a/internal/bootstrap/session_test.go
+++ b/internal/bootstrap/session_test.go
@@ -45,7 +45,7 @@ func TestRunSessionCleanup_SkipsCurrentActiveSession(t *testing.T) {
 	repo.EXPECT().DeleteExitedBefore(mock.Anything, mock.MatchedBy(func(time.Time) bool { return true })).Return(int64(0), nil).Once()
 	repo.EXPECT().DeleteOldestExited(mock.Anything, cfg.Session.MaxExitedSessions).Return(int64(0), nil).Once()
 
-	runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, current.ID, nil)
+	runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, cfg.Logging.LogDir, current.ID, nil)
 }
 
 func TestRunSessionCleanup_NoPanicOnNilSessions(t *testing.T) {
@@ -62,6 +62,6 @@ func TestRunSessionCleanup_NoPanicOnNilSessions(t *testing.T) {
 	repo.EXPECT().DeleteOldestExited(mock.Anything, cfg.Session.MaxExitedSessions).Return(int64(0), nil).Once()
 
 	require.NotPanics(t, func() {
-		runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, entity.SessionID("current"), nil)
+		runSessionCleanup(ctx, sessionUC, cleanupUC, cfg, cfg.Logging.LogDir, entity.SessionID("current"), nil)
 	})
 }

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -10,7 +10,8 @@ const (
 	defaultMaxHistoryDays = 30 // days
 
 	// Logging defaults
-	defaultMaxLogAgeDays = 7 // days
+	defaultMaxLogAgeDays = 7   // days
+	defaultMaxLogFiles   = 100 // session log files
 
 	// Appearance defaults
 	defaultFontSize = 16 // points
@@ -117,6 +118,7 @@ func DefaultConfig() *Config {
 			Level:          "info",
 			Format:         "text", // text or json
 			MaxAge:         defaultMaxLogAgeDays,
+			MaxFiles:       defaultMaxLogFiles,
 			LogDir:         getDefaultLogDir(),
 			EnableFileLog:  true,
 			CaptureConsole: false, // Disabled by default

--- a/internal/infrastructure/config/defaults_test.go
+++ b/internal/infrastructure/config/defaults_test.go
@@ -9,6 +9,7 @@ import (
 func TestDefaultConfig_CoreDefaults(t *testing.T) {
 	cfg := DefaultConfig()
 	assert.Equal(t, "info", cfg.Logging.Level)
+	assert.Equal(t, defaultMaxLogFiles, cfg.Logging.MaxFiles)
 	assert.False(t, cfg.Logging.CaptureGTKLogs)
 	assert.False(t, cfg.Media.ShowDiagnosticsOnStartup)
 	assert.False(t, cfg.Transcoding.Enabled)

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -453,6 +453,7 @@ func (m *Manager) setLoggingDefaults(defaults *Config) {
 	m.viper.SetDefault("logging.level", defaults.Logging.Level)
 	m.viper.SetDefault("logging.format", defaults.Logging.Format)
 	m.viper.SetDefault("logging.max_age", defaults.Logging.MaxAge)
+	m.viper.SetDefault("logging.max_files", defaults.Logging.MaxFiles)
 	m.viper.SetDefault("logging.log_dir", defaults.Logging.LogDir)
 	m.viper.SetDefault("logging.enable_file_log", defaults.Logging.EnableFileLog)
 	m.viper.SetDefault("logging.capture_console", defaults.Logging.CaptureConsole)

--- a/internal/infrastructure/config/schema.go
+++ b/internal/infrastructure/config/schema.go
@@ -320,9 +320,10 @@ type DmenuConfig struct {
 
 // LoggingConfig holds logging configuration.
 type LoggingConfig struct {
-	Level  string `mapstructure:"level" yaml:"level" toml:"level"`
-	Format string `mapstructure:"format" yaml:"format" toml:"format"`
-	MaxAge int    `mapstructure:"max_age" yaml:"max_age" toml:"max_age"`
+	Level    string `mapstructure:"level" yaml:"level" toml:"level"`
+	Format   string `mapstructure:"format" yaml:"format" toml:"format"`
+	MaxAge   int    `mapstructure:"max_age" yaml:"max_age" toml:"max_age"`
+	MaxFiles int    `mapstructure:"max_files" yaml:"max_files" toml:"max_files"`
 
 	// File output configuration
 	LogDir        string `mapstructure:"log_dir" yaml:"log_dir" toml:"log_dir"`

--- a/internal/infrastructure/config/schema_provider.go
+++ b/internal/infrastructure/config/schema_provider.go
@@ -198,6 +198,14 @@ func (*SchemaProvider) getLoggingKeys(defaults *Config) []entity.ConfigKeyInfo {
 			Section:     SectionLogging,
 		},
 		{
+			Key:         "logging.max_files",
+			Type:        "int",
+			Default:     fmt.Sprintf("%d", defaults.Logging.MaxFiles),
+			Description: "Maximum number of session log files to keep (0 disables count-based cleanup)",
+			Range:       ">=0",
+			Section:     SectionLogging,
+		},
+		{
 			Key:         "logging.log_dir",
 			Type:        "string",
 			Default:     defaults.Logging.LogDir,

--- a/internal/infrastructure/config/validation.go
+++ b/internal/infrastructure/config/validation.go
@@ -308,6 +308,9 @@ func validateLogging(config *Config) []string {
 	if config.Logging.MaxAge < 0 {
 		validationErrors = append(validationErrors, "logging.max_age must be non-negative")
 	}
+	if config.Logging.MaxFiles < 0 {
+		validationErrors = append(validationErrors, "logging.max_files must be non-negative")
+	}
 	switch config.Logging.Level {
 	case "trace", "debug", "info", "warn", "error", "fatal", "":
 	default:

--- a/internal/logging/session.go
+++ b/internal/logging/session.go
@@ -3,6 +3,11 @@ package logging
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"time"
 )
 
@@ -48,4 +53,90 @@ func ParseSessionFilename(filename string) (sessionID string, ok bool) {
 // Example: "20251217_205106_a7b3" -> "session_20251217_205106_a7b3.log"
 func SessionFilename(sessionID string) string {
 	return "session_" + sessionID + ".log"
+}
+
+type sessionLogFile struct {
+	path      string
+	filename  string
+	sessionID string
+	modTime   time.Time
+}
+
+// CleanupSessionLogFiles removes old session log files when their count exceeds maxFiles.
+// It keeps the newest files by modification time and never removes the supplied session IDs.
+// A maxFiles value of 0 disables count-based cleanup.
+func CleanupSessionLogFiles(logDir string, maxFiles int, keepSessionIDs ...string) (int, error) {
+	if logDir == "" || maxFiles <= 0 {
+		return 0, nil
+	}
+
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read log directory: %w", err)
+	}
+
+	keep := make(map[string]struct{}, len(keepSessionIDs))
+	for _, sessionID := range keepSessionIDs {
+		if sessionID == "" {
+			continue
+		}
+		keep[sessionID] = struct{}{}
+	}
+
+	files := make([]sessionLogFile, 0, len(entries))
+	operationErrs := make([]error, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		sessionID, ok := ParseSessionFilename(entry.Name())
+		if !ok {
+			continue
+		}
+
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			operationErrs = append(operationErrs, fmt.Errorf("stat %s: %w", filepath.Join(logDir, entry.Name()), infoErr))
+			continue
+		}
+
+		files = append(files, sessionLogFile{
+			path:      filepath.Join(logDir, entry.Name()),
+			filename:  entry.Name(),
+			sessionID: sessionID,
+			modTime:   info.ModTime(),
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].modTime.Equal(files[j].modTime) {
+			return files[i].filename > files[j].filename
+		}
+		return files[i].modTime.After(files[j].modTime)
+	})
+
+	kept := 0
+	removed := 0
+	for _, file := range files {
+		if _, shouldKeep := keep[file.sessionID]; shouldKeep {
+			kept++
+			continue
+		}
+		if kept < maxFiles {
+			kept++
+			continue
+		}
+
+		if err := os.Remove(file.path); err != nil {
+			operationErrs = append(operationErrs, fmt.Errorf("remove %s: %w", file.path, err))
+			continue
+		}
+		removed++
+	}
+
+	return removed, errors.Join(operationErrs...)
 }

--- a/internal/logging/session.go
+++ b/internal/logging/session.go
@@ -63,7 +63,7 @@ type sessionLogFile struct {
 }
 
 // CleanupSessionLogFiles removes old session log files when their count exceeds maxFiles.
-// It keeps the newest files by modification time and never removes the supplied session IDs.
+// It keeps up to maxFiles of the newest requested session IDs, then the newest remaining files by modification time.
 // A maxFiles value of 0 disables count-based cleanup.
 func CleanupSessionLogFiles(logDir string, maxFiles int, keepSessionIDs ...string) (int, error) {
 	if logDir == "" || maxFiles <= 0 {
@@ -78,12 +78,12 @@ func CleanupSessionLogFiles(logDir string, maxFiles int, keepSessionIDs ...strin
 		return 0, fmt.Errorf("read log directory: %w", err)
 	}
 
-	keep := make(map[string]struct{}, len(keepSessionIDs))
+	requestedKeep := make(map[string]struct{}, len(keepSessionIDs))
 	for _, sessionID := range keepSessionIDs {
 		if sessionID == "" {
 			continue
 		}
-		keep[sessionID] = struct{}{}
+		requestedKeep[sessionID] = struct{}{}
 	}
 
 	files := make([]sessionLogFile, 0, len(entries))
@@ -119,15 +119,20 @@ func CleanupSessionLogFiles(logDir string, maxFiles int, keepSessionIDs ...strin
 		return files[i].modTime.After(files[j].modTime)
 	})
 
+	allowedKeep := boundedKeepSessionIDs(files, requestedKeep, maxFiles)
+	maxNewestFiles := maxFiles - len(allowedKeep)
 	kept := 0
+	keptNewest := 0
 	removed := 0
 	for _, file := range files {
-		if _, shouldKeep := keep[file.sessionID]; shouldKeep {
+		if _, shouldKeep := allowedKeep[file.sessionID]; shouldKeep {
+			if kept < maxFiles {
+				kept++
+				continue
+			}
+		} else if keptNewest < maxNewestFiles && kept < maxFiles {
 			kept++
-			continue
-		}
-		if kept < maxFiles {
-			kept++
+			keptNewest++
 			continue
 		}
 
@@ -139,4 +144,17 @@ func CleanupSessionLogFiles(logDir string, maxFiles int, keepSessionIDs ...strin
 	}
 
 	return removed, errors.Join(operationErrs...)
+}
+
+func boundedKeepSessionIDs(files []sessionLogFile, requestedKeep map[string]struct{}, maxFiles int) map[string]struct{} {
+	allowedKeep := make(map[string]struct{}, len(requestedKeep))
+	for _, file := range files {
+		if len(allowedKeep) >= maxFiles {
+			break
+		}
+		if _, shouldKeep := requestedKeep[file.sessionID]; shouldKeep {
+			allowedKeep[file.sessionID] = struct{}{}
+		}
+	}
+	return allowedKeep
 }

--- a/internal/logging/session_test.go
+++ b/internal/logging/session_test.go
@@ -97,7 +97,7 @@ func TestCleanupSessionLogFiles_UsesFilenameTiebreakerForEqualModTimes(t *testin
 	assertExists(t, newestByName)
 }
 
-func TestCleanupSessionLogFiles_KeepsSpecifiedSession(t *testing.T) {
+func TestCleanupSessionLogFiles_KeepsSpecifiedSessionWithinLimit(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -112,13 +112,39 @@ func TestCleanupSessionLogFiles_KeepsSpecifiedSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cleanup session log files: %v", err)
 	}
-	if removed != 1 {
-		t.Fatalf("removed = %d, want 1", removed)
+	if removed != 2 {
+		t.Fatalf("removed = %d, want 2", removed)
 	}
 
 	assertExists(t, oldestKept)
 	assertMissing(t, middle)
-	assertExists(t, newest)
+	assertMissing(t, newest)
+}
+
+func TestCleanupSessionLogFiles_BoundsSpecifiedSessionsToMaxFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+
+	oldestKeptID := "20260424_120000_0001"
+	middleKeptID := "20260424_120001_0002"
+	newestKeptID := "20260424_120002_0003"
+	oldestKept := writeSessionLog(t, dir, oldestKeptID, base)
+	middleKept := writeSessionLog(t, dir, middleKeptID, base.Add(time.Second))
+	newestKept := writeSessionLog(t, dir, newestKeptID, base.Add(2*time.Second))
+
+	removed, err := CleanupSessionLogFiles(dir, 2, oldestKeptID, middleKeptID, newestKeptID)
+	if err != nil {
+		t.Fatalf("cleanup session log files: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+
+	assertMissing(t, oldestKept)
+	assertExists(t, middleKept)
+	assertExists(t, newestKept)
 }
 
 func TestCleanupSessionLogFiles_MissingDirectoryIsNoop(t *testing.T) {

--- a/internal/logging/session_test.go
+++ b/internal/logging/session_test.go
@@ -1,0 +1,161 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCleanupSessionLogFiles_RemovesOldestSessionLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+
+	oldest := writeSessionLog(t, dir, "20260424_120000_0001", base)
+	secondOldest := writeSessionLog(t, dir, "20260424_120001_0002", base.Add(time.Second))
+	secondNewest := writeSessionLog(t, dir, "20260424_120002_0003", base.Add(2*time.Second))
+	newest := writeSessionLog(t, dir, "20260424_120003_0004", base.Add(3*time.Second))
+	nonSession := filepath.Join(dir, "dumber.log")
+	if err := os.WriteFile(nonSession, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("write non-session log: %v", err)
+	}
+
+	removed, err := CleanupSessionLogFiles(dir, 2)
+	if err != nil {
+		t.Fatalf("cleanup session log files: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed = %d, want 2", removed)
+	}
+
+	assertMissing(t, oldest)
+	assertMissing(t, secondOldest)
+	assertExists(t, secondNewest)
+	assertExists(t, newest)
+	assertExists(t, nonSession)
+}
+
+func TestCleanupSessionLogFiles_DisabledWhenMaxFilesZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeSessionLog(t, dir, "20260424_120000_0001", time.Now())
+
+	removed, err := CleanupSessionLogFiles(dir, 0)
+	if err != nil {
+		t.Fatalf("cleanup session log files: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+	assertExists(t, path)
+}
+
+func TestCleanupSessionLogFiles_NoRemovalWhenUnderLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+
+	first := writeSessionLog(t, dir, "20260424_120000_0001", base)
+	second := writeSessionLog(t, dir, "20260424_120001_0002", base.Add(time.Second))
+
+	removed, err := CleanupSessionLogFiles(dir, 3)
+	if err != nil {
+		t.Fatalf("cleanup session log files: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+
+	assertExists(t, first)
+	assertExists(t, second)
+}
+
+func TestCleanupSessionLogFiles_UsesFilenameTiebreakerForEqualModTimes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+
+	oldestByName := writeSessionLog(t, dir, "20260424_120000_0001", base)
+	keptByName := writeSessionLog(t, dir, "20260424_120000_0002", base)
+	newestByName := writeSessionLog(t, dir, "20260424_120000_0003", base)
+
+	removed, err := CleanupSessionLogFiles(dir, 2)
+	if err != nil {
+		t.Fatalf("cleanup session log files: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+
+	assertMissing(t, oldestByName)
+	assertExists(t, keptByName)
+	assertExists(t, newestByName)
+}
+
+func TestCleanupSessionLogFiles_KeepsSpecifiedSession(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	keepID := "20260424_120000_0001"
+
+	oldestKept := writeSessionLog(t, dir, keepID, base)
+	middle := writeSessionLog(t, dir, "20260424_120001_0002", base.Add(time.Second))
+	newest := writeSessionLog(t, dir, "20260424_120002_0003", base.Add(2*time.Second))
+
+	removed, err := CleanupSessionLogFiles(dir, 1, keepID)
+	if err != nil {
+		t.Fatalf("cleanup session log files: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+
+	assertExists(t, oldestKept)
+	assertMissing(t, middle)
+	assertExists(t, newest)
+}
+
+func TestCleanupSessionLogFiles_MissingDirectoryIsNoop(t *testing.T) {
+	t.Parallel()
+
+	removed, err := CleanupSessionLogFiles(filepath.Join(t.TempDir(), "missing"), 2)
+	if err != nil {
+		t.Fatalf("cleanup session log files: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+}
+
+func writeSessionLog(t *testing.T, dir, sessionID string, modTime time.Time) string {
+	t.Helper()
+
+	path := filepath.Join(dir, SessionFilename(sessionID))
+	if err := os.WriteFile(path, []byte(sessionID), 0o644); err != nil {
+		t.Fatalf("write session log %s: %v", sessionID, err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("set mod time for %s: %v", sessionID, err)
+	}
+	return path
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}
+
+func assertMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, stat err = %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `logging.max_files` to cap retained `session_*.log` files.
- Prune old session logs during background session cleanup while preserving the current session log.
- Document the new config key and cover cleanup edge cases with tests.

## Verification
- `go test ./internal/logging ./internal/infrastructure/config ./internal/bootstrap`
- `go test ./...`
- `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logging.max_files (default 100; 0 disables count-based cleanup). Background session log cleanup now prunes old session logs and emits summary/info when removals occur.

* **Documentation**
  * logging.level now includes trace and fatal; logging.format adds console.
  * Adjusted logging.log_dir default formatting and renamed logging.capture_gtk_webkit_logs → logging.capture_gtk_logs.

* **Tests**
  * Added tests covering defaults and session log cleanup behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->