### PR TITLE
Disable WebAuthn in CEF OSR panes

### DIFF
--- a/docs/reference/permissions.md
+++ b/docs/reference/permissions.md
@@ -23,6 +23,14 @@ These permissions require explicit user approval:
 
 When both microphone and camera are requested together, a combined dialog is shown.
 
+## WebAuthn / passkeys / security keys
+
+Dumber currently **disables** WebAuthn (`PublicKeyCredential`, passkeys, FIDO2/security keys) in embedded CEF panes. The current CEF integration uses windowless/OSR Alloy browsers and does not expose the Chromium WebAuthn request UI/delegate needed for PIN, account selection, or transport UI.
+
+If a site requires passkeys or hardware security keys, use the system browser for that auth flow until a dedicated Chrome-runtime auth-window prototype exists.
+
+> ⚠️ **Developer override (unsupported)**: Set `DUMBER_CEF_ENABLE_WEBAUTHN_UNSAFE=1` to temporarily re-enable WebAuthn. This is unsupported and may crash.
+
 ## Permission Dialog
 
 When a site requests mic/camera access, a dialog appears with four options:

--- a/internal/infrastructure/cef/app.go
+++ b/internal/infrastructure/cef/app.go
@@ -8,7 +8,18 @@ import (
 	"github.com/bnema/dumber/internal/logging"
 )
 
