### PR TITLE
fix(omnibox): keep standalone launch visible on uncertainty

### DIFF
--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -98,7 +99,27 @@ func tryForwardBrowseURLToRunningInstance(ctx context.Context, relay port.Browse
 		return false, nil
 	}
 
-	return relay.DeliverOpenFreshWindow(ctx, browseURL)
+	delivered, err := relay.DeliverOpenFreshWindow(ctx, browseURL)
+	if err != nil {
+		if delivered && errors.Is(err, desktop.ErrBrowserLaunchRelayUnconfirmed) {
+			return true, nil
+		}
+		return false, err
+	}
+	return delivered, nil
+}
+
+func launchStandaloneBrowserURL(ctx context.Context, launch func(context.Context, string) error, uri string) error {
+	if launch == nil {
+		return fmt.Errorf("browser launcher is not configured")
+	}
+	if err := launch(ctx, uri); err != nil {
+		if errors.Is(err, desktop.ErrBrowserLaunchRelayUnconfirmed) || errors.Is(err, desktop.ErrBrowserLaunchUnconfirmed) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func resolveBrowserLaunchRelay(cfg *config.Config) (port.BrowserLaunchRelay, error) {
@@ -871,8 +892,8 @@ func buildUIDependencies(
 			return config.GetManager().Watch()
 		},
 		LaunchExternalURL: desktop.LaunchExternalURL,
-		LaunchBrowserURL: func(uri string) {
-			browserLauncher.LaunchURL(ctx, uri)
+		LaunchBrowserURL: func(navCtx context.Context, uri string) error {
+			return launchStandaloneBrowserURL(navCtx, browserLauncher.LaunchURL, uri)
 		},
 		BrowserLaunchRelay: browserLaunchRelay,
 		ConfigMigrator:     config.NewMigrator(),

--- a/cmd/dumber/main_test.go
+++ b/cmd/dumber/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bnema/dumber/internal/bootstrap"
 	"github.com/bnema/dumber/internal/infrastructure/colorscheme"
 	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/infrastructure/desktop"
 )
 
 func TestLaunchModeFromArgs_DetectsStandaloneOmnibox(t *testing.T) {
@@ -235,6 +236,42 @@ func TestTryForwardBrowseURLToRunningInstance_ReturnsFalseOnRelayMiss(t *testing
 	}
 	if forwarded {
 		t.Fatal("expected browse URL to remain unforwarded")
+	}
+}
+
+func TestTryForwardBrowseURLToRunningInstance_ReturnsTrueOnUnconfirmedRelayDelivery(t *testing.T) {
+	relay := mocks.NewMockBrowserLaunchRelay(t)
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, desktop.ErrBrowserLaunchRelayUnconfirmed)
+
+	forwarded, err := tryForwardBrowseURLToRunningInstance(context.Background(), relay, "https://example.com")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !forwarded {
+		t.Fatal("expected unconfirmed relay delivery to be treated as forwarded")
+	}
+}
+
+func TestLaunchStandaloneBrowserURL_TreatsUnconfirmedLaunchAsAccepted(t *testing.T) {
+	err := launchStandaloneBrowserURL(context.Background(), func(context.Context, string) error {
+		return desktop.ErrBrowserLaunchRelayUnconfirmed
+	}, "https://example.com")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestLaunchStandaloneBrowserURL_PropagatesOtherErrors(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	err := launchStandaloneBrowserURL(context.Background(), func(context.Context, string) error {
+		return wantErr
+	}, "https://example.com")
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
 	}
 }
 

--- a/internal/application/port/browser_launch.go
+++ b/internal/application/port/browser_launch.go
@@ -15,6 +15,8 @@ type BrowserLaunchRelay interface {
 	// DeliverOpenFreshWindow attempts to deliver a request to open a fresh window.
 	// The bool reports whether the relay accepted the request; false means the
 	// caller should treat it as undelivered and try another path.
+	// An error may still be returned with delivered=true when the relay accepted
+	// the request but could not confirm completion before the caller timed out.
 	DeliverOpenFreshWindow(ctx context.Context, url string) (bool, error)
 	Listen(ctx context.Context, opener BrowserWindowOpener) (io.Closer, error)
 }

--- a/internal/infrastructure/desktop/adapter.go
+++ b/internal/infrastructure/desktop/adapter.go
@@ -422,13 +422,13 @@ func launchBrowserBrowseURL(uri string, resolveExecutablePath func() (string, er
 
 	execPath, err := resolveExecutablePath()
 	if err != nil {
-		return fmt.Errorf("failed to resolve dumber executable for URL %q: %w", uri, err)
+		return fmt.Errorf("failed to resolve dumber executable for requested URL: %w", err)
 	}
 
 	cmd := exec.Command(execPath, "browse", uri)
 	cmd.Env = sanitizedChildEnv(os.Environ())
 	if err := spawnDetachedProcess(cmd); err != nil {
-		return fmt.Errorf("failed to launch dumber browse for URL %q: %w", uri, err)
+		return fmt.Errorf("failed to launch dumber browse for requested URL: %w", err)
 	}
 	return nil
 }

--- a/internal/infrastructure/desktop/adapter.go
+++ b/internal/infrastructure/desktop/adapter.go
@@ -407,10 +407,12 @@ func LaunchExternalURL(uri string) {
 
 // LaunchBrowserURL opens a URL in a new dumber browser window.
 func LaunchBrowserURL(uri string) {
-	launchBrowserBrowseURL(uri, getExecutablePath, startDetachedProcess)
+	if err := launchBrowserBrowseURL(uri, getExecutablePath, startDetachedProcess); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	}
 }
 
-func launchBrowserBrowseURL(uri string, resolveExecutablePath func() (string, error), spawnDetachedProcess func(*exec.Cmd) error) {
+func launchBrowserBrowseURL(uri string, resolveExecutablePath func() (string, error), spawnDetachedProcess func(*exec.Cmd) error) error {
 	if resolveExecutablePath == nil {
 		resolveExecutablePath = getExecutablePath
 	}
@@ -420,15 +422,15 @@ func launchBrowserBrowseURL(uri string, resolveExecutablePath func() (string, er
 
 	execPath, err := resolveExecutablePath()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to resolve dumber executable for URL %q: %v\n", uri, err)
-		return
+		return fmt.Errorf("failed to resolve dumber executable for URL %q: %w", uri, err)
 	}
 
 	cmd := exec.Command(execPath, "browse", uri)
 	cmd.Env = sanitizedChildEnv(os.Environ())
 	if err := spawnDetachedProcess(cmd); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to launch dumber browse for URL %q: %v\n", uri, err)
+		return fmt.Errorf("failed to launch dumber browse for URL %q: %w", uri, err)
 	}
+	return nil
 }
 
 func startDetachedProcess(cmd *exec.Cmd) error {

--- a/internal/infrastructure/desktop/adapter_test.go
+++ b/internal/infrastructure/desktop/adapter_test.go
@@ -1,7 +1,9 @@
 package desktop
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -171,6 +173,46 @@ func TestSessionSpawner_SpawnWithSession_OmitsEngineOverrideWhenNotConfigured(t 
 	}
 	if got := env[testRootCacheEnvVar]; got != "" {
 		t.Fatalf("engine state root env = %q, want empty", got)
+	}
+}
+
+func TestLaunchBrowserBrowseURL_ResolveErrorDoesNotLeakURL(t *testing.T) {
+	wantErr := errors.New("resolve failed")
+
+	err := launchBrowserBrowseURL(
+		"https://example.com/private?token=secret",
+		func() (string, error) { return "", wantErr },
+		nil,
+	)
+
+	if err == nil {
+		t.Fatal("expected resolve error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+	if strings.Contains(err.Error(), "token=secret") || strings.Contains(err.Error(), "https://example.com") {
+		t.Fatalf("expected error to redact URL, got %q", err)
+	}
+}
+
+func TestLaunchBrowserBrowseURL_SpawnErrorDoesNotLeakURL(t *testing.T) {
+	wantErr := errors.New("spawn failed")
+
+	err := launchBrowserBrowseURL(
+		"https://example.com/private?token=secret",
+		func() (string, error) { return "/usr/bin/dumber", nil },
+		func(*exec.Cmd) error { return wantErr },
+	)
+
+	if err == nil {
+		t.Fatal("expected spawn error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+	if strings.Contains(err.Error(), "token=secret") || strings.Contains(err.Error(), "https://example.com") {
+		t.Fatalf("expected error to redact URL, got %q", err)
 	}
 }
 

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -20,9 +21,16 @@ import (
 
 const browserLaunchSocketName = "browser-launch.sock"
 
-const browserLaunchIOTimeout = 50 * time.Millisecond
+// Local browser-launch handoff needs enough headroom for a busy browser
+// process to accept and acknowledge the request before callers classify the
+// handoff as ambiguous.
+const browserLaunchIOTimeout = 250 * time.Millisecond
 
 const browserLaunchDirPerm = 0o700
+
+// ErrBrowserLaunchRelayUnconfirmed reports that the relay accepted a launch
+// request but the caller did not receive a confirmation response in time.
+var ErrBrowserLaunchRelayUnconfirmed = errors.New("browser launch relay did not confirm delivery")
 
 type browserLaunchRelay struct {
 	ipc runtimeprofile.IPCPaths
@@ -82,7 +90,11 @@ func (r *browserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url str
 					return false, ctxErr
 				}
 				if _, ok := ctx.Deadline(); !ok {
-					return true, nil
+					logging.FromContext(ctx).Warn().
+						Str("url_host", safeURLHost(url)).
+						Dur("timeout", browserLaunchIOTimeout).
+						Msg("browser launch relay response timed out without caller deadline; delivery is unconfirmed")
+					return true, ErrBrowserLaunchRelayUnconfirmed
 				}
 				if deadlineErr := setBrowserLaunchConnDeadline(ctx, conn); deadlineErr != nil {
 					return false, deadlineErr
@@ -102,6 +114,14 @@ func (r *browserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url str
 
 func isMissingRelayListener(err error) bool {
 	return os.IsNotExist(err) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ENOENT)
+}
+
+func safeURLHost(raw string) string {
+	parsed, err := neturl.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
 }
 
 func isBrowserLaunchReadTimeout(err error) bool {

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -313,7 +313,7 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RespectsResponseReadTimeout(t
 	assert.False(t, delivered)
 }
 
-func TestBrowserLaunchRelay_DeliverOpenFreshWindow_ReturnsTrueOnNoDeadlineTimeout(t *testing.T) {
+func TestBrowserLaunchRelay_DeliverOpenFreshWindow_ReturnsUnconfirmedErrorOnNoDeadlineTimeout(t *testing.T) {
 	ipc := testIPC(shortTempDir(t))
 	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
 
@@ -355,8 +355,9 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_ReturnsTrueOnNoDeadlineTimeou
 	select {
 	case got := <-result:
 		assert.True(t, got.delivered)
-		require.NoError(t, got.err)
-	case <-time.After(300 * time.Millisecond):
+		require.Error(t, got.err)
+		require.ErrorIs(t, got.err, ErrBrowserLaunchRelayUnconfirmed)
+	case <-time.After(browserLaunchIOTimeout * 3):
 		t.Fatal("DeliverOpenFreshWindow blocked without a caller deadline")
 	}
 }

--- a/internal/infrastructure/desktop/browser_launcher.go
+++ b/internal/infrastructure/desktop/browser_launcher.go
@@ -2,12 +2,16 @@ package desktop
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/bnema/dumber/internal/application/port"
 )
+
+// ErrBrowserLaunchUnconfirmed reports that a running browser instance may have
+// received the request, but the caller could not confirm that in time.
+var ErrBrowserLaunchUnconfirmed = errors.New("browser launch could not be confirmed")
 
 // BrowserLauncher opens URLs in a relay-first dumber browser instance.
 type BrowserLauncher struct {
@@ -26,20 +30,26 @@ func NewBrowserLauncher(relay port.BrowserLaunchRelay) *BrowserLauncher {
 }
 
 // LaunchURL forwards the URL to a running instance when possible, otherwise spawns a new one.
-func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) {
+func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) error {
 	if l == nil {
-		return
+		return nil
 	}
 
 	if l.relay != nil {
 		delivered, err := l.relay.DeliverOpenFreshWindow(ctx, url)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to forward dumber browser URL %q: %v\n", url, err)
+			if delivered && errors.Is(err, ErrBrowserLaunchRelayUnconfirmed) {
+				return ErrBrowserLaunchUnconfirmed
+			}
+			return fmt.Errorf("forward dumber browser URL %q: %w", url, err)
 		}
 		if delivered {
-			return
+			return nil
 		}
 	}
 
-	launchBrowserBrowseURL(url, l.resolveExecutablePath, l.startDetachedProcess)
+	if err := launchBrowserBrowseURL(url, l.resolveExecutablePath, l.startDetachedProcess); err != nil {
+		return fmt.Errorf("launch dumber browse for URL %q: %w", url, err)
+	}
+	return nil
 }

--- a/internal/infrastructure/desktop/browser_launcher.go
+++ b/internal/infrastructure/desktop/browser_launcher.go
@@ -32,7 +32,7 @@ func NewBrowserLauncher(relay port.BrowserLaunchRelay) *BrowserLauncher {
 // LaunchURL forwards the URL to a running instance when possible, otherwise spawns a new one.
 func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) error {
 	if l == nil {
-		return nil
+		return errors.New("browser launcher is unavailable")
 	}
 
 	if l.relay != nil {
@@ -41,7 +41,7 @@ func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) error {
 			if delivered && errors.Is(err, ErrBrowserLaunchRelayUnconfirmed) {
 				return ErrBrowserLaunchUnconfirmed
 			}
-			return fmt.Errorf("forward dumber browser URL %q: %w", url, err)
+			return fmt.Errorf("forward dumber browser URL: %w", err)
 		}
 		if delivered {
 			return nil
@@ -49,7 +49,7 @@ func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) error {
 	}
 
 	if err := launchBrowserBrowseURL(url, l.resolveExecutablePath, l.startDetachedProcess); err != nil {
-		return fmt.Errorf("launch dumber browse for URL %q: %w", url, err)
+		return fmt.Errorf("launch dumber browse: %w", err)
 	}
 	return nil
 }

--- a/internal/infrastructure/desktop/browser_launcher_test.go
+++ b/internal/infrastructure/desktop/browser_launcher_test.go
@@ -93,5 +93,15 @@ func TestBrowserLauncher_LaunchURL_PropagatesRelayError(t *testing.T) {
 	err := launcher.LaunchURL(context.Background(), "https://example.com")
 
 	require.Error(t, err)
-	assert.ErrorIs(t, err, wantErr)
+	require.ErrorIs(t, err, wantErr)
+	assert.NotContains(t, err.Error(), "https://example.com")
+}
+
+func TestBrowserLauncher_LaunchURL_NilLauncherReturnsError(t *testing.T) {
+	var launcher *BrowserLauncher
+
+	err := launcher.LaunchURL(context.Background(), "https://example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unavailable")
 }

--- a/internal/infrastructure/desktop/browser_launcher_test.go
+++ b/internal/infrastructure/desktop/browser_launcher_test.go
@@ -3,8 +3,6 @@ package desktop
 import (
 	"context"
 	"errors"
-	"io"
-	"os"
 	"os/exec"
 	"testing"
 
@@ -28,8 +26,9 @@ func TestBrowserLauncher_LaunchURL_ReturnsWithoutSpawningWhenRelayDelivers(t *te
 		return nil
 	}
 
-	launcher.LaunchURL(context.Background(), "https://example.com")
+	err := launcher.LaunchURL(context.Background(), "https://example.com")
 
+	require.NoError(t, err)
 	assert.False(t, spawned)
 }
 
@@ -48,17 +47,17 @@ func TestBrowserLauncher_LaunchURL_FallsBackToSpawnWhenRelayMisses(t *testing.T)
 		return nil
 	}
 
-	launcher.LaunchURL(context.Background(), "https://example.com")
+	err := launcher.LaunchURL(context.Background(), "https://example.com")
 
+	require.NoError(t, err)
 	require.NotNil(t, gotCmd)
 	assert.Equal(t, "/usr/bin/dumber", gotCmd.Path)
 	assert.Equal(t, []string{"/usr/bin/dumber", "browse", "https://example.com"}, gotCmd.Args)
 }
 
-func TestBrowserLauncher_LaunchURL_ReportsRelayErrorWhenDelivered(t *testing.T) {
+func TestBrowserLauncher_LaunchURL_ReturnsUnconfirmedErrorWhenRelayDeliveryIsAmbiguous(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	wantErr := errors.New("relay exploded")
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, wantErr)
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, ErrBrowserLaunchRelayUnconfirmed)
 
 	launcher := NewBrowserLauncher(relay)
 	launcher.resolveExecutablePath = func() (string, error) {
@@ -66,22 +65,33 @@ func TestBrowserLauncher_LaunchURL_ReportsRelayErrorWhenDelivered(t *testing.T) 
 		return "", nil
 	}
 	launcher.startDetachedProcess = func(_ *exec.Cmd) error {
-		t.Fatal("expected launch to stop after relay delivery")
+		t.Fatal("expected launch to stop after ambiguous relay delivery")
 		return nil
 	}
 
-	oldStderr := os.Stderr
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stderr = w
-	t.Cleanup(func() {
-		os.Stderr = oldStderr
-	})
+	err := launcher.LaunchURL(context.Background(), "https://example.com")
 
-	launcher.LaunchURL(context.Background(), "https://example.com")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBrowserLaunchUnconfirmed)
+}
 
-	require.NoError(t, w.Close())
-	output, err := io.ReadAll(r)
-	require.NoError(t, err)
-	assert.Contains(t, string(output), wantErr.Error())
+func TestBrowserLauncher_LaunchURL_PropagatesRelayError(t *testing.T) {
+	relay := mocks.NewMockBrowserLaunchRelay(t)
+	wantErr := errors.New("relay exploded")
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(false, wantErr)
+
+	launcher := NewBrowserLauncher(relay)
+	launcher.resolveExecutablePath = func() (string, error) {
+		t.Fatal("expected executable path resolution to be skipped")
+		return "", nil
+	}
+	launcher.startDetachedProcess = func(_ *exec.Cmd) error {
+		t.Fatal("expected launch to stop after relay error")
+		return nil
+	}
+
+	err := launcher.LaunchURL(context.Background(), "https://example.com")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1290,7 +1290,7 @@ func (a *App) Cancel(ctx context.Context) {
 }
 
 type omniboxCallbacks struct {
-	OnNavigate         func(url string)
+	OnNavigate         func(ctx context.Context, url string) error
 	OnToast            func(ctx context.Context, message string, level component.ToastLevel)
 	OnFocusIn          func(entry *gtk.SearchEntry)
 	OnFocusOut         func()
@@ -1346,8 +1346,8 @@ func NewStandaloneOmniboxRuntime(
 	}
 
 	omniboxCfg := buildOmniboxConfig(deps, faviconAdapter, omniboxCallbacks{
-		OnNavigate: func(url string) {
-			handleStandaloneOmniboxNavigation(deps, ctx, url)
+		OnNavigate: func(navCtx context.Context, url string) error {
+			return handleStandaloneOmniboxNavigation(deps, navCtx, url)
 		},
 		OnToast: func(toastCtx context.Context, message string, level component.ToastLevel) {
 			logging.FromContext(toastCtx).Debug().Str("message", message).Int("level", int(level)).Msg("standalone omnibox toast")
@@ -1365,18 +1365,21 @@ func NewStandaloneOmniboxRuntime(
 	}}
 }
 
-func handleStandaloneOmniboxNavigation(deps *Dependencies, ctx context.Context, rawURL string) {
-	if urlutil.IsExternalScheme(rawURL) {
-		if deps != nil && deps.LaunchExternalURL != nil {
-			deps.LaunchExternalURL(rawURL)
-			return
-		}
-	} else if deps != nil && deps.LaunchBrowserURL != nil {
-		deps.LaunchBrowserURL(rawURL)
-		return
+func handleStandaloneOmniboxNavigation(deps *Dependencies, ctx context.Context, rawURL string) error {
+	if deps == nil {
+		return fmt.Errorf("standalone omnibox dependencies are not configured")
 	}
-
-	logging.FromContext(ctx).Info().Str("url", rawURL).Msg("standalone omnibox navigate submitted")
+	if urlutil.IsExternalScheme(rawURL) {
+		if deps.LaunchExternalURL == nil {
+			return fmt.Errorf("external launcher is not configured")
+		}
+		deps.LaunchExternalURL(rawURL)
+		return nil
+	}
+	if deps.LaunchBrowserURL == nil {
+		return fmt.Errorf("browser launcher is not configured")
+	}
+	return deps.LaunchBrowserURL(ctx, rawURL)
 }
 
 func (a *App) initOmniboxConfig(ctx context.Context) {
@@ -1384,12 +1387,12 @@ func (a *App) initOmniboxConfig(ctx context.Context) {
 		return
 	}
 
-	log := logging.FromContext(ctx)
 	a.omniboxCfg = buildOmniboxConfig(a.deps, a.faviconAdapter, omniboxCallbacks{
-		OnNavigate: func(url string) {
-			if err := a.navigateFromOmnibox(ctx, url); err != nil {
-				log.Error().Err(err).Str("url", url).Msg("navigation failed")
-			}
+		OnNavigate: func(navCtx context.Context, url string) error {
+			return a.navigateFromOmnibox(navCtx, url)
+		},
+		OnToast: func(toastCtx context.Context, message string, level component.ToastLevel) {
+			a.showToastOnLastFocusedBrowserWindow(toastCtx, message, level)
 		},
 		OnFocusIn: func(entry *gtk.SearchEntry) {
 			// Set omnibox entry as the focused input for accent picker
@@ -1413,7 +1416,7 @@ func (a *App) initOmniboxConfig(ctx context.Context) {
 		},
 	})
 	a.navCoord.SetOmniboxProvider(a)
-	log.Debug().Msg("omnibox config stored, provider set")
+	logging.FromContext(ctx).Debug().Msg("omnibox config stored, provider set")
 }
 
 func (a *App) initFindBarConfig(ctx context.Context) {
@@ -2128,15 +2131,12 @@ func omniboxNavigateForBrowserWindow(
 	ctx context.Context,
 	bw *browserWindow,
 	navigate func(context.Context, *browserWindow, string) error,
-) func(string) {
-	return func(url string) {
-		if err := navigate(ctx, bw, url); err != nil {
-			logging.FromContext(ctx).Error().
-				Err(err).
-				Str("url", url).
-				Str("window_id", bw.id).
-				Msg("omnibox navigation failed")
+) func(context.Context, string) error {
+	return func(navCtx context.Context, url string) error {
+		if navCtx == nil {
+			navCtx = ctx
 		}
+		return navigate(navCtx, bw, url)
 	}
 }
 
@@ -4368,13 +4368,14 @@ func (a *App) showFloatingOmnibox(ctx context.Context, session *floatingWorkspac
 
 	if session.omnibox == nil {
 		cfg := a.omniboxCfg
-		cfg.OnNavigate = func(url string) {
+		cfg.OnNavigate = func(navCtx context.Context, url string) error {
 			if session.pane == nil {
-				return
+				return fmt.Errorf("floating pane is not available")
 			}
-			if err := session.pane.Navigate(ctx, url); err != nil {
-				logging.FromContext(ctx).Error().Err(err).Str("url", url).Msg("floating omnibox navigation failed")
+			if navCtx == nil {
+				navCtx = ctx
 			}
+			return session.pane.Navigate(navCtx, url)
 		}
 		cfg.OnToast = func(toastCtx context.Context, message string, level component.ToastLevel) {
 			a.showToastOnLastFocusedBrowserWindow(toastCtx, message, level)

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -214,7 +214,7 @@ func setWindowTabBar(t *testing.T, mw *window.MainWindow, tabBar *component.TabB
 	reflect.NewAt(fv.Type(), unsafe.Pointer(fv.UnsafeAddr())).Elem().Set(reflect.ValueOf(tabBar))
 }
 
-func omniboxNavigateCallbackForTest(t *testing.T, omnibox *component.Omnibox) func(string) {
+func omniboxNavigateCallbackForTest(t *testing.T, omnibox *component.Omnibox) func(context.Context, string) error {
 	t.Helper()
 	if omnibox == nil {
 		t.Fatal("omnibox is nil")
@@ -225,7 +225,7 @@ func omniboxNavigateCallbackForTest(t *testing.T, omnibox *component.Omnibox) fu
 	if !fv.IsValid() {
 		t.Fatal("Omnibox missing onNavigate field")
 	}
-	cb, ok := reflect.NewAt(fv.Type(), unsafe.Pointer(fv.UnsafeAddr())).Elem().Interface().(func(string))
+	cb, ok := reflect.NewAt(fv.Type(), unsafe.Pointer(fv.UnsafeAddr())).Elem().Interface().(func(context.Context, string) error)
 	if !ok || cb == nil {
 		t.Fatal("omnibox onNavigate callback is nil or has unexpected type")
 	}
@@ -2117,7 +2117,9 @@ func TestApp_OmniboxNavigateCallbackCapturesBrowserWindow(t *testing.T) {
 
 	ctx := context.Background()
 	cb := omniboxNavigateForBrowserWindow(ctx, second, testNavigate)
-	cb("https://google.com")
+	if err := cb(ctx, "https://google.com"); err != nil {
+		t.Fatalf("omnibox navigate callback returned error: %v", err)
+	}
 
 	if capturedBW != second {
 		capturedID := "<nil>"
@@ -2496,7 +2498,9 @@ func TestApp_WorkspaceOmniboxNavigateUsesOwnerWindow(t *testing.T) {
 	}
 	wsView.ShowOmnibox(ctx, "")
 	cb := omniboxNavigateCallbackForTest(t, wsView.GetOmnibox())
-	cb("https://example.com")
+	if err := cb(ctx, "https://example.com"); err != nil {
+		t.Fatalf("omnibox navigate callback returned error: %v", err)
+	}
 
 	if fakeWv1.loadURICalled {
 		t.Errorf("first window webview navigated to %q, want no navigation", fakeWv1.loadURILastURI)
@@ -2530,7 +2534,9 @@ func TestApp_FloatingOmniboxNavigateUsesSessionPane(t *testing.T) {
 
 	app.showFloatingOmnibox(ctx, session)
 	cb := omniboxNavigateCallbackForTest(t, session.omnibox)
-	cb("https://example.com")
+	if err := cb(ctx, "https://example.com"); err != nil {
+		t.Fatalf("floating omnibox navigate callback returned error: %v", err)
+	}
 
 	if loadedURL != "https://example.com" {
 		t.Fatalf("floating pane loaded URL = %q, want https://example.com", loadedURL)

--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -120,7 +120,7 @@ type Omnibox struct {
 	ctx                   context.Context
 
 	// Callbacks
-	onNavigate         func(url string)
+	onNavigate         func(ctx context.Context, url string) error
 	onClose            func()
 	onToast            func(ctx context.Context, message string, level ToastLevel)
 	onAccentKeyPress   func(keyval uint, state gdk.ModifierType) bool
@@ -164,14 +164,15 @@ type OmniboxConfig struct {
 	InitialBehavior     entity.OmniboxInitialBehavior
 	MostVisitedDays     int
 	SaveInitialBehavior func(ctx context.Context, behavior entity.OmniboxInitialBehavior) error
-	UIScale             float64                                                     // UI scale for favicon sizing
-	OnNavigate          func(url string)                                            // Callback when user navigates via omnibox
-	OnToast             func(ctx context.Context, message string, level ToastLevel) // Callback to show toast notification
-	OnFocusIn           func(entry *gtk.SearchEntry)                                // Callback when entry gains focus (for accent picker)
-	OnFocusOut          func()                                                      // Callback when entry loses focus
-	OnAccentKeyPress    func(keyval uint, state gdk.ModifierType) bool              // Long-press accent detection
-	OnAccentKeyRelease  func(keyval uint)                                           // Key release for accent cancel
-	SizeConfig          ModalSizeConfig                                             // Optional geometry override for omnibox sizing
+	UIScale             float64 // UI scale for favicon sizing
+	// OnNavigate is called when the user submits a URL; returning nil closes the omnibox.
+	OnNavigate         func(ctx context.Context, url string) error
+	OnToast            func(ctx context.Context, message string, level ToastLevel) // Callback to show toast notification
+	OnFocusIn          func(entry *gtk.SearchEntry)                                // Callback when entry gains focus (for accent picker)
+	OnFocusOut         func()                                                      // Callback when entry loses focus
+	OnAccentKeyPress   func(keyval uint, state gdk.ModifierType) bool              // Long-press accent detection
+	OnAccentKeyRelease func(keyval uint)                                           // Key release for accent cancel
+	SizeConfig         ModalSizeConfig                                             // Optional geometry override for omnibox sizing
 }
 
 // NewOmnibox creates a new native GTK4 omnibox widget.
@@ -771,9 +772,8 @@ func (o *Omnibox) initList() error {
 
 		targetURL := resolveTargetURLForSelection(mode, idx, o.effectiveMaxRows(), suggestions, favorites)
 
-		if targetURL != "" && o.onNavigate != nil {
-			o.Hide(o.ctx)
-			o.onNavigate(targetURL)
+		if targetURL != "" {
+			o.submitNavigation(targetURL)
 		}
 	}
 	o.retainedCallbacks = append(o.retainedCallbacks, rowActivatedCb)
@@ -2284,10 +2284,25 @@ func (o *Omnibox) selectAndNavigate(index int) {
 		return
 	}
 
-	o.Hide(o.ctx)
-	if o.onNavigate != nil {
-		o.onNavigate(targetURL)
+	o.submitNavigation(targetURL)
+}
+
+func (o *Omnibox) submitNavigation(targetURL string) {
+	if targetURL == "" {
+		return
 	}
+	if o.onNavigate == nil {
+		logging.FromContext(o.ctx).Warn().Msg("omnibox navigate handler is nil")
+		return
+	}
+	if err := o.onNavigate(o.ctx, targetURL); err != nil {
+		logging.FromContext(o.ctx).Error().Err(err).Msg("omnibox navigation failed")
+		if o.onToast != nil {
+			o.onToast(o.ctx, "Unable to open URL", ToastError)
+		}
+		return
+	}
+	o.Hide(o.ctx)
 }
 
 // navigateToSelected navigates to the currently selected item or typed URL.
@@ -2313,10 +2328,7 @@ func (o *Omnibox) navigateToSelected() {
 				if targetURL == "" {
 					return
 				}
-				o.Hide(o.ctx)
-				if o.onNavigate != nil {
-					o.onNavigate(targetURL)
-				}
+				o.submitNavigation(targetURL)
 				return
 			}
 		}
@@ -2342,11 +2354,7 @@ func (o *Omnibox) navigateToSelected() {
 		return
 	}
 
-	o.Hide(o.ctx)
-
-	if o.onNavigate != nil {
-		o.onNavigate(targetURL)
-	}
+	o.submitNavigation(targetURL)
 }
 
 func resolveTargetURLForSelection(mode ViewMode, idx, maxVisible int, suggestions []Suggestion, favorites []Favorite) string {
@@ -2780,7 +2788,7 @@ func (o *Omnibox) IsVisible() bool {
 }
 
 // SetOnNavigate sets the callback for URL navigation.
-func (o *Omnibox) SetOnNavigate(fn func(url string)) {
+func (o *Omnibox) SetOnNavigate(fn func(ctx context.Context, url string) error) {
 	o.onNavigate = fn
 }
 

--- a/internal/ui/deps.go
+++ b/internal/ui/deps.go
@@ -102,8 +102,9 @@ type Dependencies struct {
 	// Optional: if nil, external URLs are silently dropped.
 	LaunchExternalURL func(uri string)
 	// LaunchBrowserURL opens a URL in a new dumber browser window.
-	// Optional: if nil, standalone omnibox web navigations are logged only.
-	LaunchBrowserURL func(uri string)
+	// Returns an error when the launcher is unavailable or the launch fails.
+	// Optional: if nil, standalone omnibox navigation returns a configuration error.
+	LaunchBrowserURL func(ctx context.Context, uri string) error
 	// BrowserLaunchRelay listens for in-process browser launch requests.
 	BrowserLaunchRelay port.BrowserLaunchRelay
 }

--- a/internal/ui/standalone_omnibox.go
+++ b/internal/ui/standalone_omnibox.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -154,14 +155,18 @@ func goTestFlagConsumesNextArg(arg string) bool {
 	}
 }
 
-func wrapStandaloneOmniboxNavigate(original func(string), quit func()) func(string) {
-	return func(url string) {
-		if original != nil {
-			original(url)
+func wrapStandaloneOmniboxNavigate(original func(context.Context, string) error, quit func()) func(context.Context, string) error {
+	return func(ctx context.Context, url string) error {
+		if original == nil {
+			return fmt.Errorf("standalone omnibox navigate handler is not configured")
+		}
+		if err := original(ctx, url); err != nil {
+			return err
 		}
 		if quit != nil {
 			quit()
 		}
+		return nil
 	}
 }
 

--- a/internal/ui/standalone_omnibox_test.go
+++ b/internal/ui/standalone_omnibox_test.go
@@ -12,13 +12,16 @@ import (
 
 func TestWrapStandaloneOmniboxNavigate_CallsOriginalThenQuit(t *testing.T) {
 	var calls []string
-	wrapped := wrapStandaloneOmniboxNavigate(func(url string) {
+	wrapped := wrapStandaloneOmniboxNavigate(func(_ context.Context, url string) error {
 		calls = append(calls, "navigate:"+url)
+		return nil
 	}, func() {
 		calls = append(calls, "quit")
 	})
 
-	wrapped("https://example.com")
+	if err := wrapped(context.Background(), "https://example.com"); err != nil {
+		t.Fatalf("wrapped navigate returned error: %v", err)
+	}
 
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 calls, got %d: %#v", len(calls), calls)
@@ -31,16 +34,19 @@ func TestWrapStandaloneOmniboxNavigate_CallsOriginalThenQuit(t *testing.T) {
 	}
 }
 
-func TestWrapStandaloneOmniboxNavigate_QuitsWithoutOriginalNavigate(t *testing.T) {
+func TestWrapStandaloneOmniboxNavigate_DoesNotQuitWhenNavigateFails(t *testing.T) {
 	called := false
-	wrapped := wrapStandaloneOmniboxNavigate(nil, func() {
+	wrapped := wrapStandaloneOmniboxNavigate(func(context.Context, string) error {
+		return context.DeadlineExceeded
+	}, func() {
 		called = true
 	})
 
-	wrapped("https://example.com")
-
-	if !called {
-		t.Fatalf("expected quit to be called")
+	if err := wrapped(context.Background(), "https://example.com"); err == nil {
+		t.Fatal("expected wrapped navigate to return an error")
+	}
+	if called {
+		t.Fatalf("expected quit to be skipped when navigate fails")
 	}
 }
 

--- a/internal/ui/standalone_runtime_test.go
+++ b/internal/ui/standalone_runtime_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	urlutil "github.com/bnema/dumber/internal/domain/url"
@@ -10,13 +11,19 @@ import (
 func TestHandleStandaloneOmniboxNavigation_UsesFreshBrowserWindowForHTTP(t *testing.T) {
 	browserURL := ""
 	externalURL := ""
-	handleStandaloneOmniboxNavigation(&Dependencies{
-		LaunchBrowserURL: func(uri string) { browserURL = uri },
+	err := handleStandaloneOmniboxNavigation(&Dependencies{
+		LaunchBrowserURL: func(_ context.Context, uri string) error {
+			browserURL = uri
+			return nil
+		},
 		LaunchExternalURL: func(uri string) {
 			externalURL = uri
 		},
 	}, context.Background(), "https://example.com")
 
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if browserURL != "https://example.com" {
 		t.Fatalf("expected browser launcher to receive URL, got %q", browserURL)
 	}
@@ -28,13 +35,19 @@ func TestHandleStandaloneOmniboxNavigation_UsesFreshBrowserWindowForHTTP(t *test
 func TestHandleStandaloneOmniboxNavigation_UsesExternalLauncherForCustomScheme(t *testing.T) {
 	browserURL := ""
 	externalURL := ""
-	handleStandaloneOmniboxNavigation(&Dependencies{
-		LaunchBrowserURL: func(uri string) { browserURL = uri },
+	err := handleStandaloneOmniboxNavigation(&Dependencies{
+		LaunchBrowserURL: func(_ context.Context, uri string) error {
+			browserURL = uri
+			return nil
+		},
 		LaunchExternalURL: func(uri string) {
 			externalURL = uri
 		},
 	}, context.Background(), "vscode://file/tmp/demo")
 
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if externalURL != "vscode://file/tmp/demo" {
 		t.Fatalf("expected external launcher to receive URL, got %q", externalURL)
 	}
@@ -46,18 +59,41 @@ func TestHandleStandaloneOmniboxNavigation_UsesExternalLauncherForCustomScheme(t
 func TestHandleStandaloneOmniboxNavigation_UsesExternalLauncherForMailto(t *testing.T) {
 	browserURL := ""
 	externalURL := ""
-	handleStandaloneOmniboxNavigation(&Dependencies{
-		LaunchBrowserURL: func(uri string) { browserURL = uri },
+	err := handleStandaloneOmniboxNavigation(&Dependencies{
+		LaunchBrowserURL: func(_ context.Context, uri string) error {
+			browserURL = uri
+			return nil
+		},
 		LaunchExternalURL: func(uri string) {
 			externalURL = uri
 		},
 	}, context.Background(), "mailto:foo@example.com")
 
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if externalURL != "mailto:foo@example.com" {
 		t.Fatalf("expected external launcher to receive URL, got %q", externalURL)
 	}
 	if browserURL != "" {
 		t.Fatalf("expected browser launcher to be unused, got %q", browserURL)
+	}
+}
+
+func TestHandleStandaloneOmniboxNavigation_ReturnsBrowserLaunchError(t *testing.T) {
+	wantErr := context.DeadlineExceeded
+
+	err := handleStandaloneOmniboxNavigation(&Dependencies{
+		LaunchBrowserURL: func(context.Context, string) error {
+			return wantErr
+		},
+	}, context.Background(), "https://example.com")
+
+	if err == nil {
+		t.Fatal("expected browser launch error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make standalone omnibox navigation callbacks return explicit success/failure
- keep the standalone omnibox open on real launch failures and only close after accepted submission
- harden relay/browser-launch handling for unconfirmed delivery, safer logging, and generic user-facing errors

## Verification
- gofmt ./cmd ./internal
- make lint
- make test
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Omnibox navigation and browser launch APIs are now context-aware and return errors for callers to handle.
  * Added explicit "unconfirmed" launch outcome to indicate ambiguous relay delivery.

* **Bug Fixes**
  * Increased browser-launch relay timeout and improved handling of ambiguous/unconfirmed launches.
  * Browser launch failures no longer silently print sensitive details; errors are propagated safely.
  * Omnibox shows error toasts and only closes after successful navigation.

* **Tests**
  * Expanded tests covering relay, launch, and error-propagation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->