### PR TITLE
Fix fractional-scale CEF OSR rendering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.2
 	github.com/bnema/purego-cef v0.13.0
-	github.com/bnema/purego-cef2gtk v0.1.1
+	github.com/bnema/purego-cef2gtk v0.2.0
 	github.com/bnema/purego-pipewire v0.1.3
 	github.com/bnema/purego-sqlite v0.1.2
 	github.com/bnema/puregotk v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.2 h1:7pzcdOJ8bGtLrCz6V582oyleP6css1ICQoGgj
 github.com/bnema/purego v0.11.0-bnema.2/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.13.0 h1:TNPY19mBOqlJeFi5CZCLJIDfAgTEMp9tviQEyZgnvJI=
 github.com/bnema/purego-cef v0.13.0/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
-github.com/bnema/purego-cef2gtk v0.1.1 h1:ZPmfFdry860/l+X+efkMNXGfqBuH+LIz2p7T5mI0pNw=
-github.com/bnema/purego-cef2gtk v0.1.1/go.mod h1:xDVdLTepKdPngYlwT/BscGHh5ohaCB4LLUeThW/Ml7c=
+github.com/bnema/purego-cef2gtk v0.2.0 h1:IcQdV+ILHPRp0tDIHt5zEtELM8/ru7mcsPBOFPbOQ60=
+github.com/bnema/purego-cef2gtk v0.2.0/go.mod h1:xDVdLTepKdPngYlwT/BscGHh5ohaCB4LLUeThW/Ml7c=
 github.com/bnema/purego-pipewire v0.1.3 h1:A3jYkuMe1KseJ8yr5Am1iLvRFu6yDWM2AwUIpl88460=
 github.com/bnema/purego-pipewire v0.1.3/go.mod h1:kchW7Bkfjc+NkX2IZw3LnlYfQxk6jxhl32Id88u04y8=
 github.com/bnema/purego-sqlite v0.1.2 h1:dhqfe3KfNRBh7tlrwxL7bf4FPZk2VCajdBESMbrvmoE=

--- a/internal/infrastructure/cef/cef2gtk_adapter.go
+++ b/internal/infrastructure/cef/cef2gtk_adapter.go
@@ -107,6 +107,21 @@ func (a *Cef2gtkAdapter) DeviceScaleFactor() float32 {
 	return a.view.DeviceScaleFactor()
 }
 
+// OSRBackingScaleFactor returns the device backing scale used for CEF OSR
+// coordinates. It returns 1 when purego-cef2gtk is using CEF's normal logical
+// OSR contract.
+func (a *Cef2gtkAdapter) OSRBackingScaleFactor() float64 {
+	if a == nil || a.destroyed.Load() {
+		return 1
+	}
+	a.viewMu.RLock()
+	defer a.viewMu.RUnlock()
+	if a.view == nil {
+		return 1
+	}
+	return cef2gtk.OSRBackingScaleFactorForScale(float64(a.view.DeviceScaleFactor()))
+}
+
 // AddSizeObserver registers a positive-size change callback. Register and
 // unregister from the GTK main thread; callbacks are invoked by the bridge from
 // GTK size notifications.

--- a/internal/infrastructure/cef/context_menu.go
+++ b/internal/infrastructure/cef/context_menu.go
@@ -8,6 +8,7 @@ import (
 	purecef "github.com/bnema/purego-cef/cef"
 
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/infrastructure/gtkutil"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/gtk"
 )
@@ -79,7 +80,7 @@ func (h *handlerSet) RunContextMenu(
 		return 0
 	}
 