-const dumbSchemeName = "dumb"
+const (
+	dumbSchemeName                     = "dumb"
+	chromiumDisableFeaturesSwitch      = "disable-features"
+	chromiumDisableBlinkFeaturesSwitch = "disable-blink-features"
+)
+
+// Chromium's core Blink runtime flag for the Web Authentication API is
+// "WebAuth" (PublicKeyCredential IDL uses RuntimeEnabled=WebAuth). The
+// longer "WebAuthentication*" names are separate subfeatures/metrics.
+var cefWebAuthnFeaturesDisabledByPolicy = []string{
+	"WebAuth",
+}
 
 func dumbSchemeOptions() int32 {
 	return purecef.SchemeOptionsSchemeOptionStandard |
@@ -38,6 +49,52 @@ func configureCommandLine(commandLine purecef.CommandLine) {
 	// Reddit autoplay muted videos in the feed; without this policy
 	// Chromium blocks them, showing an infinite spinner.
 	commandLine.AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required")
+
+	configureWebAuthnFeaturePolicy(commandLine)
+}
+
+func configureWebAuthnFeaturePolicy(commandLine purecef.CommandLine) {
+	if commandLine == nil || cefWebAuthnUnsafeEnabled() {
+		return
+	}
+	appendUniqueCommaSeparatedSwitchValues(commandLine, chromiumDisableFeaturesSwitch, cefWebAuthnFeaturesDisabledByPolicy...)
+	appendUniqueCommaSeparatedSwitchValues(commandLine, chromiumDisableBlinkFeaturesSwitch, cefWebAuthnFeaturesDisabledByPolicy...)
+}
+
+func appendUniqueCommaSeparatedSwitchValues(commandLine purecef.CommandLine, name string, values ...string) {
+	if commandLine == nil || len(values) == 0 {
+		return
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	combined := make([]string, 0, len(values))
+	for _, value := range strings.Split(commandLine.GetSwitchValue(name), ",") {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		combined = append(combined, value)
+	}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		combined = append(combined, value)
+	}
+
+	if len(combined) == 0 {
+		return
+	}
+	commandLine.AppendSwitchWithValue(name, strings.Join(combined, ","))
 }
 
 // dumberApp implements purecef.App to provide custom scheme registration,
@@ -73,6 +130,19 @@ func (a *dumberApp) OnBeforeCommandLineProcessing(processType string, commandLin
 	log := logging.FromContext(a.engine.ctx)
 	if commandLine != nil {
 		configureCommandLine(commandLine)
+
+		if processType == "" {
+			if cefWebAuthnUnsafeEnabled() {
+				log.Warn().
+					Str("env_var", cefEnableWebAuthnUnsafeEnvVar).
+					Msg("cef: WebAuthn enabled via unsupported developer override")
+			} else {
+				log.Info().
+					Strs("disabled_features", cefWebAuthnFeaturesDisabledByPolicy).
+					Str("override_env_var", cefEnableWebAuthnUnsafeEnvVar).
+					Msg("cef: WebAuthn disabled for CEF windowless/Alloy runtime")
+			}
+		}
 
 		cmdline := commandLine.GetCommandLineString()
 		if len(cmdline) > maxCmdLineLogLen {
@@ -124,6 +194,7 @@ func (h *dumberBPH) OnBeforeChildProcessLaunch(commandLine purecef.CommandLine) 
 	useAngle := ""
 	ozonePlatform := ""
 	if commandLine != nil {
+		configureWebAuthnFeaturePolicy(commandLine)
 		appendSwitchIfMissing(commandLine, "no-zygote")
 		processType = commandLine.GetSwitchValue("type")
 		commandLineString = commandLine.GetCommandLineString()

--- a/internal/infrastructure/cef/app.go
+++ b/internal/infrastructure/cef/app.go
@@ -54,7 +54,12 @@ func configureCommandLine(commandLine purecef.CommandLine) {
 }
 
 func configureWebAuthnFeaturePolicy(commandLine purecef.CommandLine) {
-	if commandLine == nil || cefWebAuthnUnsafeEnabled() {
+	if commandLine == nil {
+		return
+	}
+	if cefWebAuthnUnsafeEnabled() {
+		removeCommaSeparatedSwitchValues(commandLine, chromiumDisableFeaturesSwitch, cefWebAuthnFeaturesDisabledByPolicy...)
+		removeCommaSeparatedSwitchValues(commandLine, chromiumDisableBlinkFeaturesSwitch, cefWebAuthnFeaturesDisabledByPolicy...)
 		return
 	}
 	appendUniqueCommaSeparatedSwitchValues(commandLine, chromiumDisableFeaturesSwitch, cefWebAuthnFeaturesDisabledByPolicy...)
@@ -95,6 +100,48 @@ func appendUniqueCommaSeparatedSwitchValues(commandLine purecef.CommandLine, nam
 		return
 	}
 	commandLine.AppendSwitchWithValue(name, strings.Join(combined, ","))
+}
+
+func removeCommaSeparatedSwitchValues(commandLine purecef.CommandLine, name string, values ...string) {
+	if commandLine == nil || len(values) == 0 {
+		return
+	}
+
+	existing := commandLine.GetSwitchValue(name)
+	if existing == "" {
+		return
+	}
+
+	removeSet := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		removeSet[strings.TrimSpace(v)] = struct{}{}
+	}
+
+	tokens := strings.Split(existing, ",")
+	cleaned := make([]string, 0, len(tokens))
+	removed := false
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if _, ok := removeSet[token]; ok {
+			removed = true
+			continue
+		}
+		cleaned = append(cleaned, token)
+	}
+
+	if !removed {
+		return
+	}
+
+	if len(cleaned) == 0 {
+		commandLine.RemoveSwitch(name)
+		return
+	}
+
+	commandLine.AppendSwitchWithValue(name, strings.Join(cleaned, ","))
 }
 
 // dumberApp implements purecef.App to provide custom scheme registration,

--- a/internal/infrastructure/cef/app_test.go
+++ b/internal/infrastructure/cef/app_test.go
@@ -188,6 +188,8 @@ func TestConfigureCommandLine_AppendsExpectedSwitches(t *testing.T) {
 }
 
 func TestConfigureCommandLine_DisablesWebAuthnByDefault(t *testing.T) {
+	t.Setenv(cefEnableWebAuthnUnsafeEnvVar, "")
+
 	commandLine := newMutableCommandLineStub()
 	configureCommandLine(commandLine)
 
@@ -226,6 +228,36 @@ func TestConfigureCommandLine_WebAuthnDisablePreservesExistingDisableFeatures(t 
 	}
 	if got := commandLine.GetSwitchValue(chromiumDisableBlinkFeaturesSwitch); got != "ExistingBlinkFeature,WebAuth" {
 		t.Fatalf("disable-blink-features = %q, want %q", got, "ExistingBlinkFeature,WebAuth")
+	}
+}
+
+func TestConfigureCommandLine_WebAuthnUnsafeOverrideRemovesExistingWebAuthTokens(t *testing.T) {
+	t.Setenv(cefEnableWebAuthnUnsafeEnvVar, "1")
+
+	commandLine := newMutableCommandLineStub()
+	commandLine.AppendSwitchWithValue(chromiumDisableFeaturesSwitch, "ExistingFeature,WebAuth,AnotherFeature")
+	commandLine.AppendSwitchWithValue(chromiumDisableBlinkFeaturesSwitch, "WebAuth,ExistingBlinkFeature")
+
+	configureCommandLine(commandLine)
+
+	if got := commandLine.GetSwitchValue(chromiumDisableFeaturesSwitch); got != "ExistingFeature,AnotherFeature" {
+		t.Fatalf("disable-features = %q, want %q", got, "ExistingFeature,AnotherFeature")
+	}
+	if got := commandLine.GetSwitchValue(chromiumDisableBlinkFeaturesSwitch); got != "ExistingBlinkFeature" {
+		t.Fatalf("disable-blink-features = %q, want %q", got, "ExistingBlinkFeature")
+	}
+}
+
+func TestConfigureCommandLine_WebAuthnUnsafeOverrideRemovesSwitchWhenOnlyWebAuth(t *testing.T) {
+	t.Setenv(cefEnableWebAuthnUnsafeEnvVar, "1")
+
+	commandLine := newMutableCommandLineStub()
+	commandLine.AppendSwitchWithValue(chromiumDisableFeaturesSwitch, "WebAuth")
+
+	configureCommandLine(commandLine)
+
+	if commandLine.HasSwitch(chromiumDisableFeaturesSwitch) {
+		t.Fatalf("disable-features switch should have been removed entirely, but has value %q", commandLine.GetSwitchValue(chromiumDisableFeaturesSwitch))
 	}
 }
 
@@ -282,6 +314,8 @@ func TestDumberBPH_OnBeforeChildProcessLaunch_AppendsNoZygote(t *testing.T) {
 }
 
 func TestDumberBPH_OnBeforeChildProcessLaunch_DisablesWebAuthnByDefault(t *testing.T) {
+	t.Setenv(cefEnableWebAuthnUnsafeEnvVar, "")
+
 	commandLine := newMutableCommandLineStub()
 	commandLine.AppendSwitchWithValue("type", "renderer")
 

--- a/internal/infrastructure/cef/app_test.go
+++ b/internal/infrastructure/cef/app_test.go
@@ -2,6 +2,7 @@ package cef
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -175,8 +176,6 @@ func TestDumberBPH_OnAlreadyRunningAppRelaunch_DoesNotForwardNonBrowse(t *testin
 }
 
 func TestConfigureCommandLine_AppendsExpectedSwitches(t *testing.T) {
-	t.Parallel()
-
 	commandLine := newMutableCommandLineStub()
 	configureCommandLine(commandLine)
 
@@ -188,9 +187,90 @@ func TestConfigureCommandLine_AppendsExpectedSwitches(t *testing.T) {
 	}
 }
 
-func TestDumberBPH_OnBeforeChildProcessLaunch_AppendsNoZygote(t *testing.T) {
-	t.Parallel()
+func TestConfigureCommandLine_DisablesWebAuthnByDefault(t *testing.T) {
+	commandLine := newMutableCommandLineStub()
+	configureCommandLine(commandLine)
 
+	want := "WebAuth"
+	if got := commandLine.GetSwitchValue(chromiumDisableFeaturesSwitch); got != want {
+		t.Fatalf("disable-features = %q, want %q", got, want)
+	}
+	if got := commandLine.GetSwitchValue(chromiumDisableBlinkFeaturesSwitch); got != want {
+		t.Fatalf("disable-blink-features = %q, want %q", got, want)
+	}
+}
+
+func TestConfigureCommandLine_WebAuthnUnsafeOptInDoesNotDisableWebAuth(t *testing.T) {
+	t.Setenv(cefEnableWebAuthnUnsafeEnvVar, "1")
+
+	commandLine := newMutableCommandLineStub()
+	configureCommandLine(commandLine)
+
+	if got := commandLine.GetSwitchValue(chromiumDisableFeaturesSwitch); strings.Contains(got, "WebAuth") {
+		t.Fatalf("disable-features = %q, should not contain WebAuth", got)
+	}
+	if got := commandLine.GetSwitchValue(chromiumDisableBlinkFeaturesSwitch); strings.Contains(got, "WebAuth") {
+		t.Fatalf("disable-blink-features = %q, should not contain WebAuth", got)
+	}
+}
+
+func TestConfigureCommandLine_WebAuthnDisablePreservesExistingDisableFeatures(t *testing.T) {
+	commandLine := newMutableCommandLineStub()
+	commandLine.AppendSwitchWithValue(chromiumDisableFeaturesSwitch, "ExistingFeature,WebAuth")
+	commandLine.AppendSwitchWithValue(chromiumDisableBlinkFeaturesSwitch, "ExistingBlinkFeature,WebAuth")
+
+	configureCommandLine(commandLine)
+
+	if got := commandLine.GetSwitchValue(chromiumDisableFeaturesSwitch); got != "ExistingFeature,WebAuth" {
+		t.Fatalf("disable-features = %q, want %q", got, "ExistingFeature,WebAuth")
+	}
+	if got := commandLine.GetSwitchValue(chromiumDisableBlinkFeaturesSwitch); got != "ExistingBlinkFeature,WebAuth" {
+		t.Fatalf("disable-blink-features = %q, want %q", got, "ExistingBlinkFeature,WebAuth")
+	}
+}
+
+func TestAppendUniqueCommaSeparatedSwitchValues(t *testing.T) {
+	t.Run("trims whitespace and skips empty existing values", func(t *testing.T) {
+		commandLine := newMutableCommandLineStub()
+		commandLine.AppendSwitchWithValue("disable-features", " , ExistingFeature , ")
+
+		appendUniqueCommaSeparatedSwitchValues(commandLine, "disable-features", "FeatureA")
+
+		want := "ExistingFeature,FeatureA"
+		if got := commandLine.GetSwitchValue("disable-features"); got != want {
+			t.Fatalf("disable-features = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("deduplicates existing and appended values", func(t *testing.T) {
+		commandLine := newMutableCommandLineStub()
+		commandLine.AppendSwitchWithValue("disable-features", "FeatureA,FeatureA")
+
+		appendUniqueCommaSeparatedSwitchValues(commandLine, "disable-features", "FeatureA", "FeatureB")
+
+		want := "FeatureA,FeatureB"
+		if got := commandLine.GetSwitchValue("disable-features"); got != want {
+			t.Fatalf("disable-features = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty appended values are no-op", func(t *testing.T) {
+		commandLine := newMutableCommandLineStub()
+		commandLine.AppendSwitchWithValue("disable-features", "ExistingFeature")
+
+		appendUniqueCommaSeparatedSwitchValues(commandLine, "disable-features")
+
+		if got := commandLine.GetSwitchValue("disable-features"); got != "ExistingFeature" {
+			t.Fatalf("disable-features = %q, want ExistingFeature", got)
+		}
+	})
+
+	t.Run("nil command line is no-op", func(_ *testing.T) {
+		appendUniqueCommaSeparatedSwitchValues(nil, "disable-features", "FeatureA")
+	})
+}
+
+func TestDumberBPH_OnBeforeChildProcessLaunch_AppendsNoZygote(t *testing.T) {
 	commandLine := newMutableCommandLineStub()
 	commandLine.AppendSwitchWithValue("type", "renderer")
 
@@ -198,5 +278,23 @@ func TestDumberBPH_OnBeforeChildProcessLaunch_AppendsNoZygote(t *testing.T) {
 
 	if !commandLine.HasSwitch("no-zygote") {
 		t.Fatal("expected no-zygote switch to be appended for child processes")
+	}
+}
+
+func TestDumberBPH_OnBeforeChildProcessLaunch_DisablesWebAuthnByDefault(t *testing.T) {
+	commandLine := newMutableCommandLineStub()
+	commandLine.AppendSwitchWithValue("type", "renderer")
+
+	(&dumberBPH{engine: &Engine{ctx: context.Background()}}).OnBeforeChildProcessLaunch(commandLine)
+
+	want := "WebAuth"
+	if got := commandLine.GetSwitchValue(chromiumDisableFeaturesSwitch); got != want {
+		t.Fatalf("disable-features = %q, want %q", got, want)
+	}
+	if got := commandLine.GetSwitchValue(chromiumDisableBlinkFeaturesSwitch); got != want {
+		t.Fatalf("disable-blink-features = %q, want %q", got, want)
+	}
+	if !commandLine.HasSwitch("no-zygote") {
+		t.Fatal("expected no-zygote switch to be appended")
 	}
 }

--- a/internal/infrastructure/cef/env.go
+++ b/internal/infrastructure/cef/env.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const cefExternalBeginFrameEnvVar = "DUMBER_CEF_EXTERNAL_BEGIN_FRAME"
+const (
+	cefExternalBeginFrameEnvVar   = "DUMBER_CEF_EXTERNAL_BEGIN_FRAME"
+	cefEnableWebAuthnUnsafeEnvVar = "DUMBER_CEF_ENABLE_WEBAUTHN_UNSAFE"
+)
 
 // envBoolEnabled returns true when the given environment variable is set
 // to a truthy value ("1", "true", "yes", "on").
@@ -20,4 +23,8 @@ func envBoolEnabled(envVar string) bool {
 
 func externalBeginFrameEnabled() bool {
 	return envBoolEnabled(cefExternalBeginFrameEnvVar)
+}
+
+func cefWebAuthnUnsafeEnabled() bool {
+	return envBoolEnabled(cefEnableWebAuthnUnsafeEnvVar)
 }

--- a/internal/infrastructure/cef/env_test.go
+++ b/internal/infrastructure/cef/env_test.go
@@ -32,3 +32,34 @@ func TestExternalBeginFrameEnabledIsOptIn(t *testing.T) {
 		})
 	}
 }
+
+func TestCEFWebAuthnUnsafeEnabledIsOptIn(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "1", value: "1", want: true},
+		{name: "true", value: "true", want: true},
+		{name: "yes", value: "yes", want: true},
+		{name: "on", value: "on", want: true},
+		{name: "TRUE", value: "TRUE", want: true},
+		{name: "  true  ", value: "  true  ", want: true},
+		{name: "", value: "", want: false},
+		{name: "false", value: "false", want: false},
+		{name: "0", value: "0", want: false},
+		{name: "no", value: "no", want: false},
+		{name: "off", value: "off", want: false},
+		{name: "random", value: "random", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(cefEnableWebAuthnUnsafeEnvVar, tt.value)
+
+			if got := cefWebAuthnUnsafeEnabled(); got != tt.want {
+				t.Fatalf("cefWebAuthnUnsafeEnabled(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Disable Chromium/Blink `WebAuth` by default in embedded CEF OSR panes to avoid the native WebAuthn/FIDO crash path.
- Add `DUMBER_CEF_ENABLE_WEBAUTHN_UNSAFE=1` as an unsupported developer override for future experiments.
- Remove stale HID/WebAuthn diagnostic env semantics and document the passkey/security-key limitation.

## Test Plan
- [x] `rtk go test ./internal/infrastructure/cef ./internal/ui/component ./internal/ui/coordinator`
- [x] `rtk make lint`
- [x] `rtk make test`
- [x] `rtk make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on WebAuthn/passkey/security-key limitations in embedded views and advised using the system browser for those authentication flows until dedicated support exists.
  * Documented an unsupported, risky environment-variable override to temporarily re-enable WebAuthn (crash risk warning).

* **Bug Fixes**
  * WebAuthn is disabled by default in embedded environments to prevent authentication failures and crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->