### PR TITLE
fix(desktop): sync browser MIME handlers

### DIFF
--- a/internal/infrastructure/desktop/adapter.go
+++ b/internal/infrastructure/desktop/adapter.go
@@ -43,6 +43,7 @@ StartupWMClass=dumber
 // Adapter implements port.DesktopIntegration using XDG tools.
 type Adapter struct {
 	xdgSettingsPath string
+	xdgMimePath     string
 	updateDesktopDB string
 }
 
@@ -53,6 +54,11 @@ func New() port.DesktopIntegration {
 	// Detect xdg-settings
 	if path, err := exec.LookPath("xdg-settings"); err == nil {
 		a.xdgSettingsPath = path
+	}
+
+	// Detect xdg-mime
+	if path, err := exec.LookPath("xdg-mime"); err == nil {
+		a.xdgMimePath = path
 	}
 
 	// Detect update-desktop-database (optional)
@@ -160,6 +166,10 @@ func (a *Adapter) GetStatus(ctx context.Context) (*port.DesktopIntegrationStatus
 			currentDefault := strings.TrimSpace(string(out))
 			status.IsDefaultBrowser = currentDefault == desktopFileName || currentDefault == packageDesktopFileName
 		}
+	}
+
+	if status.IsDefaultBrowser && a.xdgMimePath != "" {
+		status.IsDefaultBrowser = a.hasDefaultBrowserLinkHandlers(ctx)
 	}
 
 	log.Debug().
@@ -320,12 +330,55 @@ func (a *Adapter) SetAsDefaultBrowser(ctx context.Context) error {
 		return fmt.Errorf("xdg-settings failed: %s", strings.TrimSpace(string(out)))
 	}
 
+	if a.xdgMimePath != "" {
+		mimeArgs := []string{"default", desktopFile}
+		mimeArgs = append(mimeArgs, browserMimeTypes()...)
+		cmd = exec.CommandContext(ctx, a.xdgMimePath, mimeArgs...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("xdg-mime failed: %w: %s", err, strings.TrimSpace(string(out)))
+		}
+	}
+
 	log.Info().Str("desktop_file", desktopFile).Msg("dumber set as default browser")
 	return nil
 }
 
 // findDesktopFile returns the desktop file name to use for default browser setting.
 // Checks system paths first (AUR/Flatpak), then user path (manual install).
+func browserMimeTypes() []string {
+	return []string{
+		"x-scheme-handler/http",
+		"x-scheme-handler/https",
+		"text/html",
+		"text/xml",
+		"application/xhtml+xml",
+	}
+}
+
+func browserLinkMimeTypes() []string {
+	return []string{
+		"x-scheme-handler/http",
+		"x-scheme-handler/https",
+		"text/html",
+	}
+}
+
+func (a *Adapter) hasDefaultBrowserLinkHandlers(ctx context.Context) bool {
+	for _, mimeType := range browserLinkMimeTypes() {
+		out, err := exec.CommandContext(ctx, a.xdgMimePath, "query", "default", mimeType).Output()
+		if err != nil {
+			return false
+		}
+
+		currentDefault := strings.TrimSpace(string(out))
+		if currentDefault != desktopFileName && currentDefault != packageDesktopFileName {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (a *Adapter) findDesktopFile(ctx context.Context) string {
 	log := logging.FromContext(ctx)
 

--- a/internal/infrastructure/desktop/adapter_test.go
+++ b/internal/infrastructure/desktop/adapter_test.go
@@ -1,6 +1,7 @@
 package desktop
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -8,6 +9,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/bnema/dumber/internal/domain/entity"
 )
@@ -214,6 +218,57 @@ func TestLaunchBrowserBrowseURL_SpawnErrorDoesNotLeakURL(t *testing.T) {
 	if strings.Contains(err.Error(), "token=secret") || strings.Contains(err.Error(), "https://example.com") {
 		t.Fatalf("expected error to redact URL, got %q", err)
 	}
+}
+
+func TestSetAsDefaultBrowserAlsoUpdatesMimeHandlers(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", filepath.Join(os.Getenv("HOME"), ".local", "share"))
+
+	desktopPath, err := getDesktopFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(desktopPath), 0o755))
+	require.NoError(t, os.WriteFile(desktopPath, []byte(desktopFileTemplate), 0o644))
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "commands.log")
+
+	xdgSettingsPath := writeExecutable(t, filepath.Join(binDir, "xdg-settings"), "#!/bin/sh\necho \"$@\" >> \""+logPath+"\"\n")
+	xdgMimePath := writeExecutable(t, filepath.Join(binDir, "xdg-mime"), "#!/bin/sh\necho \"$@\" >> \""+logPath+"\"\n")
+
+	a := &Adapter{xdgSettingsPath: xdgSettingsPath, xdgMimePath: xdgMimePath}
+	desktopFile := a.findDesktopFile(context.Background())
+	require.NotEmpty(t, desktopFile)
+
+	err = a.SetAsDefaultBrowser(context.Background())
+	require.NoError(t, err)
+
+	logged, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	commands := strings.Split(strings.TrimSpace(string(logged)), "\n")
+
+	assert.Contains(t, commands, "set default-web-browser "+desktopFile)
+	assert.Contains(t, commands, "default "+desktopFile+" x-scheme-handler/http x-scheme-handler/https text/html text/xml application/xhtml+xml")
+}
+
+func TestGetStatusRequiresBrowserLinkMimeHandlersToMatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", filepath.Join(os.Getenv("HOME"), ".local", "share"))
+
+	binDir := t.TempDir()
+	xdgSettingsPath := writeExecutable(t, filepath.Join(binDir, "xdg-settings"), "#!/bin/sh\nif [ \"$1\" = \"get\" ]; then\n  echo dumber.desktop\nfi\n")
+	xdgMimePath := writeExecutable(t, filepath.Join(binDir, "xdg-mime"), "#!/bin/sh\nif [ \"$1\" = \"query\" ]; then\n  if [ \"$3\" = \"x-scheme-handler/http\" ]; then\n    echo zen.desktop\n  else\n    echo dumber.desktop\n  fi\nfi\n")
+
+	a := &Adapter{xdgSettingsPath: xdgSettingsPath, xdgMimePath: xdgMimePath}
+
+	status, err := a.GetStatus(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.IsDefaultBrowser)
+}
+
+func writeExecutable(t *testing.T, path, content string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	return path
 }
 
 func requireNoError(t *testing.T, err error) {


### PR DESCRIPTION
## Summary
- sync `setup default` with xdg-mime browser handlers so links stop opening in another browser
- treat default-browser status as true only when browser link handlers still point to dumber
- add regression tests for xdg-settings/xdg-mime integration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced default browser detection and configuration on desktop systems to improve reliability and accuracy.

* **Tests**
  * Added comprehensive test coverage for default browser behavior and MIME type handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->