-	x, y := contextMenuAnchorPosition(params, h.wv.viewBridgeScale())
+	x, y := contextMenuAnchorPosition(params, h.wv.viewBridgeScale(), h.wv.osrBackingScaleFactor())
 	executor := h.contextMenuExecutor()
 	wv := h.wv
 	wv.runOnGTK(func() {
@@ -126,14 +127,14 @@ func (h *handlerSet) contextMenuExecutor() port.ContextMenuActionExecutor {
 	)
 }
 
-func contextMenuAnchorPosition(params purecef.ContextMenuParams, scale int32) (int32, int32) {
+func contextMenuAnchorPosition(params purecef.ContextMenuParams, scale, backingScale float64) (int32, int32) {
 	if params == nil {
 		return 0, 0
 	}
-	if scale <= 0 {
-		scale = 1
+	if backingScale <= 1 {
+		return params.GetXcoord(), params.GetYcoord()
 	}
-	return params.GetXcoord() / scale, params.GetYcoord() / scale
+	return gtkutil.DeviceToLogical(params.GetXcoord(), scale), gtkutil.DeviceToLogical(params.GetYcoord(), scale)
 }
 
 func logContextMenuPopupRequest(
@@ -152,7 +153,7 @@ func logContextMenuPopupRequest(
 		Int32("raw_y", rawY).
 		Int32("popup_x", x).
 		Int32("popup_y", y).
-		Int32("scale", h.wv.viewBridgeScale()).
+		Float64("scale", h.wv.viewBridgeScale()).
 		Int("anchor_width", widget.GetAllocatedWidth()).
 		Int("anchor_height", widget.GetAllocatedHeight()).
 		Int("parent_width", cefWidgetAllocatedWidth(parent)).

--- a/internal/infrastructure/cef/context_menu.go
+++ b/internal/infrastructure/cef/context_menu.go
@@ -8,7 +8,6 @@ import (
 	purecef "github.com/bnema/purego-cef/cef"
 
 	"github.com/bnema/dumber/internal/application/port"
-	"github.com/bnema/dumber/internal/infrastructure/gtkutil"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/gtk"
 )
@@ -134,7 +133,7 @@ func contextMenuAnchorPosition(params purecef.ContextMenuParams, scale, backingS
 	if backingScale <= 1 {
 		return params.GetXcoord(), params.GetYcoord()
 	}
-	return gtkutil.DeviceToLogical(params.GetXcoord(), scale), gtkutil.DeviceToLogical(params.GetYcoord(), scale)
+	return deviceToLogicalCoord(params.GetXcoord(), scale), deviceToLogicalCoord(params.GetYcoord(), scale)
 }
 
 func logContextMenuPopupRequest(

--- a/internal/infrastructure/cef/context_menu_adapter_test.go
+++ b/internal/infrastructure/cef/context_menu_adapter_test.go
@@ -216,11 +216,15 @@ func TestContextMenuSelectionFallsBackToNativeCopySelectionWhenTextUnavailable(t
 	require.Zero(t, executor.executeCalls)
 }
 
-func TestContextMenuAnchorPositionScalesCEFCoordinates(t *testing.T) {
-	x, y := contextMenuAnchorPosition(stubContextMenuParams{x: 320, y: 180}, 2)
+func TestContextMenuAnchorPositionScalesCEFCoordinatesForDeviceBacking(t *testing.T) {
+	x, y := contextMenuAnchorPosition(stubContextMenuParams{x: 320, y: 180}, 1.25, 1)
 
-	require.Equal(t, int32(160), x)
-	require.Equal(t, int32(90), y)
+	require.Equal(t, int32(320), x)
+	require.Equal(t, int32(180), y)
+
+	x, y = contextMenuAnchorPosition(stubContextMenuParams{x: 320, y: 180}, 1.25, 1.25)
+	require.Equal(t, int32(256), x)
+	require.Equal(t, int32(144), y)
 }
 
 func TestContextMenuRawPositionDefaultsToZeroWhenParamsNil(t *testing.T) {

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -208,7 +208,6 @@ func wireEngine(
 	currentConfigPayload func() ([]byte, error), defaultConfigPayload func() ([]byte, error),
 ) (*Engine, error) {
 	eng.factory = newWebViewFactory(eng, webViewFactoryOptions{
-		scale:               detectHiDPIScale(logger),
 		windowlessFrameRate: windowlessFrameRate,
 		audioOutputFactory:  audioFactory,
 	})
@@ -313,40 +312,6 @@ func registerEngineSchemeFactory(
 	logger.Info().
 		Str("origin", actualInternalOrigin).
 		Msg("cef: registered internal https handler factory")
-}
-
-// getPrimaryMonitor returns the primary GDK monitor, or nil if unavailable.
-func getPrimaryMonitor() *gdk.Monitor {
-	display := gdk.DisplayGetDefault()
-	if display == nil {
-		return nil
-	}
-	monitors := display.GetMonitors()
-	if monitors == nil {
-		return nil
-	}
-	obj := monitors.GetObject(0)
-	if obj == nil {
-		return nil
-	}
-	mon := &gdk.Monitor{}
-	mon.SetGoPointer(obj.GoPointer())
-	return mon
-}
-
-// detectHiDPIScale queries the primary GDK monitor for its scale factor.
-func detectHiDPIScale(logger *zerolog.Logger) int32 {
-	mon := getPrimaryMonitor()
-	if mon == nil {
-		logger.Debug().Msg("cef: no primary monitor, using scale=1")
-		return 1
-	}
-	if s := mon.GetScaleFactor(); s > 0 {
-		logger.Info().Int32("scale", int32(s)).Msg("cef: detected HiDPI scale from monitor")
-		return int32(s)
-	}
-	logger.Debug().Msg("cef: monitor scale factor <= 0, using scale=1")
-	return 1
 }
 
 // appendIfMissing appends flag to args if it's not already present.

--- a/internal/infrastructure/cef/env.go
+++ b/internal/infrastructure/cef/env.go
@@ -13,6 +13,8 @@ const (
 	cefRenderNodeEnvVar           = "DUMBER_CEF_RENDER_NODE"
 	cefRenderStallRecoveryEnvVar  = "DUMBER_CEF_RENDER_STALL_RECOVERY"
 	cefRenderStallBacktraceEnvVar = "DUMBER_CEF_RENDER_STALL_BACKTRACE"
+	cefScaleProbeEnvVar           = "DUMBER_CEF_SCALE_PROBE"
+	cef2GTKTraceScaleEnvVar       = "PUREGO_CEF2GTK_TRACE_SCALE"
 )
 
 // envBoolEnabled returns true when the given environment variable is set
@@ -40,4 +42,8 @@ func renderStallRecoveryEnabled() bool {
 
 func renderStallBacktraceEnabled() bool {
 	return envBoolEnabled(cefRenderStallBacktraceEnvVar)
+}
+
+func cefScaleProbeEnabled() bool {
+	return envBoolEnabled(cefScaleProbeEnvVar) || os.Getenv(cef2GTKTraceScaleEnvVar) != ""
 }

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -22,14 +22,12 @@ var _ port.WebViewFactory = (*WebViewFactory)(nil)
 type WebViewFactory struct {
 	engine              *Engine
 	nextID              atomic.Uint64
-	scale               int32
 	windowlessFrameRate int32
 	bgColor             atomic.Uint32 // packed ARGB for BrowserSettings.BackgroundColor
 	audioOutputFactory  port.AudioOutputFactory
 }
 
 type webViewFactoryOptions struct {
-	scale               int32
 	windowlessFrameRate int32
 	audioOutputFactory  port.AudioOutputFactory
 }
@@ -46,18 +44,13 @@ const (
 	pendingBrowserCreateMaxPostRetries = 3
 )
 
-// newWebViewFactory returns a factory that will create WebViews using the
-// given HiDPI scale factor.
+// newWebViewFactory returns a factory that will create WebViews.
 func newWebViewFactory(engine *Engine, opts webViewFactoryOptions) *WebViewFactory {
-	if opts.scale < 1 {
-		opts.scale = 1
-	}
 	if opts.windowlessFrameRate < 1 {
 		opts.windowlessFrameRate = 60
 	}
 	return &WebViewFactory{
 		engine:              engine,
-		scale:               opts.scale,
 		windowlessFrameRate: opts.windowlessFrameRate,
 		audioOutputFactory:  opts.audioOutputFactory,
 	}

--- a/internal/infrastructure/cef/process_diagnostics.go
+++ b/internal/infrastructure/cef/process_diagnostics.go
@@ -94,7 +94,8 @@ func safeChromiumCmdlineFlags(cmdline string) []string {
 		var safe string
 		switch name {
 		case "--type", "--lang", "--enable-features", "--disable-features", "--ozone-platform",
-			"--use-gl", "--use-angle", "--enable-logging", "--log-severity":
+			"--use-gl", "--use-angle", "--enable-logging", "--log-severity",
+			"--force-device-scale-factor", "--high-dpi-support", "--enable-use-zoom-for-dsf":
 			if hasValue && value != "" {
 				safe = name + "=" + value
 			} else {

--- a/internal/infrastructure/cef/render_stack_env.go
+++ b/internal/infrastructure/cef/render_stack_env.go
@@ -12,19 +12,20 @@ const (
 	dumberRenderStackEnvVar           = "DUMBER_RENDER_STACK"
 	dumberRenderStackAllowSplitEnvVar = "DUMBER_RENDER_STACK_ALLOW_SPLIT"
 
-	cefEngineType           = "cef"
-	renderStackAuto         = "auto"
-	renderStackVulkanDMABUF = "vulkan-dmabuf"
-	renderStackLegacyGL     = "legacy-gl"
-	cef2gtkBackendEnvVar    = "PUREGO_CEF2GTK_BACKEND"
-	cef2gtkAngleBackendVar  = "PUREGO_CEF2GTK_ANGLE_BACKEND"
-	gskRendererEnvVar       = "GSK_RENDERER"
-	cef2gtkBackendGDKDMABUF = "gdk-dmabuf"
-	cef2gtkBackendGLArea    = "glarea"
-	cef2gtkAngleVulkan      = "vulkan"
-	cef2gtkAngleGLEGL       = "gl-egl"
-	gskRendererVulkan       = "vulkan"
-	gskRendererOpenGL       = "opengl"
+	cefEngineType                = "cef"
+	renderStackAuto              = "auto"
+	renderStackVulkanDMABUF      = "vulkan-dmabuf"
+	renderStackLegacyGL          = "legacy-gl"
+	cef2gtkBackendEnvVar         = "PUREGO_CEF2GTK_BACKEND"
+	cef2gtkAngleBackendVar       = "PUREGO_CEF2GTK_ANGLE_BACKEND"
+	cef2gtkOSRBackingScaleEnvVar = "PUREGO_CEF2GTK_OSR_BACKING_SCALE"
+	gskRendererEnvVar            = "GSK_RENDERER"
+	cef2gtkBackendGDKDMABUF      = "gdk-dmabuf"
+	cef2gtkBackendGLArea         = "glarea"
+	cef2gtkAngleVulkan           = "vulkan"
+	cef2gtkAngleGLEGL            = "gl-egl"
+	gskRendererVulkan            = "vulkan"
+	gskRendererOpenGL            = "opengl"
 )
 
 // ApplyDefaultRenderStackEnvironment configures the process environment for
@@ -54,6 +55,7 @@ func applyDefaultRenderStackEnvironment(logger port.Logger) string {
 		setRenderStackEnv(logger, gskRendererEnvVar, gskRendererVulkan)
 		setRenderStackEnv(logger, cef2gtkBackendEnvVar, cef2gtkBackendGDKDMABUF)
 		setRenderStackEnv(logger, cef2gtkAngleBackendVar, cef2gtkAngleVulkan)
+		setEnvDefault(logger, cef2gtkOSRBackingScaleEnvVar, "auto")
 	}
 	logRenderStackEnvironment(logger, stack)
 	return stack
@@ -65,6 +67,7 @@ func logRenderStackEnvironment(logger port.Logger, stack string) {
 		port.Field("gsk_renderer", os.Getenv(gskRendererEnvVar)),
 		port.Field("cef2gtk_backend", os.Getenv(cef2gtkBackendEnvVar)),
 		port.Field("cef2gtk_angle_backend", os.Getenv(cef2gtkAngleBackendVar)),
+		port.Field("cef2gtk_osr_backing_scale", os.Getenv(cef2gtkOSRBackingScaleEnvVar)),
 		port.Field("split_stack_allowed", envBoolEnabled(dumberRenderStackAllowSplitEnvVar)),
 	)
 }

--- a/internal/infrastructure/cef/render_stack_env_test.go
+++ b/internal/infrastructure/cef/render_stack_env_test.go
@@ -13,6 +13,7 @@ func TestApplyDefaultRenderStackEnvironment_DefaultsToGDKDMABUFWithANGLEVulkan(t
 	t.Setenv("GSK_RENDERER", "")
 	t.Setenv("PUREGO_CEF2GTK_BACKEND", "")
 	t.Setenv("PUREGO_CEF2GTK_ANGLE_BACKEND", "")
+	t.Setenv(cef2gtkOSRBackingScaleEnvVar, "")
 
 	got := applyDefaultRenderStackEnvironment(nil)
 
@@ -28,6 +29,9 @@ func TestApplyDefaultRenderStackEnvironment_DefaultsToGDKDMABUFWithANGLEVulkan(t
 	if got := os.Getenv("PUREGO_CEF2GTK_ANGLE_BACKEND"); got != "vulkan" {
 		t.Fatalf("PUREGO_CEF2GTK_ANGLE_BACKEND = %q, want vulkan", got)
 	}
+	if got := os.Getenv(cef2gtkOSRBackingScaleEnvVar); got != "auto" {
+		t.Fatalf("%s = %q, want auto", cef2gtkOSRBackingScaleEnvVar, got)
+	}
 }
 
 func TestApplyDefaultRenderStackEnvironment_OverridesConflictingLowLevelDefaults(t *testing.T) {
@@ -36,6 +40,7 @@ func TestApplyDefaultRenderStackEnvironment_OverridesConflictingLowLevelDefaults
 	t.Setenv("GSK_RENDERER", "ngl")
 	t.Setenv("PUREGO_CEF2GTK_BACKEND", "glarea")
 	t.Setenv("PUREGO_CEF2GTK_ANGLE_BACKEND", "gl-egl")
+	t.Setenv(cef2gtkOSRBackingScaleEnvVar, "")
 
 	got := applyDefaultRenderStackEnvironment(nil)
 
@@ -51,6 +56,9 @@ func TestApplyDefaultRenderStackEnvironment_OverridesConflictingLowLevelDefaults
 	if got := os.Getenv("PUREGO_CEF2GTK_ANGLE_BACKEND"); got != "vulkan" {
 		t.Fatalf("PUREGO_CEF2GTK_ANGLE_BACKEND = %q, want coherent vulkan default", got)
 	}
+	if got := os.Getenv(cef2gtkOSRBackingScaleEnvVar); got != "auto" {
+		t.Fatalf("%s = %q, want auto", cef2gtkOSRBackingScaleEnvVar, got)
+	}
 }
 
 func TestApplyDefaultRenderStackEnvironment_AllowSplitPreservesExplicitLowLevelOverrides(t *testing.T) {
@@ -59,6 +67,7 @@ func TestApplyDefaultRenderStackEnvironment_AllowSplitPreservesExplicitLowLevelO
 	t.Setenv("GSK_RENDERER", "ngl")
 	t.Setenv("PUREGO_CEF2GTK_BACKEND", "glarea")
 	t.Setenv("PUREGO_CEF2GTK_ANGLE_BACKEND", "gl-egl")
+	t.Setenv(cef2gtkOSRBackingScaleEnvVar, "off")
 
 	got := applyDefaultRenderStackEnvironment(nil)
 
@@ -74,6 +83,9 @@ func TestApplyDefaultRenderStackEnvironment_AllowSplitPreservesExplicitLowLevelO
 	if got := os.Getenv("PUREGO_CEF2GTK_ANGLE_BACKEND"); got != "gl-egl" {
 		t.Fatalf("PUREGO_CEF2GTK_ANGLE_BACKEND = %q, want explicit gl-egl", got)
 	}
+	if got := os.Getenv(cef2gtkOSRBackingScaleEnvVar); got != "off" {
+		t.Fatalf("%s = %q, want explicit off", cef2gtkOSRBackingScaleEnvVar, got)
+	}
 }
 
 func TestApplyDefaultRenderStackEnvironment_LegacyGLUsesGLArea(t *testing.T) {
@@ -81,6 +93,7 @@ func TestApplyDefaultRenderStackEnvironment_LegacyGLUsesGLArea(t *testing.T) {
 	t.Setenv("GSK_RENDERER", "")
 	t.Setenv("PUREGO_CEF2GTK_BACKEND", "")
 	t.Setenv("PUREGO_CEF2GTK_ANGLE_BACKEND", "")
+	t.Setenv(cef2gtkOSRBackingScaleEnvVar, "")
 
 	got := applyDefaultRenderStackEnvironment(nil)
 
@@ -92,6 +105,9 @@ func TestApplyDefaultRenderStackEnvironment_LegacyGLUsesGLArea(t *testing.T) {
 	}
 	if got := os.Getenv("PUREGO_CEF2GTK_ANGLE_BACKEND"); got != "gl-egl" {
 		t.Fatalf("PUREGO_CEF2GTK_ANGLE_BACKEND = %q, want gl-egl", got)
+	}
+	if got := os.Getenv(cef2gtkOSRBackingScaleEnvVar); got != "" {
+		t.Fatalf("%s = %q, want unset for legacy-gl", cef2gtkOSRBackingScaleEnvVar, got)
 	}
 }
 

--- a/internal/infrastructure/cef/scale.go
+++ b/internal/infrastructure/cef/scale.go
@@ -1,0 +1,14 @@
+package cef
+
+import "math"
+
+func normalizeScale(scale float64) float64 {
+	if math.IsNaN(scale) || math.IsInf(scale, 0) || scale <= 0 {
+		return 1
+	}
+	return scale
+}
+
+func deviceToLogicalCoord(value int32, scale float64) int32 {
+	return int32(math.Floor(float64(value) / normalizeScale(scale)))
+}

--- a/internal/infrastructure/cef/scale_probe.go
+++ b/internal/infrastructure/cef/scale_probe.go
@@ -1,0 +1,34 @@
+package cef
+
+const cefScaleProbeScript = `(function(){
+  try {
+    var vv = window.visualViewport;
+    var probe = document.createElement('div');
+    probe.style.cssText = 'position:fixed;left:0;top:0;width:100px;height:100px;visibility:hidden;pointer-events:none;z-index:-1';
+    document.documentElement.appendChild(probe);
+    var rect = probe.getBoundingClientRect();
+    probe.remove();
+    var data = {
+      dpr: window.devicePixelRatio,
+      inner: [window.innerWidth, window.innerHeight],
+      outer: [window.outerWidth, window.outerHeight],
+      client: [document.documentElement.clientWidth, document.documentElement.clientHeight],
+      screen: [window.screen.width, window.screen.height],
+      avail: [window.screen.availWidth, window.screen.availHeight],
+      visualViewport: vv ? {
+        width: vv.width,
+        height: vv.height,
+        scale: vv.scale,
+        offsetLeft: vv.offsetLeft,
+        offsetTop: vv.offsetTop,
+        pageLeft: vv.pageLeft,
+        pageTop: vv.pageTop
+      } : null,
+      css100Rect: {width: rect.width, height: rect.height, left: rect.left, top: rect.top},
+      scroll: [window.scrollX, window.scrollY]
+    };
+    console.info('[SCALE-PROBE] ' + JSON.stringify(data));
+  } catch (e) {
+    console.warn('[SCALE-PROBE] error ' + (e && e.message ? e.message : String(e)));
+  }
+})();`

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/bnema/dumber/internal/application/dto"
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/infrastructure/gtkutil"
 	"github.com/bnema/dumber/internal/logging"
 )
 
@@ -443,6 +444,14 @@ func cefZoomFromFactor(factor float64) float64 {
 	return math.Log(factor) / math.Log(chromiumZoomBase)
 }
 
+func cefZoomFromPageAndBackingFactor(pageZoom, backingScale float64) float64 {
+	return cefZoomFromFactor(pageZoom / gtkutil.NormalizeScale(backingScale))
+}
+
+func pageZoomFromCEFAndBackingLevel(level, backingScale float64) float64 {
+	return factorFromCEFZoom(level) * gtkutil.NormalizeScale(backingScale)
+}
+
 // factorFromCEFZoom converts a Chromium/CEF logarithmic zoom level back to a
 // linear zoom factor.
 func factorFromCEFZoom(level float64) float64 {
@@ -468,10 +477,12 @@ func (wv *WebView) SetZoomLevel(_ context.Context, factor float64) error {
 	if host == nil {
 		return errNoBrowser
 	}
-	cefLevel := cefZoomFromFactor(factor)
+	backingScale := wv.osrBackingScaleFactor()
+	cefLevel := cefZoomFromPageAndBackingFactor(factor, backingScale)
 	logging.FromContext(wv.ctx).Debug().
 		Float64("factor", factor).
 		Float64("cef_level", cefLevel).
+		Float64("osr_backing_scale", backingScale).
 		Msg("cef: SetZoomLevel")
 	host.SetZoomLevel(cefLevel)
 	wv.zoomFactor.Store(factor)
@@ -1376,15 +1387,18 @@ func (wv *WebView) selectedTextSnapshot() string {
 	return wv.selectedText
 }
 
-func (wv *WebView) viewBridgeScale() int32 {
+func (wv *WebView) viewBridgeScale() float64 {
 	if wv == nil || wv.viewBridge == nil {
 		return 1
 	}
-	scale := int32(math.Round(float64(wv.viewBridge.DeviceScaleFactor())))
-	if scale < 1 {
+	return gtkutil.NormalizeScale(float64(wv.viewBridge.DeviceScaleFactor()))
+}
+
+func (wv *WebView) osrBackingScaleFactor() float64 {
+	if wv == nil || wv.viewBridge == nil {
 		return 1
 	}
-	return scale
+	return gtkutil.NormalizeScale(wv.viewBridge.OSRBackingScaleFactor())
 }
 
 func (wv *WebView) handleMiddleClickFromBridge() bool {
@@ -1637,16 +1651,41 @@ func (wv *WebView) scheduleZoomReadback(expectedFactor, expectedLevel float64) {
 			if host == nil {
 				return
 			}
+			backingScale := wv.osrBackingScaleFactor()
 			actualLevel := host.GetZoomLevel()
 			logging.FromContext(wv.ctx).Debug().
 				Int64("delay_ms", delayMs).
 				Float64("expected_factor", expectedFactor).
 				Float64("expected_cef_level", expectedLevel).
-				Float64("actual_factor", factorFromCEFZoom(actualLevel)).
+				Float64("actual_factor", pageZoomFromCEFAndBackingLevel(actualLevel, backingScale)).
+				Float64("actual_cef_factor", factorFromCEFZoom(actualLevel)).
 				Float64("actual_cef_level", actualLevel).
+				Float64("osr_backing_scale", backingScale).
 				Msg("cef: zoom level readback")
 		})), delayMs)
 	}
+}
+
+func (wv *WebView) reapplyCurrentZoomForBackingScale(reason string) {
+	if wv == nil || wv.destroyed.Load() {
+		return
+	}
+	wv.mu.RLock()
+	host := wv.host
+	wv.mu.RUnlock()
+	if host == nil {
+		return
+	}
+	factor := wv.GetZoomLevel()
+	backingScale := wv.osrBackingScaleFactor()
+	cefLevel := cefZoomFromPageAndBackingFactor(factor, backingScale)
+	host.SetZoomLevel(cefLevel)
+	logging.FromContext(wv.ctx).Debug().
+		Str("reason", reason).
+		Float64("factor", factor).
+		Float64("cef_level", cefLevel).
+		Float64("osr_backing_scale", backingScale).
+		Msg("cef: reapplied zoom for OSR backing scale")
 }
 
 func (wv *WebView) scheduleStartBeginFrameLoop() {

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -1620,7 +1620,7 @@ func (wv *WebView) updateHoverURI(uri string) {
 // These values are empirically tuned for CEF's async zoom application.
 func (wv *WebView) scheduleZoomRefresh() {
 	for _, delayMs := range [...]int64{16, 48} {
-		purecef.PostDelayedTask(purecef.ThreadIDTidUi, purecef.NewTask(cefTaskFunc(func() {
+		task := cefNewTask(cefTaskFunc(func() {
 			if wv.destroyed.Load() {
 				return
 			}
@@ -1631,7 +1631,11 @@ func (wv *WebView) scheduleZoomRefresh() {
 				return
 			}
 			host.Invalidate(purecef.PaintElementTypePetView)
-		})), delayMs)
+		}))
+		if task == nil {
+			continue
+		}
+		cefPostDelayedTask(purecef.ThreadIDTidUi, task, delayMs)
 	}
 }
 
@@ -1644,7 +1648,7 @@ func (wv *WebView) scheduleZoomRefresh() {
 // These values are empirically tuned for CEF's async zoom application.
 func (wv *WebView) scheduleZoomReadback(expectedFactor, expectedLevel float64) {
 	for _, delayMs := range [...]int64{0, 64} {
-		purecef.PostDelayedTask(purecef.ThreadIDTidUi, purecef.NewTask(cefTaskFunc(func() {
+		task := cefNewTask(cefTaskFunc(func() {
 			if wv.destroyed.Load() {
 				return
 			}
@@ -1665,7 +1669,11 @@ func (wv *WebView) scheduleZoomReadback(expectedFactor, expectedLevel float64) {
 				Float64("actual_cef_level", actualLevel).
 				Float64("osr_backing_scale", backingScale).
 				Msg("cef: zoom level readback")
-		})), delayMs)
+		}))
+		if task == nil {
+			continue
+		}
+		cefPostDelayedTask(purecef.ThreadIDTidUi, task, delayMs)
 	}
 }
 

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/bnema/dumber/internal/application/dto"
 	"github.com/bnema/dumber/internal/application/port"
-	"github.com/bnema/dumber/internal/infrastructure/gtkutil"
 	"github.com/bnema/dumber/internal/logging"
 )
 
@@ -445,11 +444,27 @@ func cefZoomFromFactor(factor float64) float64 {
 }
 
 func cefZoomFromPageAndBackingFactor(pageZoom, backingScale float64) float64 {
-	return cefZoomFromFactor(pageZoom / gtkutil.NormalizeScale(backingScale))
+	return cefZoomFromFactor(pageZoom / normalizeScale(backingScale))
 }
 
 func pageZoomFromCEFAndBackingLevel(level, backingScale float64) float64 {
-	return factorFromCEFZoom(level) * gtkutil.NormalizeScale(backingScale)
+	return factorFromCEFZoom(level) * normalizeScale(backingScale)
+}
+
+func (wv *WebView) applyCEFZoomLevel(host purecef.BrowserHost, factor, cefLevel float64) {
+	host.SetZoomLevel(cefLevel)
+	// Force CEF to produce a new frame at the new zoom level. In OSR mode,
+	// SetZoomLevel changes the Blink layout zoom but doesn't guarantee a
+	// repaint. WasResized is a no-op when view dimensions haven't changed.
+	// NotifyScreenInfoChanged forces surface ID invalidation + a full
+	// SynchronizeVisualProperties cycle, which makes the renderer produce
+	// a new compositor frame at the new zoom level.
+	host.NotifyScreenInfoChanged()
+	// Zoom is applied asynchronously in the renderer process. Request a couple
+	// of follow-up refreshes on the CEF UI thread so OSR captures the updated
+	// compositor frame after the zoom IPC has been processed.
+	wv.scheduleZoomRefresh()
+	wv.scheduleZoomReadback(factor, cefLevel)
 }
 
 // factorFromCEFZoom converts a Chromium/CEF logarithmic zoom level back to a
@@ -484,20 +499,8 @@ func (wv *WebView) SetZoomLevel(_ context.Context, factor float64) error {
 		Float64("cef_level", cefLevel).
 		Float64("osr_backing_scale", backingScale).
 		Msg("cef: SetZoomLevel")
-	host.SetZoomLevel(cefLevel)
+	wv.applyCEFZoomLevel(host, factor, cefLevel)
 	wv.zoomFactor.Store(factor)
-	// Force CEF to produce a new frame at the new zoom level. In OSR mode,
-	// SetZoomLevel changes the Blink layout zoom but doesn't guarantee a
-	// repaint. WasResized is a no-op when view dimensions haven't changed.
-	// NotifyScreenInfoChanged forces surface ID invalidation + a full
-	// SynchronizeVisualProperties cycle, which makes the renderer produce
-	// a new compositor frame at the new zoom level.
-	host.NotifyScreenInfoChanged()
-	// Zoom is applied asynchronously in the renderer process. Request a couple
-	// of follow-up refreshes on the CEF UI thread so OSR captures the updated
-	// compositor frame after the zoom IPC has been processed.
-	wv.scheduleZoomRefresh()
-	wv.scheduleZoomReadback(factor, cefLevel)
 	return nil
 }
 
@@ -1391,14 +1394,14 @@ func (wv *WebView) viewBridgeScale() float64 {
 	if wv == nil || wv.viewBridge == nil {
 		return 1
 	}
-	return gtkutil.NormalizeScale(float64(wv.viewBridge.DeviceScaleFactor()))
+	return normalizeScale(float64(wv.viewBridge.DeviceScaleFactor()))
 }
 
 func (wv *WebView) osrBackingScaleFactor() float64 {
 	if wv == nil || wv.viewBridge == nil {
 		return 1
 	}
-	return gtkutil.NormalizeScale(wv.viewBridge.OSRBackingScaleFactor())
+	return normalizeScale(wv.viewBridge.OSRBackingScaleFactor())
 }
 
 func (wv *WebView) handleMiddleClickFromBridge() bool {
@@ -1679,7 +1682,7 @@ func (wv *WebView) reapplyCurrentZoomForBackingScale(reason string) {
 	factor := wv.GetZoomLevel()
 	backingScale := wv.osrBackingScaleFactor()
 	cefLevel := cefZoomFromPageAndBackingFactor(factor, backingScale)
-	host.SetZoomLevel(cefLevel)
+	wv.applyCEFZoomLevel(host, factor, cefLevel)
 	logging.FromContext(wv.ctx).Debug().
 		Str("reason", reason).
 		Float64("factor", factor).

--- a/internal/infrastructure/cef/webview_audio_test.go
+++ b/internal/infrastructure/cef/webview_audio_test.go
@@ -26,7 +26,6 @@ func TestEngine_WiresAudioOutputFactory(t *testing.T) {
 
 	// Verify webViewFactoryOptions can hold the audio factory
 	opts := webViewFactoryOptions{
-		scale:               1,
 		windowlessFrameRate: 60,
 		audioOutputFactory:  audioFactory,
 	}
@@ -44,7 +43,6 @@ func TestEngine_WiresAudioOutputFactory(t *testing.T) {
 func TestWebViewFactory_AudioFactoryIsOptional(t *testing.T) {
 	// Arrange
 	opts := webViewFactoryOptions{
-		scale:               1,
 		windowlessFrameRate: 60,
 		audioOutputFactory:  nil,
 	}

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -16,8 +16,9 @@ import (
 
 // Console message markers used by injected JavaScript for log filtering.
 const (
-	consoleMarkerVideoDiag = "[VIDEO-DIAG]"
-	consoleMarkerAutoCopy  = "[AUTO-COPY]"
+	consoleMarkerVideoDiag  = "[VIDEO-DIAG]"
+	consoleMarkerAutoCopy   = "[AUTO-COPY]"
+	consoleMarkerScaleProbe = "[SCALE-PROBE]"
 )
 
 // handlerSet implements all CEF handler interfaces and dispatches events to the
@@ -226,7 +227,8 @@ func (h *handlerSet) OnConsoleMessage(
 ) int32 {
 	if h.wv != nil && h.wv.ctx != nil &&
 		(strings.Contains(message, consoleMarkerVideoDiag) ||
-			strings.Contains(message, consoleMarkerAutoCopy)) {
+			strings.Contains(message, consoleMarkerAutoCopy) ||
+			strings.Contains(message, consoleMarkerScaleProbe)) {
 		log := logging.FromContext(h.wv.ctx).With().
 			Str("component", "cef-console").
 			Str("source", source).
@@ -399,6 +401,14 @@ func (h *handlerSet) OnLoadEnd(_ purecef.Browser, frame purecef.Frame, httpStatu
 	// Inject scripts and styles after page load.
 	// Must run on GTK thread — OnLoadEnd fires on the CEF IO thread,
 	// and JavaScript injection requires the main thread.
+	if cefScaleProbeEnabled() && httpStatusCode >= 0 && !strings.EqualFold(strings.TrimSpace(frameURL), "about:blank") {
+		// Do not retain/use CEF callback-scoped frame wrappers across the GTK idle hop.
+		// Re-read the current main frame through WebView.RunJavaScript instead.
+		h.wv.runOnGTK(func() {
+			logging.FromContext(h.wv.ctx).Debug().Msg("cef: injecting scale probe")
+			h.wv.RunJavaScript(context.Background(), cefScaleProbeScript)
+		})
+	}
 	if h.wv.engine != nil && h.wv.engine.contentInj != nil {
 		h.wv.runOnGTK(func() {
 			h.wv.engine.contentInj.onLoadEnd(h.wv)
@@ -630,7 +640,7 @@ func (h *handlerSet) attachAfterCreatedBrowser(
 				return
 			}
 			if err := wv.viewBridge.AttachInput(host, cef2gtk.InputOptions{
-				Scale: wv.viewBridgeScale(),
+				Scale: 0,
 				OnMiddleClick: func(_, _ float64) bool {
 					return wv.handleMiddleClickFromBridge()
 				},
@@ -656,6 +666,9 @@ func (h *handlerSet) attachAfterCreatedBrowser(
 	// Mark browser as visible — CEF OSR starts in hidden state and suppresses
 	// painting/caret updates until explicitly told the browser is shown.
 	host.WasHidden(0)
+	if h.wv != nil {
+		h.wv.SyncViewport(h.wv.ctx, "after-created")
+	}
 	return state
 }
 

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -265,10 +265,19 @@ func (wv *WebView) disconnectViewportSyncHooksOnGTKThread() {
 }
 
 func (wv *WebView) notifyViewportSyncOnCEFUIThread(host viewportSyncBrowserHost, visible bool) {
-	notifyBrowserViewportSync(host, visible)
-	if wv != nil {
-		wv.reapplyCurrentZoomForBackingScale("viewport-sync")
+	if host == nil {
+		return
 	}
+	task := cefNewTask(cefTaskFunc(func() {
+		notifyBrowserViewportSync(host, visible)
+		if wv != nil {
+			wv.reapplyCurrentZoomForBackingScale("viewport-sync")
+		}
+	}))
+	if task == nil {
+		return
+	}
+	cefPostDelayedTask(purecef.ThreadIDTidUi, task, 0)
 }
 
 func notifyBrowserViewportSync(host viewportSyncBrowserHost, visible bool) {

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -101,7 +101,7 @@ func (wv *WebView) syncViewportNowOnGTK(ctx context.Context, reason string) bool
 
 	widget := wv.viewBridge.Widget()
 	visible := widget != nil && widget.IsVisible()
-	notifyBrowserViewportSync(host, visible)
+	wv.notifyViewportSyncOnCEFUIThread(host, visible)
 	logging.FromContext(ctx).Debug().
 		Uint64("webview_id", uint64(wv.id)).
 		Bool("visible", visible).
@@ -262,6 +262,13 @@ func (wv *WebView) disconnectViewportSyncHooksOnGTKThread() {
 	wv.viewportMapFunc = nil
 	wv.viewportShowFunc = nil
 	wv.viewportRealizeFunc = nil
+}
+
+func (wv *WebView) notifyViewportSyncOnCEFUIThread(host viewportSyncBrowserHost, visible bool) {
+	notifyBrowserViewportSync(host, visible)
+	if wv != nil {
+		wv.reapplyCurrentZoomForBackingScale("viewport-sync")
+	}
 }
 
 func notifyBrowserViewportSync(host viewportSyncBrowserHost, visible bool) {

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -269,10 +269,17 @@ func (wv *WebView) notifyViewportSyncOnCEFUIThread(host viewportSyncBrowserHost,
 		return
 	}
 	task := cefNewTask(cefTaskFunc(func() {
-		notifyBrowserViewportSync(host, visible)
-		if wv != nil {
-			wv.reapplyCurrentZoomForBackingScale("viewport-sync")
+		if wv == nil || wv.destroyed.Load() {
+			return
 		}
+		wv.mu.RLock()
+		currentHost := wv.host
+		wv.mu.RUnlock()
+		if currentHost != host {
+			return
+		}
+		notifyBrowserViewportSync(host, visible)
+		wv.reapplyCurrentZoomForBackingScale("viewport-sync")
 	}))
 	if task == nil {
 		return

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -48,6 +48,36 @@ func TestNotifyBrowserViewportSync_HiddenSkipsWasHidden(t *testing.T) {
 	require.Equal(t, []string{"NotifyScreenInfoChanged", "WasResized", "Invalidate"}, host.calls)
 }
 
+func TestNotifyViewportSyncOnCEFUIThread_PostsCEFWork(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled purecef.Task
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
+		require.Equal(t, purecef.ThreadIDTidUi, threadID)
+		require.Zero(t, delayMs)
+		require.NotNil(t, task)
+		scheduled = task
+		return 1
+	}
+
+	host := &viewportSyncOrderHost{}
+	wv := &WebView{}
+	wv.notifyViewportSyncOnCEFUIThread(host, true)
+
+	require.Empty(t, host.calls)
+	require.NotNil(t, scheduled)
+
+	scheduled.Execute()
+	require.Equal(t, []string{"WasHidden", "NotifyScreenInfoChanged", "WasResized", "Invalidate"}, host.calls)
+}
+
 func TestScheduleResizeRepaintPulse_CoalescesToLatestSequence(t *testing.T) {
 	oldNewTask := cefNewTask
 	oldPostDelayedTask := cefPostDelayedTask

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -10,7 +10,8 @@ import (
 
 type viewportSyncOrderHost struct {
 	purecef.BrowserHost
-	calls []string
+	calls     []string
+	zoomLevel float64
 }
 
 func (h *viewportSyncOrderHost) WasHidden(state int32) {
@@ -30,6 +31,15 @@ func (h *viewportSyncOrderHost) WasResized() {
 
 func (h *viewportSyncOrderHost) Invalidate(_ purecef.PaintElementType) {
 	h.calls = append(h.calls, "Invalidate")
+}
+
+func (h *viewportSyncOrderHost) SetZoomLevel(level float64) {
+	h.calls = append(h.calls, "SetZoomLevel")
+	h.zoomLevel = level
+}
+
+func (h *viewportSyncOrderHost) GetZoomLevel() float64 {
+	return h.zoomLevel
 }
 
 func TestNotifyBrowserViewportSync_VisibleCallsFullSequence(t *testing.T) {
@@ -61,21 +71,82 @@ func TestNotifyViewportSyncOnCEFUIThread_PostsCEFWork(t *testing.T) {
 	var scheduled purecef.Task
 	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
 		require.Equal(t, purecef.ThreadIDTidUi, threadID)
-		require.Zero(t, delayMs)
 		require.NotNil(t, task)
-		scheduled = task
+		if delayMs == 0 && scheduled == nil {
+			scheduled = task
+		}
 		return 1
 	}
 
 	host := &viewportSyncOrderHost{}
-	wv := &WebView{}
+	wv := &WebView{ctx: context.Background(), host: host}
 	wv.notifyViewportSyncOnCEFUIThread(host, true)
 
 	require.Empty(t, host.calls)
 	require.NotNil(t, scheduled)
 
 	scheduled.Execute()
-	require.Equal(t, []string{"WasHidden", "NotifyScreenInfoChanged", "WasResized", "Invalidate"}, host.calls)
+	require.Equal(t, []string{
+		"WasHidden",
+		"NotifyScreenInfoChanged",
+		"WasResized",
+		"Invalidate",
+		"SetZoomLevel",
+		"NotifyScreenInfoChanged",
+	}, host.calls)
+}
+
+func TestNotifyViewportSyncOnCEFUIThread_SkipsStaleHost(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled purecef.Task
+	cefPostDelayedTask = func(_ purecef.ThreadID, task purecef.Task, _ int64) int32 {
+		scheduled = task
+		return 1
+	}
+
+	capturedHost := &viewportSyncOrderHost{}
+	currentHost := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: currentHost}
+	wv.notifyViewportSyncOnCEFUIThread(capturedHost, true)
+
+	require.NotNil(t, scheduled)
+	scheduled.Execute()
+	require.Empty(t, capturedHost.calls)
+	require.Empty(t, currentHost.calls)
+}
+
+func TestNotifyViewportSyncOnCEFUIThread_SkipsDestroyedWebView(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled purecef.Task
+	cefPostDelayedTask = func(_ purecef.ThreadID, task purecef.Task, _ int64) int32 {
+		scheduled = task
+		return 1
+	}
+
+	host := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: host}
+	wv.destroyed.Store(true)
+	wv.notifyViewportSyncOnCEFUIThread(host, true)
+
+	require.NotNil(t, scheduled)
+	scheduled.Execute()
+	require.Empty(t, host.calls)
 }
 
 func TestScheduleResizeRepaintPulse_CoalescesToLatestSequence(t *testing.T) {

--- a/internal/infrastructure/cef/webview_zoom_test.go
+++ b/internal/infrastructure/cef/webview_zoom_test.go
@@ -17,3 +17,13 @@ func TestZoomConversionsRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestZoomConversionsCompensateOSRBackingScale(t *testing.T) {
+	level := cefZoomFromPageAndBackingFactor(1.0, 1.2)
+	assert.InDelta(t, 1.0/1.2, factorFromCEFZoom(level), 1e-9)
+	assert.InDelta(t, 1.0, pageZoomFromCEFAndBackingLevel(level, 1.2), 1e-9)
+
+	level = cefZoomFromPageAndBackingFactor(1.75, 1.2)
+	assert.InDelta(t, 1.75/1.2, factorFromCEFZoom(level), 1e-9)
+	assert.InDelta(t, 1.75, pageZoomFromCEFAndBackingLevel(level, 1.2), 1e-9)
+}

--- a/internal/infrastructure/cef/webview_zoom_test.go
+++ b/internal/infrastructure/cef/webview_zoom_test.go
@@ -19,11 +19,13 @@ func TestZoomConversionsRoundTrip(t *testing.T) {
 }
 
 func TestZoomConversionsCompensateOSRBackingScale(t *testing.T) {
-	level := cefZoomFromPageAndBackingFactor(1.0, 1.2)
-	assert.InDelta(t, 1.0/1.2, factorFromCEFZoom(level), 1e-9)
-	assert.InDelta(t, 1.0, pageZoomFromCEFAndBackingLevel(level, 1.2), 1e-9)
-
-	level = cefZoomFromPageAndBackingFactor(1.75, 1.2)
-	assert.InDelta(t, 1.75/1.2, factorFromCEFZoom(level), 1e-9)
-	assert.InDelta(t, 1.75, pageZoomFromCEFAndBackingLevel(level, 1.2), 1e-9)
+	for _, backing := range []float64{1.0, 1.25, 1.5, 2.0} {
+		for _, pageZoom := range []float64{1.0, 1.75} {
+			t.Run(fmt.Sprintf("backing_%.2f_page_%.2f", backing, pageZoom), func(t *testing.T) {
+				level := cefZoomFromPageAndBackingFactor(pageZoom, backing)
+				assert.InDelta(t, pageZoom/backing, factorFromCEFZoom(level), 1e-9)
+				assert.InDelta(t, pageZoom, pageZoomFromCEFAndBackingLevel(level, backing), 1e-9)
+			})
+		}
+	}
 }

--- a/internal/infrastructure/gtkutil/scale.go
+++ b/internal/infrastructure/gtkutil/scale.go
@@ -1,0 +1,28 @@
+package gtkutil
+
+import (
+	"math"
+
+	"github.com/bnema/puregotk/v4/gtk"
+)
+
+// NormalizeScale clamps invalid GTK/GDK scale values to 1.
+func NormalizeScale(scale float64) float64 {
+	if math.IsNaN(scale) || math.IsInf(scale, 0) || scale <= 0 {
+		return 1
+	}
+	return scale
+}
+
+// WidgetFromNativePointer wraps a native GTK widget pointer.
+func WidgetFromNativePointer(ptr uintptr) *gtk.Widget {
+	if ptr == 0 {
+		return nil
+	}
+	return gtk.WidgetNewFromInternalPtr(ptr)
+}
+
+// DeviceToLogical converts a device-pixel coordinate into a logical coordinate.
+func DeviceToLogical(value int32, scale float64) int32 {
+	return int32(math.Floor(float64(value) / NormalizeScale(scale)))
+}

--- a/internal/infrastructure/gtkutil/scale_test.go
+++ b/internal/infrastructure/gtkutil/scale_test.go
@@ -1,13 +1,29 @@
 package gtkutil
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestNormalizeScale(t *testing.T) {
-	if got := NormalizeScale(0); got != 1 {
-		t.Fatalf("NormalizeScale(0) = %v, want 1", got)
+	tests := []struct {
+		name  string
+		input float64
+		want  float64
+	}{
+		{name: "zero", input: 0, want: 1},
+		{name: "fractional", input: 1.2, want: 1.2},
+		{name: "nan", input: math.NaN(), want: 1},
+		{name: "positive_infinity", input: math.Inf(1), want: 1},
+		{name: "negative_infinity", input: math.Inf(-1), want: 1},
+		{name: "negative", input: -1, want: 1},
 	}
-	if got := NormalizeScale(1.2); got != 1.2 {
-		t.Fatalf("NormalizeScale(1.2) = %v, want 1.2", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeScale(tt.input); got != tt.want {
+				t.Fatalf("NormalizeScale(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/infrastructure/gtkutil/scale_test.go
+++ b/internal/infrastructure/gtkutil/scale_test.go
@@ -1,0 +1,18 @@
+package gtkutil
+
+import "testing"
+
+func TestNormalizeScale(t *testing.T) {
+	if got := NormalizeScale(0); got != 1 {
+		t.Fatalf("NormalizeScale(0) = %v, want 1", got)
+	}
+	if got := NormalizeScale(1.2); got != 1.2 {
+		t.Fatalf("NormalizeScale(1.2) = %v, want 1.2", got)
+	}
+}
+
+func TestDeviceLogicalConversions(t *testing.T) {
+	if got := DeviceToLogical(320, 1.25); got != 256 {
+		t.Fatalf("DeviceToLogical(320, 1.25) = %d, want 256", got)
+	}
+}

--- a/internal/ui/coordinator/content/lifecycle.go
+++ b/internal/ui/coordinator/content/lifecycle.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/gtkutil"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/dumber/internal/ui/component"
 	"github.com/bnema/dumber/internal/ui/input"
 	"github.com/bnema/dumber/internal/ui/layout"
-	"github.com/bnema/puregotk/v4/gtk"
 )
 
 // EnsureWebView acquires or reuses a WebView for the given pane.
@@ -167,8 +167,10 @@ func (c *Coordinator) WrapWidget(ctx context.Context, wv port.WebView) layout.Wi
 		return nil
 	}
 
-	gtkWidget := &gtk.Widget{}
-	gtkWidget.Ptr = ptr
+	gtkWidget := gtkutil.WidgetFromNativePointer(ptr)
+	if gtkWidget == nil {
+		return nil
+	}
 	widget := c.widgetFactory.WrapWidget(gtkWidget)
 
 	// Attach gesture handler for mouse button 8/9 navigation


### PR DESCRIPTION
## Summary
- update purego-cef2gtk to v0.2.0 and remove the local replace
- enable the OSR backing-scale compatibility path by default for the Vulkan/DMABUF CEF stack
- compensate CEF zoom/context-menu/input paths for device-sized OSR backing
- switch Dumber scale helpers to exact GTK/CEF fractional scale semantics

## Verification
- rtk go test ./internal/infrastructure/cef ./internal/infrastructure/gtkutil ./internal/ui/coordinator/content
- rtk make build-quick
- rtk make check
- manual Niri/Wayland fractional-scale CEF smoke with: ENV=dev DUMBER_LOG_LEVEL=debug ./dist/dumber browse youtube.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context‑menu positioning and coordinate accuracy on mixed‑scale / high‑DPI displays
  * Zoom handling now compensates for OSR backing scale; viewport sync re‑applies zoom when scale changes

* **New Features**
  * Runtime "scale probe" diagnostic injected into pages (opt‑in via env) to collect display/layout metrics
  * GTK scale utilities for more reliable scale and coordinate conversions
  * Console diagnostic marker for scale probe output

* **Tests**
  * Added tests for scale normalization, device→logical conversions, and zoom/backing‑scale conversions

* **Chores**
  * Bumped a CEF-related dependency version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->