### PR TITLE
fix: per-window tab scoping for Alt+1-9, Next/Prev, Close, Alt+Tab

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2097,7 +2097,7 @@ func (a *App) initCoordinators(ctx context.Context) {
 			a.setBrowserWindowForTab(tab.ID, bw)
 		}
 		// Set a window-scoped default title so "Tab N" doesn't use global position.
-		// Count tabs already owned by this window (excluding the one just added).
+		// Count tabs owned by this window. The new tab was just assigned above.
 		windowTabCount := 0
 		for _, owner := range a.windowForTab {
 			if owner == bw {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -63,6 +63,12 @@ func EnsureAdwaitaInitialized() {
 	})
 }
 
+// defaultTabName returns a window-scoped default tab name.
+// index is the 1-based tab position within the window.
+func defaultTabName(index int) string {
+	return fmt.Sprintf("Tab %d", index)
+}
+
 // App wraps the GTK Application and manages the browser lifecycle.
 type App struct {
 	deps       *Dependencies
@@ -2086,9 +2092,20 @@ func (a *App) initCoordinators(ctx context.Context) {
 	a.tabCoord.SetOnTabCreated(func(ctx context.Context, tab *entity.Tab) {
 		// Assign ownership BEFORE creating workspace view so windowForTab is set
 		// for scope filtering and browserWindowForTab resolution.
-		if bw := a.lastFocusedBrowserWindow(); bw != nil {
+		bw := a.lastFocusedBrowserWindow()
+		if bw != nil {
 			a.setBrowserWindowForTab(tab.ID, bw)
 		}
+		// Set a window-scoped default title so "Tab N" doesn't use global position.
+		// Count tabs already owned by this window (excluding the one just added).
+		windowTabCount := 0
+		for _, owner := range a.windowForTab {
+			if owner == bw {
+				windowTabCount++
+			}
+		}
+		// windowTabCount includes the tab just added, so it equals the 1-based index.
+		tab.Name = defaultTabName(windowTabCount)
 		a.createWorkspaceView(ctx, tab)
 	})
 	a.tabCoord.SetOnTabSwitched(func(ctx context.Context, tab *entity.Tab) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -511,6 +511,19 @@ func (a *App) browserWindowForTab(tabID entity.TabID) *browserWindow {
 	return a.browserWindowForMainWindow(a.mainWindow)
 }
 
+func (a *App) browserWindowHasLiveTab(bw *browserWindow, tabID entity.TabID) bool {
+	if a == nil || a.tabs == nil || bw == nil || tabID == "" {
+		return false
+	}
+	if a.tabs.Find(tabID) == nil {
+		return false
+	}
+	if a.windowForTab[tabID] != bw {
+		return false
+	}
+	return true
+}
+
 func (a *App) tabCountForBrowserWindow(bw *browserWindow) int {
 	if a.tabs == nil || bw == nil {
 		return 0
@@ -2168,10 +2181,16 @@ func (a *App) initTabCoordinator(ctx context.Context) {
 	})
 	// Wire per-window previous active tab ID provider for scoped Alt+Tab switching
 	a.tabCoord.SetPreviousActiveTabIDProvider(func(mainWindow *window.MainWindow) entity.TabID {
-		if bw := a.browserWindowForMainWindow(mainWindow); bw != nil {
-			return bw.prevActiveTabID
+		bw := a.browserWindowForMainWindow(mainWindow)
+		if bw == nil {
+			return ""
 		}
-		return ""
+		prevID := bw.prevActiveTabID
+		if !a.browserWindowHasLiveTab(bw, prevID) {
+			bw.prevActiveTabID = ""
+			return ""
+		}
+		return prevID
 	})
 	a.tabCoord.SetOnCurrentWindowEmpty(func(ctx context.Context, mainWindow *window.MainWindow) {
 		bw := a.browserWindowForMainWindow(mainWindow)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2084,10 +2084,16 @@ func (a *App) initCoordinators(ctx context.Context) {
 		HideTabBarWhenSingleTab: a.deps.Config.Workspace.HideTabBarWhenSingleTab,
 	})
 	a.tabCoord.SetOnTabCreated(func(ctx context.Context, tab *entity.Tab) {
+		// Assign ownership BEFORE creating workspace view so windowForTab is set
+		// for scope filtering and browserWindowForTab resolution.
+		if bw := a.lastFocusedBrowserWindow(); bw != nil {
+			a.setBrowserWindowForTab(tab.ID, bw)
+		}
 		a.createWorkspaceView(ctx, tab)
 	})
 	a.tabCoord.SetOnTabSwitched(func(ctx context.Context, tab *entity.Tab) {
 		if bw := a.browserWindowForTab(tab.ID); bw != nil {
+			bw.prevActiveTabID = bw.activeTabID
 			bw.activeTabID = tab.ID
 			a.activateBrowserWindow(bw)
 		}
@@ -2095,6 +2101,30 @@ func (a *App) initCoordinators(ctx context.Context) {
 	})
 	a.tabCoord.SetOnQuit(a.Quit)
 	a.tabCoord.SetOnStateChanged(a.MarkDirty)
+	// Wire per-window tab scoping
+	a.tabCoord.SetTabScope(func(tab *entity.Tab, mainWindow *window.MainWindow) bool {
+		if tab == nil {
+			return false
+		}
+		bw := a.browserWindowForMainWindow(mainWindow)
+		if bw == nil {
+			return true // backward-compatible fallback for single-window / test scenarios
+		}
+		owner := a.windowForTab[tab.ID]
+		if owner == nil {
+			return true // backward-compatible fallback for restored/unowned tabs
+		}
+		return owner == bw
+	})
+	a.tabCoord.SetOnCurrentWindowEmpty(func(ctx context.Context, mainWindow *window.MainWindow) {
+		bw := a.browserWindowForMainWindow(mainWindow)
+		if bw != nil {
+			a.removeBrowserWindow(bw.id)
+			if bw.mainWindow != nil {
+				bw.mainWindow.Destroy()
+			}
+		}
+	})
 	// Wire popup tab WebView attachment
 	a.tabCoord.SetOnAttachPopupToTab(func(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) {
 		a.attachPopupToTab(ctx, tabID, pane, wv)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2126,11 +2126,14 @@ func (a *App) initTabCoordinator(ctx context.Context) {
 		}
 		// Set a window-scoped default title so "Tab N" doesn't use global position.
 		// Count only live tabs owned by this window via the helper.
-		count := a.tabCountForBrowserWindow(bw)
-		if count <= 0 {
-			count = 1
+		// Only assign a default name if the creator did not supply one.
+		if strings.TrimSpace(tab.Name) == "" {
+			count := a.tabCountForBrowserWindow(bw)
+			if count <= 0 {
+				count = 1
+			}
+			tab.Name = defaultTabName(count)
 		}
-		tab.Name = defaultTabName(count)
 		a.createWorkspaceView(ctx, tab)
 	})
 	a.tabCoord.SetOnTabSwitched(func(ctx context.Context, tab *entity.Tab) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -511,6 +511,22 @@ func (a *App) browserWindowForTab(tabID entity.TabID) *browserWindow {
 	return a.browserWindowForMainWindow(a.mainWindow)
 }
 
+func (a *App) tabCountForBrowserWindow(bw *browserWindow) int {
+	if a.tabs == nil || bw == nil {
+		return 0
+	}
+	count := 0
+	for _, tab := range a.tabs.Tabs {
+		if tab == nil {
+			continue
+		}
+		if owner := a.windowForTab[tab.ID]; owner == bw {
+			count++
+		}
+	}
+	return count
+}
+
 func (a *App) browserWindowForPane(paneID entity.PaneID) *browserWindow {
 	if paneID == "" || a.tabs == nil {
 		return nil
@@ -1867,6 +1883,8 @@ func (a *App) restoreSession(ctx context.Context, sessionID entity.SessionID) er
 	// Replace tabs in-place to preserve references held by TabCoordinator
 	a.tabs.ReplaceFrom(restoredTabs)
 
+	a.assignRestoredTabsToCurrentWindow()
+
 	// Create UI for each restored tab and add to tab bar
 	// Don't attach to content area yet - only the active tab should be attached
 	tabBar := a.mainWindow.TabBar()
@@ -1896,6 +1914,34 @@ func (a *App) restoreSession(ctx context.Context, sessionID entity.SessionID) er
 	}
 
 	return nil
+}
+
+func (a *App) assignRestoredTabsToCurrentWindow() {
+	if a == nil || a.tabs == nil {
+		return
+	}
+
+	restoreWindow := a.browserWindowForMainWindow(a.mainWindow)
+	if restoreWindow == nil {
+		restoreWindow = a.lastFocusedBrowserWindow()
+	}
+	if restoreWindow == nil {
+		return
+	}
+
+	for _, tab := range a.tabs.Tabs {
+		if tab != nil {
+			a.setBrowserWindowForTab(tab.ID, restoreWindow)
+		}
+	}
+
+	restoreWindow.activeTabID = a.tabs.ActiveTabID
+	previousID := a.tabs.PreviousActiveTabID
+	if previousID != "" && previousID != a.tabs.ActiveTabID && a.tabs.Find(previousID) != nil {
+		restoreWindow.prevActiveTabID = previousID
+		return
+	}
+	restoreWindow.prevActiveTabID = ""
 }
 
 func (a *App) finalizeActivation(ctx context.Context) {
@@ -2063,6 +2109,86 @@ func (a *App) initContentCoordinator(
 	})
 }
 
+// initTabCoordinator creates the TabCoordinator and wires all its callbacks.
+func (a *App) initTabCoordinator(ctx context.Context) {
+	a.tabCoord = coordinator.NewTabCoordinator(ctx, coordinator.TabCoordinatorConfig{
+		TabsUC:                  a.tabsUC,
+		Tabs:                    a.tabs,
+		MainWindow:              a.mainWindow,
+		HideTabBarWhenSingleTab: a.deps.Config.Workspace.HideTabBarWhenSingleTab,
+	})
+	a.tabCoord.SetOnTabCreated(func(ctx context.Context, tab *entity.Tab) {
+		// Assign ownership BEFORE creating workspace view so windowForTab is set
+		// for scope filtering and browserWindowForTab resolution.
+		bw := a.browserWindowForTab(tab.ID)
+		if bw != nil {
+			a.setBrowserWindowForTab(tab.ID, bw)
+		}
+		// Set a window-scoped default title so "Tab N" doesn't use global position.
+		// Count only live tabs owned by this window via the helper.
+		count := a.tabCountForBrowserWindow(bw)
+		if count <= 0 {
+			count = 1
+		}
+		tab.Name = defaultTabName(count)
+		a.createWorkspaceView(ctx, tab)
+	})
+	a.tabCoord.SetOnTabSwitched(func(ctx context.Context, tab *entity.Tab) {
+		if bw := a.browserWindowForTab(tab.ID); bw != nil {
+			oldActiveID := bw.activeTabID
+			if oldActiveID != "" && oldActiveID != tab.ID && a.tabs.Find(oldActiveID) != nil {
+				bw.prevActiveTabID = oldActiveID
+			} else if bw.prevActiveTabID == tab.ID || a.tabs.Find(bw.prevActiveTabID) == nil {
+				bw.prevActiveTabID = ""
+			}
+			bw.activeTabID = tab.ID
+			a.activateBrowserWindow(bw)
+		}
+		a.switchWorkspaceView(ctx, tab.ID)
+	})
+	a.tabCoord.SetOnQuit(a.Quit)
+	a.tabCoord.SetOnStateChanged(a.MarkDirty)
+	// Wire per-window tab scoping
+	a.tabCoord.SetTabScope(func(tab *entity.Tab, mainWindow *window.MainWindow) bool {
+		if tab == nil {
+			return false
+		}
+		bw := a.browserWindowForMainWindow(mainWindow)
+		if bw == nil {
+			return true // backward-compatible fallback for single-window / test scenarios
+		}
+		owner := a.windowForTab[tab.ID]
+		if owner == nil {
+			return false // unowned tabs are out of scope when a real window exists
+		}
+		return owner == bw
+	})
+	// Wire per-window previous active tab ID provider for scoped Alt+Tab switching
+	a.tabCoord.SetPreviousActiveTabIDProvider(func(mainWindow *window.MainWindow) entity.TabID {
+		if bw := a.browserWindowForMainWindow(mainWindow); bw != nil {
+			return bw.prevActiveTabID
+		}
+		return ""
+	})
+	a.tabCoord.SetOnCurrentWindowEmpty(func(ctx context.Context, mainWindow *window.MainWindow) {
+		bw := a.browserWindowForMainWindow(mainWindow)
+		if bw != nil {
+			a.removeBrowserWindow(bw.id)
+			if bw.mainWindow != nil {
+				bw.mainWindow.Destroy()
+			}
+		}
+	})
+	// Wire popup tab WebView attachment
+	a.tabCoord.SetOnAttachPopupToTab(func(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) {
+		a.attachPopupToTab(ctx, tabID, pane, wv)
+	})
+
+	for _, bw := range a.browserWindows {
+		a.wireBrowserWindowTabBar(ctx, bw)
+	}
+}
+
 // initCoordinators initializes all coordinators and wires their callbacks.
 func (a *App) initCoordinators(ctx context.Context) {
 	log := logging.FromContext(ctx)
@@ -2083,73 +2209,7 @@ func (a *App) initCoordinators(ctx context.Context) {
 	a.initContentCoordinator(ctx, getActiveWS)
 
 	// 2. Tab Coordinator
-	a.tabCoord = coordinator.NewTabCoordinator(ctx, coordinator.TabCoordinatorConfig{
-		TabsUC:                  a.tabsUC,
-		Tabs:                    a.tabs,
-		MainWindow:              a.mainWindow,
-		HideTabBarWhenSingleTab: a.deps.Config.Workspace.HideTabBarWhenSingleTab,
-	})
-	a.tabCoord.SetOnTabCreated(func(ctx context.Context, tab *entity.Tab) {
-		// Assign ownership BEFORE creating workspace view so windowForTab is set
-		// for scope filtering and browserWindowForTab resolution.
-		bw := a.lastFocusedBrowserWindow()
-		if bw != nil {
-			a.setBrowserWindowForTab(tab.ID, bw)
-		}
-		// Set a window-scoped default title so "Tab N" doesn't use global position.
-		// Count tabs owned by this window. The new tab was just assigned above.
-		windowTabCount := 0
-		for _, owner := range a.windowForTab {
-			if owner == bw {
-				windowTabCount++
-			}
-		}
-		// windowTabCount includes the tab just added, so it equals the 1-based index.
-		tab.Name = defaultTabName(windowTabCount)
-		a.createWorkspaceView(ctx, tab)
-	})
-	a.tabCoord.SetOnTabSwitched(func(ctx context.Context, tab *entity.Tab) {
-		if bw := a.browserWindowForTab(tab.ID); bw != nil {
-			bw.prevActiveTabID = bw.activeTabID
-			bw.activeTabID = tab.ID
-			a.activateBrowserWindow(bw)
-		}
-		a.switchWorkspaceView(ctx, tab.ID)
-	})
-	a.tabCoord.SetOnQuit(a.Quit)
-	a.tabCoord.SetOnStateChanged(a.MarkDirty)
-	// Wire per-window tab scoping
-	a.tabCoord.SetTabScope(func(tab *entity.Tab, mainWindow *window.MainWindow) bool {
-		if tab == nil {
-			return false
-		}
-		bw := a.browserWindowForMainWindow(mainWindow)
-		if bw == nil {
-			return true // backward-compatible fallback for single-window / test scenarios
-		}
-		owner := a.windowForTab[tab.ID]
-		if owner == nil {
-			return true // backward-compatible fallback for restored/unowned tabs
-		}
-		return owner == bw
-	})
-	a.tabCoord.SetOnCurrentWindowEmpty(func(ctx context.Context, mainWindow *window.MainWindow) {
-		bw := a.browserWindowForMainWindow(mainWindow)
-		if bw != nil {
-			a.removeBrowserWindow(bw.id)
-			if bw.mainWindow != nil {
-				bw.mainWindow.Destroy()
-			}
-		}
-	})
-	// Wire popup tab WebView attachment
-	a.tabCoord.SetOnAttachPopupToTab(func(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) {
-		a.attachPopupToTab(ctx, tabID, pane, wv)
-	})
-
-	for _, bw := range a.browserWindows {
-		a.wireBrowserWindowTabBar(ctx, bw)
-	}
+	a.initTabCoordinator(ctx)
 
 	// Set fullscreen callback to hide/show tab bar (after tabCoord is initialized)
 	a.contentCoord.SetOnFullscreenChanged(func(paneID entity.PaneID, entering bool) {

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -20,6 +20,7 @@ type browserWindow struct {
 	id                    string
 	initialURL            string
 	activeTabID           entity.TabID
+	prevActiveTabID       entity.TabID // per-window previous active tab (for Alt+Tab behavior)
 	mainWindow            *window.MainWindow
 	appToaster            *component.Toaster
 	modeToaster           *component.Toaster

--- a/internal/ui/coordinator/tab.go
+++ b/internal/ui/coordinator/tab.go
@@ -496,6 +496,13 @@ func (c *TabCoordinator) CreateWithPane(
 	// Set new tab as active
 	c.tabs.SetActive(output.Tab.ID)
 
+	// Notify app before adding tab to the visible tab bar.
+	// The app assigns window ownership and the scoped default name here,
+	// and TabBar.AddTab reads tab.Title() immediately when creating the button.
+	if c.onTabCreated != nil {
+		c.onTabCreated(ctx, output.Tab)
+	}
+
 	// Update tab bar
 	if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
 		c.mainWindow.TabBar().AddTab(output.Tab)
@@ -504,11 +511,6 @@ func (c *TabCoordinator) CreateWithPane(
 
 	// Update tab bar visibility
 	c.UpdateBarVisibility(ctx)
-
-	// Notify app to create workspace view
-	if c.onTabCreated != nil {
-		c.onTabCreated(ctx, output.Tab)
-	}
 
 	// Attach the popup WebView to the new tab's workspace
 	if c.onAttachPopupToTab != nil {

--- a/internal/ui/coordinator/tab.go
+++ b/internal/ui/coordinator/tab.go
@@ -33,6 +33,10 @@ type TabCoordinator struct {
 	onCurrentWindowEmpty func(ctx context.Context, mainWindow *window.MainWindow)
 	onAttachPopupToTab   func(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) // For popup tabs
 	onStateChanged       func()                                                                            // For session snapshots
+
+	// previousActiveTabID provides the per-window previous active tab ID for Alt+Tab style switching.
+	// When set and tabScope is active, SwitchToLastActive prefers this over the global PreviousActiveTabID.
+	previousActiveTabID func(mainWindow *window.MainWindow) entity.TabID
 }
 
 // TabCoordinatorConfig holds configuration for TabCoordinator.
@@ -75,6 +79,13 @@ func (c *TabCoordinator) SetOnQuit(fn func()) {
 // SetOnStateChanged sets the callback for when tab state changes (for session snapshots).
 func (c *TabCoordinator) SetOnStateChanged(fn func()) {
 	c.onStateChanged = fn
+}
+
+// SetPreviousActiveTabIDProvider sets the callback for retrieving the per-window
+// previous active tab ID. When set and tabScope is active, SwitchToLastActive
+// prefers this provider over the global PreviousActiveTabID.
+func (c *TabCoordinator) SetPreviousActiveTabIDProvider(fn func(mainWindow *window.MainWindow) entity.TabID) {
+	c.previousActiveTabID = fn
 }
 
 // SetTabScope sets the function used to filter tabs to the current window.
@@ -202,6 +213,9 @@ func (c *TabCoordinator) Close(ctx context.Context) error {
 	// Compute the next scoped tab to activate BEFORE closing
 	scoped := c.scopedTabs()
 	activeIdx := indexOfTab(scoped, activeID)
+	if activeIdx < 0 && len(scoped) > 0 {
+		log.Debug().Str("active_tab_id", string(activeID)).Int("scoped_count", len(scoped)).Msg("active tab not in scoped list")
+	}
 
 	var nextScopedID entity.TabID
 	if activeIdx >= 0 && len(scoped) > 1 {
@@ -384,24 +398,35 @@ func (c *TabCoordinator) EnsureTabByIndex(ctx context.Context, index int, initia
 }
 
 // SwitchToLastActive switches to the previously active tab (Alt+Tab style).
-// Uses per-window prevActiveTabID when scope is active; falls back to global otherwise.
+// When window-scoped (tabScope is set and previousActiveTabID provider is available),
+// it uses the per-window previous active tab ID. Falls back to the global
+// PreviousActiveTabID otherwise.
 func (c *TabCoordinator) SwitchToLastActive(ctx context.Context) error {
 	log := logging.FromContext(ctx)
 
-	// Use the global PreviousActiveTabID directly when there's no window scope
-	prevID := c.tabs.PreviousActiveTabID
+	var prevID entity.TabID
+	if c.tabScope != nil && c.previousActiveTabID != nil {
+		// Use per-window previous active tab ID when scoped
+		prevID = c.previousActiveTabID(c.mainWindow)
+	} else {
+		// Fall back to global PreviousActiveTabID when not scoped or no provider
+		prevID = c.tabs.PreviousActiveTabID
+	}
+
 	if prevID == "" || prevID == c.tabs.ActiveTabID {
 		return nil
 	}
 
 	tab := c.tabs.Find(prevID)
 	if tab == nil {
-		c.tabs.PreviousActiveTabID = ""
+		// Only clear the global previous active tab ID if that's what we used
+		if c.tabScope == nil || c.previousActiveTabID == nil {
+			c.tabs.PreviousActiveTabID = ""
+		}
 		return nil
 	}
 
 	// With a scope function, only allow switching to the previous tab if it's in scope.
-	// Per-window prevActiveTabID is tracked by the App layer and always in-scope.
 	if c.tabScope != nil && !c.tabScope(tab, c.mainWindow) {
 		log.Debug().Str("tab_id", string(prevID)).Msg("previous active tab outside current window scope")
 		return nil

--- a/internal/ui/coordinator/tab.go
+++ b/internal/ui/coordinator/tab.go
@@ -156,6 +156,13 @@ func (c *TabCoordinator) create(ctx context.Context, initialURL string, activate
 		c.tabs.SetActive(output.Tab.ID)
 	}
 
+	// Notify app before adding the tab to the visible tab bar.
+	// The app assigns window ownership and the window-scoped default name here,
+	// and TabBar.AddTab reads tab.Title() immediately when creating the button.
+	if c.onTabCreated != nil {
+		c.onTabCreated(ctx, output.Tab)
+	}
+
 	// Update tab bar
 	if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
 		c.mainWindow.TabBar().AddTab(output.Tab)
@@ -166,11 +173,6 @@ func (c *TabCoordinator) create(ctx context.Context, initialURL string, activate
 
 	// Update tab bar visibility
 	c.UpdateBarVisibility(ctx)
-
-	// Notify app to create workspace view
-	if c.onTabCreated != nil {
-		c.onTabCreated(ctx, output.Tab)
-	}
 
 	// Switch to the new tab's workspace view when activation is requested.
 	if activate && c.onTabSwitched != nil {

--- a/internal/ui/coordinator/tab.go
+++ b/internal/ui/coordinator/tab.go
@@ -12,6 +12,10 @@ import (
 	"github.com/bnema/dumber/internal/ui/window"
 )
 
+// TabScopeFunc filters whether a tab belongs to the current window scope.
+// Returns true if the tab should be considered for window-local operations.
+type TabScopeFunc func(tab *entity.Tab, mainWindow *window.MainWindow) bool
+
 // TabCoordinator manages tab lifecycle operations.
 type TabCoordinator struct {
 	tabsUC                  *usecase.ManageTabsUseCase
@@ -19,12 +23,16 @@ type TabCoordinator struct {
 	mainWindow              *window.MainWindow
 	hideTabBarWhenSingleTab bool
 
+	// Window-scoped tab filtering (per-window tab ownership)
+	tabScope TabScopeFunc
+
 	// Callbacks to avoid circular dependencies
-	onTabCreated       func(ctx context.Context, tab *entity.Tab)
-	onTabSwitched      func(ctx context.Context, tab *entity.Tab)
-	onQuit             func()
-	onAttachPopupToTab func(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) // For popup tabs
-	onStateChanged     func()                                                                            // For session snapshots
+	onTabCreated         func(ctx context.Context, tab *entity.Tab)
+	onTabSwitched        func(ctx context.Context, tab *entity.Tab)
+	onQuit               func()
+	onCurrentWindowEmpty func(ctx context.Context, mainWindow *window.MainWindow)
+	onAttachPopupToTab   func(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) // For popup tabs
+	onStateChanged       func()                                                                            // For session snapshots
 }
 
 // TabCoordinatorConfig holds configuration for TabCoordinator.
@@ -67,6 +75,50 @@ func (c *TabCoordinator) SetOnQuit(fn func()) {
 // SetOnStateChanged sets the callback for when tab state changes (for session snapshots).
 func (c *TabCoordinator) SetOnStateChanged(fn func()) {
 	c.onStateChanged = fn
+}
+
+// SetTabScope sets the function used to filter tabs to the current window.
+// When set, tab operations (switch by index, next/prev, close) only consider
+// tabs for which the scope function returns true.
+func (c *TabCoordinator) SetTabScope(fn TabScopeFunc) {
+	c.tabScope = fn
+}
+
+// SetOnCurrentWindowEmpty sets the callback for when the last tab in the current
+// window is closed. This allows the app to close the window gracefully.
+func (c *TabCoordinator) SetOnCurrentWindowEmpty(fn func(ctx context.Context, mainWindow *window.MainWindow)) {
+	c.onCurrentWindowEmpty = fn
+}
+
+// scopedTabs returns tabs filtered by the tabScope function.
+// When no scope function is set, returns all tabs (backward compatible).
+func (c *TabCoordinator) scopedTabs() []*entity.Tab {
+	if c.tabs == nil {
+		return nil
+	}
+
+	if c.tabScope == nil {
+		return c.tabs.Tabs
+	}
+
+	scoped := make([]*entity.Tab, 0, len(c.tabs.Tabs))
+	for _, tab := range c.tabs.Tabs {
+		if tab != nil && c.tabScope(tab, c.mainWindow) {
+			scoped = append(scoped, tab)
+		}
+	}
+	return scoped
+}
+
+// indexOfTab returns the 0-based index of the given tab ID in a slice of tabs,
+// or -1 if not found.
+func indexOfTab(tabs []*entity.Tab, id entity.TabID) int {
+	for i, tab := range tabs {
+		if tab != nil && tab.ID == id {
+			return i
+		}
+	}
+	return -1
 }
 
 // SetMainWindow updates the window targeted by tab UI operations.
@@ -133,6 +185,9 @@ func (c *TabCoordinator) create(ctx context.Context, initialURL string, activate
 }
 
 // Close closes the active tab.
+// When scoped, prefers switching to a sibling tab in the same window.
+// If this was the last tab in the window, fires onCurrentWindowEmpty.
+// If this was the last tab globally, fires onQuit.
 func (c *TabCoordinator) Close(ctx context.Context) error {
 	log := logging.FromContext(ctx)
 
@@ -140,6 +195,19 @@ func (c *TabCoordinator) Close(ctx context.Context) error {
 	if activeID == "" {
 		log.Debug().Msg("no active tab to close")
 		return nil
+	}
+
+	// Compute the next scoped tab to activate BEFORE closing
+	scoped := c.scopedTabs()
+	activeIdx := indexOfTab(scoped, activeID)
+
+	var nextScopedID entity.TabID
+	if activeIdx >= 0 && len(scoped) > 1 {
+		if activeIdx < len(scoped)-1 {
+			nextScopedID = scoped[activeIdx+1].ID
+		} else {
+			nextScopedID = scoped[activeIdx-1].ID
+		}
 	}
 
 	wasLast, err := c.tabsUC.Close(ctx, c.tabs, activeID)
@@ -150,34 +218,51 @@ func (c *TabCoordinator) Close(ctx context.Context) error {
 
 	if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
 		c.mainWindow.TabBar().RemoveTab(activeID)
-
-		// Switch to new active tab if any
-		if c.tabs.ActiveTabID != "" {
-			c.mainWindow.TabBar().SetActive(c.tabs.ActiveTabID)
-		}
 	}
 
 	// Update tab bar visibility
 	c.UpdateBarVisibility(ctx)
 
-	// Quit if no tabs left
-	if wasLast && c.onQuit != nil {
-		c.onQuit()
-	}
-
-	// Switch workspace view to new active tab (if not last)
-	if !wasLast && c.onTabSwitched != nil {
-		if tab := c.tabs.Find(c.tabs.ActiveTabID); tab != nil {
-			c.onTabSwitched(ctx, tab)
+	// Quit if no tabs left globally
+	if wasLast {
+		if c.onQuit != nil {
+			c.onQuit()
 		}
+		log.Debug().Str("tab_id", string(activeID)).Bool("was_last", wasLast).Msg("tab closed, last globally")
+		return nil
 	}
 
-	// Notify state change for session snapshots (unless quitting)
-	if !wasLast {
+	// If there's a sibling tab in the same window, switch to it
+	if nextScopedID != "" {
+		if err := c.tabsUC.Switch(ctx, c.tabs, nextScopedID); err != nil {
+			log.Error().Err(err).Str("tab_id", string(nextScopedID)).Msg("failed to switch to scoped sibling")
+			return err
+		}
+
+		if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
+			c.mainWindow.TabBar().SetActive(nextScopedID)
+		}
+
+		if c.onTabSwitched != nil {
+			if tab := c.tabs.Find(nextScopedID); tab != nil {
+				c.onTabSwitched(ctx, tab)
+			}
+		}
+
+		// Notify state change for session snapshots
 		c.notifyStateChanged()
+
+		log.Debug().Str("tab_id", string(activeID)).Str("next", string(nextScopedID)).Msg("tab closed, switched to scoped sibling")
+		return nil
 	}
 
-	log.Debug().Str("tab_id", string(activeID)).Bool("was_last", wasLast).Msg("tab closed")
+	// Last tab in this window but not globally last — close the window
+	c.notifyStateChanged()
+	if c.onCurrentWindowEmpty != nil {
+		c.onCurrentWindowEmpty(ctx, c.mainWindow)
+	}
+
+	log.Debug().Str("tab_id", string(activeID)).Msg("tab closed, last in window")
 	return nil
 }
 
@@ -187,6 +272,14 @@ func (c *TabCoordinator) Switch(ctx context.Context, tabID entity.TabID) error {
 
 	// Skip if already active
 	if tabID == c.tabs.ActiveTabID {
+		return nil
+	}
+
+	// Reject switching to a tab outside the current window scope
+	if tab := c.tabs.Find(tabID); tab != nil && c.tabScope != nil && !c.tabScope(tab, c.mainWindow) {
+		log.Debug().
+			Str("tab_id", string(tabID)).
+			Msg("ignoring switch to tab outside current window scope")
 		return nil
 	}
 
@@ -216,79 +309,49 @@ func (c *TabCoordinator) Switch(ctx context.Context, tabID entity.TabID) error {
 	return nil
 }
 
-// SwitchNext switches to the next tab.
+// switchRelative switches to the tab delta positions away within the current window scope.
+// delta of +1 switches next, -1 switches previous, wrapping within the scoped list.
+func (c *TabCoordinator) switchRelative(ctx context.Context, delta int) error {
+	scoped := c.scopedTabs()
+	if len(scoped) <= 1 {
+		return nil
+	}
+
+	current := indexOfTab(scoped, c.tabs.ActiveTabID)
+	if current < 0 {
+		current = 0
+	} else {
+		current = (current + delta + len(scoped)) % len(scoped)
+	}
+
+	return c.Switch(ctx, scoped[current].ID)
+}
+
+// SwitchNext switches to the next tab within the current window scope.
 func (c *TabCoordinator) SwitchNext(ctx context.Context) error {
-	log := logging.FromContext(ctx)
-
-	if err := c.tabsUC.SwitchNext(ctx, c.tabs); err != nil {
-		log.Error().Err(err).Msg("failed to switch to next tab")
-		return err
-	}
-
-	if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
-		c.mainWindow.TabBar().SetActive(c.tabs.ActiveTabID)
-	}
-
-	// Invoke callback for workspace view switching
-	if c.onTabSwitched != nil {
-		if tab := c.tabs.Find(c.tabs.ActiveTabID); tab != nil {
-			c.onTabSwitched(ctx, tab)
-		}
-	}
-
-	log.Debug().Str("tab_id", string(c.tabs.ActiveTabID)).Msg("switched to next tab")
-	return nil
+	return c.switchRelative(ctx, 1)
 }
 
-// SwitchPrev switches to the previous tab.
+// SwitchPrev switches to the previous tab within the current window scope.
 func (c *TabCoordinator) SwitchPrev(ctx context.Context) error {
-	log := logging.FromContext(ctx)
-
-	if err := c.tabsUC.SwitchPrevious(ctx, c.tabs); err != nil {
-		log.Error().Err(err).Msg("failed to switch to previous tab")
-		return err
-	}
-
-	if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
-		c.mainWindow.TabBar().SetActive(c.tabs.ActiveTabID)
-	}
-
-	// Invoke callback for workspace view switching
-	if c.onTabSwitched != nil {
-		if tab := c.tabs.Find(c.tabs.ActiveTabID); tab != nil {
-			c.onTabSwitched(ctx, tab)
-		}
-	}
-
-	log.Debug().Str("tab_id", string(c.tabs.ActiveTabID)).Msg("switched to previous tab")
-	return nil
+	return c.switchRelative(ctx, -1)
 }
 
-// SwitchByIndex switches to a tab by 0-based index.
+// SwitchByIndex switches to a tab by 0-based index within the current window scope.
 func (c *TabCoordinator) SwitchByIndex(ctx context.Context, index int) error {
 	log := logging.FromContext(ctx)
 
-	if err := c.tabsUC.SwitchByIndex(ctx, c.tabs, index); err != nil {
-		log.Error().Err(err).Int("index", index).Msg("failed to switch to tab by index")
-		return err
+	scoped := c.scopedTabs()
+	if index < 0 || index >= len(scoped) {
+		log.Debug().Int("index", index).Int("scoped_count", len(scoped)).Msg("invalid scoped tab index")
+		return nil
 	}
 
-	if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
-		c.mainWindow.TabBar().SetActive(c.tabs.ActiveTabID)
-	}
-
-	// Invoke callback for workspace view switching
-	if c.onTabSwitched != nil {
-		if tab := c.tabs.Find(c.tabs.ActiveTabID); tab != nil {
-			c.onTabSwitched(ctx, tab)
-		}
-	}
-
-	log.Debug().Int("index", index).Str("tab_id", string(c.tabs.ActiveTabID)).Msg("switched to tab by index")
-	return nil
+	return c.Switch(ctx, scoped[index].ID)
 }
 
-// EnsureTabByIndex creates tabs until the requested index exists, then switches to it.
+// EnsureTabByIndex creates tabs until the requested index exists within the current
+// window scope, then switches to it.
 func (c *TabCoordinator) EnsureTabByIndex(ctx context.Context, index int, initialURL string) error {
 	log := logging.FromContext(ctx)
 
@@ -301,12 +364,14 @@ func (c *TabCoordinator) EnsureTabByIndex(ctx context.Context, index int, initia
 		return fmt.Errorf("tab list is required")
 	}
 
-	if c.tabs.Count() <= index && initialURL == "" {
-		log.Debug().Int("index", index).Msg("cannot auto-create missing tabs without initial URL")
+	// Create tabs within the current window scope until we have enough
+	scoped := c.scopedTabs()
+	if len(scoped) <= index && initialURL == "" {
+		log.Debug().Int("index", index).Int("scoped_count", len(scoped)).Msg("cannot auto-create missing tabs without initial URL")
 		return fmt.Errorf("initial URL is required to auto-create missing tabs")
 	}
 
-	for c.tabs.Count() <= index {
+	for len(c.scopedTabs()) <= index {
 		if _, err := c.create(ctx, initialURL, false); err != nil {
 			log.Error().Err(err).Int("index", index).Msg("failed to create tab while ensuring tab index")
 			return err
@@ -317,27 +382,30 @@ func (c *TabCoordinator) EnsureTabByIndex(ctx context.Context, index int, initia
 }
 
 // SwitchToLastActive switches to the previously active tab (Alt+Tab style).
+// Uses per-window prevActiveTabID when scope is active; falls back to global otherwise.
 func (c *TabCoordinator) SwitchToLastActive(ctx context.Context) error {
 	log := logging.FromContext(ctx)
 
-	if err := c.tabsUC.SwitchToLastActive(ctx, c.tabs); err != nil {
-		log.Error().Err(err).Msg("failed to switch to last active tab")
-		return err
+	// Use the global PreviousActiveTabID directly when there's no window scope
+	prevID := c.tabs.PreviousActiveTabID
+	if prevID == "" || prevID == c.tabs.ActiveTabID {
+		return nil
 	}
 
-	if c.mainWindow != nil && c.mainWindow.TabBar() != nil {
-		c.mainWindow.TabBar().SetActive(c.tabs.ActiveTabID)
+	tab := c.tabs.Find(prevID)
+	if tab == nil {
+		c.tabs.PreviousActiveTabID = ""
+		return nil
 	}
 
-	// Invoke callback for workspace view switching
-	if c.onTabSwitched != nil {
-		if tab := c.tabs.Find(c.tabs.ActiveTabID); tab != nil {
-			c.onTabSwitched(ctx, tab)
-		}
+	// With a scope function, only allow switching to the previous tab if it's in scope.
+	// Per-window prevActiveTabID is tracked by the App layer and always in-scope.
+	if c.tabScope != nil && !c.tabScope(tab, c.mainWindow) {
+		log.Debug().Str("tab_id", string(prevID)).Msg("previous active tab outside current window scope")
+		return nil
 	}
 
-	log.Debug().Str("tab_id", string(c.tabs.ActiveTabID)).Msg("switched to last active tab")
-	return nil
+	return c.Switch(ctx, prevID)
 }
 
 // UpdateBarVisibility shows or hides the tab bar based on tab count.


### PR DESCRIPTION
## Problem

Alt+1/2/3 shortcuts in a second window navigated tabs in the first window instead of creating/switching tabs in the active window.

## Root Cause

`TabList` is a single global list shared across all browser windows. `TabCoordinator` operations (`EnsureTabByIndex`, `SwitchByIndex`, `SwitchNext`, `SwitchPrev`, `Close`, `SwitchToLastActive`) all operated on the global list without filtering by window ownership.

## Solution

Added a `TabScopeFunc` callback to `TabCoordinator` that filters tabs to the current window. The app already tracked ownership via `App.windowForTab` — it just wasn't consulted by tab operations.

### Changes

- **`internal/ui/coordinator/tab.go`**: Added `TabScopeFunc`, `scopedTabs()`, `indexOfTab()` helpers. Modified `EnsureTabByIndex`, `SwitchByIndex`, `SwitchNext`/`SwitchPrev`, `Close`, `SwitchToLastActive` to use scoped views. Added scope guard in `Switch()`. Added `onCurrentWindowEmpty` callback for closing windows when their last tab is closed.
- **`internal/ui/app.go`**: Wired `SetTabScope` using `App.windowForTab`, fixed `windowForTab` assignment in `onTabCreated`, added per-window `prevActiveTabID` tracking.
- **`internal/ui/browser_window.go`**: Added `prevActiveTabID` field.

### Behavior

- **Alt+1 in window 2** with no tabs: creates tab 1 in window 2 (not window 1)
- **Next/Prev tab**: wraps within current window only
- **Close last tab in window**: closes the window instead of switching to another window's tab
- **Alt+Tab**: only switches to previous tab within the same window
- Nil scope function: backward-compatible global behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-window tab ownership with window-local default tab naming and per-window previous-active-tab tracking.
  * Restored tabs are assigned to their window and previous-tab switching is preserved.
  * Empty windows are automatically cleaned up and their UI removed.

* **Enhancements**
  * Tab creation, switching and navigation now operate within window-scoped boundaries.
  * Closing a tab selects the next tab within the same window and avoids quitting while other windows have tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->