### PR TITLE
fix(cef): respect effective HiDPI scale for zoom

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.3
 	github.com/bnema/purego-cef v0.13.2
-	github.com/bnema/purego-cef2gtk v0.5.5
+	github.com/bnema/purego-cef2gtk v0.5.6
 	github.com/bnema/purego-pipewire v0.1.4
 	github.com/bnema/purego-sqlite v0.1.3
 	github.com/bnema/puregotk v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.3 h1:lpTXuapRIBH2OTgLJTjYlK1olHmZkEQLloqgP
 github.com/bnema/purego v0.11.0-bnema.3/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.13.2 h1:weSttuJVxjyzp/A5J15ZdzOAVWO/jvvd6nBf8/N4zsI=
 github.com/bnema/purego-cef v0.13.2/go.mod h1:Jbc4GgUvGakEOfbRnXJGYrDbXz03YEpVgTWKPk5ss9k=
-github.com/bnema/purego-cef2gtk v0.5.5 h1:AY/0gLqyBUJliGwyiIB3e6ACOudV6ZI6PeT+IKpHGgA=
-github.com/bnema/purego-cef2gtk v0.5.5/go.mod h1:LGMP/8ip347wu5wnLiQh8m+I+yq4H+aiuMAEICrbVFk=
+github.com/bnema/purego-cef2gtk v0.5.6 h1:eG4zFGBUhkCfLksFJ/Wo2p9sbMIgQ6dTrTzOJ6oNKZY=
+github.com/bnema/purego-cef2gtk v0.5.6/go.mod h1:LGMP/8ip347wu5wnLiQh8m+I+yq4H+aiuMAEICrbVFk=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=
 github.com/bnema/purego-pipewire v0.1.4/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.3 h1:aXysq9+wuRkbFzlVe2oIiooYseFZFb6ArwbfDYYafvY=

--- a/internal/application/port/engine.go
+++ b/internal/application/port/engine.go
@@ -142,22 +142,22 @@ type Engine interface {
 	SetHandlerContext(ctx context.Context)
 }
 
+// EngineSettingsPayload is the engine-facing boundary view of runtime config.
+// Add fields here only when an engine needs to react to them at runtime.
+type EngineSettingsPayload struct {
+	DefaultUIScale float64
+}
+
 // EngineSettingsUpdate carries a runtime config change to the engine.
 //
-// The Raw field holds the implementation-specific config object; each engine
-// implementation type-asserts it to its concrete config type (e.g. the WebKit
-// engine asserts to *infrastructure/config.Config).
-//
-// This is the only intentional use of `any` in the Engine port. A fully typed
-// approach would require either moving the entire config schema into the domain
-// layer (a large refactor) or defining a SettingsProvider interface — which
-// would itself reduce to `any` because callers would embed engine-specific data
-// behind an empty interface. Until the config schema is promoted to domain,
-// the type assertion in the engine implementation is the least-invasive option.
+// Settings exposes the typed boundary payload that engine adapters should prefer.
+// Raw remains for legacy adapters that still consume implementation-specific
+// config until their settings managers are narrowed to boundary fields.
 type EngineSettingsUpdate struct {
-	// Raw holds the implementation-specific config.
-	// WebKit engine expects *infrastructure/config.Config.
-	Raw any //nolint:iface // intentional: see type comment above
+	Settings EngineSettingsPayload
+	// Raw holds the implementation-specific config for legacy adapters.
+	// WebKit engine currently expects *infrastructure/config.Config.
+	Raw any //nolint:iface // intentional legacy bridge; prefer Settings for new code
 }
 
 // WebUIMessageHandler handles a decoded message payload from the JS bridge.

