### PR TITLE
Harden CEF viewport sync and live resize repaint

### DIFF
--- a/internal/application/port/webview.go
+++ b/internal/application/port/webview.go
@@ -336,6 +336,16 @@ type PopupOpenerCapable interface {
 	HasActivePopupOpenerBridge() bool
 }
 
+// ViewportSyncCapable is implemented by WebViews that can explicitly resync
+// their internal viewport state after UI lifecycle events such as reparenting,
+// visibility toggles, or layout promotion that may not emit a size change.
+//
+// Implementations should make this cheap, safe to call often, and resilient to
+// duplicate requests.
+type ViewportSyncCapable interface {
+	SyncViewport(ctx context.Context, reason string)
+}
+
 // OAuthCallbackCapable is implemented by WebViews that support OAuth auto-close callbacks.
 // It is an optional capability; callers should type-assert port.WebView to this interface
 // before use and degrade gracefully when it is absent.

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -113,6 +113,7 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 		id:                  id,
 		ctx:                 ctx,
 		engine:              f.engine,
+		factory:             f,
 		viewBridge:          viewBridge,
 		audioOutputFactory:  f.audioOutputFactory,
 		windowlessFrameRate: f.windowlessFrameRate,
@@ -131,6 +132,7 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 			logging.FromContext(ctx).Warn().Err(err).Uint64("webview_id", uint64(id)).Msg("cef2gtk: failed to enable profiling")
 		}
 	}
+	wv.installViewportSyncHooks()
 	wv.startRenderStallWatchdog()
 	return wv, nil
 }

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -177,27 +177,13 @@ func (f *WebViewFactory) configureInitialBrowserCreation(
 				return
 			}
 
-			wv.mu.RLock()
-			host := wv.host
-			wv.mu.RUnlock()
-			if host == nil {
-				logging.FromContext(ctx).Debug().
-					Uint64("webview_id", uint64(wv.id)).
-					Int32("resize_width", w).
-					Int32("resize_height", h).
-					Bool("host_nil", true).
-					Bool("browser_ready", false).
-					Msg("cef: resize observed before browser host existed")
-				return
-			}
-			notifyBrowserResize(host)
+			synced := wv.syncResizeViewportOnGTK(ctx, "gtk-size-observer")
 			logging.FromContext(ctx).Debug().
 				Uint64("webview_id", uint64(wv.id)).
 				Int32("resize_width", w).
 				Int32("resize_height", h).
-				Bool("host_nil", false).
-				Bool("browser_ready", true).
-				Msg("cef: browser host WasResized invoked")
+				Bool("browser_ready", synced).
+				Msg("cef: viewport sync handled after GTK size change")
 		})
 	})
 }

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -29,6 +29,7 @@ var (
 	_ port.DevToolsOpener        = (*WebView)(nil)
 	_ port.PopupLifecycleCapable = (*WebView)(nil)
 	_ port.PopupOpenerCapable    = (*WebView)(nil)
+	_ port.ViewportSyncCapable   = (*WebView)(nil)
 	_ port.OAuthCallbackCapable  = (*WebView)(nil)
 )
 
