### PR TITLE
feat(cef): add render stack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ CEF_DIR=/custom/path dumber browse
 
 Then set `engine.type = "cef"` in your config.
 
-CEF uses Dumber's GPU-first Wayland render stack by default: GDK DMABUF presentation with ANGLE/GSK Vulkan. You normally do not need render environment variables or helper scripts. For diagnostics only, set `DUMBER_RENDER_STACK=legacy-gl` to use the older GtkGLArea/OpenGL bridge, or `DUMBER_RENDER_STACK=vulkan-dmabuf` to force the default explicitly.
+CEF uses Dumber's GPU-first Wayland render stack by default: GDK DMABUF presentation with ANGLE/GSK Vulkan. For driver compatibility, switch to the EGL/OpenGL stack with `engine.cef.render_stack = "egl"`; the default is `"vulkan"`.
 
 ## Keyboard-Driven
 

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -328,7 +328,7 @@ func applyCEFRenderStackDefault(ctx context.Context, cfg *config.Config) {
 		return
 	}
 	logger := logging.NewPortLogger(ctx)
-	infracef.ApplyDefaultRenderStackEnvironment(logger)
+	infracef.ApplyConfiguredRenderStackEnvironment(string(cfg.Engine.CEF.CEFRenderStack()), logger)
 	infracef.ApplyDefaultHardwareDecodeEnvironment(ctx, infracef.HardwareDecodeEnvironmentOptions{
 		EngineType:               cfg.Engine.ResolveEngineType(),
 		HardwareDecodingDisabled: cfg.Media.HardwareDecodingMode == config.HardwareDecodingDisable,

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -189,6 +189,7 @@ border = "#363636"
 | `rendering.show_fps` | bool | `false` | - | Show WebKit FPS counter (`WEBKIT_SHOW_FPS`) |
 | `rendering.sample_memory` | bool | `false` | - | Enable WebKit memory sampling (`WEBKIT_SAMPLE_MEMORY`) |
 | `rendering.debug_frames` | bool | `false` | - | Enable GTK frame timing debug (`GDK_DEBUG=frames`) |
+| `engine.cef.render_stack` | string | `"vulkan"` | `vulkan`, `egl` | CEF GPU render stack |
 | `default_ui_scale` | float | `1.0` | > 0 | GTK widget UI scale (1.0=100%, 2.0=200%) |
 | `default_webpage_zoom` | float | `1.2` | > 0 | Default page zoom (1.0=100%, 1.2=120%) |
 
@@ -691,8 +692,8 @@ DUMBER_DATABASE_PATH=/custom/path/db.sqlite
 
 # Rendering (examples)
 # CEF defaults to the GPU-first Vulkan DMABUF stack.
-# Use legacy-gl only as a diagnostic fallback.
-# DUMBER_RENDER_STACK=legacy-gl
+# Use EGL/OpenGL for driver compatibility:
+# DUMBER_ENGINE_CEF_RENDER_STACK=egl
 DUMBER_RENDERING_MODE=cpu
 # WebKit-specific rendering overrides:
 # DUMBER_RENDERING_DISABLE_DMABUF_RENDERER=true

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -59,7 +59,7 @@
 | `rendering.show_fps` | bool | `false` | |
 | `rendering.sample_memory` | bool | `false` | |
 | `rendering.debug_frames` | bool | `false` | |
-| `DUMBER_RENDER_STACK` env | string | `vulkan-dmabuf` | `vulkan-dmabuf`, `auto`, `legacy-gl` |
+| `engine.cef.render_stack` | string | `vulkan` | `vulkan`, `egl` |
 | `default_ui_scale` | float | `1.0` | > 0 |
 | `default_webpage_zoom` | float | `1.2` | > 0 |
 | `workspace.new_pane_url` | string | `about:blank` | |

--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -73,7 +73,7 @@ sudo pacman -S vulkan-tools  # for vulkaninfo
 
 ### CEF Wayland rendering
 
-When `engine.type = "cef"`, Dumber defaults to the GPU-first Wayland stack: GDK DMABUF presentation with ANGLE/GSK Vulkan. No launch wrapper or render environment variables are required for normal use. Set `DUMBER_RENDER_STACK=legacy-gl` only when diagnosing the older GtkGLArea/OpenGL fallback path.
+When `engine.type = "cef"`, Dumber defaults to the GPU-first Wayland stack: GDK DMABUF presentation with ANGLE/GSK Vulkan. No launch wrapper or render environment variables are required for normal use. For driver compatibility, set `engine.cef.render_stack = "egl"` (or `DUMBER_ENGINE_CEF_RENDER_STACK=egl`) to use the GtkGLArea/EGL/OpenGL stack.
 
 ## Debian/Ubuntu
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.2
 	github.com/bnema/purego-cef v0.13.0
-	github.com/bnema/purego-cef2gtk v0.2.0
+	github.com/bnema/purego-cef2gtk v0.3.0
 	github.com/bnema/purego-pipewire v0.1.3
 	github.com/bnema/purego-sqlite v0.1.2
 	github.com/bnema/puregotk v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.2 h1:7pzcdOJ8bGtLrCz6V582oyleP6css1ICQoGgj
 github.com/bnema/purego v0.11.0-bnema.2/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.13.0 h1:TNPY19mBOqlJeFi5CZCLJIDfAgTEMp9tviQEyZgnvJI=
 github.com/bnema/purego-cef v0.13.0/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
-github.com/bnema/purego-cef2gtk v0.2.0 h1:IcQdV+ILHPRp0tDIHt5zEtELM8/ru7mcsPBOFPbOQ60=
-github.com/bnema/purego-cef2gtk v0.2.0/go.mod h1:xDVdLTepKdPngYlwT/BscGHh5ohaCB4LLUeThW/Ml7c=
+github.com/bnema/purego-cef2gtk v0.3.0 h1:hNiCRDXjzAZ5KEnhmbWMQ+gaJQXNG7WdwaQvHwdPMRk=
+github.com/bnema/purego-cef2gtk v0.3.0/go.mod h1:xDVdLTepKdPngYlwT/BscGHh5ohaCB4LLUeThW/Ml7c=
 github.com/bnema/purego-pipewire v0.1.3 h1:A3jYkuMe1KseJ8yr5Am1iLvRFu6yDWM2AwUIpl88460=
 github.com/bnema/purego-pipewire v0.1.3/go.mod h1:kchW7Bkfjc+NkX2IZw3LnlYfQxk6jxhl32Id88u04y8=
 github.com/bnema/purego-sqlite v0.1.2 h1:dhqfe3KfNRBh7tlrwxL7bf4FPZk2VCajdBESMbrvmoE=

--- a/internal/bootstrap/engine.go
+++ b/internal/bootstrap/engine.go
@@ -80,6 +80,7 @@ func BuildEngine(input EngineInput) (port.Engine, error) {
 			CEFDir:              cfg.Engine.CEF.CEFDir,
 			LogFile:             cfg.Engine.CEF.LogFile,
 			LogSeverity:         cfg.Engine.CEF.LogSeverity,
+			RenderStack:         string(cfg.Engine.CEF.CEFRenderStack()),
 			WindowlessFrameRate: cfg.Engine.CEF.WindowlessFrameRate,
 			EnableAudioHandler:  cfg.Engine.CEF.EnableAudioHandler,
 			TraceHandlers:       cfg.Engine.CEF.TraceHandlers,

--- a/internal/infrastructure/cef/app.go
+++ b/internal/infrastructure/cef/app.go
@@ -41,6 +41,10 @@ func registerDumbScheme(registrar purecef.SchemeRegistrar) {
 }
 
 func configureCommandLine(commandLine purecef.CommandLine) {
+	configureCommandLineWithRenderStack(commandLine, cef2gtk.RenderStackPlan{})
+}
+
+func configureCommandLineWithRenderStack(commandLine purecef.CommandLine, renderStackPlan cef2gtk.RenderStackPlan) {
 	if commandLine == nil {
 		return
 	}
@@ -48,7 +52,7 @@ func configureCommandLine(commandLine purecef.CommandLine) {
 	// Delegate Wayland accelerated rendering setup to the GTK bridge.
 	// Preserves any pre-existing ozone-platform value (e.g. set via
 	// CEF command-line args) — the bridge is a no-op when already present.
-	cef2gtk.ConfigureCommandLine(commandLine, cef2gtk.CommandLineOptions{})
+	cef2gtk.ConfigureCommandLine(commandLine, cef2gtk.CommandLineOptions{RenderStackPlan: renderStackPlan})
 
 	// Enable Chromium's built-in smooth scrolling animation — without this,
 	// mouse wheel scroll jumps in discrete steps with no momentum/easing.
@@ -292,7 +296,7 @@ const maxCmdLineLogLen = 200
 func (a *dumberApp) OnBeforeCommandLineProcessing(processType string, commandLine purecef.CommandLine) {
 	log := logging.FromContext(a.engine.ctx)
 	if commandLine != nil {
-		configureCommandLine(commandLine)
+		configureCommandLineWithRenderStack(commandLine, a.engine.renderStackPlan)
 
 		if processType == "" {
 			if cefWebAuthnUnsafeEnabled() {
@@ -360,7 +364,7 @@ func (h *dumberBPH) OnBeforeChildProcessLaunch(commandLine purecef.CommandLine) 
 	ozonePlatform := ""
 	renderNodeOverride := ""
 	if commandLine != nil {
-		configureCommandLine(commandLine)
+		configureCommandLineWithRenderStack(commandLine, h.engine.renderStackPlan)
 		appendSwitchIfMissing(commandLine, "no-zygote")
 		processType = commandLine.GetSwitchValue("type")
 		commandLineString = commandLine.GetCommandLineString()

--- a/internal/infrastructure/cef/app_test.go
+++ b/internal/infrastructure/cef/app_test.go
@@ -297,6 +297,17 @@ func TestConfigureCommandLine_PreservesExistingOzonePlatform(t *testing.T) {
 	}
 }
 
+func TestConfigureCommandLine_PreservesInheritedANGLEBackend(t *testing.T) {
+	commandLine := newMutableCommandLineStub()
+	commandLine.AppendSwitchWithValue("use-angle", "gl-egl")
+
+	configureCommandLine(commandLine)
+
+	if got := commandLine.GetSwitchValue("use-angle"); got != "gl-egl" {
+		t.Fatalf("use-angle = %q, want inherited gl-egl", got)
+	}
+}
+
 func TestConfigureCommandLine_EnableVAAPIEnvAppendsHardwareDecodeFlags(t *testing.T) {
 	t.Setenv(cefEnableVAAPIEnvVar, "1")
 
@@ -337,8 +348,8 @@ func TestConfigureCommandLine_ChromiumFlagsEnvAppendsSwitches(t *testing.T) {
 
 	configureCommandLine(commandLine)
 
-	if got := commandLine.GetSwitchValue(chromiumEnableFeaturesSwitch); got != "ExistingFeature,VaapiVideoDecoder,VaapiIgnoreDriverChecks" {
-		t.Fatalf("enable-features = %q, want env features appended", got)
+	if got := commandLine.GetSwitchValue(chromiumEnableFeaturesSwitch); got != "ExistingFeature,Vulkan,DefaultANGLEVulkan,VulkanFromANGLE,VaapiVideoDecoder,VaapiIgnoreDriverChecks" {
+		t.Fatalf("enable-features = %q, want render stack and env features appended", got)
 	}
 	if !commandLine.HasSwitch("ignore-gpu-blocklist") {
 		t.Fatal("expected ignore-gpu-blocklist switch")

--- a/internal/infrastructure/cef/cef2gtk_adapter.go
+++ b/internal/infrastructure/cef/cef2gtk_adapter.go
@@ -33,8 +33,8 @@ type Cef2gtkAdapter struct {
 
 // NewCef2gtkAdapter creates an accelerated CEF view and wraps it in a thin
 // Dumber adapter.
-func NewCef2gtkAdapter() *Cef2gtkAdapter {
-	v := cef2gtk.NewView()
+func NewCef2gtkAdapter(renderStackPlan cef2gtk.RenderStackPlan) *Cef2gtkAdapter {
+	v := cef2gtk.NewViewWithOptions(cef2gtk.ViewOptions{RenderStackPlan: renderStackPlan})
 	if v == nil {
 		return nil
 	}

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	purecef "github.com/bnema/purego-cef/cef"
+	cef2gtk "github.com/bnema/purego-cef2gtk"
 
 	"github.com/bnema/dumber/internal/application/dto"
 	"github.com/bnema/dumber/internal/application/port"
@@ -24,11 +25,12 @@ var _ port.AlreadyRunningAppRelaunchHandlerSetter = (*Engine)(nil)
 // Engine implements port.Engine for the CEF browser backend.
 // It manages the CEF lifecycle and provides access to all engine subsystems.
 type Engine struct {
-	ctx           context.Context
-	factory       *WebViewFactory
-	pool          *WebViewPool
-	profileLogDir string
-	runtimeCEFDir string
+	ctx             context.Context
+	factory         *WebViewFactory
+	pool            *WebViewPool
+	profileLogDir   string
+	runtimeCEFDir   string
+	renderStackPlan cef2gtk.RenderStackPlan
 
 	messageRouter *MessageRouter
 	schemeHandler *dumbSchemeHandler

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	purecef "github.com/bnema/purego-cef/cef"
+	cef2gtk "github.com/bnema/purego-cef2gtk"
 	"github.com/bnema/puregotk/v4/gdk"
 	"github.com/bnema/puregotk/v4/glib"
 	"github.com/rs/zerolog"
@@ -44,6 +45,11 @@ func NewEngine(
 	stateRoot := resolvedStateRoot(paths.StateRoot, opts)
 	cleanStaleSingletonLocks(logger, stateRoot)
 	windowlessFrameRate := normalizedWindowlessFrameRate(cfg.WindowlessFrameRate)
+	renderStackPlan, err := resolveCEFRenderStackPlan(cfg.RenderStack)
+	if err != nil {
+		return nil, err
+	}
+	cef2gtk.ConfigureRenderStackEnvironment(renderStackPlan)
 
 	settings, err := prepareCEFSettings(opts, paths, cfg, logger)
 	if err != nil {
@@ -59,6 +65,7 @@ func NewEngine(
 		ctx:                    ctx,
 		profileLogDir:          paths.ProfileLogDir,
 		runtimeCEFDir:          settings.CEFDir,
+		renderStackPlan:        renderStackPlan,
 		registerHandlers:       deps.RegisterHandlers,
 		registerAccentHandlers: deps.RegisterAccentHandlers,
 		currentConfigPayload:   deps.CurrentConfigPayload,
@@ -72,6 +79,10 @@ func NewEngine(
 
 	logger.Info().
 		Int32("windowless_frame_rate", windowlessFrameRate).
+		Str("render_stack", string(renderStackPlan.Stack)).
+		Str("render_backend", renderStackPlan.Backend.String()).
+		Str("angle_backend", renderStackPlan.ANGLEBackend).
+		Str("gsk_renderer", renderStackPlan.GSKRenderer).
 		Bool("external_begin_frame", externalBeginFrameEnabled()).
 		Bool("trace_handlers", cfg.TraceHandlers).
 		Bool("enable_audio_handler", cfg.EnableAudioHandler).

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -81,7 +81,7 @@ func (f *WebViewFactory) Create(ctx context.Context) (port.WebView, error) {
 
 	// Configure BrowserSettings.
 	settings := purecef.NewBrowserSettings()
-	settings.WindowlessFrameRate = f.windowlessFrameRate
+	cef2gtk.ConfigureBrowserSettings(&settings, cef2gtk.BrowserSettingsOptions{WindowlessFrameRate: f.windowlessFrameRate})
 	settings.LocalStorage = 1 // CEF_STATE_ENABLED
 	if bg := f.bgColor.Load(); bg != 0 {
 		settings.BackgroundColor = bg
@@ -97,7 +97,7 @@ func (f *WebViewFactory) Create(ctx context.Context) (port.WebView, error) {
 
 func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 	id := port.WebViewID(f.nextID.Add(1))
-	viewBridge := NewCef2gtkAdapter()
+	viewBridge := NewCef2gtkAdapter(f.engine.renderStackPlan)
 	if viewBridge == nil {
 		return nil, fmt.Errorf("create cef2gtk view")
 	}
@@ -300,7 +300,7 @@ func (f *WebViewFactory) CreateRelated(ctx context.Context, parentID port.WebVie
 	}
 
 	settings := purecef.NewBrowserSettings()
-	settings.WindowlessFrameRate = f.windowlessFrameRate
+	cef2gtk.ConfigureBrowserSettings(&settings, cef2gtk.BrowserSettingsOptions{WindowlessFrameRate: f.windowlessFrameRate})
 	settings.LocalStorage = 1 // CEF_STATE_ENABLED
 	if bg := f.bgColor.Load(); bg != 0 {
 		settings.BackgroundColor = bg

--- a/internal/infrastructure/cef/render_stack.go
+++ b/internal/infrastructure/cef/render_stack.go
@@ -1,0 +1,36 @@
+package cef
+
+import (
+	"fmt"
+
+	cef2gtk "github.com/bnema/purego-cef2gtk"
+
+	"github.com/bnema/dumber/internal/application/port"
+)
+
+func resolveCEFRenderStackPlan(stack string) (cef2gtk.RenderStackPlan, error) {
+	plan, err := cef2gtk.ResolveRenderStack(cef2gtk.RenderStack(stack))
+	if err != nil {
+		return cef2gtk.RenderStackPlan{}, fmt.Errorf("resolve CEF render stack: %w", err)
+	}
+	return plan, nil
+}
+
+// ApplyConfiguredRenderStackEnvironment applies Dumber's CEF render-stack
+// process environment before GTK/libadwaita initialize.
+func ApplyConfiguredRenderStackEnvironment(stack string, logger port.Logger) cef2gtk.RenderStackPlan {
+	plan, err := resolveCEFRenderStackPlan(stack)
+	if err != nil {
+		logWarn(logger, "cef: invalid render stack, falling back to Vulkan", port.Field("error", err.Error()))
+		plan, _ = cef2gtk.ResolveRenderStack(cef2gtk.RenderStackVulkan)
+	}
+	cef2gtk.ConfigureRenderStackEnvironment(plan)
+	logInfo(logger, "cef: render stack environment configured",
+		port.Field("render_stack", string(plan.Stack)),
+		port.Field("render_backend", plan.Backend.String()),
+		port.Field("angle_backend", plan.ANGLEBackend),
+		port.Field("gsk_renderer", plan.GSKRenderer),
+		port.Field("osr_backing_scale", plan.OSRBackingScale),
+	)
+	return plan
+}

--- a/internal/infrastructure/cef/render_stack_plan_test.go
+++ b/internal/infrastructure/cef/render_stack_plan_test.go
@@ -1,0 +1,48 @@
+package cef
+
+import (
+	"testing"
+
+	cef2gtk "github.com/bnema/purego-cef2gtk"
+)
+
+func TestResolveCEFRenderStackPlan(t *testing.T) {
+	tests := []struct {
+		name      string
+		stack     string
+		wantStack cef2gtk.RenderStack
+		wantAngle string
+	}{
+		{name: "vulkan", stack: "vulkan", wantStack: cef2gtk.RenderStackVulkan, wantAngle: "vulkan"},
+		{name: "egl", stack: "egl", wantStack: cef2gtk.RenderStackEGL, wantAngle: "gl-egl"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := resolveCEFRenderStackPlan(tt.stack)
+			if err != nil {
+				t.Fatalf("resolveCEFRenderStackPlan(%q) error = %v", tt.stack, err)
+			}
+			if plan.Stack != tt.wantStack {
+				t.Fatalf("Stack = %q, want %q", plan.Stack, tt.wantStack)
+			}
+			if plan.ANGLEBackend != tt.wantAngle {
+				t.Fatalf("ANGLEBackend = %q, want %q", plan.ANGLEBackend, tt.wantAngle)
+			}
+		})
+	}
+}
+
+func TestConfigureCommandLineWithRenderStackUsesPlan(t *testing.T) {
+	plan, err := resolveCEFRenderStackPlan("egl")
+	if err != nil {
+		t.Fatalf("resolveCEFRenderStackPlan(egl) error = %v", err)
+	}
+	commandLine := newMutableCommandLineStub()
+
+	configureCommandLineWithRenderStack(commandLine, plan)
+
+	if got := commandLine.GetSwitchValue("use-angle"); got != "gl-egl" {
+		t.Fatalf("use-angle = %q, want gl-egl", got)
+	}
+}

--- a/internal/infrastructure/cef/runtime_config.go
+++ b/internal/infrastructure/cef/runtime_config.go
@@ -18,6 +18,7 @@ type RuntimeConfig struct {
 	CEFDir              string
 	LogFile             string
 	LogSeverity         int32
+	RenderStack         string
 	WindowlessFrameRate int32
 	EnableAudioHandler  bool
 	TraceHandlers       bool

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -965,9 +965,7 @@ func configureNativePopupWindow(
 	if settings == nil {
 		return
 	}
-	if frameRate > 0 {
-		settings.WindowlessFrameRate = frameRate
-	}
+	cef2gtk.ConfigureBrowserSettings(settings, cef2gtk.BrowserSettingsOptions{WindowlessFrameRate: frameRate})
 	settings.LocalStorage = 1
 	if backgroundColor != 0 {
 		settings.BackgroundColor = backgroundColor

--- a/internal/infrastructure/config/cef_render_stack_test.go
+++ b/internal/infrastructure/config/cef_render_stack_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCEFRenderStackDefaultIsVulkan(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.Equal(t, CEFRenderStackVulkan, cfg.Engine.CEF.CEFRenderStack())
+}
+
+func TestValidateConfig_CEFRenderStack(t *testing.T) {
+	tests := []struct {
+		name    string
+		stack   CEFRenderStack
+		wantErr bool
+	}{
+		{name: "vulkan", stack: CEFRenderStackVulkan},
+		{name: "egl", stack: CEFRenderStackEGL},
+		{name: "empty uses default", stack: ""},
+		{name: "invalid", stack: CEFRenderStack("auto"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Engine.CEF.RenderStack = tt.stack
+
+			err := validateConfig(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "engine.cef.render_stack")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -171,6 +171,7 @@ func DefaultConfig() *Config {
 			// matches Epiphany's model and avoids a misleading setting.
 			CookiePolicy: CookiePolicyAlways,
 			CEF: CEFEngineConfig{
+				RenderStack:         CEFRenderStackVulkan,
 				WindowlessFrameRate: defaultCEFWindowlessFrameRate,
 				LogFile:             "",
 				EnableAudioHandler:  true,

--- a/internal/infrastructure/config/defaults_test.go
+++ b/internal/infrastructure/config/defaults_test.go
@@ -18,6 +18,7 @@ func TestDefaultConfig_CoreDefaults(t *testing.T) {
 	assert.Equal(t, "webkit", cfg.Engine.Type)
 	assert.Equal(t, ProfileDefault, cfg.Engine.Profile)
 	assert.Equal(t, CookiePolicyAlways, cfg.Engine.CookiePolicy)
+	assert.Equal(t, CEFRenderStackVulkan, cfg.Engine.CEF.CEFRenderStack())
 	assert.Equal(t, int32(defaultCEFWindowlessFrameRate), cfg.Engine.CEF.CEFWindowlessFrameRate())
 	assert.Empty(t, cfg.Engine.CEF.LogFile)
 	assert.True(t, cfg.Engine.CEF.EnableAudioHandler)

--- a/internal/infrastructure/config/engine.go
+++ b/internal/infrastructure/config/engine.go
@@ -7,6 +7,14 @@ const (
 	EngineTypeCEF    = "cef"
 )
 
+// CEFRenderStack selects Dumber's CEF GPU render stack.
+type CEFRenderStack string
+
+const (
+	CEFRenderStackVulkan CEFRenderStack = "vulkan"
+	CEFRenderStackEGL    CEFRenderStack = "egl"
+)
+
 // EngineConfig holds engine selection and universal engine options.
 type EngineConfig struct {
 	Type             string             `mapstructure:"type" toml:"type" yaml:"type"`
@@ -90,6 +98,8 @@ type CEFEngineConfig struct {
 	// LogSeverity controls CEF's internal log verbosity.
 	// 0 = default, 1 = verbose, 2 = info, 3 = warning, 4 = error, 99 = disable.
 	LogSeverity int32 `mapstructure:"log_severity" toml:"log_severity" yaml:"log_severity"`
+	// RenderStack selects the CEF GPU render stack. Empty falls back to vulkan.
+	RenderStack CEFRenderStack `mapstructure:"render_stack" toml:"render_stack" yaml:"render_stack"`
 	// WindowlessFrameRate is the maximum frame rate for off-screen rendering.
 	// Default: 60. Higher values increase CPU usage.
 	WindowlessFrameRate int32 `mapstructure:"windowless_frame_rate" toml:"windowless_frame_rate" yaml:"windowless_frame_rate"`
@@ -97,6 +107,14 @@ type CEFEngineConfig struct {
 	EnableAudioHandler bool `mapstructure:"enable_audio_handler" toml:"enable_audio_handler" yaml:"enable_audio_handler"`
 	// TraceHandlers enables purego-cef handler/refcount tracing for diagnostics.
 	TraceHandlers bool `mapstructure:"trace_handlers" toml:"trace_handlers" yaml:"trace_handlers"`
+}
+
+// CEFRenderStack returns the effective CEF GPU render stack.
+func (c CEFEngineConfig) CEFRenderStack() CEFRenderStack {
+	if c.RenderStack != "" {
+		return c.RenderStack
+	}
+	return CEFRenderStackVulkan
 }
 
 // CEFWindowlessFrameRate returns the effective OSR frame rate.

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -691,6 +691,7 @@ func (m *Manager) setEngineDefaults(defaults *Config) {
 
 	ce := e.CEF
 	m.viper.SetDefault("engine.cef.cef_dir", ce.CEFDir)
+	m.viper.SetDefault("engine.cef.render_stack", string(ce.CEFRenderStack()))
 	m.viper.SetDefault("engine.cef.log_file", ce.LogFile)
 	m.viper.SetDefault("engine.cef.log_severity", ce.LogSeverity)
 	m.viper.SetDefault("engine.cef.windowless_frame_rate", ce.CEFWindowlessFrameRate())

--- a/internal/infrastructure/config/schema_provider.go
+++ b/internal/infrastructure/config/schema_provider.go
@@ -932,6 +932,14 @@ func (*SchemaProvider) getPerformanceKeys(defaults *Config) []entity.ConfigKeyIn
 			Section:     SectionPerformance,
 		},
 		{
+			Key:         "engine.cef.render_stack",
+			Type:        "string",
+			Default:     string(defaults.Engine.CEF.CEFRenderStack()),
+			Description: "CEF GPU render stack",
+			Values:      []string{"vulkan", "egl"},
+			Section:     SectionPerformance,
+		},
+		{
 			Key:         "engine.cef.windowless_frame_rate",
 			Type:        "int32",
 			Default:     fmt.Sprintf("%d", defaults.Engine.CEF.CEFWindowlessFrameRate()),

--- a/internal/infrastructure/config/validation.go
+++ b/internal/infrastructure/config/validation.go
@@ -336,6 +336,15 @@ func validateLogging(config *Config) []string {
 func validateCEF(config *Config) []string {
 	var validationErrors []string
 
+	switch config.Engine.CEF.CEFRenderStack() {
+	case CEFRenderStackVulkan, CEFRenderStackEGL:
+	default:
+		validationErrors = append(validationErrors, fmt.Sprintf(
+			"engine.cef.render_stack must be one of: vulkan, egl (got: %s)",
+			config.Engine.CEF.RenderStack,
+		))
+	}
+
 	switch config.Engine.CEF.LogSeverity {
 	case 0, 1, 2, 3, 4, cefLogSeverityDisabled:
 	default:


### PR DESCRIPTION
## Summary
- Upgrade `github.com/bnema/purego-cef2gtk` to v0.3.0.
- Add `engine.cef.render_stack` with `vulkan` default and `egl` compatibility option.
- Wire the resolved render stack through CEF environment setup, command-line configuration, cef2gtk view creation, and browser settings frame-rate helper.

## Test Plan
- [x] go test ./internal/infrastructure/config ./internal/infrastructure/cef ./internal/bootstrap ./cmd/dumber

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `engine.cef.render_stack` configuration option to select between Vulkan (default) and EGL rendering stacks for CEF engine.
  * Added `DUMBER_ENGINE_CEF_RENDER_STACK` environment variable override for render stack selection.

* **Documentation**
  * Updated configuration and dependency documentation to reflect new render stack options and default Vulkan GPU-first Wayland rendering.
  * Removed legacy render stack guidance and environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->