### PR TITLE
fix(cef): render native popup surfaces without focus regressions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.2
 	github.com/bnema/purego-cef v0.13.0
-	github.com/bnema/purego-cef2gtk v0.5.1
+	github.com/bnema/purego-cef2gtk v0.5.2
 	github.com/bnema/purego-pipewire v0.1.3
 	github.com/bnema/purego-sqlite v0.1.2
 	github.com/bnema/puregotk v0.5.2
@@ -83,6 +83,3 @@ require (
 )
 
 tool github.com/a-h/templ/cmd/templ
-
-replace github.com/bnema/purego-cef2gtk => ../purego-cef2gtk
-

--- a/go.mod
+++ b/go.mod
@@ -84,3 +84,5 @@ require (
 
 tool github.com/a-h/templ/cmd/templ
 
+replace github.com/bnema/purego-cef2gtk => ../purego-cef2gtk
+

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.2 h1:7pzcdOJ8bGtLrCz6V582oyleP6css1ICQoGgj
 github.com/bnema/purego v0.11.0-bnema.2/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.13.0 h1:TNPY19mBOqlJeFi5CZCLJIDfAgTEMp9tviQEyZgnvJI=
 github.com/bnema/purego-cef v0.13.0/go.mod h1:AIW4lrXr4f2vesO4WnMDN49yAyfivYHV4x6hxpu5SmM=
-github.com/bnema/purego-cef2gtk v0.5.1 h1:/34AfjhaRbQy3EoRjwUOiYtdNkdmp9KPMQhuOWhSVvI=
-github.com/bnema/purego-cef2gtk v0.5.1/go.mod h1:xDVdLTepKdPngYlwT/BscGHh5ohaCB4LLUeThW/Ml7c=
+github.com/bnema/purego-cef2gtk v0.5.2 h1:pLanIzsCdgckZbRGLyicUPZ9EeZ4zrb4gfDdrRuS7lg=
+github.com/bnema/purego-cef2gtk v0.5.2/go.mod h1:xDVdLTepKdPngYlwT/BscGHh5ohaCB4LLUeThW/Ml7c=
 github.com/bnema/purego-pipewire v0.1.3 h1:A3jYkuMe1KseJ8yr5Am1iLvRFu6yDWM2AwUIpl88460=
 github.com/bnema/purego-pipewire v0.1.3/go.mod h1:kchW7Bkfjc+NkX2IZw3LnlYfQxk6jxhl32Id88u04y8=
 github.com/bnema/purego-sqlite v0.1.2 h1:dhqfe3KfNRBh7tlrwxL7bf4FPZk2VCajdBESMbrvmoE=

--- a/internal/infrastructure/cef/cef2gtk_adapter.go
+++ b/internal/infrastructure/cef/cef2gtk_adapter.go
@@ -25,10 +25,11 @@ var ErrAdapterDestroyed = errors.New("cef2gtk_adapter: adapter is destroyed")
 // The adapter does NOT own GL/PBO staging, dirty-rect uploads, or GTK input
 // controller implementation — those belong to purego-cef2gtk.
 type Cef2gtkAdapter struct {
-	viewMu     sync.RWMutex
-	view       *cef2gtk.View
-	destroyed  atomic.Bool
-	destroyCnt atomic.Uint64
+	viewMu            sync.RWMutex
+	view              *cef2gtk.View
+	inputTargetWidget *gtk.Widget
+	destroyed         atomic.Bool
+	destroyCnt        atomic.Uint64
 }
 
 // NewCef2gtkAdapter creates an accelerated CEF view and wraps it in a thin
@@ -137,8 +138,8 @@ func (a *Cef2gtkAdapter) AddSizeObserver(fn func(width, height int32)) func() {
 	return a.view.AddSizeObserver(fn)
 }
 
-// HasFocus reports whether the bridge widget currently has GTK focus. Must be
-// called on the GTK main thread.
+// HasFocus reports whether the effective GTK input target currently has focus.
+// Must be called on the GTK main thread.
 func (a *Cef2gtkAdapter) HasFocus() bool {
 	if a == nil || a.destroyed.Load() {
 		return false
@@ -147,6 +148,9 @@ func (a *Cef2gtkAdapter) HasFocus() bool {
 	defer a.viewMu.RUnlock()
 	if a.view == nil {
 		return false
+	}
+	if a.inputTargetWidget != nil {
+		return a.inputTargetWidget.HasFocus()
 	}
 	return a.view.HasFocus()
 }
@@ -243,15 +247,41 @@ func (a *Cef2gtkAdapter) RecordExternalBeginFrameSent() {
 //
 // opts.Scale configures HiDPI scale for pointer coordinate translation.
 func (a *Cef2gtkAdapter) AttachInput(host purecef.BrowserHost, opts cef2gtk.InputOptions) error {
+	return a.AttachInputToWidget(host, nil, opts)
+}
+
+// AttachInputToWidget attaches GTK event controllers to the specified target
+// widget and forwards input to the given CEF browser host. When targetWidget is
+// nil, it falls back to the bridge render widget. Must be called on the GTK
+// main thread.
+func (a *Cef2gtkAdapter) AttachInputToWidget(host purecef.BrowserHost, targetWidget *gtk.Widget, opts cef2gtk.InputOptions) error {
 	if a == nil || a.destroyed.Load() {
 		return ErrAdapterDestroyed
 	}
-	a.viewMu.RLock()
-	defer a.viewMu.RUnlock()
+	a.viewMu.Lock()
+	defer a.viewMu.Unlock()
 	if a.view == nil {
 		return ErrAdapterDestroyed
 	}
-	return a.view.AttachInput(host, opts)
+	effectiveTarget := targetWidget
+	if effectiveTarget == nil {
+		effectiveTarget = a.view.Widget()
+	}
+	type inputWidgetAttacher interface {
+		AttachInputToWidget(purecef.BrowserHost, *gtk.Widget, cef2gtk.InputOptions) error
+	}
+	var err error
+	if attacher, ok := any(a.view).(inputWidgetAttacher); ok {
+		err = attacher.AttachInputToWidget(host, effectiveTarget, opts)
+	} else {
+		err = a.view.AttachInput(host, opts)
+	}
+	if err != nil {
+		a.inputTargetWidget = nil
+		return err
+	}
+	a.inputTargetWidget = effectiveTarget
+	return nil
 }
 
 // SetInputHost updates the CEF browser host used by the attached input bridge.
@@ -275,12 +305,14 @@ func (a *Cef2gtkAdapter) DetachInput() error {
 	if a == nil || a.destroyed.Load() {
 		return ErrAdapterDestroyed
 	}
-	a.viewMu.RLock()
-	defer a.viewMu.RUnlock()
+	a.viewMu.Lock()
+	defer a.viewMu.Unlock()
 	if a.view == nil {
 		return ErrAdapterDestroyed
 	}
-	return a.view.DetachInput()
+	err := a.view.DetachInput()
+	a.inputTargetWidget = nil
+	return err
 }
 
 // Diagnostics returns a point-in-time snapshot of bridge rendering diagnostics
@@ -311,6 +343,7 @@ func (a *Cef2gtkAdapter) Destroy() error {
 	}
 	err := a.view.Destroy()
 	a.view = nil
+	a.inputTargetWidget = nil
 	a.destroyCnt.Add(1)
 	return err
 }

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -123,6 +123,17 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 		windowlessFrameRateMax:      f.windowlessFrameRateMax,
 		backgroundColor:             f.bgColor.Load(),
 	}
+	wv.runOnGTKSync(func() {
+		nativeWidget := viewBridge.Widget()
+		popupSurface := newPopupBridgeSurface(ctx, nativeWidget, f.engine.renderStackPlan)
+		wv.nativeWidget = nativeWidget
+		if popupSurface != nil {
+			wv.popupSurface = popupSurface
+			if popupRoot := popupSurface.RootWidget(); popupRoot != nil {
+				wv.nativeWidget = popupRoot
+			}
+		}
+	})
 
 	handlers := &handlerSet{wv: wv}
 	wv.handlers = handlers

--- a/internal/infrastructure/cef/popup_surface.go
+++ b/internal/infrastructure/cef/popup_surface.go
@@ -61,8 +61,9 @@ func newPopupBridgeSurface(ctx context.Context, mainWidget *gtk.Widget, plan cef
 	root := &overlay.Widget
 	root.SetHexpand(true)
 	root.SetVexpand(true)
+	root.SetCanFocus(true)
+	root.SetFocusable(true)
 	root.SetFocusOnClick(true)
-	root.SetFocusChild(mainWidget)
 	return &popupBridgeSurface{
 		ctx:         ctx,
 		root:        root,

--- a/internal/infrastructure/cef/popup_surface.go
+++ b/internal/infrastructure/cef/popup_surface.go
@@ -1,0 +1,155 @@
+package cef
+
+import (
+	"context"
+	"sync/atomic"
+
+	purecef "github.com/bnema/purego-cef/cef"
+	cef2gtk "github.com/bnema/purego-cef2gtk"
+	"github.com/bnema/puregotk/v4/glib"
+	"github.com/bnema/puregotk/v4/gtk"
+
+	"github.com/bnema/dumber/internal/logging"
+)
+
+type popupBridgeSurface struct {
+	ctx         context.Context
+	root        *gtk.Widget
+	mainWidget  *gtk.Widget
+	bridge      *Cef2gtkAdapter
+	popupWidget *gtk.Widget
+	prepared    atomic.Uint32
+}
+
+// newPopupBridgeSurface must be called on the GTK thread because it creates
+// and packs GTK widgets around the primary CEF widget.
+func newPopupBridgeSurface(ctx context.Context, mainWidget *gtk.Widget, plan cef2gtk.RenderStackPlan) *popupBridgeSurface {
+	mainContext := glib.MainContextDefault()
+	if mainContext == nil || !mainContext.IsOwner() {
+		logging.FromContext(popupSurfaceLogContext(ctx)).Error().Msg("cef: newPopupBridgeSurface called off GTK thread")
+		return nil
+	}
+	if mainWidget == nil {
+		return nil
+	}
+	bridge := NewCef2gtkAdapter(plan)
+	if bridge == nil {
+		return nil
+	}
+	popupWidget := bridge.Widget()
+	if popupWidget == nil {
+		_ = bridge.Destroy()
+		return nil
+	}
+	overlay := gtk.NewOverlay()
+	if overlay == nil {
+		_ = bridge.Destroy()
+		return nil
+	}
+	overlay.SetChild(mainWidget)
+	popupWidget.SetVisible(false)
+	popupWidget.SetHalign(gtk.AlignStartValue)
+	popupWidget.SetValign(gtk.AlignStartValue)
+	popupWidget.SetHexpand(false)
+	popupWidget.SetVexpand(false)
+	popupWidget.SetCanTarget(false)
+	popupWidget.SetCanFocus(false)
+	popupWidget.SetFocusable(false)
+	overlay.AddOverlay(popupWidget)
+	overlay.SetClipOverlay(popupWidget, true)
+	overlay.SetMeasureOverlay(popupWidget, false)
+	root := &overlay.Widget
+	root.SetHexpand(true)
+	root.SetVexpand(true)
+	root.SetFocusOnClick(true)
+	root.SetFocusChild(mainWidget)
+	return &popupBridgeSurface{
+		ctx:         ctx,
+		root:        root,
+		mainWidget:  mainWidget,
+		bridge:      bridge,
+		popupWidget: popupWidget,
+	}
+}
+
+func (s *popupBridgeSurface) RootWidget() *gtk.Widget {
+	if s == nil {
+		return nil
+	}
+	return s.root
+}
+
+func (s *popupBridgeSurface) RenderHandler(hooks cef2gtk.Hooks) purecef.RenderHandler {
+	if s == nil || s.bridge == nil {
+		return nil
+	}
+	return s.bridge.RenderHandler(hooks)
+}
+
+func (s *popupBridgeSurface) PrepareOnGTKThread() error {
+	if s == nil || s.bridge == nil {
+		return nil
+	}
+	if !s.prepared.CompareAndSwap(0, 1) {
+		return nil
+	}
+	if err := s.bridge.PrepareOnGTKThread(); err != nil {
+		s.prepared.Store(0)
+		return err
+	}
+	return nil
+}
+
+func (s *popupBridgeSurface) SetPopupVisible(visible bool) {
+	if s == nil || s.popupWidget == nil {
+		return
+	}
+	if visible {
+		if err := s.PrepareOnGTKThread(); err != nil {
+			logging.FromContext(popupSurfaceLogContext(s.ctx)).Error().
+				Err(err).
+				Msg("cef: popupBridgeSurface.SetPopupVisible failed to PrepareOnGTKThread")
+			return
+		}
+	}
+	s.popupWidget.SetVisible(visible)
+	if s.root != nil {
+		s.root.QueueAllocate()
+	}
+}
+
+func (s *popupBridgeSurface) SetPopupRect(rect purecef.Rect) {
+	if s == nil || s.popupWidget == nil {
+		return
+	}
+	if rect.Width <= 0 || rect.Height <= 0 {
+		s.popupWidget.SetVisible(false)
+		return
+	}
+	s.popupWidget.SetMarginStart(int(rect.X))
+	s.popupWidget.SetMarginTop(int(rect.Y))
+	s.popupWidget.SetSizeRequest(int(rect.Width), int(rect.Height))
+	s.popupWidget.QueueResize()
+	if s.root != nil {
+		s.root.QueueResize()
+	}
+}
+
+func popupSurfaceLogContext(ctx context.Context) context.Context {
+	if ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+func (s *popupBridgeSurface) DestroyOnGTKThread() {
+	if s == nil || s.bridge == nil {
+		return
+	}
+	_ = s.bridge.Destroy()
+	s.bridge = nil
+	s.popupWidget = nil
+	s.mainWidget = nil
+	s.root = nil
+	s.prepared.Store(0)
+}

--- a/internal/infrastructure/cef/render_handler_adapter.go
+++ b/internal/infrastructure/cef/render_handler_adapter.go
@@ -9,12 +9,28 @@ import (
 	"github.com/bnema/dumber/internal/logging"
 )
 
+type popupSurface interface {
+	SetPopupVisible(bool)
+	SetPopupRect(purecef.Rect)
+}
+
+type dumberRenderHandler struct {
+	wv           *WebView
+	main         purecef.RenderHandler
+	popup        purecef.RenderHandler
+	popupSurface popupSurface
+}
+
+var _ purecef.RenderHandler = (*dumberRenderHandler)(nil)
+
 func newDumberRenderHandler(wv *WebView) purecef.RenderHandler {
 	if wv == nil || wv.viewBridge == nil {
 		return nil
 	}
+	h := &dumberRenderHandler{wv: wv}
+
 	var unsupportedPaintOnce sync.Once
-	hooks := cef2gtk.Hooks{
+	h.main = wv.viewBridge.RenderHandler(cef2gtk.Hooks{
 		OnUnsupportedPaint: func() {
 			unsupportedPaintOnce.Do(func() {
 				if wv.ctx != nil {
@@ -30,8 +46,216 @@ func newDumberRenderHandler(wv *WebView) purecef.RenderHandler {
 		OnTextSelectionChanged: func(selectedText string, _ *purecef.Range) {
 			handleRenderTextSelectionChanged(wv, selectedText)
 		},
+	})
+
+	if wv.popupSurface != nil {
+		var popupUnsupportedPaintOnce sync.Once
+		h.popupSurface = wv.popupSurface
+		h.popup = wv.popupSurface.RenderHandler(cef2gtk.Hooks{
+			OnUnsupportedPaint: func() {
+				popupUnsupportedPaintOnce.Do(func() {
+					if wv.ctx != nil {
+						logging.FromContext(wv.ctx).Warn().Msg("cef: unsupported CPU paint from popup surface")
+					}
+				})
+			},
+			OnError: func(err error) {
+				if wv.ctx != nil {
+					logging.FromContext(wv.ctx).Warn().Err(err).Msg("cef: popup surface render error")
+				}
+			},
+		})
 	}
-	return wv.viewBridge.RenderHandler(hooks)
+
+	return h
+}
+
+func (h *dumberRenderHandler) renderTargetForPaint(elementType purecef.PaintElementType) purecef.RenderHandler {
+	if h == nil {
+		return nil
+	}
+	if elementType == purecef.PaintElementTypePetPopup && h.popup != nil {
+		return h.popup
+	}
+	return h.main
+}
+
+func (h *dumberRenderHandler) GetAccessibilityHandler() purecef.AccessibilityHandler {
+	if h == nil || h.main == nil {
+		return nil
+	}
+	return h.main.GetAccessibilityHandler()
+}
+
+func (h *dumberRenderHandler) GetRootScreenRect(browser purecef.Browser, rect *purecef.Rect) int32 {
+	if h == nil || h.main == nil {
+		return 0
+	}
+	return h.main.GetRootScreenRect(browser, rect)
+}
+
+func (h *dumberRenderHandler) GetViewRect(browser purecef.Browser, rect *purecef.Rect) {
+	if h == nil || h.main == nil {
+		if rect != nil {
+			rect.X, rect.Y, rect.Width, rect.Height = 0, 0, 1, 1
+		}
+		return
+	}
+	h.main.GetViewRect(browser, rect)
+}
+
+func (h *dumberRenderHandler) GetScreenPoint(browser purecef.Browser, viewX, viewY int32, screenX, screenY *int32) int32 {
+	if h == nil || h.main == nil {
+		return 0
+	}
+	return h.main.GetScreenPoint(browser, viewX, viewY, screenX, screenY)
+}
+
+func (h *dumberRenderHandler) GetScreenInfo(browser purecef.Browser, info *purecef.ScreenInfo) int32 {
+	if h == nil || h.main == nil {
+		return 0
+	}
+	return h.main.GetScreenInfo(browser, info)
+}
+
+func (h *dumberRenderHandler) OnPopupShow(browser purecef.Browser, show int32) {
+	if h != nil && h.popupSurface != nil {
+		visible := show != 0
+		if h.wv != nil {
+			h.wv.runOnGTKSync(func() {
+				h.popupSurface.SetPopupVisible(visible)
+			})
+		} else {
+			h.popupSurface.SetPopupVisible(visible)
+		}
+	}
+	if h != nil && h.popup != nil {
+		h.popup.OnPopupShow(browser, show)
+	}
+}
+
+func (h *dumberRenderHandler) OnPopupSize(browser purecef.Browser, rect *purecef.Rect) {
+	if h != nil && h.popupSurface != nil && rect != nil {
+		popupRect := *rect
+		if h.wv != nil {
+			popupRect = popupRectForWidget(h.wv, popupRect)
+			h.wv.runOnGTKSync(func() {
+				h.popupSurface.SetPopupRect(popupRect)
+			})
+		} else {
+			h.popupSurface.SetPopupRect(popupRect)
+		}
+	}
+	if h != nil && h.popup != nil {
+		h.popup.OnPopupSize(browser, rect)
+	}
+}
+
+func popupRectForWidget(wv *WebView, rect purecef.Rect) purecef.Rect {
+	if wv == nil {
+		return rect
+	}
+	// Only convert when the OSR backing-scale compatibility path is active.
+	// A monitor scale above 1 is not enough by itself because CEF already reports
+	// logical popup coordinates when backing-scale mode is off.
+	if wv.osrBackingScaleFactor() <= 1 {
+		return rect
+	}
+	scale := wv.viewBridgeScale()
+	return purecef.Rect{
+		X:      deviceToLogicalCoord(rect.X, scale),
+		Y:      deviceToLogicalCoord(rect.Y, scale),
+		Width:  deviceToLogicalSize(rect.Width, scale),
+		Height: deviceToLogicalSize(rect.Height, scale),
+	}
+}
+
+func (h *dumberRenderHandler) OnPaint(
+	browser purecef.Browser,
+	elementType purecef.PaintElementType,
+	dirtyRects []purecef.Rect,
+	buffer []byte,
+	width, height int32,
+) {
+	if delegate := h.renderTargetForPaint(elementType); delegate != nil {
+		delegate.OnPaint(browser, elementType, dirtyRects, buffer, width, height)
+	}
+}
+
+func (h *dumberRenderHandler) OnAcceleratedPaint(
+	browser purecef.Browser,
+	elementType purecef.PaintElementType,
+	dirtyRects []purecef.Rect,
+	info *purecef.AcceleratedPaintInfo,
+) {
+	if delegate := h.renderTargetForPaint(elementType); delegate != nil {
+		delegate.OnAcceleratedPaint(browser, elementType, dirtyRects, info)
+	}
+}
+
+func (h *dumberRenderHandler) GetTouchHandleSize(browser purecef.Browser, orientation purecef.HorizontalAlignment, size *purecef.Size) {
+	if h == nil || h.main == nil {
+		return
+	}
+	h.main.GetTouchHandleSize(browser, orientation, size)
+}
+
+func (h *dumberRenderHandler) OnTouchHandleStateChanged(browser purecef.Browser, state *purecef.TouchHandleState) {
+	if h == nil || h.main == nil {
+		return
+	}
+	h.main.OnTouchHandleStateChanged(browser, state)
+}
+
+func (h *dumberRenderHandler) StartDragging(
+	browser purecef.Browser,
+	dragData purecef.DragData,
+	allowedOps purecef.DragOperationsMask,
+	x, y int32,
+) int32 {
+	if h == nil || h.main == nil {
+		return 0
+	}
+	return h.main.StartDragging(browser, dragData, allowedOps, x, y)
+}
+
+func (h *dumberRenderHandler) UpdateDragCursor(browser purecef.Browser, operation purecef.DragOperationsMask) {
+	if h == nil || h.main == nil {
+		return
+	}
+	h.main.UpdateDragCursor(browser, operation)
+}
+
+func (h *dumberRenderHandler) OnScrollOffsetChanged(browser purecef.Browser, x, y float64) {
+	if h == nil || h.main == nil {
+		return
+	}
+	h.main.OnScrollOffsetChanged(browser, x, y)
+}
+
+func (h *dumberRenderHandler) OnImeCompositionRangeChanged(
+	browser purecef.Browser,
+	selectedRange *purecef.Range,
+	characterBounds []purecef.Rect,
+) {
+	if h == nil || h.main == nil {
+		return
+	}
+	h.main.OnImeCompositionRangeChanged(browser, selectedRange, characterBounds)
+}
+
+func (h *dumberRenderHandler) OnTextSelectionChanged(browser purecef.Browser, selectedText string, selectedRange *purecef.Range) {
+	if h == nil || h.main == nil {
+		return
+	}
+	h.main.OnTextSelectionChanged(browser, selectedText, selectedRange)
+}
+
+func (h *dumberRenderHandler) OnVirtualKeyboardRequested(browser purecef.Browser, mode purecef.TextInputMode) {
+	if h == nil || h.main == nil {
+		return
+	}
+	h.main.OnVirtualKeyboardRequested(browser, mode)
 }
 
 func handleRenderTextSelectionChanged(wv *WebView, selectedText string) {

--- a/internal/infrastructure/cef/render_handler_popup_test.go
+++ b/internal/infrastructure/cef/render_handler_popup_test.go
@@ -1,0 +1,71 @@
+package cef
+
+import (
+	"testing"
+
+	purecef "github.com/bnema/purego-cef/cef"
+	cefmocks "github.com/bnema/purego-cef/cef/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type popupSurfaceRecorder struct {
+	visible bool
+	rect    purecef.Rect
+	calls   []string
+}
+
+func (r *popupSurfaceRecorder) SetPopupVisible(visible bool) {
+	r.visible = visible
+	r.calls = append(r.calls, "visible")
+}
+
+func (r *popupSurfaceRecorder) SetPopupRect(rect purecef.Rect) {
+	r.rect = rect
+	r.calls = append(r.calls, "rect")
+}
+
+func TestDumberRenderHandler_RoutesPopupAcceleratedPaintToPopupSurface(t *testing.T) {
+	mainHandler := cefmocks.NewMockRenderHandler(t)
+	popupHandler := cefmocks.NewMockRenderHandler(t)
+	h := &dumberRenderHandler{
+		main:  mainHandler,
+		popup: popupHandler,
+	}
+
+	info := &purecef.AcceleratedPaintInfo{}
+	popupHandler.EXPECT().OnAcceleratedPaint(nil, purecef.PaintElementTypePetPopup, []purecef.Rect(nil), info).Return().Once()
+
+	h.OnAcceleratedPaint(nil, purecef.PaintElementTypePetPopup, []purecef.Rect(nil), info)
+
+	mainHandler.AssertNotCalled(t, "OnAcceleratedPaint", nil, purecef.PaintElementTypePetPopup, []purecef.Rect(nil), info)
+}
+
+func TestDumberRenderHandler_TracksPopupLifecycle(t *testing.T) {
+	recorder := &popupSurfaceRecorder{}
+	// With a nil engine, WebView.runOnGTK/webview.go executes inline so popup
+	// lifecycle updates stay synchronous in this unit test.
+	wv := &WebView{}
+	wv.engine = nil
+	h := &dumberRenderHandler{
+		wv:           wv,
+		popupSurface: recorder,
+	}
+
+	popupRect := &purecef.Rect{X: 12, Y: 34, Width: 180, Height: 240}
+	h.OnPopupShow(nil, 1)
+	h.OnPopupSize(nil, popupRect)
+	h.OnPopupShow(nil, 0)
+
+	assert.Equal(t, []string{"visible", "rect", "visible"}, recorder.calls)
+	assert.Equal(t, purecef.Rect{X: 12, Y: 34, Width: 180, Height: 240}, recorder.rect)
+	assert.False(t, recorder.visible)
+}
+
+func TestDeviceToLogicalSize_RoundsUp(t *testing.T) {
+	assert.Equal(t, int32(4), deviceToLogicalSize(5, 1.25))
+	assert.Equal(t, int32(1), deviceToLogicalSize(1, 1.5))
+	assert.Equal(t, int32(0), deviceToLogicalSize(0, 2.0))
+	assert.Equal(t, int32(0), deviceToLogicalSize(-1, 2.0))
+	assert.Equal(t, int32(10), deviceToLogicalSize(10, 1.0))
+	assert.Equal(t, int32(1), deviceToLogicalSize(1, 100.0))
+}

--- a/internal/infrastructure/cef/scale.go
+++ b/internal/infrastructure/cef/scale.go
@@ -12,3 +12,14 @@ func normalizeScale(scale float64) float64 {
 func deviceToLogicalCoord(value int32, scale float64) int32 {
 	return int32(math.Floor(float64(value) / normalizeScale(scale)))
 }
+
+func deviceToLogicalSize(value int32, scale float64) int32 {
+	if value <= 0 {
+		return 0
+	}
+	scaled := int32(math.Ceil(float64(value) / normalizeScale(scale)))
+	if scaled < 1 {
+		return 1
+	}
+	return scaled
+}

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -1413,6 +1413,24 @@ func (wv *WebView) selectedTextSnapshot() string {
 	return wv.selectedText
 }
 
+func (wv *WebView) bridgeInputOptions() cef2gtk.InputOptions {
+	if wv == nil {
+		return cef2gtk.InputOptions{}
+	}
+	return cef2gtk.InputOptions{
+		Scale: 0,
+		OnMiddleClick: func(_, _ float64) bool {
+			return wv.handleMiddleClickFromBridge()
+		},
+		SelectionText: wv.selectedTextSnapshot,
+		OnClipboardShortcut: func(action, text string) {
+			if wv.engine != nil {
+				wv.engine.handleExplicitClipboardBridgeText(wv.id, action, text)
+			}
+		},
+	}
+}
+
 func (wv *WebView) viewBridgeScale() float64 {
 	if wv == nil || wv.viewBridge == nil {
 		return 1

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -79,6 +79,8 @@ type WebView struct {
 	host                      purecef.BrowserHost
 	client                    purecef.RawClient // prevent GC from collecting the client before CEF AddRef's it
 	viewBridge                *Cef2gtkAdapter
+	popupSurface              *popupBridgeSurface
+	nativeWidget              *gtk.Widget
 	handlers                  *handlerSet
 	findCtrl                  *cefFindController
 	profileCleanup            func()
@@ -1156,9 +1158,14 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 		wv.removeSizeObserver = nil
 	}
 	wv.disconnectViewportSyncHooksOnGTKThread()
+	if wv.popupSurface != nil {
+		wv.popupSurface.DestroyOnGTKThread()
+		wv.popupSurface = nil
+	}
 	_ = wv.viewBridge.DetachInput()
 	_ = wv.viewBridge.Destroy()
 	wv.viewBridge = nil
+	wv.nativeWidget = nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1167,12 +1174,15 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 
 // NativeWidget returns the uintptr for embedding the bridge GTK widget.
 func (wv *WebView) NativeWidget() uintptr {
-	if wv.viewBridge == nil {
+	if wv == nil {
 		return 0
 	}
 	var ptr uintptr
 	wv.runOnGTKSync(func() {
-		if wv.viewBridge != nil {
+		switch {
+		case wv.nativeWidget != nil:
+			ptr = wv.nativeWidget.GoPointer()
+		case wv.viewBridge != nil:
 			ptr = wv.viewBridge.NativeWidget()
 		}
 	})

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	purecef "github.com/bnema/purego-cef/cef"
-	cef2gtk "github.com/bnema/purego-cef2gtk"
 
 	"github.com/bnema/dumber/internal/application/dto"
 	"github.com/bnema/dumber/internal/application/port"
@@ -640,18 +639,7 @@ func (h *handlerSet) attachAfterCreatedBrowser(
 				wv.handleInputAttachFailure(ErrAdapterDestroyed, host)
 				return
 			}
-			if err := wv.viewBridge.AttachInput(host, cef2gtk.InputOptions{
-				Scale: 0,
-				OnMiddleClick: func(_, _ float64) bool {
-					return wv.handleMiddleClickFromBridge()
-				},
-				SelectionText: wv.selectedTextSnapshot,
-				OnClipboardShortcut: func(action, text string) {
-					if wv.engine != nil {
-						wv.engine.handleExplicitClipboardBridgeText(wv.id, action, text)
-					}
-				},
-			}); err != nil {
+			if err := wv.viewBridge.AttachInputToWidget(host, wv.nativeWidget, wv.bridgeInputOptions()); err != nil {
 				wv.handleInputAttachFailure(err, host)
 				return
 			}

--- a/internal/infrastructure/cef/webview_input_test.go
+++ b/internal/infrastructure/cef/webview_input_test.go
@@ -1,0 +1,21 @@
+package cef
+
+import (
+	"testing"
+
+	"github.com/bnema/puregotk/v4/gtk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebViewBridgeInputOptions_LeavesTargetSelectionToAdapter(t *testing.T) {
+	nativeWidget := &gtk.Widget{}
+	wv := &WebView{nativeWidget: nativeWidget}
+
+	opts := wv.bridgeInputOptions()
+
+	require.Zero(t, opts.Scale)
+	require.NotNil(t, opts.OnMiddleClick)
+	require.NotNil(t, opts.SelectionText)
+	require.NotNil(t, opts.OnClipboardShortcut)
+	require.Same(t, nativeWidget, wv.nativeWidget)
+}

--- a/internal/ui/layout/gtk_widgets.go
+++ b/internal/ui/layout/gtk_widgets.go
@@ -27,26 +27,13 @@ type gtkWidget struct {
 	inner *gtk.Widget
 }
 
-func (w *gtkWidget) Show()                      { w.inner.Show() }
-func (w *gtkWidget) Hide()                      { w.inner.Hide() }
-func (w *gtkWidget) SetVisible(visible bool)    { w.inner.SetVisible(visible) }
-func (w *gtkWidget) IsVisible() bool            { return w.inner.GetVisible() }
-func (w *gtkWidget) SetOpacity(opacity float64) { w.inner.SetOpacity(opacity) }
-func (w *gtkWidget) GrabFocus() bool {
-	if focusChild := gtkWidgetFocusChild(w.inner); focusChild != nil && focusChild.GrabFocus() {
-		return true
-	}
-	return w.inner.GrabFocus()
-}
-func (w *gtkWidget) HasFocus() bool {
-	if w.inner.HasFocus() {
-		return true
-	}
-	if focusChild := gtkWidgetFocusChild(w.inner); focusChild != nil {
-		return focusChild.HasFocus()
-	}
-	return false
-}
+func (w *gtkWidget) Show()                         { w.inner.Show() }
+func (w *gtkWidget) Hide()                         { w.inner.Hide() }
+func (w *gtkWidget) SetVisible(visible bool)       { w.inner.SetVisible(visible) }
+func (w *gtkWidget) IsVisible() bool               { return w.inner.GetVisible() }
+func (w *gtkWidget) SetOpacity(opacity float64)    { w.inner.SetOpacity(opacity) }
+func (w *gtkWidget) GrabFocus() bool               { return w.inner.GrabFocus() }
+func (w *gtkWidget) HasFocus() bool                { return w.inner.HasFocus() }
 func (w *gtkWidget) SetCanFocus(canFocus bool)     { w.inner.SetCanFocus(canFocus) }
 func (w *gtkWidget) SetFocusable(focusable bool)   { w.inner.SetFocusable(focusable) }
 func (w *gtkWidget) SetFocusOnClick(focus bool)    { w.inner.SetFocusOnClick(focus) }
@@ -90,17 +77,6 @@ func (w *gtkWidget) ComputePoint(target Widget) (x, y float64, ok bool) {
 		return 0, 0, false
 	}
 	return float64(outPoint.X), float64(outPoint.Y), true
-}
-
-func gtkWidgetFocusChild(widget *gtk.Widget) *gtk.Widget {
-	if widget == nil {
-		return nil
-	}
-	focusChild := widget.GetFocusChild()
-	if focusChild == nil || focusChild.GoPointer() == widget.GoPointer() {
-		return nil
-	}
-	return focusChild
 }
 
 // gtkPaned wraps gtk.Paned to implement PanedWidget.

--- a/internal/ui/layout/gtk_widgets.go
+++ b/internal/ui/layout/gtk_widgets.go
@@ -27,13 +27,26 @@ type gtkWidget struct {
 	inner *gtk.Widget
 }
 
-func (w *gtkWidget) Show()                         { w.inner.Show() }
-func (w *gtkWidget) Hide()                         { w.inner.Hide() }
-func (w *gtkWidget) SetVisible(visible bool)       { w.inner.SetVisible(visible) }
-func (w *gtkWidget) IsVisible() bool               { return w.inner.GetVisible() }
-func (w *gtkWidget) SetOpacity(opacity float64)    { w.inner.SetOpacity(opacity) }
-func (w *gtkWidget) GrabFocus() bool               { return w.inner.GrabFocus() }
-func (w *gtkWidget) HasFocus() bool                { return w.inner.HasFocus() }
+func (w *gtkWidget) Show()                      { w.inner.Show() }
+func (w *gtkWidget) Hide()                      { w.inner.Hide() }
+func (w *gtkWidget) SetVisible(visible bool)    { w.inner.SetVisible(visible) }
+func (w *gtkWidget) IsVisible() bool            { return w.inner.GetVisible() }
+func (w *gtkWidget) SetOpacity(opacity float64) { w.inner.SetOpacity(opacity) }
+func (w *gtkWidget) GrabFocus() bool {
+	if focusChild := gtkWidgetFocusChild(w.inner); focusChild != nil && focusChild.GrabFocus() {
+		return true
+	}
+	return w.inner.GrabFocus()
+}
+func (w *gtkWidget) HasFocus() bool {
+	if w.inner.HasFocus() {
+		return true
+	}
+	if focusChild := gtkWidgetFocusChild(w.inner); focusChild != nil {
+		return focusChild.HasFocus()
+	}
+	return false
+}
 func (w *gtkWidget) SetCanFocus(canFocus bool)     { w.inner.SetCanFocus(canFocus) }
 func (w *gtkWidget) SetFocusable(focusable bool)   { w.inner.SetFocusable(focusable) }
 func (w *gtkWidget) SetFocusOnClick(focus bool)    { w.inner.SetFocusOnClick(focus) }
@@ -77,6 +90,17 @@ func (w *gtkWidget) ComputePoint(target Widget) (x, y float64, ok bool) {
 		return 0, 0, false
 	}
 	return float64(outPoint.X), float64(outPoint.Y), true
+}
+
+func gtkWidgetFocusChild(widget *gtk.Widget) *gtk.Widget {
+	if widget == nil {
+		return nil
+	}
+	focusChild := widget.GetFocusChild()
+	if focusChild == nil || focusChild.GoPointer() == widget.GoPointer() {
+		return nil
+	}
+	return focusChild
 }
 
 // gtkPaned wraps gtk.Paned to implement PanedWidget.


### PR DESCRIPTION
## Summary
- render native CEF popup content on a dedicated popup surface instead of stretching `<select>` menus across the whole webview
- restore keyboard focus when the webview is wrapped in a popup overlay by routing input/focus through the released `purego-cef2gtk v0.5.2`
- remove the temporary local `replace` and consume the tagged dependency release directly

## Details
This fixes the native CEF `<select>` popup regression and the follow-up focus regression.

The branch now:
- creates the popup bridge surface on the GTK thread
- renders `PET_POPUP` into a dedicated overlay surface
- preserves focus/typing behavior with overlay-backed webviews
- rounds popup sizing safely for HiDPI/fractional scale cases
- adds regression coverage for popup lifecycle and focus/input integration

## Validation
- `make lint`
- `go test ./internal/infrastructure/cef ./internal/ui/layout`
- `go test ./...`
- `go-reviewer` against the final dependency bump
- `coderabbit review --agent --base main --no-color` (0 findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added popup surface support for improved rendering and event handling.
  * Enhanced input attachment with flexible widget targeting.

* **Bug Fixes**
  * Improved focus reporting and input state tracking.

* **Tests**
  * Added comprehensive unit tests for popup lifecycle and rendering.

* **Chores**
  * Updated dependencies to latest versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->