--- a/internal/bootstrap/engine.go
+++ b/internal/bootstrap/engine.go
@@ -86,6 +86,7 @@ func BuildEngine(input EngineInput) (port.Engine, error) {
 			WindowlessFrameRateMax:      cfg.Engine.CEF.CEFWindowlessFrameRateMax(),
 			EnableAudioHandler:          cfg.Engine.CEF.EnableAudioHandler,
 			TraceHandlers:               cfg.Engine.CEF.TraceHandlers,
+			ApplicationScale:            cfg.DefaultUIScale,
 		}
 		deps := cef.EngineDependencies{
 			RegisterHandlers:           handlers.RegisterAll,

--- a/internal/infrastructure/cef/cef2gtk_adapter.go
+++ b/internal/infrastructure/cef/cef2gtk_adapter.go
@@ -34,8 +34,8 @@ type Cef2gtkAdapter struct {
 
 // NewCef2gtkAdapter creates an accelerated CEF view and wraps it in a thin
 // Dumber adapter.
-func NewCef2gtkAdapter(renderStackPlan cef2gtk.RenderStackPlan) *Cef2gtkAdapter {
-	v := cef2gtk.NewViewWithOptions(cef2gtk.ViewOptions{RenderStackPlan: renderStackPlan})
+func NewCef2gtkAdapter(renderStackPlan cef2gtk.RenderStackPlan, applicationScale float64) *Cef2gtkAdapter {
+	v := cef2gtk.NewViewWithOptions(cef2gtk.ViewOptions{RenderStackPlan: renderStackPlan, ScaleMultiplier: applicationScale})
 	if v == nil {
 		return nil
 	}

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -10,6 +10,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/bnema/dumber/internal/infrastructure/config"
+
 	purecef "github.com/bnema/purego-cef/cef"
 	cef2gtk "github.com/bnema/purego-cef2gtk"
 
@@ -25,12 +27,13 @@ var _ port.AlreadyRunningAppRelaunchHandlerSetter = (*Engine)(nil)
 // Engine implements port.Engine for the CEF browser backend.
 // It manages the CEF lifecycle and provides access to all engine subsystems.
 type Engine struct {
-	ctx             context.Context
-	factory         *WebViewFactory
-	pool            *WebViewPool
-	profileLogDir   string
-	runtimeCEFDir   string
-	renderStackPlan cef2gtk.RenderStackPlan
+	ctx              context.Context
+	factory          *WebViewFactory
+	pool             *WebViewPool
+	profileLogDir    string
+	runtimeCEFDir    string
+	renderStackPlan  cef2gtk.RenderStackPlan
+	applicationScale float64
 
 	messageRouter *MessageRouter
 	schemeHandler *dumbSchemeHandler
@@ -346,8 +349,26 @@ func (e *Engine) UpdateAppearance(_ context.Context, r, g, b, alpha float64) err
 	return nil
 }
 
-// UpdateSettings applies runtime config changes to engine internals (Phase 1 stub).
-func (e *Engine) UpdateSettings(_ context.Context, _ port.EngineSettingsUpdate) error {
+// UpdateSettings applies runtime config changes to engine internals.
+//
+// CEF view scaling is fixed when each cef2gtk view is constructed. Changes to
+// default_ui_scale therefore apply to newly-created CEF views in this engine;
+// existing views continue using their construction-time scale until reload under
+// a new engine lifetime. Browser zoom remains independently adjustable at
+// runtime through SetZoomLevel.
+func (e *Engine) UpdateSettings(ctx context.Context, update port.EngineSettingsUpdate) error {
+	cfg, ok := update.Raw.(*config.Config)
+	if !ok {
+		return fmt.Errorf("UpdateSettings: expected *config.Config, got %T", update.Raw)
+	}
+	newScale := normalizedApplicationScale(cfg.DefaultUIScale)
+	if e.applicationScale != newScale {
+		logging.FromContext(ctx).Info().
+			Float64("old_application_scale", e.applicationScale).
+			Float64("new_application_scale", newScale).
+			Msg("cef: application scale update will apply to newly-created CEF views")
+		e.applicationScale = newScale
+	}
 	return nil
 }
 

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -10,8 +10,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/bnema/dumber/internal/infrastructure/config"
-
 	purecef "github.com/bnema/purego-cef/cef"
 	cef2gtk "github.com/bnema/purego-cef2gtk"
 
@@ -27,13 +25,14 @@ var _ port.AlreadyRunningAppRelaunchHandlerSetter = (*Engine)(nil)
 // Engine implements port.Engine for the CEF browser backend.
 // It manages the CEF lifecycle and provides access to all engine subsystems.
 type Engine struct {
-	ctx              context.Context
-	factory          *WebViewFactory
-	pool             *WebViewPool
-	profileLogDir    string
-	runtimeCEFDir    string
-	renderStackPlan  cef2gtk.RenderStackPlan
-	applicationScale float64
+	ctx                context.Context
+	factory            *WebViewFactory
+	pool               *WebViewPool
+	profileLogDir      string
+	runtimeCEFDir      string
+	renderStackPlan    cef2gtk.RenderStackPlan
+	applicationScaleMu sync.RWMutex
+	applicationScale   float64
 
 	messageRouter *MessageRouter
 	schemeHandler *dumbSchemeHandler
@@ -357,19 +356,30 @@ func (e *Engine) UpdateAppearance(_ context.Context, r, g, b, alpha float64) err
 // a new engine lifetime. Browser zoom remains independently adjustable at
 // runtime through SetZoomLevel.
 func (e *Engine) UpdateSettings(ctx context.Context, update port.EngineSettingsUpdate) error {
-	cfg, ok := update.Raw.(*config.Config)
-	if !ok {
-		return fmt.Errorf("UpdateSettings: expected *config.Config, got %T", update.Raw)
-	}
-	newScale := normalizedApplicationScale(cfg.DefaultUIScale)
-	if e.applicationScale != newScale {
-		logging.FromContext(ctx).Info().
-			Float64("old_application_scale", e.applicationScale).
-			Float64("new_application_scale", newScale).
-			Msg("cef: application scale update will apply to newly-created CEF views")
+	newScale := normalizedApplicationScale(update.Settings.DefaultUIScale)
+	e.applicationScaleMu.Lock()
+	oldScale := e.applicationScale
+	if oldScale != newScale {
 		e.applicationScale = newScale
 	}
+	e.applicationScaleMu.Unlock()
+
+	if oldScale != newScale {
+		logging.FromContext(ctx).Info().
+			Float64("old_application_scale", oldScale).
+			Float64("new_application_scale", newScale).
+			Msg("cef: application scale update will apply to newly-created CEF views")
+	}
 	return nil
+}
+
+func (e *Engine) currentApplicationScale() float64 {
+	if e == nil {
+		return 1
+	}
+	e.applicationScaleMu.RLock()
+	defer e.applicationScaleMu.RUnlock()
+	return normalizedApplicationScale(e.applicationScale)
 }
 
 func (e *Engine) handleExplicitClipboardBridgeText(viewID port.WebViewID, action, text string) {

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -66,6 +67,7 @@ func NewEngine(
 		profileLogDir:          paths.ProfileLogDir,
 		runtimeCEFDir:          settings.CEFDir,
 		renderStackPlan:        renderStackPlan,
+		applicationScale:       normalizedApplicationScale(cfg.ApplicationScale),
 		registerHandlers:       deps.RegisterHandlers,
 		registerAccentHandlers: deps.RegisterAccentHandlers,
 		currentConfigPayload:   deps.CurrentConfigPayload,
@@ -86,6 +88,7 @@ func NewEngine(
 		Bool("external_begin_frame", externalBeginFrameEnabled()).
 		Bool("trace_handlers", cfg.TraceHandlers).
 		Bool("enable_audio_handler", cfg.EnableAudioHandler).
+		Float64("application_scale", eng.applicationScale).
 		Msg("cef: configured engine")
 
 	if err := initializeCEF(eng, settings, logger); err != nil {
@@ -107,6 +110,13 @@ func NewEngine(
 		deps.CurrentConfigPayload,
 		deps.DefaultConfigPayload,
 	)
+}
+
+func normalizedApplicationScale(scale float64) float64 {
+	if math.IsNaN(scale) || math.IsInf(scale, 0) || scale <= 0 {
+		return 1
+	}
+	return scale
 }
 
 func normalizedWindowlessFrameRate(frameRate int32) int32 {

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -88,7 +88,7 @@ func NewEngine(
 		Bool("external_begin_frame", externalBeginFrameEnabled()).
 		Bool("trace_handlers", cfg.TraceHandlers).
 		Bool("enable_audio_handler", cfg.EnableAudioHandler).
-		Float64("application_scale", eng.applicationScale).
+		Float64("application_scale", eng.currentApplicationScale()).
 		Msg("cef: configured engine")
 
 	if err := initializeCEF(eng, settings, logger); err != nil {

--- a/internal/infrastructure/cef/engine_settings_test.go
+++ b/internal/infrastructure/cef/engine_settings_test.go
@@ -2,27 +2,51 @@ package cef
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/bnema/dumber/internal/application/port"
-	"github.com/bnema/dumber/internal/infrastructure/config"
 )
 
-func TestEngineUpdateSettingsUpdatesApplicationScaleForNewViews(t *testing.T) {
+func TestEngineUpdateSettingsUpdatesApplicationScaleFromBoundaryPayload(t *testing.T) {
 	e := &Engine{applicationScale: 1}
-	cfg := &config.Config{DefaultUIScale: 1.25}
 
-	if err := e.UpdateSettings(context.Background(), port.EngineSettingsUpdate{Raw: cfg}); err != nil {
+	if err := e.UpdateSettings(context.Background(), port.EngineSettingsUpdate{
+		Settings: port.EngineSettingsPayload{DefaultUIScale: 1.25},
+	}); err != nil {
 		t.Fatalf("UpdateSettings returned error: %v", err)
 	}
-	if e.applicationScale != 1.25 {
-		t.Fatalf("applicationScale=%v, want 1.25", e.applicationScale)
+	if got := e.currentApplicationScale(); got != 1.25 {
+		t.Fatalf("applicationScale=%v, want 1.25", got)
 	}
 }
 
-func TestEngineUpdateSettingsRejectsUnexpectedConfig(t *testing.T) {
-	e := &Engine{}
-	if err := e.UpdateSettings(context.Background(), port.EngineSettingsUpdate{Raw: "wrong"}); err == nil {
-		t.Fatal("expected error for unexpected config type")
+func TestEngineUpdateSettingsIgnoresLegacyRawForApplicationScale(t *testing.T) {
+	e := &Engine{applicationScale: 1}
+
+	if err := e.UpdateSettings(context.Background(), port.EngineSettingsUpdate{Raw: "wrong"}); err != nil {
+		t.Fatalf("UpdateSettings returned error: %v", err)
 	}
+	if got := e.currentApplicationScale(); got != 1 {
+		t.Fatalf("applicationScale=%v, want default 1", got)
+	}
+}
+
+func TestEngineApplicationScaleConcurrentAccess(_ *testing.T) {
+	e := &Engine{applicationScale: 1}
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = e.currentApplicationScale()
+		}()
+		go func(scale float64) {
+			defer wg.Done()
+			_ = e.UpdateSettings(context.Background(), port.EngineSettingsUpdate{
+				Settings: port.EngineSettingsPayload{DefaultUIScale: scale},
+			})
+		}(1 + float64(i)/10)
+	}
+	wg.Wait()
 }

--- a/internal/infrastructure/cef/engine_settings_test.go
+++ b/internal/infrastructure/cef/engine_settings_test.go
@@ -1,0 +1,28 @@
+package cef
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/infrastructure/config"
+)
+
+func TestEngineUpdateSettingsUpdatesApplicationScaleForNewViews(t *testing.T) {
+	e := &Engine{applicationScale: 1}
+	cfg := &config.Config{DefaultUIScale: 1.25}
+
+	if err := e.UpdateSettings(context.Background(), port.EngineSettingsUpdate{Raw: cfg}); err != nil {
+		t.Fatalf("UpdateSettings returned error: %v", err)
+	}
+	if e.applicationScale != 1.25 {
+		t.Fatalf("applicationScale=%v, want 1.25", e.applicationScale)
+	}
+}
+
+func TestEngineUpdateSettingsRejectsUnexpectedConfig(t *testing.T) {
+	e := &Engine{}
+	if err := e.UpdateSettings(context.Background(), port.EngineSettingsUpdate{Raw: "wrong"}); err == nil {
+		t.Fatal("expected error for unexpected config type")
+	}
+}

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -106,7 +106,8 @@ func (f *WebViewFactory) Create(ctx context.Context) (port.WebView, error) {
 
 func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 	id := port.WebViewID(f.nextID.Add(1))
-	viewBridge := NewCef2gtkAdapter(f.engine.renderStackPlan, f.engine.applicationScale)
+	applicationScale := f.engine.currentApplicationScale()
+	viewBridge := NewCef2gtkAdapter(f.engine.renderStackPlan, applicationScale)
 	if viewBridge == nil {
 		return nil, fmt.Errorf("create cef2gtk view")
 	}
@@ -125,7 +126,7 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 	}
 	wv.runOnGTKSync(func() {
 		nativeWidget := viewBridge.Widget()
-		popupSurface := newPopupBridgeSurface(ctx, nativeWidget, f.engine.renderStackPlan, f.engine.applicationScale)
+		popupSurface := newPopupBridgeSurface(ctx, nativeWidget, f.engine.renderStackPlan, applicationScale)
 		wv.nativeWidget = nativeWidget
 		if popupSurface != nil {
 			wv.popupSurface = popupSurface

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -106,7 +106,7 @@ func (f *WebViewFactory) Create(ctx context.Context) (port.WebView, error) {
 
 func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 	id := port.WebViewID(f.nextID.Add(1))
-	viewBridge := NewCef2gtkAdapter(f.engine.renderStackPlan)
+	viewBridge := NewCef2gtkAdapter(f.engine.renderStackPlan, f.engine.applicationScale)
 	if viewBridge == nil {
 		return nil, fmt.Errorf("create cef2gtk view")
 	}
@@ -125,7 +125,7 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 	}
 	wv.runOnGTKSync(func() {
 		nativeWidget := viewBridge.Widget()
-		popupSurface := newPopupBridgeSurface(ctx, nativeWidget, f.engine.renderStackPlan)
+		popupSurface := newPopupBridgeSurface(ctx, nativeWidget, f.engine.renderStackPlan, f.engine.applicationScale)
 		wv.nativeWidget = nativeWidget
 		if popupSurface != nil {
 			wv.popupSurface = popupSurface

--- a/internal/infrastructure/cef/popup_surface.go
+++ b/internal/infrastructure/cef/popup_surface.go
@@ -23,7 +23,12 @@ type popupBridgeSurface struct {
 
 // newPopupBridgeSurface must be called on the GTK thread because it creates
 // and packs GTK widgets around the primary CEF widget.
-func newPopupBridgeSurface(ctx context.Context, mainWidget *gtk.Widget, plan cef2gtk.RenderStackPlan, applicationScale float64) *popupBridgeSurface {
+func newPopupBridgeSurface(
+	ctx context.Context,
+	mainWidget *gtk.Widget,
+	plan cef2gtk.RenderStackPlan,
+	applicationScale float64,
+) *popupBridgeSurface {
 	mainContext := glib.MainContextDefault()
 	if mainContext == nil || !mainContext.IsOwner() {
 		logging.FromContext(popupSurfaceLogContext(ctx)).Error().Msg("cef: newPopupBridgeSurface called off GTK thread")

--- a/internal/infrastructure/cef/popup_surface.go
+++ b/internal/infrastructure/cef/popup_surface.go
@@ -23,7 +23,7 @@ type popupBridgeSurface struct {
 
 // newPopupBridgeSurface must be called on the GTK thread because it creates
 // and packs GTK widgets around the primary CEF widget.
-func newPopupBridgeSurface(ctx context.Context, mainWidget *gtk.Widget, plan cef2gtk.RenderStackPlan) *popupBridgeSurface {
+func newPopupBridgeSurface(ctx context.Context, mainWidget *gtk.Widget, plan cef2gtk.RenderStackPlan, applicationScale float64) *popupBridgeSurface {
 	mainContext := glib.MainContextDefault()
 	if mainContext == nil || !mainContext.IsOwner() {
 		logging.FromContext(popupSurfaceLogContext(ctx)).Error().Msg("cef: newPopupBridgeSurface called off GTK thread")
@@ -32,7 +32,7 @@ func newPopupBridgeSurface(ctx context.Context, mainWidget *gtk.Widget, plan cef
 	if mainWidget == nil {
 		return nil
 	}
-	bridge := NewCef2gtkAdapter(plan)
+	bridge := NewCef2gtkAdapter(plan, applicationScale)
 	if bridge == nil {
 		return nil
 	}

--- a/internal/infrastructure/cef/runtime_config.go
+++ b/internal/infrastructure/cef/runtime_config.go
@@ -24,6 +24,7 @@ type RuntimeConfig struct {
 	WindowlessFrameRateMax      int32
 	EnableAudioHandler          bool
 	TraceHandlers               bool
+	ApplicationScale            float64
 }
 
 type HandlerRegistrar func(context.Context, port.WebUIHandlerRouter, port.HandlerDependencies) error

--- a/internal/infrastructure/cef/scale_probe.go
+++ b/internal/infrastructure/cef/scale_probe.go
@@ -1,5 +1,70 @@
 package cef
 
+import (
+	"math"
+	"strings"
+)
+
+type cefScaleProbeMetrics struct {
+	SurfaceWidth      int32
+	SurfaceHeight     int32
+	SurfaceScale      float64
+	OSRBackingScale   float64
+	UserZoom          float64
+	InternalCEFFactor float64
+}
+
+func shouldRunCEFScaleProbe(frameURL string, httpStatusCode int32) bool {
+	url := strings.ToLower(strings.TrimSpace(frameURL))
+	if url == "" || url == "about:blank" {
+		return false
+	}
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return httpStatusCode >= 200 && httpStatusCode < 400
+	}
+	return httpStatusCode >= 0
+}
+
+func cefScaleProbeSnapshot(wv *WebView) cefScaleProbeMetrics {
+	m := cefScaleProbeMetrics{
+		SurfaceWidth:      1,
+		SurfaceHeight:     1,
+		SurfaceScale:      1,
+		OSRBackingScale:   1,
+		UserZoom:          1,
+		InternalCEFFactor: 1,
+	}
+	if wv == nil {
+		return m
+	}
+	m.UserZoom = normalizeScale(wv.GetZoomLevel())
+	m.OSRBackingScale = normalizeScale(wv.osrBackingScaleFactor())
+	m.InternalCEFFactor = m.UserZoom * m.OSRBackingScale
+	if wv.viewBridge != nil {
+		m.SurfaceWidth, m.SurfaceHeight = wv.viewBridge.Size()
+		m.SurfaceScale = normalizeScale(float64(wv.viewBridge.DeviceScaleFactor()))
+	}
+	return m
+}
+
+func (m cefScaleProbeMetrics) logFields() map[string]interface{} {
+	return map[string]interface{}{
+		"surface_width":       m.SurfaceWidth,
+		"surface_height":      m.SurfaceHeight,
+		"surface_scale":       roundedScale(m.SurfaceScale),
+		"osr_backing_scale":   roundedScale(m.OSRBackingScale),
+		"user_zoom":           roundedScale(m.UserZoom),
+		"internal_cef_factor": roundedScale(m.InternalCEFFactor),
+	}
+}
+
+func roundedScale(v float64) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 1
+	}
+	return math.Round(v*1_000_000) / 1_000_000
+}
+
 const cefScaleProbeScript = `(function(){
   try {
     var vv = window.visualViewport;

--- a/internal/infrastructure/cef/scale_probe.go
+++ b/internal/infrastructure/cef/scale_probe.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const scaleProbeRoundFactor = 1_000_000
+
 type cefScaleProbeMetrics struct {
 	SurfaceWidth      int32
 	SurfaceHeight     int32
@@ -62,7 +64,7 @@ func roundedScale(v float64) float64 {
 	if math.IsNaN(v) || math.IsInf(v, 0) {
 		return 1
 	}
-	return math.Round(v*1_000_000) / 1_000_000
+	return math.Round(v*scaleProbeRoundFactor) / scaleProbeRoundFactor
 }
 
 const cefScaleProbeScript = `(function(){

--- a/internal/infrastructure/cef/scale_probe_test.go
+++ b/internal/infrastructure/cef/scale_probe_test.go
@@ -1,0 +1,49 @@
+package cef
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCEFScaleProbeScriptCapturesViewportMetrics(t *testing.T) {
+	for _, want := range []string{
+		"window.devicePixelRatio",
+		"window.innerWidth",
+		"document.documentElement.clientWidth",
+		"window.visualViewport",
+		"width:100px;height:100px",
+		"[SCALE-PROBE]",
+	} {
+		if !strings.Contains(cefScaleProbeScript, want) {
+			t.Fatalf("cefScaleProbeScript missing %q", want)
+		}
+	}
+}
+
+func TestShouldRunCEFScaleProbeSkipsIntermediateHTTPStatusZero(t *testing.T) {
+	if shouldRunCEFScaleProbe("https://example.com", 0) {
+		t.Fatal("probe should skip intermediate HTTP status 0 for http URLs")
+	}
+	if !shouldRunCEFScaleProbe("https://example.com", 200) {
+		t.Fatal("probe should run for successful HTTP load")
+	}
+	if shouldRunCEFScaleProbe("about:blank", 200) {
+		t.Fatal("probe should skip about:blank")
+	}
+	if !shouldRunCEFScaleProbe("file:///tmp/probe.html", 0) {
+		t.Fatal("probe should allow non-HTTP status 0 loads")
+	}
+}
+
+func TestCEFScaleProbeSnapshotNormalizesMissingBridge(t *testing.T) {
+	s := cefScaleProbeSnapshot(nil)
+	if s.SurfaceWidth != 1 || s.SurfaceHeight != 1 {
+		t.Fatalf("surface size = %dx%d, want 1x1", s.SurfaceWidth, s.SurfaceHeight)
+	}
+	if s.SurfaceScale != 1 || s.OSRBackingScale != 1 {
+		t.Fatalf("scales = surface %v backing %v, want 1/1", s.SurfaceScale, s.OSRBackingScale)
+	}
+	if s.UserZoom != 1 || s.InternalCEFFactor != 1 {
+		t.Fatalf("zoom = user %v internal %v, want 1/1", s.UserZoom, s.InternalCEFFactor)
+	}
+}

--- a/internal/infrastructure/cef/ui_scale_test.go
+++ b/internal/infrastructure/cef/ui_scale_test.go
@@ -1,0 +1,28 @@
+package cef
+
+import (
+	"math"
+	"testing"
+)
+
+func TestNormalizedApplicationScale(t *testing.T) {
+	tests := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{name: "default zero", in: 0, want: 1},
+		{name: "negative", in: -1, want: 1},
+		{name: "nan", in: math.NaN(), want: 1},
+		{name: "inf", in: math.Inf(1), want: 1},
+		{name: "valid", in: 1.2, want: 1.2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizedApplicationScale(tt.in); got != tt.want {
+				t.Fatalf("normalizedApplicationScale(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -459,11 +459,11 @@ func cefZoomFromFactor(factor float64) float64 {
 }
 
 func cefZoomFromPageAndBackingFactor(pageZoom, backingScale float64) float64 {
-	return cefZoomFromFactor(pageZoom / normalizeScale(backingScale))
+	return cefZoomFromFactor(pageZoom * normalizeScale(backingScale))
 }
 
 func pageZoomFromCEFAndBackingLevel(level, backingScale float64) float64 {
-	return factorFromCEFZoom(level) * normalizeScale(backingScale)
+	return factorFromCEFZoom(level) / normalizeScale(backingScale)
 }
 
 func (wv *WebView) applyCEFZoomLevel(host purecef.BrowserHost, factor, cefLevel, backingScale float64) {
@@ -1765,7 +1765,7 @@ func (wv *WebView) reapplyCurrentZoomForBackingScale(reason string) {
 		Float64("factor", factor).
 		Float64("cef_level", cefLevel).
 		Float64("osr_backing_scale", backingScale).
-		Msg("cef: reapplied zoom for OSR backing scale")
+		Msg("cef: reapplied zoom after OSR backing scale change")
 }
 
 func (wv *WebView) scheduleStartBeginFrameLoop() {

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -400,11 +400,16 @@ func (h *handlerSet) OnLoadEnd(_ purecef.Browser, frame purecef.Frame, httpStatu
 	// Inject scripts and styles after page load.
 	// Must run on GTK thread — OnLoadEnd fires on the CEF IO thread,
 	// and JavaScript injection requires the main thread.
-	if cefScaleProbeEnabled() && httpStatusCode >= 0 && !strings.EqualFold(strings.TrimSpace(frameURL), "about:blank") {
+	if cefScaleProbeEnabled() && shouldRunCEFScaleProbe(frameURL, httpStatusCode) {
 		// Do not retain/use CEF callback-scoped frame wrappers across the GTK idle hop.
 		// Re-read the current main frame through WebView.RunJavaScript instead.
 		h.wv.runOnGTK(func() {
-			logging.FromContext(h.wv.ctx).Debug().Msg("cef: injecting scale probe")
+			snapshot := cefScaleProbeSnapshot(h.wv)
+			event := logging.FromContext(h.wv.ctx).Debug()
+			for key, value := range snapshot.logFields() {
+				event = event.Interface(key, value)
+			}
+			event.Msg("cef: injecting scale probe")
 			h.wv.RunJavaScript(context.Background(), cefScaleProbeScript)
 		})
 	}

--- a/internal/infrastructure/cef/webview_zoom_test.go
+++ b/internal/infrastructure/cef/webview_zoom_test.go
@@ -18,12 +18,12 @@ func TestZoomConversionsRoundTrip(t *testing.T) {
 	}
 }
 
-func TestZoomConversionsCompensateOSRBackingScale(t *testing.T) {
-	for _, backing := range []float64{1.0, 1.25, 1.5, 2.0} {
+func TestZoomConversionsCompensateDeviceSizedOSRBackingInternally(t *testing.T) {
+	for _, backing := range []float64{1.0, 1.25, 1.44, 2.0} {
 		for _, pageZoom := range []float64{1.0, 1.75} {
 			t.Run(fmt.Sprintf("backing_%.2f_page_%.2f", backing, pageZoom), func(t *testing.T) {
 				level := cefZoomFromPageAndBackingFactor(pageZoom, backing)
-				assert.InDelta(t, pageZoom/backing, factorFromCEFZoom(level), 1e-9)
+				assert.InDelta(t, pageZoom*backing, factorFromCEFZoom(level), 1e-9)
 				assert.InDelta(t, pageZoom, pageZoomFromCEFAndBackingLevel(level, backing), 1e-9)
 			})
 		}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4827,7 +4827,10 @@ func (a *App) applyAppearanceConfig(ctx context.Context) {
 	cfg := a.deps.Config
 
 	if a.engine != nil {
-		if err := a.engine.UpdateSettings(ctx, port.EngineSettingsUpdate{Raw: cfg}); err != nil {
+		if err := a.engine.UpdateSettings(ctx, port.EngineSettingsUpdate{
+			Settings: port.EngineSettingsPayload{DefaultUIScale: cfg.DefaultUIScale},
+			Raw:      cfg,
+		}); err != nil {
 			log.Warn().Err(err).Msg("failed to apply engine settings update")
 		}
 	}


### PR DESCRIPTION
## Summary
- update purego-cef2gtk to v0.5.6 and pass Dumber UI scale into the CEF GTK bridge
- keep user-facing web zoom independent while compensating CEF's device-sized OSR backing internally
- add a dev-only CEF scale probe for DPR/viewport diagnostics

## Test Plan
- [x] rtk make check
- [x] rtk go test ./internal/infrastructure/cef -count=1
- [x] cd ../purego-cef2gtk && rtk go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable application UI scaling with runtime adjustment
  * Scale-probe mechanism to collect display/rendering metrics

* **Bug Fixes**
  * Zoom math corrected to properly compensate for backing/device scale factors

* **Tests**
  * Added unit tests for UI scale normalization, scale probe behavior, and zoom conversions

* **Chores**
  * Bumped a third-party dependency version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->