### PR TITLE
Support zoom for local file URLs

### DIFF
--- a/internal/application/usecase/manage_zoom.go
+++ b/internal/application/usecase/manage_zoom.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/domain/entity"
@@ -196,6 +197,28 @@ func (uc *ManageZoomUseCase) GetAll(ctx context.Context) ([]*entity.ZoomLevel, e
 
 	log.Debug().Int("count", len(levels)).Msg("retrieved zoom levels")
 	return levels, nil
+}
+
+// ExtractZoomKey extracts the persistent zoom storage key from a URL string.
+// Host-based URLs use their host; file:// URLs use the file URI without query
+// or fragment so local documents can persist zoom too.
+func ExtractZoomKey(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if strings.EqualFold(u.Scheme, "file") {
+		if u.Path == "" {
+			return "", fmt.Errorf("file URL has no path: %s", rawURL)
+		}
+		u.RawQuery = ""
+		u.Fragment = ""
+		return u.String(), nil
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("URL has no host: %s", rawURL)
+	}
+	return u.Host, nil
 }
 
 // ExtractDomain extracts the host from a URL string.

--- a/internal/application/usecase/manage_zoom_test.go
+++ b/internal/application/usecase/manage_zoom_test.go
@@ -1,0 +1,46 @@
+package usecase
+
+import "testing"
+
+func TestExtractZoomKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "host based url uses host",
+			rawURL: "https://example.com/docs?q=1#top",
+			want:   "example.com",
+		},
+		{
+			name:   "file url uses canonical file uri without query or fragment",
+			rawURL: "file:///tmp/demo.html?print=1#section",
+			want:   "file:///tmp/demo.html",
+		},
+		{
+			name:    "about blank has no zoom key",
+			rawURL:  "about:blank",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractZoomKey(tt.rawURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ExtractZoomKey(%q) error = nil, want error", tt.rawURL)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ExtractZoomKey(%q) error = %v", tt.rawURL, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ExtractZoomKey(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2221,9 +2221,9 @@ func (a *App) zoomBrowserWindow(ctx context.Context, bw *browserWindow, action s
 		return nil
 	}
 
-	domain, err := usecase.ExtractDomain(wv.URI())
+	zoomKey, err := usecase.ExtractZoomKey(wv.URI())
 	if err != nil {
-		logging.FromContext(ctx).Debug().Str("uri", wv.URI()).Msg("cannot extract domain for zoom")
+		logging.FromContext(ctx).Debug().Str("uri", wv.URI()).Msg("cannot extract zoom key")
 		return nil
 	}
 
@@ -2231,13 +2231,13 @@ func (a *App) zoomBrowserWindow(ctx context.Context, bw *browserWindow, action s
 	var newZoom *entity.ZoomLevel
 	switch action {
 	case "in":
-		newZoom, err = a.deps.ZoomUC.ZoomIn(ctx, domain, current)
+		newZoom, err = a.deps.ZoomUC.ZoomIn(ctx, zoomKey, current)
 	case "out":
-		newZoom, err = a.deps.ZoomUC.ZoomOut(ctx, domain, current)
+		newZoom, err = a.deps.ZoomUC.ZoomOut(ctx, zoomKey, current)
 	case "reset":
-		err = a.deps.ZoomUC.ResetZoom(ctx, domain)
+		err = a.deps.ZoomUC.ResetZoom(ctx, zoomKey)
 		if err == nil {
-			newZoom = entity.NewZoomLevel(domain, a.deps.ZoomUC.DefaultZoom())
+			newZoom = entity.NewZoomLevel(zoomKey, a.deps.ZoomUC.DefaultZoom())
 		}
 	default:
 		return fmt.Errorf("unknown zoom action %q", action)

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2195,6 +2196,39 @@ func TestApp_DispatchBrowserWindowActionUsesSourceWindow(t *testing.T) {
 
 	// Assert second fake webview receives exactly one call per action.
 	assertRecordingWebViewBrowserActionsCalledOnce(t, "second", fakeWv2)
+}
+
+func TestApp_DispatchBrowserWindowActionZoomInSupportsFileURLs(t *testing.T) {
+	ctx := context.Background()
+
+	tab := entity.NewTab(entity.TabID("tab-1"), entity.WorkspaceID("ws-1"), entity.NewPane(entity.PaneID("pane-1")))
+	tabs := entity.NewTabList()
+	tabs.Add(tab)
+	tabs.SetActive(tab.ID)
+	bw := &browserWindow{id: "window-1", tabs: tabs}
+
+	fakeWv := &fakeRecordingWebView{id: 1, loadURILastURI: "file:///tmp/demo.html"}
+	contentCoord := contentcoord.NewCoordinator(ctx, nil, nil, nil, nil, nil, nil, nil)
+	contentCoord.RegisterPopupWebView(entity.PaneID("pane-1"), fakeWv)
+
+	app := &App{
+		browserWindows: map[string]*browserWindow{bw.id: bw},
+		contentCoord:   contentCoord,
+		deps:           &Dependencies{ZoomUC: usecase.NewManageZoomUseCase(&fakeZoomRepo{}, 1.0, nil)},
+		workspaceViews: map[entity.TabID]*component.WorkspaceView{
+			tab.ID: &component.WorkspaceView{},
+		},
+	}
+
+	if err := app.dispatchBrowserWindowAction(ctx, bw, input.ActionZoomIn); err != nil {
+		t.Fatalf("dispatchBrowserWindowAction returned error: %v", err)
+	}
+	if fakeWv.setZoomLevelCalls != 1 {
+		t.Fatalf("webview SetZoomLevel calls = %d, want 1", fakeWv.setZoomLevelCalls)
+	}
+	if diff := math.Abs(fakeWv.setZoomLevelLastLevel - 1.1); diff > 0.0001 {
+		t.Fatalf("webview SetZoomLevel level = %f, want 1.1", fakeWv.setZoomLevelLastLevel)
+	}
 }
 
 func counterIDGen() func() string {

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -2213,12 +2213,16 @@ func TestApp_DispatchBrowserWindowActionZoomInSupportsFileURLs(t *testing.T) {
 
 	app := &App{
 		browserWindows: map[string]*browserWindow{bw.id: bw},
+		tabs:           entity.NewTabList(),
+		windowForTab:   map[entity.TabID]*browserWindow{tab.ID: bw},
 		contentCoord:   contentCoord,
 		deps:           &Dependencies{ZoomUC: usecase.NewManageZoomUseCase(&fakeZoomRepo{}, 1.0, nil)},
 		workspaceViews: map[entity.TabID]*component.WorkspaceView{
 			tab.ID: &component.WorkspaceView{},
 		},
 	}
+	app.tabs.Add(tab)
+	app.tabs.SetActive(tab.ID)
 
 	if err := app.dispatchBrowserWindowAction(ctx, bw, input.ActionZoomIn); err != nil {
 		t.Fatalf("dispatchBrowserWindowAction returned error: %v", err)

--- a/internal/ui/coordinator/content/navigation.go
+++ b/internal/ui/coordinator/content/navigation.go
@@ -108,6 +108,7 @@ func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID,
 
 	zoomKey, err := usecase.ExtractZoomKey(uri)
 	if err != nil {
+		log.Debug().Err(err).Str("uri", uri).Msg("skipping zoom application: cannot extract zoom key")
 		return
 	}
 

--- a/internal/ui/coordinator/content/navigation.go
+++ b/internal/ui/coordinator/content/navigation.go
@@ -106,12 +106,12 @@ func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID,
 		return
 	}
 
-	domain, err := usecase.ExtractDomain(uri)
+	zoomKey, err := usecase.ExtractZoomKey(uri)
 	if err != nil {
 		return
 	}
 
-	_ = c.zoomUC.ApplyToWebView(ctx, wv, domain)
+	_ = c.zoomUC.ApplyToWebView(ctx, wv, zoomKey)
 }
 
 func (c *Coordinator) notifyActiveNavigation(paneID entity.PaneID, uri string) {

--- a/internal/ui/dispatcher/keyboard.go
+++ b/internal/ui/dispatcher/keyboard.go
@@ -435,9 +435,9 @@ func (d *KeyboardDispatcher) handleZoom(ctx context.Context, action string) erro
 		return nil
 	}
 
-	domain, err := usecase.ExtractDomain(wv.URI())
+	zoomKey, err := usecase.ExtractZoomKey(wv.URI())
 	if err != nil {
-		log.Debug().Str("uri", wv.URI()).Msg("cannot extract domain for zoom")
+		log.Debug().Str("uri", wv.URI()).Msg("cannot extract zoom key")
 		return nil
 	}
 
@@ -446,13 +446,13 @@ func (d *KeyboardDispatcher) handleZoom(ctx context.Context, action string) erro
 
 	switch action {
 	case "in":
-		newZoom, err = d.zoomUC.ZoomIn(ctx, domain, current)
+		newZoom, err = d.zoomUC.ZoomIn(ctx, zoomKey, current)
 	case "out":
-		newZoom, err = d.zoomUC.ZoomOut(ctx, domain, current)
+		newZoom, err = d.zoomUC.ZoomOut(ctx, zoomKey, current)
 	case "reset":
-		err = d.zoomUC.ResetZoom(ctx, domain)
+		err = d.zoomUC.ResetZoom(ctx, zoomKey)
 		if err == nil {
-			newZoom = entity.NewZoomLevel(domain, d.zoomUC.DefaultZoom())
+			newZoom = entity.NewZoomLevel(zoomKey, d.zoomUC.DefaultZoom())
 		}
 	}
 
@@ -475,7 +475,7 @@ func (d *KeyboardDispatcher) handleZoom(ctx context.Context, action string) erro
 		d.wsCoord.ShowZoomToast(ctx, zoomPercent)
 
 		log.Debug().
-			Str("domain", domain).
+			Str("zoom_key", zoomKey).
 			Str("action", action).
 			Float64("zoom", newZoom.ZoomFactor).
 			Msg("zoom applied")


### PR DESCRIPTION
## Summary
- add a persistent zoom key helper that supports both host-based URLs and file:// URLs
- use the zoom key for manual zoom actions and zoom reapplication on navigation
- add regression coverage for file:// zoom and follow up on the trivial CodeRabbit suggestions

## Testing
- rtk go test -mod=mod ./internal/ui -run TestApp_DispatchBrowserWindowActionZoomInSupportsFileURLs -count=1
- rtk go test -mod=mod ./internal/ui/coordinator/content -count=1
- rtk go test -mod=mod ./internal/ui -run 'TestApp_(BrowserWindowWebViewActionsIgnoreStaleFocusedWindow|DispatchBrowserWindowActionZoomInSupportsFileURLs)$' -count=1
- rtk go test -mod=mod ./internal/application/usecase -count=1

## Review
- coderabbit review --agent --base main (2 trivial findings addressed in follow-up commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced zoom level persistence with improved URL handling for both web and local file URLs, ensuring consistent zoom behavior across different URL schemes.

* **Tests**
  * Added comprehensive test coverage for zoom operations with local file and web URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/251)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->