### PR TITLE
docs(readme): refresh project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,50 +2,81 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Go Report Card](https://goreportcard.com/badge/github.com/bnema/dumber)](https://goreportcard.com/report/github.com/bnema/dumber)
 
-A TTY-inspired web browser multiplexer for tiling window managers.
+Dumber is a keyboard-driven web browser for Wayland compositors, built around panes, workspaces, and modal controls.
 
-- Website: [dumber.bnema.dev](https://dumber.bnema.dev)
-- Documentation: [dumber.bnema.dev/docs](https://dumber.bnema.dev/docs)
+The page is the interface. There are no permanent tab bars, bookmark bars, or browser chrome around the content. Navigation and browser commands appear when you ask for them with the keyboard.
 
----
+Tabs contain workspaces. Workspaces contain panes. Panes can be split, stacked, moved, resized, and closed from the keyboard.
 
-## What is Dumber?
+The layout model is inspired by terminal multiplexers such as Zellij and tmux, but applied to browsing on tiling Wayland compositors.
 
-Dumber is a web browser that works like your terminal multiplexer. Tabs hold workspaces. Workspaces hold panes. Panes split and stack like Zellij.
+[Website](https://dumber.bnema.dev) · [Documentation](https://dumber.bnema.dev/docs) · [Keybindings](https://dumber.bnema.dev/docs/reference/keybindings)
+
+## Demo
 
 https://github.com/user-attachments/assets/232822af-08e4-4a74-9416-87f79c96b118
 
+The demo shows split panes, stacked panes, modal navigation, and workspace switching.
 
+## Overview
 
-**Features:**
-- Zellij-style panes with modal keyboard navigation
-- Floating workspace pane with profile shortcuts
-- Wayland native (Sway, Hyprland, River, Niri)
-- Session resurrection with auto-snapshots
-- Built-in ad blocking (uBlock-based)
-- GPU accelerated video (VA-API/VDPAU)
-- Launcher integration (rofi/fuzzel/dmenu)
-- Search bangs (!g, !gi, !ddg)
-- Single config.toml with hot reload
+Dumber uses three layout levels:
 
-## Documentation
+- **Tabs** group separate browser contexts.
+- **Workspaces** hold a layout of panes.
+- **Panes** display web pages and can be split, stacked, moved, resized, or closed.
 
-Full documentation is available at **[dumber.bnema.dev](https://dumber.bnema.dev)**
+Most browser-management actions are exposed through modal keybindings. Enter a mode, run one or more commands, then leave the mode. The default modes cover pane management, tabs, resizing, and session commands.
 
-- [Documentation](https://dumber.bnema.dev/docs) - Installation, configuration, CLI reference
-- [Keybindings](https://dumber.bnema.dev/docs/reference/keybindings) - Keyboard shortcuts
+The browser chrome stays out of the way by default. Open the omnibox when you want to navigate; otherwise the pane is just the page or web app you are using. This makes Dumber work well as a side pane next to an editor, terminal, or another desktop application.
 
-## Quick Start
+## Features
+
+### Content-first browsing
+
+- No permanent tab bar, bookmark bar, or toolbar around the page
+- Omnibox and browser commands appear through keyboard shortcuts
+- Web apps can feel closer to desktop applications because the browser frame is not always visible
+- Works well as a narrow side pane next to an editor, terminal, or other application
+
+### Pane-based browsing
+
+- Split panes horizontally or vertically
+- Stack panes in the same area
+- Move, resize, and close panes with modal keybindings
+- Keep related pages together in a workspace
+
+### Keyboard workflow
+
+- Pane, tab, resize, and session modes
+- Vim/Zellij-style navigation patterns
+- Search bangs such as `!g`, `!gi`, and `!ddg`
+- Launcher integration for `rofi`, `fuzzel`, and `dmenu`
+
+### Desktop integration
+
+- Wayland-native on Sway, Hyprland, River, Niri, and similar compositors
+- Floating pane with configurable profile shortcuts
+- Single `config.toml` file with hot reload
+
+### Browser features
+
+- Chromium Embedded Framework backend by default
+- WebKit backend available as a fallback
+- Built-in ad blocking based on uBlock filter lists
+- GPU-accelerated video through VA-API/VDPAU where supported
+- Snapshot-based restoration of tabs, workspaces, and pane layout
+
+## Installation
+
+### Install script
 
 ```bash
-# Install
 curl -fsSL https://dumber.bnema.dev/install | sh
-
-# Launch
 dumber browse
 ```
 
-### Arch Linux (AUR)
+### Arch Linux
 
 ```bash
 yay -S dumber-browser-bin   # Pre-built binary
@@ -59,6 +90,91 @@ wget https://github.com/bnema/dumber/releases/latest/download/dumber.flatpak
 flatpak install --user dumber.flatpak
 flatpak run dev.bnema.Dumber browse
 ```
+
+For dependencies, distribution notes, and troubleshooting, see the [installation documentation](https://dumber.bnema.dev/docs).
+
+## Keyboard modes
+
+Dumber uses modal keybindings for browser management.
+
+| Mode | Default key | Used for |
+|------|-------------|----------|
+| Pane | `Ctrl+P` | Split, stack, close, and move panes |
+| Tab | `Ctrl+T` | Create, close, switch, and rename tabs |
+| Resize | `Ctrl+N` | Resize panes with `hjkl` or arrow keys |
+| Session | `Ctrl+O` | Snapshot, restore, and browse sessions |
+
+## Floating pane
+
+The floating pane is a temporary browser pane that can be toggled without changing the main workspace layout.
+
+- `Alt+F` toggles the floating pane and preserves its state while hidden.
+- `Ctrl+W` closes the active pane; if the floating pane is active, it is fully released for a fresh next open.
+- Profile shortcuts such as `Alt+G` are optional and configured under `workspace.floating_pane.profiles`.
+- Some `Alt+<key>` bindings may conflict with WebKit shortcuts or desktop-level handlers.
+
+See the [floating pane reference](https://dumber.bnema.dev/docs/reference/floating-pane) for setup and behavior details.
+
+## Configuration
+
+Dumber is configured with a single TOML file.
+
+```toml
+[engine]
+type = "cef"
+
+[workspace.floating_pane]
+enabled = true
+```
+
+The config reloads while Dumber is running. See the [configuration documentation](https://dumber.bnema.dev/docs) for all options.
+
+## Browser engine
+
+Dumber uses Chromium Embedded Framework by default. WebKitGTK is available as a fallback backend.
+
+On Arch Linux, install the CEF runtime with:
+
+```bash
+sudo pacman -S cef
+```
+
+For hardware video decoding, `cef-vaapi` is also available from the AUR as an optional CEF build.
+
+CEF runtime lookup order:
+
+1. `CEF_DIR`
+2. `engine.cef.cef_dir`
+3. `/usr/lib/cef`
+4. `~/.local/share/cef`
+
+Set `engine.cef.cef_dir` in config when `CEF_DIR` is unset:
+
+```toml
+[engine.cef]
+cef_dir = "/custom/path"
+```
+
+Or set the higher-precedence `CEF_DIR` environment variable:
+
+```bash
+CEF_DIR=/custom/path dumber browse
+```
+
+WebKit can be selected explicitly:
+
+```toml
+[engine]
+type = "webkit"
+```
+
+### Rendering notes
+
+CEF uses Dumber's GPU-first Wayland render stack by default: GDK DMABUF presentation with ANGLE/GSK Vulkan. For driver compatibility, switch to the EGL/OpenGL stack with `engine.cef.render_stack = "egl"`; the default is `"vulkan"`.
+
+CEF OSR frame rate adapts to the active Wayland monitor refresh rate when both `engine.cef.adaptive_windowless_frame_rate = true` and `engine.cef.windowless_frame_rate = 0` are set, which are the defaults. Adaptive mode is capped by `engine.cef.windowless_frame_rate_max = 240`. Setting `engine.cef.windowless_frame_rate` to a positive value forces a fixed rate instead. This adaptive polling path is Wayland-specific; other platforms fall back to the configured fixed/default CEF behavior.
+
+## Platform notes
 
 ### Dependencies
 
@@ -74,77 +190,29 @@ sudo pacman -S cef webkitgtk-6.0 gtk4 gst-plugins-base gst-plugins-good gst-plug
 sudo apt install libwebkitgtk-6.0-4 libgtk-4-1 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
 ```
 
-> ⚠️ Ubuntu 24.04 ships GLib 2.80, but Dumber requires GLib 2.84+. Use Arch, Fedora 41+, or the Flatpak.
+> Ubuntu 24.04 ships GLib 2.80, but Dumber requires GLib 2.84+. Use Arch, Fedora 41+, or the Flatpak.
 
-### Browser engine
+## Status
 
-Dumber uses the Chromium Embedded Framework engine by default. On Arch, install the CEF runtime with:
+Dumber is usable for regular web browsing on Wayland compositors, with the main focus on panes, keyboard control, floating workflows, and desktop integration.
 
-```bash
-sudo pacman -S cef
-```
+It is not a drop-in replacement for every mainstream browser workflow. Extension compatibility, engine behavior, and media support depend on the selected backend and system libraries.
 
-For hardware video decoding, `cef-vaapi` is also available from the AUR as an optional CEF build.
-
-CEF runtime precedence is deterministic: `CEF_DIR` wins first, then `engine.cef.cef_dir`, then `/usr/lib/cef`, then `~/.local/share/cef`.
-Set `engine.cef.cef_dir` in config when `CEF_DIR` is unset:
-
-```toml
-[engine.cef]
-cef_dir = "/custom/path"
-```
-
-Or set the higher-precedence `CEF_DIR` environment variable:
-
-```bash
-CEF_DIR=/custom/path dumber browse
-```
-
-WebKit remains available as a fallback:
-
-```toml
-[engine]
-type = "webkit"
-```
-
-CEF uses Dumber's GPU-first Wayland render stack by default: GDK DMABUF presentation with ANGLE/GSK Vulkan. For driver compatibility, switch to the EGL/OpenGL stack with `engine.cef.render_stack = "egl"`; the default is `"vulkan"`.
-
-CEF OSR frame rate adapts to the active Wayland monitor refresh rate when both `engine.cef.adaptive_windowless_frame_rate = true` and `engine.cef.windowless_frame_rate = 0` (the defaults). Adaptive mode is capped by `engine.cef.windowless_frame_rate_max = 240`. Setting `engine.cef.windowless_frame_rate` to a positive value forces a fixed rate instead. This adaptive polling path is Wayland-specific; other platforms fall back to the configured fixed/default CEF behavior.
-
-## Keyboard-Driven
-
-Four modal modes. Enter a mode, act, escape out. Vim and Zellij users already know this pattern.
-
-| Mode | Key | Actions |
-|------|-----|---------|
-| Pane | `Ctrl+P` | Split · Stack · Close · Move |
-| Tab | `Ctrl+T` | New · Close · Switch · Rename |
-| Resize | `Ctrl+N` | Grow · Shrink · hjkl/arrows |
-| Session | `Ctrl+O` | Save · Restore · Browse |
-
-## Floating Pane
-
-- `Alt+F` toggles the floating pane and preserves its state while hidden.
-- `Ctrl+W` closes the active pane; if the floating pane is active, it is fully released for a fresh next open.
-- Profile shortcuts like `Alt+G` are optional and configured under `workspace.floating_pane.profiles`.
-- Some `Alt+<key>` bindings may conflict with default WebKit shortcuts or desktop-level handlers.
-
-See [Floating Pane Reference](https://dumber.bnema.dev/docs/reference/floating-pane) for setup and behavior details.
+Bug reports and reproducible Wayland/backend issues are welcome.
 
 ## Development
 
-Dumber uses pure-Go bindings (no CGO) but requires GTK4/WebKitGTK runtime libraries for the GUI.
+Dumber uses pure-Go bindings and requires GTK4/WebKitGTK runtime libraries for the GUI.
 
-### Environment
+Set `ENV=dev` to use `.dev/dumber/` for config and data instead of XDG paths.
 
-Set `ENV=dev` to use `.dev/dumber/` for config/data instead of XDG paths.
-
-### Build From Source
+### Build from source
 
 **Prerequisites:**
+
 - Go 1.25+
-- Node.js 20+ (for frontend assets)
-- WebKitGTK 6.0 and GTK4 dev packages
+- Node.js 20+ for frontend assets
+- WebKitGTK 6.0 and GTK4 development packages
 
 ```bash
 git clone https://github.com/bnema/dumber
@@ -153,12 +221,12 @@ make build
 ./dist/dumber browse
 ```
 
-### Make Targets
+### Make targets
 
 | Target | Description |
 |--------|-------------|
-| `make build` | Build frontend + binary |
-| `make build-quick` | Build binary only (skip frontend) |
+| `make build` | Build frontend and binary |
+| `make build-quick` | Build binary only, skipping frontend |
 | `make dev` | Run with `go run` |
 | `make test` | Run tests |
 | `make lint` | Run golangci-lint |
@@ -166,9 +234,9 @@ make build
 
 ## Contributing
 
-We welcome bug fixes, performance/stability improvements, and WebUI/UX enhancements. We're not accepting new feature PRs.
+Dumber is currently focused on stability, performance, browser-engine behavior, and core UI/UX polish.
 
-**All PRs must target the `next` branch.** We test there first before releasing to `main`.
+Bug fixes, documentation improvements, packaging fixes, and targeted UX improvements are welcome. Larger feature ideas should start as issues before PRs.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 


### PR DESCRIPTION
## Summary
- Rework README around Dumber's pane/workspace model and content-first browsing
- Move demo and overview earlier, group features by workflow, and keep install path concise
- Move engine/platform details lower and remove the obsolete next-branch contribution note

## Verification
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with improved organization and clearer navigation
  * Enhanced installation instructions with setup guidance and troubleshooting
  * Added detailed sections on keyboard modes, configuration, browser engine options, and platform-specific behavior
  * Expanded development and build prerequisites documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/dumber/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->