@@ -72,6 +73,7 @@ type WebView struct {
 	id                        port.WebViewID
 	ctx                       context.Context
 	engine                    *Engine
+	factory                   *WebViewFactory
 	browser                   purecef.Browser
 	host                      purecef.BrowserHost
 	client                    purecef.RawClient // prevent GC from collecting the client before CEF AddRef's it
@@ -88,7 +90,13 @@ type WebView struct {
 	previousProfileSnapshot   cef2gtk.ProfileSnapshot
 	latestProfileSnapshotAt   time.Time
 
-	removeSizeObserver func()
+	removeSizeObserver  func()
+	viewportSyncMu      sync.Mutex
+	viewportSyncPending bool
+	viewportSyncReason  string
+	viewportMapFunc     func(gtk.Widget)
+	viewportShowFunc    func(gtk.Widget)
+	viewportRealizeFunc func(gtk.Widget)
 
 	// beginFrameTick drives CEF external BeginFrame requests while the GTK
 	// widget is visible. Access is guarded by mu.
@@ -541,12 +549,7 @@ func (wv *WebView) Show() {
 	if wv == nil || wv.destroyed.Load() {
 		return
 	}
-	wv.mu.RLock()
-	host := wv.host
-	wv.mu.RUnlock()
-	if host != nil {
-		host.WasHidden(0)
-	}
+	wv.SyncViewport(wv.ctx, "popup-show")
 }
 
 // PrimePopupNavigation implements port.PopupLifecycleCapable.
@@ -1081,6 +1084,9 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 		wv.removeSizeObserver()
 		wv.removeSizeObserver = nil
 	}
+	wv.viewportMapFunc = nil
+	wv.viewportShowFunc = nil
+	wv.viewportRealizeFunc = nil
 	_ = wv.viewBridge.DetachInput()
 	_ = wv.viewBridge.Destroy()
 	wv.viewBridge = nil

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -90,13 +90,17 @@ type WebView struct {
 	previousProfileSnapshot   cef2gtk.ProfileSnapshot
 	latestProfileSnapshotAt   time.Time
 
-	removeSizeObserver  func()
-	viewportSyncMu      sync.Mutex
-	viewportSyncPending bool
-	viewportSyncReason  string
-	viewportMapFunc     func(gtk.Widget)
-	viewportShowFunc    func(gtk.Widget)
-	viewportRealizeFunc func(gtk.Widget)
+	removeSizeObserver      func()
+	viewportSyncMu          sync.Mutex
+	viewportSyncPending     bool
+	viewportSyncReason      string
+	viewportMapFunc         func(gtk.Widget)
+	viewportShowFunc        func(gtk.Widget)
+	viewportRealizeFunc     func(gtk.Widget)
+	viewportMapSignalID     uint
+	viewportShowSignalID    uint
+	viewportRealizeSignalID uint
+	viewportResizePulseSeq  atomic.Uint64
 
 	// beginFrameTick drives CEF external BeginFrame requests while the GTK
 	// widget is visible. Access is guarded by mu.
@@ -1084,9 +1088,7 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 		wv.removeSizeObserver()
 		wv.removeSizeObserver = nil
 	}
-	wv.viewportMapFunc = nil
-	wv.viewportShowFunc = nil
-	wv.viewportRealizeFunc = nil
+	wv.disconnectViewportSyncHooksOnGTKThread()
 	_ = wv.viewBridge.DetachInput()
 	_ = wv.viewBridge.Destroy()
 	wv.viewBridge = nil

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -1,0 +1,196 @@
+package cef
+
+import (
+	"context"
+	"strings"
+
+	"github.com/bnema/dumber/internal/logging"
+	"github.com/bnema/puregotk/v4/gtk"
+)
+
+type viewportSyncBrowserHost interface {
+	resizeNotifiableBrowserHost
+	NotifyScreenInfoChanged()
+	WasHidden(int32)
+}
+
+// SyncViewport requests an explicit viewport resync for CEF OSR browsers.
+//
+// This is a hardening path for UI lifecycle transitions that may not emit a
+// fresh size change (reparenting, stacked visibility toggles, floating pane
+// updates, popup show, sibling promotion after close, etc.). Calls are
+// coalesced and executed on the GTK thread before notifying the CEF host.
+func (wv *WebView) SyncViewport(ctx context.Context, reason string) {
+	if wv == nil || wv.destroyed.Load() {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "manual"
+	}
+
+	wv.viewportSyncMu.Lock()
+	wv.viewportSyncReason = reason
+	if wv.viewportSyncPending {
+		wv.viewportSyncMu.Unlock()
+		return
+	}
+	wv.viewportSyncPending = true
+	wv.viewportSyncMu.Unlock()
+
+	wv.runOnGTK(func() {
+		wv.syncViewportOnGTK(wv.viewportSyncContext(ctx))
+	})
+}
+
+func (wv *WebView) viewportSyncContext(ctx context.Context) context.Context {
+	if ctx != nil {
+		return ctx
+	}
+	if wv != nil && wv.ctx != nil {
+		return wv.ctx
+	}
+	return context.Background()
+}
+
+func (wv *WebView) takeViewportSyncReason() string {
+	wv.viewportSyncMu.Lock()
+	defer wv.viewportSyncMu.Unlock()
+	reason := wv.viewportSyncReason
+	wv.viewportSyncReason = ""
+	wv.viewportSyncPending = false
+	return reason
+}
+
+func (wv *WebView) syncViewportOnGTK(ctx context.Context) {
+	if wv == nil {
+		return
+	}
+	reason := wv.takeViewportSyncReason()
+	if wv.destroyed.Load() || wv.viewBridge == nil {
+		return
+	}
+
+	if wv.tryStartPendingBrowserCreateOnGTKThread(ctx, reason) {
+		return
+	}
+
+	wv.mu.RLock()
+	host := wv.host
+	wv.mu.RUnlock()
+	if host == nil {
+		logging.FromContext(ctx).Debug().
+			Uint64("webview_id", uint64(wv.id)).
+			Str("reason", reason).
+			Msg("cef: viewport sync skipped; browser host not ready")
+		return
+	}
+
+	widget := wv.viewBridge.Widget()
+	visible := widget != nil && widget.IsVisible()
+	notifyBrowserViewportSync(host, visible)
+	logging.FromContext(ctx).Debug().
+		Uint64("webview_id", uint64(wv.id)).
+		Bool("visible", visible).
+		Str("reason", reason).
+		Msg("cef: viewport sync requested")
+}
+
+func (wv *WebView) tryStartPendingBrowserCreateOnGTKThread(ctx context.Context, reason string) bool {
+	if wv == nil || wv.destroyed.Load() || wv.factory == nil || wv.viewBridge == nil {
+		return false
+	}
+
+	wv.mu.RLock()
+	hasHost := wv.host != nil
+	pending := wv.pendingCreate != nil
+	wv.mu.RUnlock()
+	if hasHost || !pending {
+		return false
+	}
+
+	widget := wv.viewBridge.Widget()
+	if widget == nil {
+		return false
+	}
+	width := int32(widget.GetAllocatedWidth())
+	height := int32(widget.GetAllocatedHeight())
+	if width <= 0 {
+		width = int32(widget.GetWidth())
+	}
+	if height <= 0 {
+		height = int32(widget.GetHeight())
+	}
+	if width <= 0 || height <= 0 {
+		logging.FromContext(ctx).Debug().
+			Uint64("webview_id", uint64(wv.id)).
+			Int32("width", width).
+			Int32("height", height).
+			Str("reason", reason).
+			Msg("cef: viewport sync skipped pending browser creation; widget has no allocation yet")
+		return false
+	}
+	if err := wv.viewBridge.PrepareOnGTKThread(); err != nil {
+		logging.FromContext(ctx).Debug().
+			Err(err).
+			Uint64("webview_id", uint64(wv.id)).
+			Int32("width", width).
+			Int32("height", height).
+			Str("reason", reason).
+			Msg("cef: viewport sync could not prepare bridge for pending browser creation")
+		return false
+	}
+
+	wv.factory.postPendingBrowserCreate(ctx, wv, width, height)
+	logging.FromContext(ctx).Debug().
+		Uint64("webview_id", uint64(wv.id)).
+		Int32("width", width).
+		Int32("height", height).
+		Str("reason", reason).
+		Msg("cef: viewport sync nudged pending browser creation")
+	return true
+}
+
+func (wv *WebView) installViewportSyncHooks() {
+	if wv == nil || wv.viewBridge == nil {
+		return
+	}
+	wv.runOnGTKSync(func() {
+		wv.installViewportSyncHooksOnGTKThread()
+	})
+}
+
+func (wv *WebView) installViewportSyncHooksOnGTKThread() {
+	if wv == nil || wv.viewBridge == nil || wv.viewportMapFunc != nil {
+		return
+	}
+	widget := wv.viewBridge.Widget()
+	if widget == nil {
+		return
+	}
+
+	wv.viewportMapFunc = func(gtk.Widget) {
+		wv.SyncViewport(wv.ctx, "gtk-map")
+	}
+	wv.viewportShowFunc = func(gtk.Widget) {
+		wv.SyncViewport(wv.ctx, "gtk-show")
+	}
+	wv.viewportRealizeFunc = func(gtk.Widget) {
+		wv.SyncViewport(wv.ctx, "gtk-realize")
+	}
+
+	widget.ConnectMap(&wv.viewportMapFunc)
+	widget.ConnectShow(&wv.viewportShowFunc)
+	widget.ConnectRealize(&wv.viewportRealizeFunc)
+}
+
+func notifyBrowserViewportSync(host viewportSyncBrowserHost, visible bool) {
+	if host == nil {
+		return
+	}
+	if visible {
+		host.WasHidden(0)
+	}
+	host.NotifyScreenInfoChanged()
+	notifyBrowserResize(host)
+}

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"strings"
 
-	"github.com/bnema/dumber/internal/logging"
+	purecef "github.com/bnema/purego-cef/cef"
+	"github.com/bnema/puregotk/v4/gobject"
 	"github.com/bnema/puregotk/v4/gtk"
+
+	"github.com/bnema/dumber/internal/logging"
 )
 
 type viewportSyncBrowserHost interface {
@@ -66,13 +69,23 @@ func (wv *WebView) syncViewportOnGTK(ctx context.Context) {
 	if wv == nil {
 		return
 	}
-	reason := wv.takeViewportSyncReason()
+	wv.syncViewportNowOnGTK(ctx, wv.takeViewportSyncReason())
+}
+
+func (wv *WebView) syncViewportNowOnGTK(ctx context.Context, reason string) bool {
+	if wv == nil {
+		return false
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "manual"
+	}
 	if wv.destroyed.Load() || wv.viewBridge == nil {
-		return
+		return false
 	}
 
 	if wv.tryStartPendingBrowserCreateOnGTKThread(ctx, reason) {
-		return
+		return false
 	}
 
 	wv.mu.RLock()
@@ -83,7 +96,7 @@ func (wv *WebView) syncViewportOnGTK(ctx context.Context) {
 			Uint64("webview_id", uint64(wv.id)).
 			Str("reason", reason).
 			Msg("cef: viewport sync skipped; browser host not ready")
-		return
+		return false
 	}
 
 	widget := wv.viewBridge.Widget()
@@ -94,6 +107,46 @@ func (wv *WebView) syncViewportOnGTK(ctx context.Context) {
 		Bool("visible", visible).
 		Str("reason", reason).
 		Msg("cef: viewport sync requested")
+	return true
+}
+
+func (wv *WebView) syncResizeViewportOnGTK(ctx context.Context, reason string) bool {
+	if !wv.syncViewportNowOnGTK(ctx, reason) {
+		return false
+	}
+	wv.scheduleResizeRepaintPulse(ctx, reason)
+	return true
+}
+
+func (wv *WebView) scheduleResizeRepaintPulse(ctx context.Context, reason string) {
+	if wv == nil || wv.destroyed.Load() {
+		return
+	}
+	seq := wv.viewportResizePulseSeq.Add(1)
+	for _, delayMs := range [...]int64{16, 48} {
+		delayMs := delayMs
+		task := cefNewTask(cefTaskFunc(func() {
+			if wv == nil || wv.destroyed.Load() || wv.viewportResizePulseSeq.Load() != seq {
+				return
+			}
+			wv.mu.RLock()
+			host := wv.host
+			wv.mu.RUnlock()
+			if host == nil {
+				return
+			}
+			host.Invalidate(purecef.PaintElementTypePetView)
+			logging.FromContext(ctx).Debug().
+				Uint64("webview_id", uint64(wv.id)).
+				Int64("delay_ms", delayMs).
+				Str("reason", reason).
+				Msg("cef: delayed resize repaint pulse")
+		}))
+		if task == nil {
+			continue
+		}
+		cefPostDelayedTask(purecef.ThreadIDTidUi, task, delayMs)
+	}
 }
 
 func (wv *WebView) tryStartPendingBrowserCreateOnGTKThread(ctx context.Context, reason string) bool {
@@ -179,9 +232,37 @@ func (wv *WebView) installViewportSyncHooksOnGTKThread() {
 		wv.SyncViewport(wv.ctx, "gtk-realize")
 	}
 
-	widget.ConnectMap(&wv.viewportMapFunc)
-	widget.ConnectShow(&wv.viewportShowFunc)
-	widget.ConnectRealize(&wv.viewportRealizeFunc)
+	wv.viewportMapSignalID = widget.ConnectMap(&wv.viewportMapFunc)
+	wv.viewportShowSignalID = widget.ConnectShow(&wv.viewportShowFunc)
+	wv.viewportRealizeSignalID = widget.ConnectRealize(&wv.viewportRealizeFunc)
+}
+
+func (wv *WebView) disconnectViewportSyncHooksOnGTKThread() {
+	if wv == nil || wv.viewBridge == nil {
+		return
+	}
+	widget := wv.viewBridge.Widget()
+	if widget != nil {
+		widgetPtr := widget.GoPointer()
+		if widgetPtr != 0 {
+			obj := gobject.ObjectNewFromInternalPtr(widgetPtr)
+			if wv.viewportMapSignalID != 0 {
+				gobject.SignalHandlerDisconnect(obj, wv.viewportMapSignalID)
+				wv.viewportMapSignalID = 0
+			}
+			if wv.viewportShowSignalID != 0 {
+				gobject.SignalHandlerDisconnect(obj, wv.viewportShowSignalID)
+				wv.viewportShowSignalID = 0
+			}
+			if wv.viewportRealizeSignalID != 0 {
+				gobject.SignalHandlerDisconnect(obj, wv.viewportRealizeSignalID)
+				wv.viewportRealizeSignalID = 0
+			}
+		}
+	}
+	wv.viewportMapFunc = nil
+	wv.viewportShowFunc = nil
+	wv.viewportRealizeFunc = nil
 }
 
 func notifyBrowserViewportSync(host viewportSyncBrowserHost, visible bool) {

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -124,7 +124,6 @@ func (wv *WebView) scheduleResizeRepaintPulse(ctx context.Context, reason string
 	}
 	seq := wv.viewportResizePulseSeq.Add(1)
 	for _, delayMs := range [...]int64{16, 48} {
-		delayMs := delayMs
 		task := cefNewTask(cefTaskFunc(func() {
 			if wv == nil || wv.destroyed.Load() || wv.viewportResizePulseSeq.Load() != seq {
 				return

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -1,0 +1,47 @@
+package cef
+
+import (
+	"testing"
+
+	purecef "github.com/bnema/purego-cef/cef"
+	"github.com/stretchr/testify/require"
+)
+
+type viewportSyncOrderHost struct {
+	calls []string
+}
+
+func (h *viewportSyncOrderHost) WasHidden(state int32) {
+	h.calls = append(h.calls, "WasHidden")
+	if state != 0 {
+		h.calls = append(h.calls, "WasHidden(nonzero)")
+	}
+}
+
+func (h *viewportSyncOrderHost) NotifyScreenInfoChanged() {
+	h.calls = append(h.calls, "NotifyScreenInfoChanged")
+}
+
+func (h *viewportSyncOrderHost) WasResized() {
+	h.calls = append(h.calls, "WasResized")
+}
+
+func (h *viewportSyncOrderHost) Invalidate(_ purecef.PaintElementType) {
+	h.calls = append(h.calls, "Invalidate")
+}
+
+func TestNotifyBrowserViewportSync_VisibleCallsFullSequence(t *testing.T) {
+	host := &viewportSyncOrderHost{}
+
+	notifyBrowserViewportSync(host, true)
+
+	require.Equal(t, []string{"WasHidden", "NotifyScreenInfoChanged", "WasResized", "Invalidate"}, host.calls)
+}
+
+func TestNotifyBrowserViewportSync_HiddenSkipsWasHidden(t *testing.T) {
+	host := &viewportSyncOrderHost{}
+
+	notifyBrowserViewportSync(host, false)
+
+	require.Equal(t, []string{"NotifyScreenInfoChanged", "WasResized", "Invalidate"}, host.calls)
+}

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -1,6 +1,7 @@
 package cef
 
 import (
+	"context"
 	"testing"
 
 	purecef "github.com/bnema/purego-cef/cef"
@@ -8,6 +9,7 @@ import (
 )
 
 type viewportSyncOrderHost struct {
+	purecef.BrowserHost
 	calls []string
 }
 
@@ -44,4 +46,42 @@ func TestNotifyBrowserViewportSync_HiddenSkipsWasHidden(t *testing.T) {
 	notifyBrowserViewportSync(host, false)
 
 	require.Equal(t, []string{"NotifyScreenInfoChanged", "WasResized", "Invalidate"}, host.calls)
+}
+
+func TestScheduleResizeRepaintPulse_CoalescesToLatestSequence(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled []purecef.Task
+	var delays []int64
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
+		require.Equal(t, purecef.ThreadIDTidUi, threadID)
+		require.NotNil(t, task)
+		scheduled = append(scheduled, task)
+		delays = append(delays, delayMs)
+		return 1
+	}
+
+	host := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: host}
+
+	wv.scheduleResizeRepaintPulse(context.Background(), "first")
+	wv.scheduleResizeRepaintPulse(context.Background(), "second")
+
+	require.Equal(t, []int64{16, 48, 16, 48}, delays)
+	require.Len(t, scheduled, 4)
+
+	scheduled[0].Execute()
+	scheduled[1].Execute()
+	require.Empty(t, host.calls)
+
+	scheduled[2].Execute()
+	scheduled[3].Execute()
+	require.Equal(t, []string{"Invalidate", "Invalidate"}, host.calls)
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3826,11 +3826,15 @@ func (a *App) attachPopupToTab(ctx context.Context, tabID entity.TabID, pane *en
 
 		// Wrap and attach widget
 		widget := a.contentCoord.WrapWidget(ctx, wv)
-		if widget != nil {
-			if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
-				log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
-				return
-			}
+		if widget == nil {
+			a.contentCoord.ReleaseWebView(ctx, pane.ID)
+			log.Warn().Str("pane_id", string(pane.ID)).Msg("failed to wrap popup webview")
+			return
+		}
+		if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
+			a.contentCoord.ReleaseWebView(ctx, pane.ID)
+			log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
+			return
 		}
 	}
 	log.Debug().

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3804,38 +3804,48 @@ func (a *App) getActiveWebViewTarget() port.TextInputTarget {
 // This is called when a popup uses tabbed behavior.
 func (a *App) attachPopupToTab(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) {
 	log := logging.FromContext(ctx)
+	cleanupUnattachedPopup := func() {
+		if wv != nil {
+			wv.Destroy()
+		}
+	}
 
 	wsView := a.workspaceViews[tabID]
 	if wsView == nil {
+		cleanupUnattachedPopup()
 		log.Warn().Str("tab_id", string(tabID)).Msg("workspace view not found for popup tab")
 		return
 	}
 	if pane == nil {
+		cleanupUnattachedPopup()
 		log.Warn().Str("tab_id", string(tabID)).Msg("popup pane is nil")
 		return
 	}
 	if wsView.GetPaneView(pane.ID) == nil {
+		cleanupUnattachedPopup()
 		log.Warn().Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
 		return
 	}
+	if a.contentCoord == nil {
+		cleanupUnattachedPopup()
+		log.Warn().Str("pane_id", string(pane.ID)).Msg("content coordinator not configured for popup")
+		return
+	}
 
-	// Register WebView with content coordinator
-	if a.contentCoord != nil {
-		// Track the WebView
-		a.contentCoord.RegisterPopupWebView(pane.ID, wv)
+	// Register WebView with content coordinator.
+	a.contentCoord.RegisterPopupWebView(pane.ID, wv)
 
-		// Wrap and attach widget
-		widget := a.contentCoord.WrapWidget(ctx, wv)
-		if widget == nil {
-			a.contentCoord.ReleaseWebView(ctx, pane.ID)
-			log.Warn().Str("pane_id", string(pane.ID)).Msg("failed to wrap popup webview")
-			return
-		}
-		if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
-			a.contentCoord.ReleaseWebView(ctx, pane.ID)
-			log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
-			return
-		}
+	// Wrap and attach widget.
+	widget := a.contentCoord.WrapWidget(ctx, wv)
+	if widget == nil {
+		a.contentCoord.ReleaseWebView(ctx, pane.ID)
+		log.Warn().Str("pane_id", string(pane.ID)).Msg("failed to wrap popup webview")
+		return
+	}
+	if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
+		a.contentCoord.ReleaseWebView(ctx, pane.ID)
+		log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
+		return
 	}
 	log.Debug().
 		Str("tab_id", string(tabID)).

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3687,7 +3687,7 @@ func (a *App) createWorkspaceViewWithoutAttach(ctx context.Context, tab *entity.
 	}
 	a.installFloatingOverlayPositioning(tab.ID, wsView.WorkspaceOverlayWidget())
 	if a.contentCoord != nil {
-		syncCtx := ctx
+		syncCtx := context.Background()
 		if a.deps != nil && a.deps.Ctx != nil {
 			syncCtx = a.deps.Ctx
 		}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3821,6 +3821,7 @@ func (a *App) attachPopupToTab(ctx context.Context, tabID entity.TabID, pane *en
 		if widget != nil {
 			if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
 				log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
+				return
 			}
 		}
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3810,6 +3810,14 @@ func (a *App) attachPopupToTab(ctx context.Context, tabID entity.TabID, pane *en
 		log.Warn().Str("tab_id", string(tabID)).Msg("workspace view not found for popup tab")
 		return
 	}
+	if pane == nil {
+		log.Warn().Str("tab_id", string(tabID)).Msg("popup pane is nil")
+		return
+	}
+	if wsView.GetPaneView(pane.ID) == nil {
+		log.Warn().Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
+		return
+	}
 
 	// Register WebView with content coordinator
 	if a.contentCoord != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3686,6 +3686,18 @@ func (a *App) createWorkspaceViewWithoutAttach(ctx context.Context, tab *entity.
 		return
 	}
 	a.installFloatingOverlayPositioning(tab.ID, wsView.WorkspaceOverlayWidget())
+	if a.contentCoord != nil {
+		syncCtx := ctx
+		if a.deps != nil && a.deps.Ctx != nil {
+			syncCtx = a.deps.Ctx
+		}
+		wsView.SetOnWebViewAttached(func(paneID entity.PaneID) {
+			a.contentCoord.SyncWebViewViewport(syncCtx, paneID, "workspace-widget-attached")
+		})
+		wsView.SetOnActivePaneChanged(func(paneID entity.PaneID) {
+			a.contentCoord.SyncWebViewViewport(syncCtx, paneID, "workspace-pane-activated")
+		})
+	}
 
 	// Set the workspace
 	if err := wsView.SetWorkspace(ctx, tab.Workspace); err != nil {
@@ -3807,11 +3819,8 @@ func (a *App) attachPopupToTab(ctx context.Context, tabID entity.TabID, pane *en
 		// Wrap and attach widget
 		widget := a.contentCoord.WrapWidget(ctx, wv)
 		if widget != nil {
-			paneView := wsView.GetPaneView(pane.ID)
-			if paneView != nil {
-				paneView.SetWebViewWidget(widget)
-			} else {
-				log.Warn().Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
+			if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
+				log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("pane view not found for popup")
 			}
 		}
 	}
@@ -4393,6 +4402,13 @@ func (a *App) resizeFloatingWidget(session *floatingWorkspaceSession) {
 	session.widget.SetSizeRequest(width, height)
 	session.appliedWidth = width
 	session.appliedHeight = height
+	if a.contentCoord != nil {
+		syncCtx := context.Background()
+		if a.deps != nil && a.deps.Ctx != nil {
+			syncCtx = a.deps.Ctx
+		}
+		a.contentCoord.SyncWebViewViewport(syncCtx, session.paneID, "floating-resize")
+	}
 }
 
 func (a *App) handleFloatingViewportTick(session *floatingWorkspaceSession) bool {

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -1913,11 +1913,15 @@ func TestApp_AttachPopupToTabReleasesRegistrationWhenWrapFails(t *testing.T) {
 			tabID: wsView,
 		},
 	}
+	popupWV := &fakeRecordingWebView{id: 1}
 
-	app.attachPopupToTab(ctx, tabID, pane, &fakeRecordingWebView{id: 1})
+	app.attachPopupToTab(ctx, tabID, pane, popupWV)
 
 	if got := contentCoord.GetWebView(pane.ID); got != nil {
 		t.Fatalf("popup webview registration remained after wrap failure: %v", got)
+	}
+	if popupWV.destroyCalls != 1 {
+		t.Fatalf("popup webview destroy calls = %d, want 1", popupWV.destroyCalls)
 	}
 }
 

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -1854,6 +1854,43 @@ func TestApp_AttachPopupToTabSkipsRegistrationWhenPaneViewMissing(t *testing.T) 
 	}
 }
 
+func TestApp_AttachPopupToTabReleasesRegistrationWhenWrapFails(t *testing.T) {
+	ctx := context.Background()
+	contentCoord := contentcoord.NewCoordinator(ctx, nil, nil, nil, nil, nil, nil, nil)
+	tabID := entity.TabID("tab-1")
+	pane := entity.NewPane(entity.PaneID("popup-pane"))
+
+	factory := layoutmocks.NewMockWidgetFactory(t)
+	container := layoutmocks.NewMockBoxWidget(t)
+	overlay := layoutmocks.NewMockOverlayWidget(t)
+	factory.EXPECT().NewBox(layout.OrientationVertical, 0).Return(container).Once()
+	container.EXPECT().SetHexpand(true).Once()
+	container.EXPECT().SetVexpand(true).Once()
+	container.EXPECT().SetVisible(true).Once()
+	factory.EXPECT().NewOverlay().Return(overlay).Once()
+	overlay.EXPECT().SetHexpand(true).Once()
+	overlay.EXPECT().SetVexpand(true).Once()
+	overlay.EXPECT().SetChild(container).Once()
+	overlay.EXPECT().SetVisible(true).Once()
+
+	wsView := component.NewWorkspaceView(ctx, factory)
+	container.EXPECT().AddCssClass("single-pane").Once()
+	wsView.RegisterPaneView(pane.ID, &component.PaneView{})
+
+	app := &App{
+		contentCoord: contentCoord,
+		workspaceViews: map[entity.TabID]*component.WorkspaceView{
+			tabID: wsView,
+		},
+	}
+
+	app.attachPopupToTab(ctx, tabID, pane, &fakeRecordingWebView{id: 1})
+
+	if got := contentCoord.GetWebView(pane.ID); got != nil {
+		t.Fatalf("popup webview registration remained after wrap failure: %v", got)
+	}
+}
+
 type fakeZoomRepo struct{}
 
 func (f *fakeZoomRepo) Get(context.Context, string) (*entity.ZoomLevel, error) { return nil, nil }

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -1763,6 +1763,7 @@ type fakeRecordingWebView struct {
 	setZoomLevelLastLevel  float64
 	openDevToolsCalls      int
 	printPageCalls         int
+	destroyCalls           int
 }
 
 func (f *fakeRecordingWebView) ID() port.WebViewID { return f.id }
@@ -1832,8 +1833,33 @@ func (f *fakeRecordingWebView) Favicon() port.Texture                     { retu
 func (f *fakeRecordingWebView) Generation() uint64                        { return 0 }
 func (f *fakeRecordingWebView) IsFullscreen() bool                        { return false }
 func (f *fakeRecordingWebView) IsPlayingAudio() bool                      { return false }
-func (f *fakeRecordingWebView) IsDestroyed() bool                         { return false }
-func (f *fakeRecordingWebView) Destroy()                                  {}
+func (f *fakeRecordingWebView) IsDestroyed() bool                         { return f.destroyCalls > 0 }
+func (f *fakeRecordingWebView) Destroy()                                  { f.destroyCalls++ }
+
+func TestApp_AttachPopupToTabDestroysPopupWhenWorkspaceViewMissing(t *testing.T) {
+	ctx := context.Background()
+	popupWV := &fakeRecordingWebView{id: 1}
+	app := &App{workspaceViews: map[entity.TabID]*component.WorkspaceView{}}
+
+	app.attachPopupToTab(ctx, entity.TabID("missing-tab"), entity.NewPane(entity.PaneID("popup-pane")), popupWV)
+
+	if popupWV.destroyCalls != 1 {
+		t.Fatalf("popup webview destroy calls = %d, want 1", popupWV.destroyCalls)
+	}
+}
+
+func TestApp_AttachPopupToTabDestroysPopupWhenPaneNil(t *testing.T) {
+	ctx := context.Background()
+	popupWV := &fakeRecordingWebView{id: 1}
+	tabID := entity.TabID("tab-1")
+	app := &App{workspaceViews: map[entity.TabID]*component.WorkspaceView{tabID: &component.WorkspaceView{}}}
+
+	app.attachPopupToTab(ctx, tabID, nil, popupWV)
+
+	if popupWV.destroyCalls != 1 {
+		t.Fatalf("popup webview destroy calls = %d, want 1", popupWV.destroyCalls)
+	}
+}
 
 func TestApp_AttachPopupToTabSkipsRegistrationWhenPaneViewMissing(t *testing.T) {
 	ctx := context.Background()
@@ -1847,10 +1873,14 @@ func TestApp_AttachPopupToTabSkipsRegistrationWhenPaneViewMissing(t *testing.T) 
 		},
 	}
 
-	app.attachPopupToTab(ctx, tabID, pane, &fakeRecordingWebView{id: 1})
+	popupWV := &fakeRecordingWebView{id: 1}
+	app.attachPopupToTab(ctx, tabID, pane, popupWV)
 
 	if got := contentCoord.GetWebView(pane.ID); got != nil {
 		t.Fatalf("popup webview was registered for missing pane view: %v", got)
+	}
+	if popupWV.destroyCalls != 1 {
+		t.Fatalf("popup webview destroy calls = %d, want 1", popupWV.destroyCalls)
 	}
 }
 

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -1835,6 +1835,25 @@ func (f *fakeRecordingWebView) IsPlayingAudio() bool                      { retu
 func (f *fakeRecordingWebView) IsDestroyed() bool                         { return false }
 func (f *fakeRecordingWebView) Destroy()                                  {}
 
+func TestApp_AttachPopupToTabSkipsRegistrationWhenPaneViewMissing(t *testing.T) {
+	ctx := context.Background()
+	contentCoord := contentcoord.NewCoordinator(ctx, nil, nil, nil, nil, nil, nil, nil)
+	tabID := entity.TabID("tab-1")
+	pane := entity.NewPane(entity.PaneID("missing-pane"))
+	app := &App{
+		contentCoord: contentCoord,
+		workspaceViews: map[entity.TabID]*component.WorkspaceView{
+			tabID: &component.WorkspaceView{},
+		},
+	}
+
+	app.attachPopupToTab(ctx, tabID, pane, &fakeRecordingWebView{id: 1})
+
+	if got := contentCoord.GetWebView(pane.ID); got != nil {
+		t.Fatalf("popup webview was registered for missing pane view: %v", got)
+	}
+}
+
 type fakeZoomRepo struct{}
 
 func (f *fakeZoomRepo) Get(context.Context, string) (*entity.ZoomLevel, error) { return nil, nil }

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -256,6 +256,13 @@ func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID) error {
 		Str("to_pane", string(paneID)).
 		Msg("active pane changing")
 
+	// Validate the target pane before mutating UI state. Invalid/stale IDs
+	// should leave the current active pane styling and overlays untouched.
+	newPV, ok := wv.paneViews[paneID]
+	if !ok {
+		return ErrPaneNotFound
+	}
+
 	// Destroy find bar if active pane is changing
 	if currentActiveID != paneID && wv.findBar != nil {
 		wv.hideFindBarInternal()
@@ -271,12 +278,6 @@ func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID) error {
 		if oldPV, ok := wv.paneViews[currentActiveID]; ok {
 			oldPV.SetActive(false)
 		}
-	}
-
-	// Activate new pane
-	newPV, ok := wv.paneViews[paneID]
-	if !ok {
-		return ErrPaneNotFound
 	}
 
 	newPV.SetActive(true)

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -260,10 +260,33 @@ func (wv *WorkspaceView) restoreActivePaneInternal() {
 		wv.workspace.ActivePaneID = ""
 	}
 
-	for fallbackID := range wv.paneViews {
+	if fallbackID, ok := wv.firstPaneIDInTreeInternal(); ok {
 		_ = wv.setActivePaneIDInternal(fallbackID)
-		return
 	}
+}
+
+func (wv *WorkspaceView) firstPaneIDInTreeInternal() (entity.PaneID, bool) {
+	if wv.workspace == nil {
+		return "", false
+	}
+	return wv.firstPaneIDInNodeInternal(wv.workspace.Root)
+}
+
+func (wv *WorkspaceView) firstPaneIDInNodeInternal(node *entity.PaneNode) (entity.PaneID, bool) {
+	if node == nil {
+		return "", false
+	}
+	if node.Pane != nil {
+		paneID := node.Pane.ID
+		_, ok := wv.paneViews[paneID]
+		return paneID, ok
+	}
+	for _, child := range node.Children {
+		if paneID, ok := wv.firstPaneIDInNodeInternal(child); ok {
+			return paneID, true
+		}
+	}
+	return "", false
 }
 
 // setActivePaneIDInternal updates active pane without locking.

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -217,9 +217,10 @@ func (wv *WorkspaceView) SetWorkspace(ctx context.Context, ws *entity.Workspace)
 		}
 	}
 
-	// Set initial active pane
+	// Set initial active pane. A persisted workspace can contain a stale active
+	// pane ID after restore/rebuild; that should not abort initialization.
 	if ws.ActivePaneID != "" {
-		if err := wv.setActivePaneIDInternal(ws.ActivePaneID); err != nil {
+		if err := wv.setActivePaneIDInternal(ws.ActivePaneID, true); err != nil {
 			return fmt.Errorf("set initial active pane: %w", err)
 		}
 	}
@@ -234,7 +235,7 @@ func (wv *WorkspaceView) SetWorkspace(ctx context.Context, ws *entity.Workspace)
 func (wv *WorkspaceView) SetActivePaneID(paneID entity.PaneID) error {
 	wv.mu.Lock()
 	currentActiveID := wv.getActivePaneIDInternal()
-	err := wv.setActivePaneIDInternal(paneID)
+	err := wv.setActivePaneIDInternal(paneID, false)
 	callback := wv.onActivePaneChanged
 	wv.mu.Unlock()
 	if err != nil {
@@ -248,7 +249,7 @@ func (wv *WorkspaceView) SetActivePaneID(paneID entity.PaneID) error {
 
 // setActivePaneIDInternal updates active pane without locking.
 // Updates the domain model as the single source of truth.
-func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID) error {
+func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID, allowMissing bool) error {
 	currentActiveID := wv.getActivePaneIDInternal()
 
 	wv.logger.Debug().
@@ -260,6 +261,10 @@ func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID) error {
 	// should leave the current active pane styling and overlays untouched.
 	newPV, ok := wv.paneViews[paneID]
 	if !ok {
+		if allowMissing {
+			wv.logger.Debug().Str("pane_id", string(paneID)).Msg("stale active pane ignored")
+			return nil
+		}
 		return ErrPaneNotFound
 	}
 

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -4,7 +4,6 @@ package component
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -218,12 +217,9 @@ func (wv *WorkspaceView) SetWorkspace(ctx context.Context, ws *entity.Workspace)
 	}
 
 	// Set initial active pane. A persisted workspace can contain a stale active
-	// pane ID after restore/rebuild; that should not abort initialization.
-	if ws.ActivePaneID != "" {
-		if err := wv.setActivePaneIDInternal(ws.ActivePaneID, true); err != nil {
-			return fmt.Errorf("set initial active pane: %w", err)
-		}
-	}
+	// pane ID after restore/rebuild; choose a valid fallback instead of leaving
+	// later active-pane logic pointing at a missing pane.
+	wv.restoreActivePaneInternal()
 
 	// Update single-pane mode based on pane count
 	wv.updateSinglePaneModeInternal()
@@ -235,7 +231,7 @@ func (wv *WorkspaceView) SetWorkspace(ctx context.Context, ws *entity.Workspace)
 func (wv *WorkspaceView) SetActivePaneID(paneID entity.PaneID) error {
 	wv.mu.Lock()
 	currentActiveID := wv.getActivePaneIDInternal()
-	err := wv.setActivePaneIDInternal(paneID, false)
+	err := wv.setActivePaneIDInternal(paneID)
 	callback := wv.onActivePaneChanged
 	wv.mu.Unlock()
 	if err != nil {
@@ -247,9 +243,32 @@ func (wv *WorkspaceView) SetActivePaneID(paneID entity.PaneID) error {
 	return nil
 }
 
+// restoreActivePaneInternal restores the active pane after building paneViews.
+// Must be called with the lock held.
+func (wv *WorkspaceView) restoreActivePaneInternal() {
+	if wv.workspace == nil {
+		return
+	}
+
+	paneID := wv.workspace.ActivePaneID
+	if paneID != "" {
+		if _, ok := wv.paneViews[paneID]; ok {
+			_ = wv.setActivePaneIDInternal(paneID)
+			return
+		}
+		wv.logger.Debug().Str("pane_id", string(paneID)).Msg("stale active pane ignored")
+		wv.workspace.ActivePaneID = ""
+	}
+
+	for fallbackID := range wv.paneViews {
+		_ = wv.setActivePaneIDInternal(fallbackID)
+		return
+	}
+}
+
 // setActivePaneIDInternal updates active pane without locking.
 // Updates the domain model as the single source of truth.
-func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID, allowMissing bool) error {
+func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID) error {
 	currentActiveID := wv.getActivePaneIDInternal()
 
 	wv.logger.Debug().
@@ -261,10 +280,6 @@ func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID, allowMiss
 	// should leave the current active pane styling and overlays untouched.
 	newPV, ok := wv.paneViews[paneID]
 	if !ok {
-		if allowMissing {
-			wv.logger.Debug().Str("pane_id", string(paneID)).Msg("stale active pane ignored")
-			return nil
-		}
 		return ErrPaneNotFound
 	}
 

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -51,6 +51,8 @@ type WorkspaceView struct {
 	paneViews map[entity.PaneID]*PaneView
 
 	onPaneFocused       func(paneID entity.PaneID)
+	onActivePaneChanged func(paneID entity.PaneID)
+	onWebViewAttached   func(paneID entity.PaneID)
 	onSplitRatioDragged func(nodeID string, ratio float64)
 
 	// Hover suppression for keyboard navigation (Issue #89)
@@ -231,9 +233,17 @@ func (wv *WorkspaceView) SetWorkspace(ctx context.Context, ws *entity.Workspace)
 // SetActivePaneID updates which pane is visually marked as active.
 func (wv *WorkspaceView) SetActivePaneID(paneID entity.PaneID) error {
 	wv.mu.Lock()
-	defer wv.mu.Unlock()
-
-	return wv.setActivePaneIDInternal(paneID)
+	currentActiveID := wv.getActivePaneIDInternal()
+	err := wv.setActivePaneIDInternal(paneID)
+	callback := wv.onActivePaneChanged
+	wv.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if currentActiveID != paneID && callback != nil {
+		callback(paneID)
+	}
+	return nil
 }
 
 // setActivePaneIDInternal updates active pane without locking.
@@ -357,6 +367,22 @@ func (wv *WorkspaceView) SetOnPaneFocused(fn func(paneID entity.PaneID)) {
 	wv.onPaneFocused = fn
 }
 
+// SetOnActivePaneChanged sets the callback invoked after the active pane changes.
+func (wv *WorkspaceView) SetOnActivePaneChanged(fn func(paneID entity.PaneID)) {
+	wv.mu.Lock()
+	defer wv.mu.Unlock()
+
+	wv.onActivePaneChanged = fn
+}
+
+// SetOnWebViewAttached sets the callback invoked after a pane receives a WebView widget.
+func (wv *WorkspaceView) SetOnWebViewAttached(fn func(paneID entity.PaneID)) {
+	wv.mu.Lock()
+	defer wv.mu.Unlock()
+
+	wv.onWebViewAttached = fn
+}
+
 func (wv *WorkspaceView) SetOnSplitRatioDragged(fn func(nodeID string, ratio float64)) {
 	wv.mu.Lock()
 	defer wv.mu.Unlock()
@@ -408,6 +434,7 @@ func (wv *WorkspaceView) DeactivatePane(paneID entity.PaneID) {
 func (wv *WorkspaceView) SetWebViewWidget(paneID entity.PaneID, widget layout.Widget) error {
 	wv.mu.RLock()
 	pv, ok := wv.paneViews[paneID]
+	callback := wv.onWebViewAttached
 	wv.mu.RUnlock()
 
 	if !ok {
@@ -415,6 +442,9 @@ func (wv *WorkspaceView) SetWebViewWidget(paneID entity.PaneID, widget layout.Wi
 	}
 
 	pv.SetWebViewWidget(widget)
+	if widget != nil && callback != nil {
+		callback(paneID)
+	}
 	return nil
 }
 

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -252,7 +252,7 @@ func (wv *WorkspaceView) restoreActivePaneInternal() {
 
 	paneID := wv.workspace.ActivePaneID
 	if paneID != "" {
-		if _, ok := wv.paneViews[paneID]; ok {
+		if pv, ok := wv.paneViews[paneID]; ok && pv != nil {
 			_ = wv.setActivePaneIDInternal(paneID)
 			return
 		}
@@ -278,8 +278,8 @@ func (wv *WorkspaceView) firstPaneIDInNodeInternal(node *entity.PaneNode) (entit
 	}
 	if node.Pane != nil {
 		paneID := node.Pane.ID
-		_, ok := wv.paneViews[paneID]
-		return paneID, ok
+		pv, ok := wv.paneViews[paneID]
+		return paneID, ok && pv != nil
 	}
 	for _, child := range node.Children {
 		if paneID, ok := wv.firstPaneIDInNodeInternal(child); ok {
@@ -302,7 +302,7 @@ func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID) error {
 	// Validate the target pane before mutating UI state. Invalid/stale IDs
 	// should leave the current active pane styling and overlays untouched.
 	newPV, ok := wv.paneViews[paneID]
-	if !ok {
+	if !ok || newPV == nil {
 		return ErrPaneNotFound
 	}
 
@@ -318,7 +318,7 @@ func (wv *WorkspaceView) setActivePaneIDInternal(paneID entity.PaneID) error {
 
 	// Deactivate current active pane
 	if currentActiveID != "" {
-		if oldPV, ok := wv.paneViews[currentActiveID]; ok {
+		if oldPV, ok := wv.paneViews[currentActiveID]; ok && oldPV != nil {
 			oldPV.SetActive(false)
 		}
 	}
@@ -481,7 +481,7 @@ func (wv *WorkspaceView) SetWebViewWidget(paneID entity.PaneID, widget layout.Wi
 	callback := wv.onWebViewAttached
 	wv.mu.RUnlock()
 
-	if !ok {
+	if !ok || pv == nil {
 		return ErrPaneNotFound
 	}
 

--- a/internal/ui/component/workspace_view_test.go
+++ b/internal/ui/component/workspace_view_test.go
@@ -292,6 +292,60 @@ func TestSetWorkspace_StaleActivePaneID_DoesNotFailInitialization(t *testing.T) 
 	assert.True(t, wv.GetPaneView(pane.ID).IsActive())
 }
 
+func TestSetWorkspace_StaleActivePaneID_UsesFirstPaneInTree(t *testing.T) {
+	// Arrange
+	mockFactory := mocks.NewMockWidgetFactory(t)
+	ctx, mockBox := setupWorkspaceViewBase(t, mockFactory)
+	wv := component.NewWorkspaceView(ctx, mockFactory)
+
+	pane1 := entity.NewPane(entity.PaneID("pane-1"))
+	pane2 := entity.NewPane(entity.PaneID("pane-2"))
+	node1 := &entity.PaneNode{ID: "node-1", Pane: pane1}
+	node2 := &entity.PaneNode{ID: "node-2", Pane: pane2}
+
+	mockPaned := mocks.NewMockPanedWidget(t)
+	mockOverlay1, mockBorderBox1 := setupWorkspacePaneViewMocks(t, mockFactory)
+	mockStackBox1 := setupStackedLeafMocks(t, mockFactory, mockOverlay1)
+	mockOverlay2, _ := setupWorkspacePaneViewMocks(t, mockFactory)
+	mockStackBox2 := setupStackedLeafMocks(t, mockFactory, mockOverlay2)
+
+	mockFactory.EXPECT().NewPaned(layout.OrientationHorizontal).Return(mockPaned).Once()
+	mockPaned.EXPECT().SetResizeStartChild(true).Once()
+	mockPaned.EXPECT().SetResizeEndChild(true).Once()
+	mockPaned.EXPECT().SetVisible(true).Twice()
+	mockStackBox1.EXPECT().SetVisible(true).Once()
+	mockStackBox2.EXPECT().SetVisible(true).Once()
+	mockPaned.EXPECT().SetStartChild(mockStackBox1).Once()
+	mockPaned.EXPECT().SetEndChild(mockStackBox2).Once()
+	mockPaned.EXPECT().ConnectNotifyPosition(mock.Anything).Return(uint(0)).Once()
+	mockPaned.EXPECT().GetAllocatedWidth().Return(0).Once()
+	mockPaned.EXPECT().ConnectMap(mock.Anything).Return(uint(0)).Once()
+	mockPaned.EXPECT().AddTickCallback(mock.Anything).Return(uint(0)).Once()
+	mockBox.EXPECT().Append(mockPaned).Once()
+	mockBox.EXPECT().RemoveCssClass("single-pane").Once()
+	mockBorderBox1.EXPECT().AddCssClass("pane-active").Once()
+
+	ws := &entity.Workspace{
+		ID: "ws-1",
+		Root: &entity.PaneNode{
+			ID:         "split",
+			SplitDir:   entity.SplitHorizontal,
+			SplitRatio: 0.5,
+			Children:   []*entity.PaneNode{node1, node2},
+		},
+		ActivePaneID: entity.PaneID("stale-pane"),
+	}
+
+	// Act
+	err := wv.SetWorkspace(ctx, ws)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, pane1.ID, wv.GetActivePaneID())
+	assert.True(t, wv.GetPaneView(pane1.ID).IsActive())
+	assert.False(t, wv.GetPaneView(pane2.ID).IsActive())
+}
+
 func TestWorkspaceView_HoverFocusLockState(t *testing.T) {
 	// Intentional zero-value check: hoverFocusLock is an atomic.Bool and should
 	// be safe with its language-level zero value before constructor wiring.

--- a/internal/ui/component/workspace_view_test.go
+++ b/internal/ui/component/workspace_view_test.go
@@ -530,6 +530,38 @@ func TestSetActivePaneID_InvalidID_ReturnsError(t *testing.T) {
 	assert.ErrorIs(t, err, component.ErrPaneNotFound)
 }
 
+func TestSetActivePaneID_NilRegisteredPaneView_ReturnsError(t *testing.T) {
+	// Arrange
+	mockFactory := mocks.NewMockWidgetFactory(t)
+	ctx, mockBox := setupWorkspaceViewBase(t, mockFactory)
+
+	wv := component.NewWorkspaceView(ctx, mockFactory)
+	mockBox.EXPECT().AddCssClass("single-pane").Once()
+	wv.RegisterPaneView(entity.PaneID("pane-1"), nil)
+
+	// Act
+	err := wv.SetActivePaneID(entity.PaneID("pane-1"))
+
+	// Assert
+	require.ErrorIs(t, err, component.ErrPaneNotFound)
+}
+
+func TestSetWebViewWidget_NilRegisteredPaneView_ReturnsError(t *testing.T) {
+	// Arrange
+	mockFactory := mocks.NewMockWidgetFactory(t)
+	ctx, mockBox := setupWorkspaceViewBase(t, mockFactory)
+
+	wv := component.NewWorkspaceView(ctx, mockFactory)
+	mockBox.EXPECT().AddCssClass("single-pane").Once()
+	wv.RegisterPaneView(entity.PaneID("pane-1"), nil)
+
+	// Act
+	err := wv.SetWebViewWidget(entity.PaneID("pane-1"), mocks.NewMockWidget(t))
+
+	// Assert
+	require.ErrorIs(t, err, component.ErrPaneNotFound)
+}
+
 func TestSetActivePaneID_InvalidID_PreservesCurrentActivePane(t *testing.T) {
 	// Arrange
 	mockFactory := mocks.NewMockWidgetFactory(t)

--- a/internal/ui/component/workspace_view_test.go
+++ b/internal/ui/component/workspace_view_test.go
@@ -259,6 +259,38 @@ func TestSetWorkspace_SinglePane_CreatesPaneView(t *testing.T) {
 	assert.NotNil(t, wv.GetPaneView(pane.ID))
 }
 
+func TestSetWorkspace_StaleActivePaneID_DoesNotFailInitialization(t *testing.T) {
+	// Arrange
+	mockFactory := mocks.NewMockWidgetFactory(t)
+	ctx, mockBox := setupWorkspaceViewBase(t, mockFactory)
+
+	wv := component.NewWorkspaceView(ctx, mockFactory)
+
+	mockOverlay, _ := setupWorkspacePaneViewMocks(t, mockFactory)
+	mockStackBox := setupStackedLeafMocks(t, mockFactory, mockOverlay)
+
+	mockStackBox.EXPECT().SetVisible(true).Once()
+	mockBox.EXPECT().Append(mockStackBox).Once()
+	mockBox.EXPECT().AddCssClass("single-pane").Once()
+
+	pane := entity.NewPane(entity.PaneID("pane-1"))
+	node := &entity.PaneNode{ID: "node-1", Pane: pane}
+	ws := &entity.Workspace{
+		ID:           "ws-1",
+		Root:         node,
+		ActivePaneID: entity.PaneID("stale-pane"),
+	}
+
+	// Act
+	err := wv.SetWorkspace(ctx, ws)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 1, wv.PaneCount())
+	assert.Equal(t, entity.PaneID("stale-pane"), wv.GetActivePaneID())
+	assert.False(t, wv.GetPaneView(pane.ID).IsActive())
+}
+
 func TestWorkspaceView_HoverFocusLockState(t *testing.T) {
 	// Intentional zero-value check: hoverFocusLock is an atomic.Bool and should
 	// be safe with its language-level zero value before constructor wiring.

--- a/internal/ui/component/workspace_view_test.go
+++ b/internal/ui/component/workspace_view_test.go
@@ -128,7 +128,7 @@ func setupWorkspacePaneViewMocks(t *testing.T, mockFactory *mocks.MockWidgetFact
 	mockOverlay.EXPECT().SetMeasureOverlay(mockBorderBox, false).Once()
 
 	// GtkWidget is called when attaching hover handler - return nil for tests
-	mockOverlay.EXPECT().GtkWidget().Return(nil).Once()
+	mockOverlay.EXPECT().GtkWidget().Return(nil).Maybe()
 
 	return mockOverlay, mockBorderBox
 }
@@ -415,6 +415,10 @@ func TestSetActivePaneID_UpdatesStyling(t *testing.T) {
 	// Now change active pane
 	mockBorderBox1.EXPECT().RemoveCssClass("pane-active").Once()
 	mockBorderBox2.EXPECT().AddCssClass("pane-active").Once()
+	activatedPane := entity.PaneID("")
+	wv.SetOnActivePaneChanged(func(paneID entity.PaneID) {
+		activatedPane = paneID
+	})
 
 	// Act
 	err = wv.SetActivePaneID(pane2.ID)
@@ -422,6 +426,7 @@ func TestSetActivePaneID_UpdatesStyling(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, pane2.ID, wv.GetActivePaneID())
+	assert.Equal(t, pane2.ID, activatedPane)
 }
 
 func TestSetActivePaneID_InvalidID_ReturnsError(t *testing.T) {
@@ -436,4 +441,34 @@ func TestSetActivePaneID_InvalidID_ReturnsError(t *testing.T) {
 
 	// Assert
 	assert.ErrorIs(t, err, component.ErrPaneNotFound)
+}
+
+func TestSetWebViewWidget_InvokesAttachedCallback(t *testing.T) {
+	mockFactory := mocks.NewMockWidgetFactory(t)
+	ctx, mockBox := setupWorkspaceViewBase(t, mockFactory)
+
+	wv := component.NewWorkspaceView(ctx, mockFactory)
+	mockOverlay, _ := setupWorkspacePaneViewMocks(t, mockFactory)
+	pv := component.NewPaneView(ctx, mockFactory, entity.PaneID("pane-1"), nil)
+	mockBox.EXPECT().AddCssClass("single-pane").Once()
+	wv.RegisterPaneView(entity.PaneID("pane-1"), pv)
+
+	attachedPane := entity.PaneID("")
+	wv.SetOnWebViewAttached(func(paneID entity.PaneID) {
+		attachedPane = paneID
+	})
+
+	mockWebViewWidget := mocks.NewMockWidget(t)
+	mockOverlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
+	mockOverlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
+	mockWebViewWidget.EXPECT().GetParent().Return(nil).Once()
+	mockWebViewWidget.EXPECT().IsVisible().Return(false).Once()
+	mockWebViewWidget.EXPECT().GetAllocatedWidth().Return(0).Twice()
+	mockWebViewWidget.EXPECT().GetAllocatedHeight().Return(0).Twice()
+	mockOverlay.EXPECT().SetChild(mockWebViewWidget).Once()
+
+	err := wv.SetWebViewWidget(entity.PaneID("pane-1"), mockWebViewWidget)
+
+	require.NoError(t, err)
+	assert.Equal(t, entity.PaneID("pane-1"), attachedPane)
 }

--- a/internal/ui/component/workspace_view_test.go
+++ b/internal/ui/component/workspace_view_test.go
@@ -266,12 +266,13 @@ func TestSetWorkspace_StaleActivePaneID_DoesNotFailInitialization(t *testing.T) 
 
 	wv := component.NewWorkspaceView(ctx, mockFactory)
 
-	mockOverlay, _ := setupWorkspacePaneViewMocks(t, mockFactory)
+	mockOverlay, mockBorderBox := setupWorkspacePaneViewMocks(t, mockFactory)
 	mockStackBox := setupStackedLeafMocks(t, mockFactory, mockOverlay)
 
 	mockStackBox.EXPECT().SetVisible(true).Once()
 	mockBox.EXPECT().Append(mockStackBox).Once()
 	mockBox.EXPECT().AddCssClass("single-pane").Once()
+	mockBorderBox.EXPECT().AddCssClass("pane-active").Once()
 
 	pane := entity.NewPane(entity.PaneID("pane-1"))
 	node := &entity.PaneNode{ID: "node-1", Pane: pane}
@@ -287,8 +288,8 @@ func TestSetWorkspace_StaleActivePaneID_DoesNotFailInitialization(t *testing.T) 
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, 1, wv.PaneCount())
-	assert.Equal(t, entity.PaneID("stale-pane"), wv.GetActivePaneID())
-	assert.False(t, wv.GetPaneView(pane.ID).IsActive())
+	assert.Equal(t, pane.ID, wv.GetActivePaneID())
+	assert.True(t, wv.GetPaneView(pane.ID).IsActive())
 }
 
 func TestWorkspaceView_HoverFocusLockState(t *testing.T) {

--- a/internal/ui/component/workspace_view_test.go
+++ b/internal/ui/component/workspace_view_test.go
@@ -443,6 +443,66 @@ func TestSetActivePaneID_InvalidID_ReturnsError(t *testing.T) {
 	assert.ErrorIs(t, err, component.ErrPaneNotFound)
 }
 
+func TestSetActivePaneID_InvalidID_PreservesCurrentActivePane(t *testing.T) {
+	// Arrange
+	mockFactory := mocks.NewMockWidgetFactory(t)
+	ctx, mockBox := setupWorkspaceViewBase(t, mockFactory)
+
+	wv := component.NewWorkspaceView(ctx, mockFactory)
+
+	pane1 := entity.NewPane(entity.PaneID("pane-1"))
+	pane2 := entity.NewPane(entity.PaneID("pane-2"))
+	node1 := &entity.PaneNode{ID: "node-1", Pane: pane1}
+	node2 := &entity.PaneNode{ID: "node-2", Pane: pane2}
+
+	mockPaned := mocks.NewMockPanedWidget(t)
+	mockOverlay1, mockBorderBox1 := setupWorkspacePaneViewMocks(t, mockFactory)
+	mockStackBox1 := setupStackedLeafMocks(t, mockFactory, mockOverlay1)
+	mockOverlay2, _ := setupWorkspacePaneViewMocks(t, mockFactory)
+	mockStackBox2 := setupStackedLeafMocks(t, mockFactory, mockOverlay2)
+
+	mockFactory.EXPECT().NewPaned(layout.OrientationHorizontal).Return(mockPaned).Once()
+	mockPaned.EXPECT().SetResizeStartChild(true).Once()
+	mockPaned.EXPECT().SetResizeEndChild(true).Once()
+	mockPaned.EXPECT().SetVisible(true).Twice()
+	mockStackBox1.EXPECT().SetVisible(true).Once()
+	mockStackBox2.EXPECT().SetVisible(true).Once()
+	mockPaned.EXPECT().SetStartChild(mockStackBox1).Once()
+	mockPaned.EXPECT().SetEndChild(mockStackBox2).Once()
+	mockPaned.EXPECT().ConnectNotifyPosition(mock.Anything).Return(uint(0)).Once()
+	mockPaned.EXPECT().GetAllocatedWidth().Return(0).Once()
+	mockPaned.EXPECT().ConnectMap(mock.Anything).Return(uint(0)).Once()
+	mockPaned.EXPECT().AddTickCallback(mock.Anything).Return(uint(0)).Once()
+
+	mockBox.EXPECT().Append(mockPaned).Once()
+	mockBox.EXPECT().RemoveCssClass("single-pane").Once()
+	mockBorderBox1.EXPECT().AddCssClass("pane-active").Once()
+
+	splitNode := &entity.PaneNode{
+		ID:         "split",
+		SplitDir:   entity.SplitHorizontal,
+		SplitRatio: 0.5,
+		Children:   []*entity.PaneNode{node1, node2},
+	}
+	ws := &entity.Workspace{
+		ID:           "ws-1",
+		Root:         splitNode,
+		ActivePaneID: pane1.ID,
+	}
+
+	err := wv.SetWorkspace(ctx, ws)
+	require.NoError(t, err)
+	require.True(t, wv.GetPaneView(pane1.ID).IsActive())
+
+	// Act
+	err = wv.SetActivePaneID(entity.PaneID("non-existent"))
+
+	// Assert
+	require.ErrorIs(t, err, component.ErrPaneNotFound)
+	assert.Equal(t, pane1.ID, wv.GetActivePaneID())
+	assert.True(t, wv.GetPaneView(pane1.ID).IsActive())
+}
+
 func TestSetWebViewWidget_InvokesAttachedCallback(t *testing.T) {
 	mockFactory := mocks.NewMockWidgetFactory(t)
 	ctx, mockBox := setupWorkspaceViewBase(t, mockFactory)

--- a/internal/ui/coordinator/content/lifecycle.go
+++ b/internal/ui/coordinator/content/lifecycle.go
@@ -137,6 +137,7 @@ func (c *Coordinator) AttachToWorkspace(ctx context.Context, ws *entity.Workspac
 
 		if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
 			log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("failed to attach webview widget")
+			continue
 		}
 		logging.Trace().Mark("webview_attached")
 	}
@@ -228,4 +229,22 @@ func (c *Coordinator) RegisterPopupWebView(paneID entity.PaneID, wv port.WebView
 	if wv != nil && paneID != "" {
 		c.setWebViewLocked(paneID, wv)
 	}
+}
+
+// SyncWebViewViewport requests an explicit viewport resync when the engine
+// supports it. This is useful after widget attachment, reparenting, visibility
+// changes, or layout promotion paths that may not emit a size change.
+func (c *Coordinator) SyncWebViewViewport(ctx context.Context, paneID entity.PaneID, reason string) {
+	if c == nil || paneID == "" {
+		return
+	}
+	wv := c.getWebViewLocked(paneID)
+	if wv == nil {
+		return
+	}
+	syncer, ok := wv.(port.ViewportSyncCapable)
+	if !ok {
+		return
+	}
+	syncer.SyncViewport(ctx, reason)
 }

--- a/internal/ui/coordinator/content/lifecycle_test.go
+++ b/internal/ui/coordinator/content/lifecycle_test.go
@@ -258,3 +258,42 @@ func TestLifecycle_RegisterPopupWebView_IgnoresNil(t *testing.T) {
 
 	assert.Nil(t, c.GetWebView("popup-1"))
 }
+
+type syncViewportCapableStub struct {
+	port.WebView
+	called bool
+	ctx    context.Context
+	reason string
+}
+
+func (s *syncViewportCapableStub) SyncViewport(ctx context.Context, reason string) {
+	s.called = true
+	s.ctx = ctx
+	s.reason = reason
+}
+
+func TestLifecycle_SyncWebViewViewport_DelegatesWhenCapabilityPresent(t *testing.T) {
+	t.Parallel()
+
+	base := mocks.NewMockWebView(t)
+	wv := &syncViewportCapableStub{WebView: base}
+	c := newMinimalCoordinator()
+	c.webViews[entity.PaneID("pane-1")] = wv
+
+	ctx := context.WithValue(context.Background(), struct{}{}, "marker")
+	c.SyncWebViewViewport(ctx, "pane-1", "unit-test")
+
+	require.True(t, wv.called)
+	require.Equal(t, "unit-test", wv.reason)
+	require.Same(t, ctx, wv.ctx)
+}
+
+func TestLifecycle_SyncWebViewViewport_NoopWithoutCapability(t *testing.T) {
+	t.Parallel()
+
+	wv := mocks.NewMockWebView(t)
+	c := newMinimalCoordinator()
+	c.webViews[entity.PaneID("pane-1")] = wv
+
+	c.SyncWebViewViewport(context.Background(), "pane-1", "unit-test")
+}

--- a/internal/ui/coordinator/content/lifecycle_test.go
+++ b/internal/ui/coordinator/content/lifecycle_test.go
@@ -259,6 +259,8 @@ func TestLifecycle_RegisterPopupWebView_IgnoresNil(t *testing.T) {
 	assert.Nil(t, c.GetWebView("popup-1"))
 }
 
+type syncViewportContextKey struct{}
+
 type syncViewportCapableStub struct {
 	port.WebView
 	called bool
@@ -280,7 +282,7 @@ func TestLifecycle_SyncWebViewViewport_DelegatesWhenCapabilityPresent(t *testing
 	c := newMinimalCoordinator()
 	c.webViews[entity.PaneID("pane-1")] = wv
 
-	ctx := context.WithValue(context.Background(), struct{}{}, "marker")
+	ctx := context.WithValue(context.Background(), syncViewportContextKey{}, "marker")
 	c.SyncWebViewViewport(ctx, "pane-1", "unit-test")
 
 	require.True(t, wv.called)

--- a/internal/ui/coordinator/workspace.go
+++ b/internal/ui/coordinator/workspace.go
@@ -605,7 +605,9 @@ func (c *WorkspaceCoordinator) doIncrementalStackSplit(
 
 	widget := c.contentCoord.WrapWidget(ctx, wv)
 	if widget != nil {
-		newPaneView.SetWebViewWidget(widget)
+		if err := wsView.SetWebViewWidget(output.NewPaneNode.Pane.ID, widget); err != nil {
+			log.Warn().Err(err).Str("pane_id", string(output.NewPaneNode.Pane.ID)).Msg("failed to attach webview widget for stack split")
+		}
 	}
 
 	log.Debug().Msg("incremental stack split completed successfully")
@@ -743,7 +745,9 @@ func (c *WorkspaceCoordinator) doIncrementalSplit(
 
 	widget := c.contentCoord.WrapWidget(ctx, wv)
 	if widget != nil {
-		newPaneView.SetWebViewWidget(widget)
+		if err := wsView.SetWebViewWidget(output.NewPaneNode.Pane.ID, widget); err != nil {
+			log.Warn().Err(err).Str("pane_id", string(output.NewPaneNode.Pane.ID)).Msg("failed to attach webview widget for split")
+		}
 	}
 
 	log.Debug().Msg("incremental split completed successfully")
@@ -1622,7 +1626,9 @@ func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
 	} else {
 		widget := c.contentCoord.WrapWidget(ctx, wv)
 		if widget != nil {
-			newPaneView.SetWebViewWidget(widget)
+			if err := stackCtx.wsView.SetWebViewWidget(newPaneID, widget); err != nil {
+				log.Warn().Err(err).Str("pane_id", string(newPaneID)).Msg("failed to attach webview widget for stacked pane")
+			}
 		}
 		// Load initial page for the new pane
 		if err := wv.LoadURI(ctx, newPane.URI); err != nil {
@@ -2089,11 +2095,9 @@ func (c *WorkspaceCoordinator) attachPopupWebView(
 		return
 	}
 
-	paneView := wsView.GetPaneView(input.PopupPane.ID)
-	if paneView == nil {
-		return
+	if err := wsView.SetWebViewWidget(input.PopupPane.ID, widget); err != nil {
+		logging.FromContext(ctx).Warn().Err(err).Str("pane_id", string(input.PopupPane.ID)).Msg("failed to attach popup webview widget")
 	}
-	paneView.SetWebViewWidget(widget)
 }
 
 // insertPopupStacked inserts a popup as a stacked pane on top of the parent.
@@ -2259,7 +2263,9 @@ func (c *WorkspaceCoordinator) attachPopupPaneView(
 	if input.WebView != nil {
 		widget := c.contentCoord.WrapWidget(ctx, input.WebView)
 		if widget != nil {
-			newPaneView.SetWebViewWidget(widget)
+			if err := wsView.SetWebViewWidget(input.PopupPane.ID, widget); err != nil {
+				log.Warn().Err(err).Str("pane_id", string(input.PopupPane.ID)).Msg("failed to attach stacked popup webview widget")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- centralize CEF viewport syncing around webview attachment and pane activation
- strengthen the resize path with screen-info sync and delayed repaint pulses during live resize
- clean up viewport hook lifecycle and add focused tests for viewport sync behavior

## Testing
- go test ./internal/infrastructure/cef ./internal/ui/component ./internal/ui/coordinator/content ./internal/ui/coordinator ./internal/ui


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit viewport resynchronization for WebViews and workspace callbacks to trigger sync when panes or WebViews change.

* **Bug Fixes**
  * Improved reliability of viewport/resize handling (popup show, GTK resize, floating widgets) and hardened popup attachment with safer cleanup and teardown.

* **Tests**
  * Added unit tests for viewport/resize pulses, sync ordering, and workspace lifecycle/attachment behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->