### PR TITLE
fix(omnibox): avoid per-row hover callback churn

### DIFF
--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -779,7 +779,48 @@ func (o *Omnibox) initList() error {
 	o.retainedCallbacks = append(o.retainedCallbacks, rowActivatedCb)
 	o.listBox.ConnectRowActivated(&rowActivatedCb)
 
+	o.setupListHoverSelection()
+
 	return nil
+}
+
+func (o *Omnibox) setupListHoverSelection() {
+	motionCtrl := gtk.NewEventControllerMotion()
+	if motionCtrl == nil {
+		logging.FromContext(o.ctx).Error().Msg("failed to create motion event controller")
+		return
+	}
+
+	motionCb := func(_ gtk.EventControllerMotion, _ float64, y float64) {
+		o.handleListHoverSelection(y)
+	}
+	o.retainedCallbacks = append(o.retainedCallbacks, motionCb)
+	motionCtrl.ConnectMotion(&motionCb)
+	o.listBox.AddController(&motionCtrl.EventController)
+}
+
+func (o *Omnibox) handleListHoverSelection(y float64) {
+	o.mu.RLock()
+	realInput := o.realInput
+	hasGhostText := o.ghostSuffix != ""
+	hasNavigated := o.hasNavigated
+	selectedIndex := o.selectedIndex
+	o.mu.RUnlock()
+
+	if !shouldPromoteHoverSelection(realInput, hasGhostText, hasNavigated) {
+		return
+	}
+
+	row := o.listBox.GetRowAtY(int(y))
+	if row == nil {
+		return
+	}
+
+	index := row.GetIndex()
+	if index < 0 || index == selectedIndex {
+		return
+	}
+	o.selectIndex(index)
 }
 
 func (o *Omnibox) assembleWidgets() {
@@ -2087,7 +2128,6 @@ func (o *Omnibox) createRowWithFaviconURL(
 		return nil
 	}
 	row.AddCssClass("omnibox-row")
-	o.attachRowHoverSelection(row, index)
 
 	const rowSpacing = 8
 	hbox := gtk.NewBox(gtk.OrientationHorizontalValue, rowSpacing)
@@ -2117,29 +2157,6 @@ func (o *Omnibox) createRowWithFaviconURL(
 
 	row.SetChild(&hbox.Widget)
 	return row
-}
-
-func (o *Omnibox) attachRowHoverSelection(row *gtk.ListBoxRow, index int) {
-	motionCtrl := gtk.NewEventControllerMotion()
-	if motionCtrl == nil {
-		return
-	}
-
-	enterCb := func(_ gtk.EventControllerMotion, _ float64, _ float64) {
-		o.mu.RLock()
-		realInput := o.realInput
-		hasGhostText := o.ghostSuffix != ""
-		hasNavigated := o.hasNavigated
-		o.mu.RUnlock()
-
-		if !shouldPromoteHoverSelection(realInput, hasGhostText, hasNavigated) {
-			return
-		}
-		o.selectIndex(index)
-	}
-	o.retainedCallbacks = append(o.retainedCallbacks, enterCb)
-	motionCtrl.ConnectEnter(&enterCb)
-	row.AddController(&motionCtrl.EventController)
 }
 
 func shouldPromoteHoverSelection(realInput string, hasGhostText, hasNavigated bool) bool {


### PR DESCRIPTION
## Summary
- Replace per-row omnibox hover callbacks with a single list-level motion handler.
- Select hovered rows via `ListBox.GetRowAtY`, avoiding purego callback slot exhaustion during suggestion rebuilds.
- Log if the hover motion controller cannot be created.

## Test Plan
- [x] go test ./internal/ui/component
- [x] git diff --check

Note: `go test ./...` was attempted but `internal/infrastructure/audio/factory` hung at `TestNewAudioOutputFactory_ReturnsWorkingFactory`, which appears unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized omnibox list hover and keyboard-selection handling by consolidating motion detection into a single unified handler that intelligently determines when hover should promote selection based on user input state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->