### PR TITLE
fix(cef): harden Vulkan navigation handoff

### DIFF
--- a/internal/infrastructure/cef/cef2gtk_boundary_test.go
+++ b/internal/infrastructure/cef/cef2gtk_boundary_test.go
@@ -19,7 +19,7 @@ func TestCEF2GTKImportStaysInInfrastructureCEF(t *testing.T) {
 		}
 		if d.IsDir() {
 			switch d.Name() {
-			case ".git", "vendor", "dist", "tmp":
+			case ".git", ".worktrees", "vendor", "dist", "tmp":
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -2,6 +2,7 @@ package cef
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -102,7 +103,10 @@ func (f *WebViewFactory) Create(ctx context.Context) (port.WebView, error) {
 	// Defer browser creation until the bridge view has a non-zero size.
 	// CEF requires GetViewRect to return a non-empty rect, but the GL area
 	// is not yet realized at this point.
-	f.configureInitialBrowserCreation(ctx, wv, wv.client, &windowInfo, &settings, nil)
+	if err := f.configureInitialBrowserCreation(ctx, wv, wv.client, &windowInfo, &settings, nil); err != nil {
+		wv.Destroy()
+		return nil, err
+	}
 
 	return wv, nil
 }
@@ -128,7 +132,7 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 		inputConfig:                 f.inputConfig,
 		backgroundColor:             f.bgColor.Load(),
 	}
-	wv.runOnGTKSync(func() {
+	result := wv.runOnGTKSyncLabel("cef.new_webview.init_widgets", func() {
 		nativeWidget := viewBridge.Widget()
 		popupSurface := newPopupBridgeSurface(ctx, nativeWidget, f.engine.renderStackPlan, applicationScale)
 		wv.nativeWidget = nativeWidget
@@ -139,6 +143,10 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 			}
 		}
 	})
+	if !result.Completed() {
+		wv.destroyViewBridgeOnGTKAsync()
+		return nil, errGTKSyncDispatchIncomplete("initialize CEF GTK widgets", result)
+	}
 
 	handlers := &handlerSet{wv: wv}
 	wv.handlers = handlers
@@ -152,7 +160,11 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 			logging.FromContext(ctx).Warn().Err(err).Uint64("webview_id", uint64(id)).Msg("cef2gtk: failed to enable profiling")
 		}
 	}
-	wv.installViewportSyncHooks()
+	viewportHooksResult := wv.installViewportSyncHooks()
+	if !viewportHooksResult.Completed() {
+		wv.destroyViewBridgeOnGTKAsync()
+		return nil, errGTKSyncDispatchIncomplete("install CEF viewport sync hooks", viewportHooksResult)
+	}
 	wv.startRenderStallWatchdog()
 	return wv, nil
 }
@@ -161,7 +173,10 @@ func (f *WebViewFactory) configureInitialBrowserCreation(
 	ctx context.Context, wv *WebView, client purecef.RawClient,
 	windowInfo *purecef.WindowInfo, settings *purecef.BrowserSettings,
 	onFirstResize func(w, h int32),
-) {
+) error {
+	if wv == nil {
+		return errors.New("configure initial browser creation: webview is nil")
+	}
 	wv.pendingCreate = &pendingBrowserCreate{
 		windowInfo: windowInfo,
 		client:     client,
@@ -174,9 +189,9 @@ func (f *WebViewFactory) configureInitialBrowserCreation(
 		}
 	}
 	if wv.viewBridge == nil {
-		return
+		return nil
 	}
-	wv.runOnGTKSync(func() {
+	result := wv.runOnGTKSyncLabel("cef.configure_initial_browser_creation", func() {
 		wv.removeSizeObserver = wv.viewBridge.AddSizeObserver(func(w, h int32) {
 			// Size observers run on the GTK thread. Prepare the GtkGLArea only for
 			// the one-shot initial resize path; once that path has been consumed,
@@ -195,6 +210,11 @@ func (f *WebViewFactory) configureInitialBrowserCreation(
 				Msg("cef: viewport sync handled after GTK size change")
 		})
 	})
+	if !result.Completed() {
+		wv.pendingCreate = nil
+		return errGTKSyncDispatchIncomplete("configure initial browser creation", result)
+	}
+	return nil
 }
 
 func (f *WebViewFactory) handleInitialBrowserCreateSizeObserver(
@@ -365,11 +385,14 @@ func (f *WebViewFactory) CreateRelated(ctx context.Context, parentID port.WebVie
 		settings.BackgroundColor = bg
 	}
 
-	f.configureInitialBrowserCreation(ctx, popupWV, popupWV.client, &windowInfo, &settings, func(w, h int32) {
+	if err := f.configureInitialBrowserCreation(ctx, popupWV, popupWV.client, &windowInfo, &settings, func(w, h int32) {
 		f.handlePopupShellInitialResize(ctx, popupWV, func(w, h int32) {
 			f.postPendingBrowserCreate(ctx, popupWV, w, h)
 		}, w, h)
-	})
+	}); err != nil {
+		popupWV.Destroy()
+		return nil, err
+	}
 	return popupWV, nil
 }
 

--- a/internal/infrastructure/cef/gtk_sync_required_test.go
+++ b/internal/infrastructure/cef/gtk_sync_required_test.go
@@ -1,0 +1,104 @@
+package cef
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
+	purecef "github.com/bnema/purego-cef/cef"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureInitialBrowserCreationClearsPendingCreateWhenGTKDispatchTimesOut(t *testing.T) {
+	factory := &WebViewFactory{}
+	wv := &WebView{
+		ctx:            context.Background(),
+		viewBridge:     &Cef2gtkAdapter{},
+		gtkSyncTimeout: 5 * time.Millisecond,
+		gtkSyncIsOwner: func() bool { return false },
+		gtkSyncDispatch: func(func()) {
+			// Simulate a GTK main loop that does not service the callback.
+		},
+	}
+	windowInfo := purecef.NewWindowInfo()
+	settings := purecef.NewBrowserSettings()
+
+	err := factory.configureInitialBrowserCreation(context.Background(), wv, nil, &windowInfo, &settings, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "configure initial browser creation")
+	require.Nil(t, wv.pendingCreate)
+}
+
+func TestInstallViewportSyncHooksReportsIncompleteGTKDispatch(t *testing.T) {
+	wv := &WebView{
+		ctx:            context.Background(),
+		viewBridge:     &Cef2gtkAdapter{},
+		gtkSyncTimeout: 5 * time.Millisecond,
+		gtkSyncIsOwner: func() bool { return false },
+		gtkSyncDispatch: func(func()) {
+			// Simulate a GTK main loop that does not service the callback.
+		},
+	}
+
+	result := wv.installViewportSyncHooks()
+
+	require.False(t, result.Completed())
+	require.Equal(t, syncdispatch.SyncDispatchTimedOut, result.Status)
+}
+
+func TestDestroyViewBridgeOnGTKSyncLeavesCleanupQueuedAfterTimeout(t *testing.T) {
+	delayed := make(chan func(), 1)
+	wv := &WebView{
+		ctx:            context.Background(),
+		engine:         &Engine{},
+		viewBridge:     &Cef2gtkAdapter{},
+		gtkSyncTimeout: 5 * time.Millisecond,
+		gtkSyncIsOwner: func() bool { return false },
+		gtkSyncDispatch: func(fn func()) {
+			delayed <- fn
+		},
+	}
+
+	wv.destroyViewBridgeOnGTKSync()
+
+	require.NotNil(t, wv.viewBridge)
+	select {
+	case fn := <-delayed:
+		fn()
+	case <-time.After(time.Second):
+		t.Fatal("cleanup callback was not captured")
+	}
+	require.Nil(t, wv.viewBridge)
+}
+
+func TestRunOnGTKSyncCompletedAfterTimeoutStillCountsAsCompleted(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	wv := &WebView{
+		ctx:            context.Background(),
+		engine:         &Engine{},
+		gtkSyncTimeout: 5 * time.Millisecond,
+		gtkSyncIsOwner: func() bool { return false },
+		gtkSyncDispatch: func(fn func()) {
+			go fn()
+		},
+	}
+
+	resultCh := make(chan syncdispatch.SyncDispatchResult, 1)
+	go func() {
+		resultCh <- wv.runOnGTKSync(func() {
+			close(started)
+			<-release
+		})
+	}()
+
+	<-started
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+
+	result := <-resultCh
+	require.Equal(t, syncdispatch.SyncDispatchCompletedAfterTimeout, result.Status)
+	require.True(t, result.Completed())
+}

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bnema/dumber/internal/application/dto"
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/logging"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
 )
 
 // Compile-time interface checks.
@@ -59,6 +60,11 @@ var cefLoadWatchdogDelays = []time.Duration{
 	15 * time.Second,
 	30 * time.Second,
 }
+
+const (
+	cefGTKSyncDispatchTimeout       = 2 * time.Second
+	cefGTKSyncDispatchSlowThreshold = 250 * time.Millisecond
+)
 
 var (
 	cefNewTask         = purecef.NewTask
@@ -124,7 +130,15 @@ type WebView struct {
 	initialBrowserCreateResizeHandled bool
 
 	// pendingURI is set when LoadURI is called before the browser exists.
-	pendingURI string
+	pendingURI          string
+	pendingURISetAt     time.Time
+	pendingURIStartedAt time.Time
+
+	// GTK sync dispatch hooks are injectable for tests. Production uses the GTK
+	// default main context through runOnGTK and isOnGTKThread.
+	gtkSyncDispatch func(func())
+	gtkSyncIsOwner  func() bool
+	gtkSyncTimeout  time.Duration
 
 	// crashCount tracks consecutive renderer crashes to prevent infinite
 	// crash → redirect → crash loops.
@@ -259,7 +273,7 @@ func (wv *WebView) LoadURI(_ context.Context, uri string) error {
 	browser := wv.browser
 	// Always remember the latest requested URI so a browser/main-frame race
 	// cannot strand startup on about:blank.
-	wv.pendingURI = actualURI
+	wv.setPendingNavigationLocked(actualURI, time.Now())
 	wv.mu.Unlock()
 	if browser == nil {
 		return nil
@@ -604,7 +618,7 @@ func (wv *WebView) PrimePopupNavigation(uri string) {
 	}
 	wv.mu.Lock()
 	browser := wv.browser
-	wv.pendingURI = actualURI
+	wv.setPendingNavigationLocked(actualURI, time.Now())
 	wv.mu.Unlock()
 	if browser != nil {
 		wv.schedulePendingNavigationReplay(0)
@@ -965,7 +979,7 @@ func (wv *WebView) activateNativePopup(popupID int32, targetURL string) (purecef
 	wv.nativePopupID = popupID
 	wv.nativePopupFallbackStarted = false
 	if strings.TrimSpace(wv.pendingURI) == "" {
-		wv.pendingURI = toActualInternalURL(targetURL)
+		wv.setPendingNavigationLocked(toActualInternalURL(targetURL), time.Now())
 	}
 	if strings.TrimSpace(wv.pendingURI) != "" {
 		wv.uri = toConceptualInternalURL(wv.pendingURI)
@@ -1147,7 +1161,7 @@ func (wv *WebView) destroyViewBridgeOnGTKSync() {
 	if wv == nil || wv.viewBridge == nil {
 		return
 	}
-	wv.runOnGTKSync(func() {
+	wv.runOnGTKSyncLabelAllowLateStart("cef.destroy_view_bridge", true, func() {
 		wv.destroyViewBridgeOnGTKThread()
 	})
 }
@@ -1212,10 +1226,7 @@ func (wv *WebView) updateURI(uri string) {
 	wv.uri = uri
 	wv.loadDiagLastAddressAt = now
 	cb := wv.callbacks
-	pendingMatched := pendingURIEquivalent(wv.pendingURI, uri)
-	if pendingMatched {
-		wv.pendingURI = ""
-	}
+	pendingMatched := wv.clearPendingNavigationIfEquivalentLocked(uri)
 	wv.mu.Unlock()
 
 	if pendingMatched && wv.ctx != nil {
@@ -1276,8 +1287,20 @@ func (wv *WebView) updateLoadState(loading, back, fwd bool) {
 		wv.loadDiagLastAddressAt = time.Time{}
 		loadDiagSeq = wv.loadDiagSeq
 	}
+	clearedPendingURI := ""
+	currentURI := ""
+	if !loading && wv.hasObservedAddressForPendingNavigationLocked() {
+		clearedPendingURI = wv.clearPendingNavigationLocked()
+		currentURI = wv.uri
+	}
 	wv.mu.Unlock()
 
+	if clearedPendingURI != "" && wv.ctx != nil {
+		logging.FromContext(wv.ctx).Debug().
+			Str("pending_uri", logging.TruncateURL(clearedPendingURI, logging.PermissionLogURLMaxLen)).
+			Str("uri", logging.TruncateURL(currentURI, logging.PermissionLogURLMaxLen)).
+			Msg("cef: cleared pending navigation after load finished at final address")
+	}
 	if loadDiagSeq != 0 {
 		wv.scheduleLoadWatchdogs(loadDiagSeq)
 	}
@@ -1675,6 +1698,49 @@ func (wv *WebView) pendingNavigationURI() string {
 	return wv.pendingURI
 }
 
+func (wv *WebView) setPendingNavigationLocked(uri string, at time.Time) {
+	wv.pendingURI = uri
+	wv.pendingURIStartedAt = time.Time{}
+	if uri == "" {
+		wv.pendingURISetAt = time.Time{}
+		return
+	}
+	wv.pendingURISetAt = at
+}
+
+func (wv *WebView) markPendingNavigationStartedLocked(uri string, at time.Time) {
+	if !pendingURIEquivalent(wv.pendingURI, uri) {
+		return
+	}
+	wv.pendingURIStartedAt = at
+}
+
+func (wv *WebView) clearPendingNavigationLocked() string {
+	cleared := wv.pendingURI
+	wv.pendingURI = ""
+	wv.pendingURISetAt = time.Time{}
+	wv.pendingURIStartedAt = time.Time{}
+	return cleared
+}
+
+func (wv *WebView) clearPendingNavigationIfEquivalentLocked(uri string) bool {
+	if !pendingURIEquivalent(wv.pendingURI, uri) {
+		return false
+	}
+	wv.clearPendingNavigationLocked()
+	return true
+}
+
+func (wv *WebView) hasObservedAddressForPendingNavigationLocked() bool {
+	if strings.TrimSpace(wv.pendingURI) == "" || strings.TrimSpace(wv.uri) == "" {
+		return false
+	}
+	if wv.loadDiagLastAddressAt.IsZero() || wv.pendingURIStartedAt.IsZero() {
+		return false
+	}
+	return !wv.loadDiagLastAddressAt.Before(wv.pendingURIStartedAt)
+}
+
 func (wv *WebView) schedulePendingNavigationReplay(attempt int) {
 	if wv == nil || wv.destroyed.Load() {
 		return
@@ -1746,9 +1812,7 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 	currentURL := frame.GetURL()
 	if pendingURIEquivalent(currentURL, uri) {
 		wv.mu.Lock()
-		if pendingURIEquivalent(wv.pendingURI, uri) {
-			wv.pendingURI = ""
-		}
+		wv.clearPendingNavigationIfEquivalentLocked(uri)
 		wv.mu.Unlock()
 		if wv.ctx != nil {
 			logging.FromContext(wv.ctx).Debug().
@@ -1758,6 +1822,9 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 		}
 		return
 	}
+	wv.mu.Lock()
+	wv.markPendingNavigationStartedLocked(uri, time.Now())
+	wv.mu.Unlock()
 	frame.LoadURL(uri)
 	if wv.ctx != nil {
 		logging.FromContext(wv.ctx).Debug().
@@ -1973,23 +2040,106 @@ func (wv *WebView) isOnGTKThread() bool {
 }
 
 // runOnGTKSync executes fn on the GTK main context and waits for completion.
-// Callers already running on the GTK thread must execute inline to avoid
-// self-deadlocking while waiting for an IdleAddOnce callback.
-func (wv *WebView) runOnGTKSync(fn func()) {
-	if fn == nil {
-		return
+// Callers already running on the GTK thread execute inline to avoid
+// self-deadlocking while waiting for an IdleAddOnce callback. Calls are bounded
+// so a wedged GTK loop cannot block CEF callbacks forever.
+func (wv *WebView) runOnGTKSync(fn func()) syncdispatch.SyncDispatchResult {
+	return wv.runOnGTKSyncLabel("cef.gtk_sync", fn)
+}
+
+func (wv *WebView) runOnGTKSyncLabel(label string, fn func()) syncdispatch.SyncDispatchResult {
+	return wv.runOnGTKSyncLabelAllowLateStart(label, false, fn)
+}
+
+func (wv *WebView) runOnGTKSyncLabelAllowLateStart(
+	label string,
+	allowLateStartAfterTimeout bool,
+	fn func(),
+) syncdispatch.SyncDispatchResult {
+	if wv == nil {
+		if fn != nil {
+			fn()
+		}
+		return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchInline}
 	}
-	if wv == nil || wv.engine == nil || wv.isOnGTKThread() {
-		fn()
-		return
+	if wv.engine == nil && wv.gtkSyncDispatch == nil && wv.gtkSyncIsOwner == nil {
+		if fn != nil {
+			fn()
+		}
+		return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchInline}
 	}
 
-	done := make(chan struct{})
-	wv.runOnGTK(func() {
-		defer close(done)
-		fn()
-	})
-	<-done
+	isOwner := wv.gtkSyncIsOwner
+	if isOwner == nil {
+		isOwner = wv.isOnGTKThread
+	}
+	dispatch := wv.gtkSyncDispatch
+	if dispatch == nil {
+		dispatch = wv.runOnGTK
+	}
+	timeout := wv.gtkSyncTimeout
+	if timeout <= 0 {
+		timeout = cefGTKSyncDispatchTimeout
+	}
+
+	result := syncdispatch.RunSynchronousDispatch(syncdispatch.SyncDispatchOptions{
+		Label:                      label,
+		Timeout:                    timeout,
+		IsOwner:                    isOwner,
+		Dispatch:                   dispatch,
+		AllowLateStartAfterTimeout: allowLateStartAfterTimeout,
+	}, fn)
+	wv.logGTKSyncDispatchResult(result)
+	return result
+}
+
+func (wv *WebView) logGTKSyncDispatchResult(result syncdispatch.SyncDispatchResult) {
+	if wv == nil {
+		return
+	}
+	logger := logging.FromContext(wv.ctx)
+	switch result.Status {
+	case syncdispatch.SyncDispatchTimedOut:
+		logger.Warn().
+			Str("dispatch_label", result.Label).
+			Dur("elapsed", result.Elapsed).
+			Dur("timeout", wv.effectiveGTKSyncTimeout()).
+			Uint64("webview_id", uint64(wv.id)).
+			Msg("cef: GTK synchronous dispatch timed out before callback started")
+	case syncdispatch.SyncDispatchCompletedAfterTimeout:
+		logger.Warn().
+			Str("dispatch_label", result.Label).
+			Dur("elapsed", result.Elapsed).
+			Dur("timeout", wv.effectiveGTKSyncTimeout()).
+			Uint64("webview_id", uint64(wv.id)).
+			Msg("cef: GTK synchronous dispatch completed after timeout")
+	case syncdispatch.SyncDispatchQueuedAfterTimeout:
+		logger.Warn().
+			Str("dispatch_label", result.Label).
+			Dur("elapsed", result.Elapsed).
+			Dur("timeout", wv.effectiveGTKSyncTimeout()).
+			Uint64("webview_id", uint64(wv.id)).
+			Msg("cef: GTK synchronous dispatch left queued after timeout")
+	case syncdispatch.SyncDispatchCompleted:
+		if result.Elapsed >= cefGTKSyncDispatchSlowThreshold {
+			logger.Debug().
+				Str("dispatch_label", result.Label).
+				Dur("elapsed", result.Elapsed).
+				Uint64("webview_id", uint64(wv.id)).
+				Msg("cef: GTK synchronous dispatch completed slowly")
+		}
+	}
+}
+
+func (wv *WebView) effectiveGTKSyncTimeout() time.Duration {
+	if wv != nil && wv.gtkSyncTimeout > 0 {
+		return wv.gtkSyncTimeout
+	}
+	return cefGTKSyncDispatchTimeout
+}
+
+func errGTKSyncDispatchIncomplete(operation string, result syncdispatch.SyncDispatchResult) error {
+	return fmt.Errorf("%s: GTK dispatch did not complete: %s", operation, result.Status)
 }
 
 func (wv *WebView) runCloseCallbacks() {

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -494,7 +494,7 @@ func (h *handlerSet) OnBeforePopup(
 		sourceFrameURL = frame.GetURL()
 	}
 
-	h.wv.runOnGTKSync(func() {
+	dispatchResult := h.wv.runOnGTKSyncLabel("cef.on_before_popup", func() {
 		popup = cb.OnCreate(port.PopupRequest{
 			TargetURI:          targetURL,
 			FrameName:          targetFrameName,
@@ -507,6 +507,15 @@ func (h *handlerSet) OnBeforePopup(
 			TargetDisposition:  mapCEFWindowDisposition(targetDisposition),
 		})
 	})
+	if !dispatchResult.Completed() {
+		logging.FromContext(h.currentContext()).Warn().
+			Str("target_url", logging.TruncateURL(targetURL, logging.PermissionLogURLMaxLen)).
+			Str("target_frame", targetFrameName).
+			Dur("elapsed", dispatchResult.Elapsed).
+			Str("dispatch_status", string(dispatchResult.Status)).
+			Msg("cef: blocked popup after GTK dispatch did not complete")
+		return true
+	}
 
 	cefPopup, ok := popup.(*WebView)
 	if !ok || cefPopup == nil {

--- a/internal/infrastructure/cef/webview_handlers_test.go
+++ b/internal/infrastructure/cef/webview_handlers_test.go
@@ -3,6 +3,7 @@ package cef
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -215,6 +216,27 @@ func TestStartNativePopupFallback_RejectsDestroyedWebView(t *testing.T) {
 	require.False(t, wv.startNativePopupFallback())
 }
 
+func TestNativePopupActivationDoesNotLetInitialBlankLoadClearPendingNavigationBeforeReplay(t *testing.T) {
+	parent := &WebView{}
+	wv := &WebView{
+		ctx:                  context.Background(),
+		nativePopupCandidate: true,
+		nativePopupParent:    parent,
+		client:               cefmocks.NewMockRawClient(t),
+		pendingCreate:        &pendingBrowserCreate{},
+	}
+
+	rawClient, ok := wv.activateNativePopup(55, "https://example.com/oauth")
+	require.True(t, ok)
+	require.NotNil(t, rawClient)
+	require.Equal(t, "https://example.com/oauth", wv.pendingNavigationURI())
+
+	wv.updateURI("about:blank")
+	wv.updateLoadState(false, false, false)
+
+	require.Equal(t, "https://example.com/oauth", wv.pendingNavigationURI())
+}
+
 func TestHandleNativePopupAborted_PreservesPrimedNavigationForFallback(t *testing.T) {
 	closed := false
 	parent := &WebView{}
@@ -238,6 +260,36 @@ func TestHandleNativePopupAborted_PreservesPrimedNavigationForFallback(t *testin
 	require.Same(t, parent, wv.nativePopupParent)
 	require.Equal(t, int32(0), wv.nativePopupID)
 	require.True(t, wv.isLoading)
+}
+
+func TestOnBeforePopup_TimesOutGTKDispatchAndBlocksPopup(t *testing.T) {
+	var delayed func()
+	parentWV := &WebView{
+		ctx:            context.Background(),
+		id:             16,
+		gtkSyncTimeout: 5 * time.Millisecond,
+		gtkSyncIsOwner: func() bool { return false },
+		gtkSyncDispatch: func(fn func()) {
+			delayed = fn
+		},
+	}
+	var createCalls atomic.Int32
+	parentWV.SetCallbacks(&port.WebViewCallbacks{
+		OnCreate: func(_ port.PopupRequest) port.WebView {
+			createCalls.Add(1)
+			return &WebView{ctx: context.Background(), id: 24}
+		},
+	})
+
+	h := &handlerSet{wv: parentWV}
+	blocked := h.OnBeforePopup(nil, nil, 90, "https://example.com/slow-popup", "slow-popup", 0, 1, nil, nil, nil, nil, nil, nil)
+
+	require.True(t, blocked)
+	require.Zero(t, createCalls.Load())
+	require.NotNil(t, delayed)
+
+	delayed()
+	require.Zero(t, createCalls.Load())
 }
 
 func TestOnBeforePopup_PrimesPopupNavigationWhenCEFPopupBlocksNativeCreation(t *testing.T) {

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -162,3 +162,62 @@ func TestWebViewUpdateURI_ClearsMatchingPendingNavigation(t *testing.T) {
 
 	require.Empty(t, wv.pendingNavigationURI())
 }
+
+func TestWebViewUpdateLoadState_ClearsStalePendingNavigationAfterStartedRedirectCompletes(t *testing.T) {
+	wv := &WebView{ctx: context.Background()}
+	pending := "https://duckduckgo.com/?q=pi+agent+reddit"
+	startedAt := time.Now().Add(-time.Second)
+	wv.mu.Lock()
+	wv.setPendingNavigationLocked(pending, startedAt.Add(-time.Millisecond))
+	wv.markPendingNavigationStartedLocked(pending, startedAt)
+	wv.mu.Unlock()
+	wv.updateURI("https://www.reddit.com/r/somewhere/")
+
+	wv.updateLoadState(false, true, false)
+
+	require.Empty(t, wv.pendingNavigationURI())
+}
+
+func TestWebViewUpdateLoadState_KeepsPendingNavigationBeforeReplayStarts(t *testing.T) {
+	wv := &WebView{ctx: context.Background()}
+	pending := "https://duckduckgo.com/?q=pi+agent+reddit"
+	wv.updateURI("https://old.example/still-finishing")
+	wv.mu.Lock()
+	wv.setPendingNavigationLocked(pending, time.Now())
+	wv.mu.Unlock()
+
+	wv.updateLoadState(false, true, false)
+
+	require.Equal(t, pending, wv.pendingNavigationURI())
+}
+
+func TestWebViewUpdateLoadState_DoesNotClearPendingNavigationWhenOnlyOlderAddressWasObserved(t *testing.T) {
+	wv := &WebView{ctx: context.Background()}
+	pending := "https://duckduckgo.com/?q=pi+agent+reddit"
+	observedAt := time.Now()
+	wv.mu.Lock()
+	wv.uri = "https://old.example/final"
+	wv.loadDiagLastAddressAt = observedAt
+	wv.setPendingNavigationLocked(pending, observedAt.Add(time.Millisecond))
+	wv.markPendingNavigationStartedLocked(pending, observedAt.Add(time.Millisecond))
+	wv.mu.Unlock()
+
+	wv.updateLoadState(false, true, false)
+
+	require.Equal(t, pending, wv.pendingNavigationURI())
+}
+
+func TestWebViewUpdateLoadState_KeepsPendingNavigationWhileLoading(t *testing.T) {
+	wv := &WebView{ctx: context.Background()}
+	pending := "https://duckduckgo.com/?q=pi+agent+reddit"
+	startedAt := time.Now().Add(-time.Second)
+	wv.mu.Lock()
+	wv.setPendingNavigationLocked(pending, startedAt.Add(-time.Millisecond))
+	wv.markPendingNavigationStartedLocked(pending, startedAt)
+	wv.mu.Unlock()
+	wv.updateURI("https://www.reddit.com/r/somewhere/")
+
+	wv.updateLoadState(true, true, false)
+
+	require.Equal(t, pending, wv.pendingNavigationURI())
+}

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bnema/puregotk/v4/gtk"
 
 	"github.com/bnema/dumber/internal/logging"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
 )
 
 type viewportSyncBrowserHost interface {
@@ -402,11 +403,11 @@ func (wv *WebView) schedulePendingBrowserCreateObservedSizeRetry(ctx context.Con
 	})
 }
 
-func (wv *WebView) installViewportSyncHooks() {
+func (wv *WebView) installViewportSyncHooks() syncdispatch.SyncDispatchResult {
 	if wv == nil || wv.viewBridge == nil {
-		return
+		return syncdispatch.SyncDispatchResult{Label: "cef.install_viewport_sync_hooks", Status: syncdispatch.SyncDispatchInline}
 	}
-	wv.runOnGTKSync(func() {
+	return wv.runOnGTKSyncLabel("cef.install_viewport_sync_hooks", func() {
 		wv.installViewportSyncHooksOnGTKThread()
 	})
 }

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -2,6 +2,8 @@ package desktop
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,11 +39,14 @@ type browserLaunchRelay struct {
 }
 
 type browserLaunchRequest struct {
-	URL string `json:"url"`
+	RequestID string `json:"request_id,omitempty"`
+	URL       string `json:"url"`
 }
 
 type browserLaunchResponse struct {
-	Error string `json:"error,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
+	Accepted  bool   `json:"accepted,omitempty"`
+	Error     string `json:"error,omitempty"`
 }
 
 type browserLaunchRelayListener struct {
@@ -49,6 +54,14 @@ type browserLaunchRelayListener struct {
 	socketPath string
 	once       sync.Once
 	err        error
+}
+
+var newBrowserLaunchRequestID = func() string {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err == nil {
+		return "blr-" + hex.EncodeToString(buf[:])
+	}
+	return fmt.Sprintf("blr-%d", time.Now().UnixNano())
 }
 
 func NewBrowserLaunchRelay(ipc runtimeprofile.IPCPaths) port.BrowserLaunchRelay {
@@ -70,10 +83,17 @@ func (r *browserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url str
 	}
 	defer func() { _ = conn.Close() }()
 
+	requestID := newBrowserLaunchRequestID()
+	log := logging.FromContext(ctx)
+	log.Debug().
+		Str("request_id", requestID).
+		Str("url_host", safeURLHost(url)).
+		Msg("browser launch relay delivery started")
+
 	if err := setBrowserLaunchConnDeadline(ctx, conn); err != nil {
 		return false, err
 	}
-	if err := json.NewEncoder(conn).Encode(browserLaunchRequest{URL: url}); err != nil {
+	if err := json.NewEncoder(conn).Encode(browserLaunchRequest{RequestID: requestID, URL: url}); err != nil {
 		return false, err
 	}
 
@@ -90,7 +110,8 @@ func (r *browserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url str
 					return false, ctxErr
 				}
 				if _, ok := ctx.Deadline(); !ok {
-					logging.FromContext(ctx).Warn().
+					log.Warn().
+						Str("request_id", requestID).
 						Str("url_host", safeURLHost(url)).
 						Dur("timeout", browserLaunchIOTimeout).
 						Msg("browser launch relay response timed out without caller deadline; delivery is unconfirmed")
@@ -105,10 +126,23 @@ func (r *browserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url str
 		}
 		break
 	}
+	if response.RequestID != "" && response.RequestID != requestID {
+		return true, fmt.Errorf("mismatched browser launch relay response request id: got %q, want %q", response.RequestID, requestID)
+	}
 	if response.Error != "" {
+		log.Warn().
+			Str("request_id", requestID).
+			Str("url_host", safeURLHost(url)).
+			Str("relay_error", response.Error).
+			Msg("browser launch relay delivery rejected")
 		return true, errors.New(response.Error)
 	}
 
+	log.Debug().
+		Str("request_id", requestID).
+		Str("url_host", safeURLHost(url)).
+		Bool("accepted", response.Accepted || response.RequestID == "").
+		Msg("browser launch relay delivery acknowledged")
 	return true, nil
 }
 
@@ -240,6 +274,7 @@ func (l *browserLaunchRelayListener) serve(ctx context.Context, opener port.Brow
 
 func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *net.UnixConn, opener port.BrowserWindowOpener) {
 	defer func() { _ = conn.Close() }()
+	log := logging.FromContext(ctx)
 	if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
 		return
 	}
@@ -248,20 +283,53 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 	if err := json.NewDecoder(conn).Decode(&request); err != nil {
 		return
 	}
+	requestID := request.RequestID
+	if requestID == "" {
+		requestID = newBrowserLaunchRequestID()
+	}
+	log.Debug().
+		Str("request_id", requestID).
+		Str("url_host", safeURLHost(request.URL)).
+		Msg("browser launch relay request received")
 
 	if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
 		return
 	}
-	if err := json.NewEncoder(conn).Encode(browserLaunchResponse{}); err != nil {
-		log := logging.FromContext(ctx)
-		log.Warn().Err(err).Str("url", request.URL).Msg("failed to encode browser launch response")
+	if err := json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Accepted: true}); err != nil {
+		log.Warn().Err(err).
+			Str("request_id", requestID).
+			Str("url_host", safeURLHost(request.URL)).
+			Msg("failed to encode browser launch response")
 		return
 	}
+	log.Debug().
+		Str("request_id", requestID).
+		Str("url_host", safeURLHost(request.URL)).
+		Msg("browser launch relay request accepted")
 
 	go func() {
-		if err := opener.OpenFreshWindow(ctx, request.URL); err != nil {
-			logging.FromContext(ctx).Warn().Err(err).Str("url", request.URL).Msg("failed to open fresh browser window")
+		if opener == nil {
+			log.Warn().
+				Str("request_id", requestID).
+				Str("url_host", safeURLHost(request.URL)).
+				Msg("browser launch relay accepted request without opener")
+			return
 		}
+		log.Debug().
+			Str("request_id", requestID).
+			Str("url_host", safeURLHost(request.URL)).
+			Msg("browser launch relay opening fresh window")
+		if err := opener.OpenFreshWindow(ctx, request.URL); err != nil {
+			log.Warn().Err(err).
+				Str("request_id", requestID).
+				Str("url_host", safeURLHost(request.URL)).
+				Msg("failed to open fresh browser window")
+			return
+		}
+		log.Debug().
+			Str("request_id", requestID).
+			Str("url_host", safeURLHost(request.URL)).
+			Msg("browser launch relay opened fresh window")
 	}()
 }
 

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -3,6 +3,7 @@ package desktop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -66,6 +67,13 @@ func testNamespacedIPC(root, engine string) runtimeprofile.IPCPaths {
 	}
 }
 
+func overrideBrowserLaunchRequestID(t *testing.T, id string) func() {
+	t.Helper()
+	previous := newBrowserLaunchRequestID
+	newBrowserLaunchRequestID = func() string { return id }
+	return func() { newBrowserLaunchRequestID = previous }
+}
+
 func TestBrowserLaunchRelay_DeliverOpenFreshWindow_MissingListenerReturnsFalseNil(t *testing.T) {
 	relay := NewBrowserLaunchRelay(testIPC(shortTempDir(t)))
 
@@ -104,6 +112,78 @@ func TestBrowserLaunchRelay_DevCEFAndDevWebKit_UseDifferentSockets(t *testing.T)
 	cefIPC := testNamespacedIPC(root, "cef")
 	wkIPC := testNamespacedIPC(root, "webkit")
 	require.NotEqual(t, cefIPC.BrowserLaunchSocket, wkIPC.BrowserLaunchSocket)
+}
+
+func TestBrowserLaunchRelay_DeliverOpenFreshWindow_SendsRequestIDAndAcceptsMatchingResponse(t *testing.T) {
+	ipc := testIPC(shortTempDir(t))
+	relay := NewBrowserLaunchRelay(ipc)
+	restore := overrideBrowserLaunchRequestID(t, "request-test-1")
+	defer restore()
+
+	receivedRequest := make(chan browserLaunchRequest, 1)
+	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: ipc.BrowserLaunchSocket, Net: "unix"})
+	require.NoError(t, err)
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(ipc.BrowserLaunchSocket)
+	}()
+
+	go func() {
+		conn, acceptErr := listener.AcceptUnix()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		var request browserLaunchRequest
+		if decodeErr := json.NewDecoder(conn).Decode(&request); decodeErr != nil {
+			return
+		}
+		receivedRequest <- request
+		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: request.RequestID, Accepted: true})
+	}()
+
+	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/request-id")
+
+	require.NoError(t, err)
+	require.True(t, delivered)
+	request := <-receivedRequest
+	require.Equal(t, "request-test-1", request.RequestID)
+	require.Equal(t, "https://example.com/request-id", request.URL)
+}
+
+func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RejectsMismatchedResponseRequestID(t *testing.T) {
+	ipc := testIPC(shortTempDir(t))
+	relay := NewBrowserLaunchRelay(ipc)
+	restore := overrideBrowserLaunchRequestID(t, "request-test-2")
+	defer restore()
+
+	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: ipc.BrowserLaunchSocket, Net: "unix"})
+	require.NoError(t, err)
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(ipc.BrowserLaunchSocket)
+	}()
+
+	go func() {
+		conn, acceptErr := listener.AcceptUnix()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		var request browserLaunchRequest
+		if decodeErr := json.NewDecoder(conn).Decode(&request); decodeErr != nil {
+			return
+		}
+		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: "different-request", Accepted: true})
+	}()
+
+	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/request-id-mismatch")
+
+	require.Error(t, err)
+	require.True(t, delivered)
+	require.Contains(t, err.Error(), "mismatched browser launch relay response")
 }
 
 func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RoundTrip(t *testing.T) {
@@ -385,11 +465,13 @@ func TestBrowserLaunchRelay_AcknowledgesBeforeOpenerReturns(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 	require.NoError(t, conn.SetDeadline(time.Now().Add(300*time.Millisecond)))
-	require.NoError(t, json.NewEncoder(conn).Encode(browserLaunchRequest{URL: "https://example.com/slow-but-healthy"}))
+	require.NoError(t, json.NewEncoder(conn).Encode(browserLaunchRequest{RequestID: "raw-request-1", URL: "https://example.com/slow-but-healthy"}))
 
 	var response browserLaunchResponse
 	require.NoError(t, json.NewDecoder(conn).Decode(&response))
 	assert.Empty(t, response.Error)
+	assert.True(t, response.Accepted)
+	assert.Equal(t, "raw-request-1", response.RequestID)
 
 	select {
 	case <-started:
@@ -397,6 +479,42 @@ func TestBrowserLaunchRelay_AcknowledgesBeforeOpenerReturns(t *testing.T) {
 		t.Fatal("expected opener to be invoked after acknowledgement")
 	}
 	close(release)
+}
+
+func TestBrowserLaunchRelay_AcknowledgesAcceptedEvenWhenOpenerReturnsLateError(t *testing.T) {
+	ipc := testIPC(shortTempDir(t))
+	relay := NewBrowserLaunchRelay(ipc)
+
+	started := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	closer, err := relay.Listen(ctx, browserWindowOpenerFunc(func(_ context.Context, _ string) error {
+		close(started)
+		return errors.New("late open failure")
+	}))
+	require.NoError(t, err)
+	defer closer.Close()
+
+	waitForSocket(t, ipc.BrowserLaunchSocket)
+
+	conn, err := net.Dial("unix", ipc.BrowserLaunchSocket)
+	require.NoError(t, err)
+	defer conn.Close()
+	require.NoError(t, conn.SetDeadline(time.Now().Add(300*time.Millisecond)))
+	require.NoError(t, json.NewEncoder(conn).Encode(browserLaunchRequest{RequestID: "raw-request-2", URL: "https://example.com/fails-later"}))
+
+	var response browserLaunchResponse
+	require.NoError(t, json.NewDecoder(conn).Decode(&response))
+	assert.Empty(t, response.Error)
+	assert.True(t, response.Accepted)
+	assert.Equal(t, "raw-request-2", response.RequestID)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("expected opener to be invoked after accepted acknowledgement")
+	}
 }
 
 func TestBrowserLaunchRelay_SilentClientDoesNotStallListener(t *testing.T) {

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -172,6 +172,11 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	}
 
 	windows, activeWindowIndex := s.provider.GetWindowSnapshotState()
+	if windows == nil && activeWindowIndex < 0 {
+		s.markDirty()
+		logging.FromContext(ctx).Warn().Msg("window snapshot unavailable; keeping session snapshot dirty")
+		return nil
+	}
 	if windows == nil {
 		windows = make([]entity.WindowTabListState, 0)
 	}

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -172,6 +172,8 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	}
 
 	windows, activeWindowIndex := s.provider.GetWindowSnapshotState()
+	// A nil window list with no active index means the snapshot is truly unavailable,
+	// not merely empty. Keep the session dirty so a later capture can retry.
 	if windows == nil && activeWindowIndex < 0 {
 		s.markDirty()
 		logging.FromContext(ctx).Warn().Msg("window snapshot unavailable; keeping session snapshot dirty")

--- a/internal/infrastructure/snapshot/service_test.go
+++ b/internal/infrastructure/snapshot/service_test.go
@@ -176,6 +176,22 @@ func TestService_SaveNowPassesWindowSnapshots(t *testing.T) {
 	assert.False(t, svc.dirty)
 }
 
+func TestService_SaveSnapshotKeepsDirtyWhenWindowSnapshotUnavailable(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	provider := mocks.NewMockWindowStateProvider(t)
+	provider.EXPECT().GetSessionID().Return(entity.SessionID("20260501_snapshot_unavailable")).Once()
+	provider.EXPECT().GetWindowSnapshotState().Return(nil, -1).Once()
+
+	svc := NewService(uc, provider, 1)
+	svc.ready = true
+	svc.dirty = true
+
+	err := svc.saveSnapshot(context.Background())
+	require.NoError(t, err)
+	assert.True(t, svc.dirty)
+}
+
 func TestService_SaveNowPersistsEmptyWindowSnapshotAsV2(t *testing.T) {
 	repo := repomocks.NewMockSessionStateRepository(t)
 	sessionID := entity.SessionID("20260501_empty_window_snap")

--- a/internal/shared/syncdispatch/sync_dispatch.go
+++ b/internal/shared/syncdispatch/sync_dispatch.go
@@ -122,6 +122,9 @@ func RunSynchronousDispatch(opts SyncDispatchOptions, fn func()) SyncDispatchRes
 		if state != dispatchStateInit {
 			return false
 		}
+		// Check deadline and transition to dispatchStateStarted under one lock so
+		// the timer cannot mark dispatchStateTimedOut after this callback is allowed
+		// to start. Late-start cleanup opts out through AllowLateStartAfterTimeout.
 		if !opts.AllowLateStartAfterTimeout && time.Now().After(deadline) {
 			state = dispatchStateTimedOut
 			return false
@@ -159,6 +162,8 @@ func RunSynchronousDispatch(opts SyncDispatchOptions, fn func()) SyncDispatchRes
 		stateMu.Lock()
 		currentState := state
 		if opts.AllowLateStartAfterTimeout && currentState == dispatchStateInit {
+			// Cleanup work may remain queued after timer expiry; decision callbacks
+			// instead fall through and mark dispatchStateTimedOut while still unstarted.
 			stateMu.Unlock()
 			result.Status = SyncDispatchQueuedAfterTimeout
 			result.Elapsed = time.Since(start)
@@ -172,6 +177,8 @@ func RunSynchronousDispatch(opts SyncDispatchOptions, fn func()) SyncDispatchRes
 			return result
 		}
 		stateMu.Unlock()
+		// dispatchStateStarted means the worker already owns fn side effects; wait on
+		// done so the caller reports completed-after-timeout only after completion.
 		<-done
 		if loadState() == dispatchStateTimedOut {
 			result.Status = SyncDispatchTimedOut

--- a/internal/shared/syncdispatch/sync_dispatch.go
+++ b/internal/shared/syncdispatch/sync_dispatch.go
@@ -1,0 +1,184 @@
+package syncdispatch
+
+import (
+	"sync"
+	"time"
+)
+
+// SyncDispatchStatus describes how a synchronous event-loop dispatch finished.
+type SyncDispatchStatus string
+
+const (
+	// SyncDispatchInline means the callback ran immediately because the caller
+	// already owned the target main context.
+	SyncDispatchInline SyncDispatchStatus = "inline"
+	// SyncDispatchCompleted means the callback was dispatched and completed before
+	// the configured timeout elapsed.
+	SyncDispatchCompleted SyncDispatchStatus = "completed"
+	// SyncDispatchTimedOut means the callback did not start before the timeout and
+	// was canceled before running side effects.
+	SyncDispatchTimedOut SyncDispatchStatus = "timed_out"
+	// SyncDispatchCompletedAfterTimeout means the callback started before the
+	// timeout and completed after the timeout elapsed. Callers must treat it as
+	// completed because side effects have run.
+	SyncDispatchCompletedAfterTimeout SyncDispatchStatus = "completed_after_timeout"
+	// SyncDispatchQueuedAfterTimeout means the callback did not start before the
+	// timeout, but the dispatch was intentionally left queued so it may run later.
+	SyncDispatchQueuedAfterTimeout SyncDispatchStatus = "queued_after_timeout"
+	// SyncDispatchSkipped means required inputs were missing, so no callback ran.
+	SyncDispatchSkipped SyncDispatchStatus = "skipped"
+)
+
+// SyncDispatchOptions configures RunSynchronousDispatch.
+type SyncDispatchOptions struct {
+	// Label identifies the caller in diagnostics. The helper does not log by
+	// itself, but callers can include this label when reporting the returned
+	// result.
+	Label string
+	// Timeout bounds how long the caller waits for dispatched work. Non-positive
+	// durations fall back to DefaultSyncDispatchTimeout.
+	Timeout time.Duration
+	// IsOwner returns whether the caller already owns the target main context.
+	IsOwner func() bool
+	// Dispatch schedules a callback on the target main context.
+	Dispatch func(func())
+	// AllowLateStartAfterTimeout keeps queued work runnable when the timeout fires
+	// before Dispatch starts the callback. Use this only for cleanup work where
+	// canceling would leak resources; decision callbacks should leave this false.
+	AllowLateStartAfterTimeout bool
+}
+
+// SyncDispatchResult is returned by RunSynchronousDispatch.
+type SyncDispatchResult struct {
+	Label   string
+	Status  SyncDispatchStatus
+	Elapsed time.Duration
+}
+
+// Completed reports whether the callback completed before returning.
+func (r SyncDispatchResult) Completed() bool {
+	return r.Status == SyncDispatchInline || r.Status == SyncDispatchCompleted || r.Status == SyncDispatchCompletedAfterTimeout
+}
+
+// DefaultSyncDispatchTimeout is a conservative upper bound for synchronous
+// waits on a target event loop. It is long enough for normal idle dispatch but
+// short enough to avoid converting a stalled loop into an unbounded caller
+// deadlock.
+const DefaultSyncDispatchTimeout = 2 * time.Second
+
+const (
+	dispatchStateInit int32 = iota
+	dispatchStateStarted
+	dispatchStateCompleted
+	dispatchStateTimedOut
+)
+
+// RunSynchronousDispatch executes fn inline when the target main context is
+// already owned by the caller; otherwise it schedules fn with opts.Dispatch and
+// waits for completion up to opts.Timeout.
+//
+// If the timeout fires before the dispatched callback starts, the default
+// behavior is to skip the callback when the main loop eventually services it. If
+// AllowLateStartAfterTimeout is true, queued work is left runnable and the
+// result reports queued_after_timeout instead. If the callback has already
+// started, Go cannot preempt it safely; this helper waits for it to finish and
+// reports completed_after_timeout so callers do not fail closed while side
+// effects are still possible.
+func RunSynchronousDispatch(opts SyncDispatchOptions, fn func()) SyncDispatchResult {
+	start := time.Now()
+	result := SyncDispatchResult{Label: opts.Label, Status: SyncDispatchSkipped}
+	if fn == nil {
+		result.Elapsed = time.Since(start)
+		return result
+	}
+	if opts.IsOwner != nil && opts.IsOwner() {
+		fn()
+		result.Status = SyncDispatchInline
+		result.Elapsed = time.Since(start)
+		return result
+	}
+	if opts.Dispatch == nil {
+		result.Elapsed = time.Since(start)
+		return result
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultSyncDispatchTimeout
+	}
+
+	deadline := start.Add(timeout)
+	done := make(chan struct{})
+	state := dispatchStateInit
+	var stateMu sync.Mutex
+	loadState := func() int32 {
+		stateMu.Lock()
+		defer stateMu.Unlock()
+		return state
+	}
+	markCallbackStarted := func() bool {
+		stateMu.Lock()
+		defer stateMu.Unlock()
+		if state != dispatchStateInit {
+			return false
+		}
+		if !opts.AllowLateStartAfterTimeout && time.Now().After(deadline) {
+			state = dispatchStateTimedOut
+			return false
+		}
+		state = dispatchStateStarted
+		return true
+	}
+	markCallbackCompleted := func() {
+		stateMu.Lock()
+		defer stateMu.Unlock()
+		state = dispatchStateCompleted
+	}
+	go func() {
+		opts.Dispatch(func() {
+			if !markCallbackStarted() {
+				close(done)
+				return
+			}
+			defer close(done)
+			fn()
+			markCallbackCompleted()
+		})
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		if loadState() == dispatchStateTimedOut {
+			result.Status = SyncDispatchTimedOut
+		} else {
+			result.Status = SyncDispatchCompleted
+		}
+	case <-timer.C:
+		stateMu.Lock()
+		currentState := state
+		if opts.AllowLateStartAfterTimeout && currentState == dispatchStateInit {
+			stateMu.Unlock()
+			result.Status = SyncDispatchQueuedAfterTimeout
+			result.Elapsed = time.Since(start)
+			return result
+		}
+		if currentState == dispatchStateInit {
+			state = dispatchStateTimedOut
+			stateMu.Unlock()
+			result.Status = SyncDispatchTimedOut
+			result.Elapsed = time.Since(start)
+			return result
+		}
+		stateMu.Unlock()
+		<-done
+		if loadState() == dispatchStateTimedOut {
+			result.Status = SyncDispatchTimedOut
+		} else {
+			result.Status = SyncDispatchCompletedAfterTimeout
+		}
+	}
+	result.Elapsed = time.Since(start)
+	return result
+}

--- a/internal/shared/syncdispatch/sync_dispatch_test.go
+++ b/internal/shared/syncdispatch/sync_dispatch_test.go
@@ -1,0 +1,294 @@
+package syncdispatch
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRunSynchronousDispatchRunsInlineWhenOwner(t *testing.T) {
+	var dispatched atomic.Bool
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:   "test.inline",
+		Timeout: time.Second,
+		IsOwner: func() bool { return true },
+		Dispatch: func(func()) {
+			dispatched.Store(true)
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchInline {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchInline)
+	}
+	if !ran.Load() {
+		t.Fatal("callback did not run inline")
+	}
+	if dispatched.Load() {
+		t.Fatal("callback was dispatched despite owner context")
+	}
+}
+
+func TestRunSynchronousDispatchCompletesWhenDispatchedCallbackRuns(t *testing.T) {
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:   "test.dispatch",
+		Timeout: time.Second,
+		IsOwner: func() bool { return false },
+		Dispatch: func(fn func()) {
+			go fn()
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchCompleted {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchCompleted)
+	}
+	if !result.Completed() {
+		t.Fatal("result.Completed() = false, want true")
+	}
+	if !ran.Load() {
+		t.Fatal("callback did not run")
+	}
+}
+
+func TestRunSynchronousDispatchTimesOutWhenDispatchBlocks(t *testing.T) {
+	releaseDispatch := make(chan struct{})
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:   "test.blocking_dispatch",
+		Timeout: 5 * time.Millisecond,
+		IsOwner: func() bool { return false },
+		Dispatch: func(fn func()) {
+			<-releaseDispatch
+			fn()
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchTimedOut {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchTimedOut)
+	}
+	if ran.Load() {
+		t.Fatal("callback ran while dispatch was blocked")
+	}
+	close(releaseDispatch)
+	time.Sleep(20 * time.Millisecond)
+	if ran.Load() {
+		t.Fatal("callback ran after a blocking dispatch timed out")
+	}
+}
+
+func TestRunSynchronousDispatchTimesOutWhenCallbackNeverStarts(t *testing.T) {
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:   "test.timeout",
+		Timeout: 5 * time.Millisecond,
+		IsOwner: func() bool { return false },
+		Dispatch: func(func()) {
+			// Simulate an event loop that never services the queued callback.
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchTimedOut {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchTimedOut)
+	}
+	if result.Completed() {
+		t.Fatal("result.Completed() = true, want false")
+	}
+	if ran.Load() {
+		t.Fatal("callback ran despite timeout before dispatch start")
+	}
+}
+
+func TestRunSynchronousDispatchWaitsForStartedCallbackPastTimeout(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	resultCh := make(chan SyncDispatchResult, 1)
+	var ran atomic.Bool
+
+	go func() {
+		resultCh <- RunSynchronousDispatch(SyncDispatchOptions{
+			Label:   "test.started_late_finish",
+			Timeout: 50 * time.Millisecond,
+			IsOwner: func() bool { return false },
+			Dispatch: func(fn func()) {
+				go fn()
+			},
+		}, func() {
+			close(started)
+			<-release
+			ran.Store(true)
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("callback did not start")
+	}
+	time.Sleep(100 * time.Millisecond)
+	if ran.Load() {
+		t.Fatal("callback ran before release")
+	}
+	close(release)
+
+	select {
+	case result := <-resultCh:
+		if result.Status != SyncDispatchCompletedAfterTimeout {
+			t.Fatalf("status = %s, want %s", result.Status, SyncDispatchCompletedAfterTimeout)
+		}
+		if !result.Completed() {
+			t.Fatal("result.Completed() = false, want true")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunSynchronousDispatch did not return after started callback completed")
+	}
+	if !ran.Load() {
+		t.Fatal("callback did not run")
+	}
+}
+
+func TestRunSynchronousDispatchCancelsCallbackThatAttemptsToStartAfterDeadline(t *testing.T) {
+	callbackAttempted := make(chan struct{}, 1)
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:   "test.after_deadline",
+		Timeout: 5 * time.Millisecond,
+		IsOwner: func() bool { return false },
+		Dispatch: func(fn func()) {
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				fn()
+				callbackAttempted <- struct{}{}
+			}()
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchTimedOut {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchTimedOut)
+	}
+	select {
+	case <-callbackAttempted:
+	case <-time.After(time.Second):
+		t.Fatal("callback did not attempt late start")
+	}
+	if ran.Load() {
+		t.Fatal("callback ran after deadline")
+	}
+}
+
+func TestRunSynchronousDispatchLeavesCallbackQueuedWhenBlockingDispatchTimesOutAndLateStartAllowed(t *testing.T) {
+	releaseDispatch := make(chan struct{})
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:                      "test.blocking_cleanup_dispatch",
+		Timeout:                    5 * time.Millisecond,
+		IsOwner:                    func() bool { return false },
+		AllowLateStartAfterTimeout: true,
+		Dispatch: func(fn func()) {
+			<-releaseDispatch
+			fn()
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchQueuedAfterTimeout {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchQueuedAfterTimeout)
+	}
+	if ran.Load() {
+		t.Fatal("callback ran before dispatch was released")
+	}
+	close(releaseDispatch)
+	deadline := time.Now().Add(time.Second)
+	for !ran.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !ran.Load() {
+		t.Fatal("queued cleanup callback did not run")
+	}
+}
+
+func TestRunSynchronousDispatchLeavesCallbackQueuedAfterTimeoutWhenConfigured(t *testing.T) {
+	delayed := make(chan func(), 1)
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:                      "test.late_cleanup",
+		Timeout:                    5 * time.Millisecond,
+		IsOwner:                    func() bool { return false },
+		AllowLateStartAfterTimeout: true,
+		Dispatch: func(fn func()) {
+			delayed <- fn
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchQueuedAfterTimeout {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchQueuedAfterTimeout)
+	}
+	if result.Completed() {
+		t.Fatal("result.Completed() = true, want false")
+	}
+	if ran.Load() {
+		t.Fatal("callback ran before late dispatch")
+	}
+
+	select {
+	case fn := <-delayed:
+		fn()
+	case <-time.After(time.Second):
+		t.Fatal("dispatch callback was not captured")
+	}
+
+	if !ran.Load() {
+		t.Fatal("queued callback did not run after timeout")
+	}
+}
+
+func TestRunSynchronousDispatchCancelsCallbackThatStartsAfterTimeout(t *testing.T) {
+	delayed := make(chan func(), 1)
+	var ran atomic.Bool
+
+	result := RunSynchronousDispatch(SyncDispatchOptions{
+		Label:   "test.late",
+		Timeout: 5 * time.Millisecond,
+		IsOwner: func() bool { return false },
+		Dispatch: func(fn func()) {
+			delayed <- fn
+		},
+	}, func() {
+		ran.Store(true)
+	})
+
+	if result.Status != SyncDispatchTimedOut {
+		t.Fatalf("status = %s, want %s", result.Status, SyncDispatchTimedOut)
+	}
+
+	select {
+	case fn := <-delayed:
+		fn()
+	case <-time.After(time.Second):
+		t.Fatal("dispatch callback was not captured")
+	}
+
+	if ran.Load() {
+		t.Fatal("late callback ran after timeout")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -10,12 +10,14 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/bnema/dumber/internal/domain/entity"
 	urlutil "github.com/bnema/dumber/internal/domain/url"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
 
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/dumber/internal/ui/adapter"
@@ -81,7 +83,7 @@ type App struct {
 	lastFocusedWindowID  string
 	nativePopupWindows   map[port.WebViewID]*nativePopupWindow
 	browserWindowFactory func(context.Context, string) (*browserWindow, error)
-	dispatchOnMainThread func(func())
+	dispatchOnMainThread func(string, func()) syncdispatch.SyncDispatchResult
 
 	// State
 	tabs   *entity.TabList
@@ -179,17 +181,22 @@ func New(deps *Dependencies) (*App, error) {
 	ctx, cancel := context.WithCancelCause(deps.Ctx)
 
 	app := &App{
-		deps:                 deps,
-		tabs:                 entity.NewTabList(),
-		tabsUC:               deps.TabsUC,
-		panesUC:              deps.PanesUC,
-		workspaceViews:       make(map[entity.TabID]*component.WorkspaceView),
-		windowForTab:         make(map[entity.TabID]*browserWindow),
-		floatingSessions:     make(map[floatingSessionKey]*floatingWorkspaceSession),
-		browserWindows:       make(map[string]*browserWindow),
-		dispatchOnMainThread: func(fn func()) { fn() },
-		engine:               deps.Engine,
-		cancel:               cancel,
+		deps:             deps,
+		tabs:             entity.NewTabList(),
+		tabsUC:           deps.TabsUC,
+		panesUC:          deps.PanesUC,
+		workspaceViews:   make(map[entity.TabID]*component.WorkspaceView),
+		windowForTab:     make(map[entity.TabID]*browserWindow),
+		floatingSessions: make(map[floatingSessionKey]*floatingWorkspaceSession),
+		browserWindows:   make(map[string]*browserWindow),
+		dispatchOnMainThread: func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			if fn != nil {
+				fn()
+			}
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchInline}
+		},
+		engine: deps.Engine,
+		cancel: cancel,
 	}
 	var autoCopyConfig port.AutoCopyConfig
 	var clipboardOrchestrator port.ClipboardTextOrchestrator
@@ -1911,82 +1918,102 @@ func (a *App) GetSessionID() entity.SessionID {
 	return a.deps.CurrentSessionID
 }
 
+type windowSnapshotCapture struct {
+	browserTabs         map[string]*entity.TabList
+	windowOrder         []string
+	globalTabs          *entity.TabList
+	tabOwners           map[entity.TabID]string
+	lastFocusedWindowID string
+}
+
 // GetWindowSnapshotState implements port.WindowStateProvider.
 // Returns per-window tab lists and active window index from one main-thread capture.
 func (a *App) GetWindowSnapshotState() ([]entity.WindowTabListState, int) {
-	var (
-		browserTabs         map[string]*entity.TabList
-		windowOrder         []string
-		globalTabs          *entity.TabList
-		tabOwners           map[entity.TabID]string
-		lastFocusedWindowID string
-	)
-
-	capture := func() {
-		globalTabs = entity.NewTabList()
-		if a.tabs != nil {
-			globalTabs = a.tabs.Snapshot()
-		}
-
-		browserTabs = make(map[string]*entity.TabList, len(a.browserWindows))
-		for id, bw := range a.browserWindows {
-			if bw == nil {
-				continue
-			}
-			if bw.tabs != nil {
-				browserTabs[id] = bw.tabs.Snapshot()
-			} else {
-				browserTabs[id] = nil
-			}
-		}
-
-		windowOrder = append([]string(nil), a.browserWindowOrder...)
-		tabOwners = make(map[entity.TabID]string, len(a.windowForTab))
-		for tabID, bw := range a.windowForTab {
-			if bw != nil {
-				tabOwners[tabID] = bw.id
-			}
-		}
-		lastFocusedWindowID = a.lastFocusedWindowID
+	capture, ok := a.captureWindowSnapshotState()
+	if !ok {
+		return nil, -1
 	}
-	if a.dispatchOnMainThread != nil {
-		a.dispatchOnMainThread(capture)
-	} else {
+	return buildWindowSnapshotState(capture)
+}
+
+func (a *App) captureWindowSnapshotState() (windowSnapshotCapture, bool) {
+	var capture windowSnapshotCapture
+	captureFn := func() {
+		capture = a.captureWindowSnapshotStateOnMainThread()
+	}
+	if a.dispatchOnMainThread == nil {
 		// nil dispatchOnMainThread is for single-threaded tests only;
 		// production should marshal capture to GTK main thread.
-		capture()
+		captureFn()
+		return capture, true
 	}
 
-	if len(browserTabs) == 0 {
+	result := a.dispatchOnMainThread("ui.snapshot_window_state", captureFn)
+	if result.Completed() {
+		return capture, true
+	}
+
+	ctx := context.Background()
+	if a.deps != nil && a.deps.Ctx != nil {
+		ctx = a.deps.Ctx
+	}
+	logging.FromContext(ctx).Warn().
+		Dur("elapsed", result.Elapsed).
+		Str("dispatch_status", string(result.Status)).
+		Msg("ui: window state snapshot unavailable after main-thread dispatch did not complete")
+	return windowSnapshotCapture{}, false
+}
+
+func (a *App) captureWindowSnapshotStateOnMainThread() windowSnapshotCapture {
+	capture := windowSnapshotCapture{
+		globalTabs: entity.NewTabList(),
+	}
+	if a.tabs != nil {
+		capture.globalTabs = a.tabs.Snapshot()
+	}
+
+	capture.browserTabs = make(map[string]*entity.TabList, len(a.browserWindows))
+	for id, bw := range a.browserWindows {
+		if bw == nil {
+			continue
+		}
+		if bw.tabs != nil {
+			capture.browserTabs[id] = bw.tabs.Snapshot()
+		} else {
+			capture.browserTabs[id] = nil
+		}
+	}
+
+	capture.windowOrder = append([]string(nil), a.browserWindowOrder...)
+	capture.tabOwners = make(map[entity.TabID]string, len(a.windowForTab))
+	for tabID, bw := range a.windowForTab {
+		if bw != nil {
+			capture.tabOwners[tabID] = bw.id
+		}
+	}
+	capture.lastFocusedWindowID = a.lastFocusedWindowID
+	return capture
+}
+
+func buildWindowSnapshotState(capture windowSnapshotCapture) ([]entity.WindowTabListState, int) {
+	if len(capture.browserTabs) == 0 {
 		return []entity.WindowTabListState{
-			{WindowID: "", Tabs: globalTabs},
+			{WindowID: "", Tabs: capture.globalTabs},
 		}, 0
 	}
 
-	windowIDs := windowOrderFrom(browserTabs, windowOrder)
+	windowIDs := windowOrderFrom(capture.browserTabs, capture.windowOrder)
 	result := make([]entity.WindowTabListState, 0, len(windowIDs))
 	activeWindowIndex := 0
 	anyOwnedWindow := false
 	for i, wid := range windowIDs {
-		if wid == lastFocusedWindowID {
+		if wid == capture.lastFocusedWindowID {
 			activeWindowIndex = i
 		}
 
-		tabs := browserTabs[wid]
+		tabs := capture.browserTabs[wid]
 		if tabs == nil {
-			tabs = entity.NewTabList()
-			for _, tab := range globalTabs.Tabs {
-				if tabOwners[tab.ID] == wid {
-					tabs.Add(cloneTabForGlobalList(tab))
-				}
-			}
-
-			// Derive active tab from the global list when no per-window TabList
-			// exists only for snapshot/export compatibility with older flat snapshot state.
-			globalActive := globalTabs.ActiveTabID
-			if globalActive != "" && tabs.Find(globalActive) != nil {
-				tabs.SetActive(globalActive)
-			}
+			tabs = tabsForWindowFromGlobalList(capture.globalTabs, capture.tabOwners, wid)
 		}
 		if tabs.Count() > 0 {
 			anyOwnedWindow = true
@@ -1997,13 +2024,33 @@ func (a *App) GetWindowSnapshotState() ([]entity.WindowTabListState, int) {
 			Tabs:     tabs,
 		})
 	}
-	if !anyOwnedWindow && globalTabs.Count() > 0 {
+	if !anyOwnedWindow && capture.globalTabs.Count() > 0 {
 		// No window ownership populated; return the flat global list for
 		// snapshot/export compatibility rather than snapshotting empty windows.
-		return []entity.WindowTabListState{{WindowID: "", Tabs: globalTabs}}, 0
+		return []entity.WindowTabListState{{WindowID: "", Tabs: capture.globalTabs}}, 0
 	}
 
 	return result, activeWindowIndex
+}
+
+func tabsForWindowFromGlobalList(globalTabs *entity.TabList, tabOwners map[entity.TabID]string, windowID string) *entity.TabList {
+	tabs := entity.NewTabList()
+	if globalTabs == nil {
+		return tabs
+	}
+	for _, tab := range globalTabs.Tabs {
+		if tabOwners[tab.ID] == windowID {
+			tabs.Add(cloneTabForGlobalList(tab))
+		}
+	}
+
+	// Derive active tab from the global list when no per-window TabList exists
+	// only for snapshot/export compatibility with older flat snapshot state.
+	globalActive := globalTabs.ActiveTabID
+	if globalActive != "" && tabs.Find(globalActive) != nil {
+		tabs.SetActive(globalActive)
+	}
+	return tabs
 }
 
 // GetWindowTabLists implements port.WindowStateProvider.
@@ -3470,25 +3517,65 @@ func (a *App) generateWindowID() string {
 	return fmt.Sprintf("w%d", a.windowIDCounter)
 }
 
-// runOnMainThread executes fn inline when already on the GTK main context;
-// otherwise it dispatches fn to the GTK main loop and waits for completion.
-func (a *App) runOnMainThread(fn func()) {
-	if fn == nil {
-		return
-	}
-	glibCtx := glib.MainContextDefault()
-	if glibCtx != nil && glibCtx.IsOwner() {
-		fn()
-		return
-	}
+const (
+	uiMainThreadDispatchTimeout       = 2 * time.Second
+	uiMainThreadDispatchSlowThreshold = 250 * time.Millisecond
+)
 
-	done := make(chan struct{})
-	cb := glib.SourceOnceFunc(func(_ uintptr) {
-		fn()
-		close(done)
-	})
-	glib.IdleAddOnce(&cb, 0)
-	<-done
+// runOnMainThread executes fn inline when already on the GTK main context;
+// otherwise it dispatches fn to the GTK main loop and waits for bounded
+// completion so IPC and CEF callback paths do not wait forever on a wedged UI.
+func (a *App) runOnMainThread(label string, fn func()) syncdispatch.SyncDispatchResult {
+	result := syncdispatch.RunSynchronousDispatch(syncdispatch.SyncDispatchOptions{
+		Label:   label,
+		Timeout: uiMainThreadDispatchTimeout,
+		IsOwner: func() bool {
+			glibCtx := glib.MainContextDefault()
+			return glibCtx != nil && glibCtx.IsOwner()
+		},
+		Dispatch: func(cb func()) {
+			wrapped := new(glib.SourceOnceFunc)
+			*wrapped = func(_ uintptr) { cb() }
+			glib.IdleAddOnce(wrapped, 0)
+		},
+	}, fn)
+	a.logMainThreadDispatchResult(result)
+	return result
+}
+
+func (a *App) logMainThreadDispatchResult(result syncdispatch.SyncDispatchResult) {
+	ctx := context.Background()
+	if a != nil && a.deps != nil && a.deps.Ctx != nil {
+		ctx = a.deps.Ctx
+	}
+	logger := logging.FromContext(ctx)
+	switch result.Status {
+	case syncdispatch.SyncDispatchTimedOut:
+		logger.Warn().
+			Str("dispatch_label", result.Label).
+			Dur("elapsed", result.Elapsed).
+			Dur("timeout", uiMainThreadDispatchTimeout).
+			Msg("ui: main-thread dispatch timed out before callback started")
+	case syncdispatch.SyncDispatchCompletedAfterTimeout:
+		logger.Warn().
+			Str("dispatch_label", result.Label).
+			Dur("elapsed", result.Elapsed).
+			Dur("timeout", uiMainThreadDispatchTimeout).
+			Msg("ui: main-thread dispatch completed after timeout")
+	case syncdispatch.SyncDispatchQueuedAfterTimeout:
+		logger.Warn().
+			Str("dispatch_label", result.Label).
+			Dur("elapsed", result.Elapsed).
+			Dur("timeout", uiMainThreadDispatchTimeout).
+			Msg("ui: main-thread dispatch left queued after timeout")
+	case syncdispatch.SyncDispatchCompleted:
+		if result.Elapsed >= uiMainThreadDispatchSlowThreshold {
+			logger.Debug().
+				Str("dispatch_label", result.Label).
+				Dur("elapsed", result.Elapsed).
+				Msg("ui: main-thread dispatch completed slowly")
+		}
+	}
 }
 
 // generateID generates a unique ID for tabs and panes.

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/bnema/dumber/internal/domain/repository"
 	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
 	"github.com/bnema/dumber/internal/ui/component"
 	"github.com/bnema/dumber/internal/ui/coordinator"
 	contentcoord "github.com/bnema/dumber/internal/ui/coordinator/content"
@@ -31,6 +32,7 @@ import (
 	"github.com/bnema/puregotk/v4/gdk"
 	"github.com/bnema/puregotk/v4/gio"
 	"github.com/bnema/puregotk/v4/gtk"
+	"github.com/stretchr/testify/require"
 )
 
 type testBrowserLaunchRelay struct {
@@ -397,6 +399,49 @@ func TestApp_FinalizeActivationStartsBrowserLaunchRelayOnceAndClosesOnShutdown(t
 
 	if !relay.closer.closed {
 		t.Fatalf("relay listener closer was not closed")
+	}
+}
+
+func TestApp_GetWindowSnapshotStateReturnsUnavailableWhenMainThreadDispatchTimesOut(t *testing.T) {
+	app := &App{
+		tabs:           entity.NewTabList(),
+		browserWindows: map[string]*browserWindow{},
+		dispatchOnMainThread: func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			if label != "ui.snapshot_window_state" {
+				t.Fatalf("dispatch label = %q, want ui.snapshot_window_state", label)
+			}
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchTimedOut, Elapsed: 5 * time.Millisecond}
+		},
+	}
+
+	windows, activeWindowIndex := app.GetWindowSnapshotState()
+
+	require.Nil(t, windows)
+	require.Equal(t, -1, activeWindowIndex)
+}
+
+func TestApp_OpenFreshWindowReportsMainThreadDispatchTimeout(t *testing.T) {
+	var factoryCalls int
+	app := &App{
+		dispatchOnMainThread: func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchTimedOut, Elapsed: 5 * time.Millisecond}
+		},
+		browserWindowFactory: func(context.Context, string) (*browserWindow, error) {
+			factoryCalls++
+			return &browserWindow{id: "window-timeout", tabs: entity.NewTabList()}, nil
+		},
+	}
+
+	err := app.OpenFreshWindow(context.Background(), "https://example.com")
+
+	if err == nil {
+		t.Fatal("OpenFreshWindow returned nil error, want dispatch timeout")
+	}
+	if !strings.Contains(err.Error(), "main thread dispatch did not complete") {
+		t.Fatalf("OpenFreshWindow error = %q, want dispatch timeout", err.Error())
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("browserWindowFactory calls = %d, want 0", factoryCalls)
 	}
 }
 

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -2,12 +2,14 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/bnema/dumber/internal/logging"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
 	"github.com/bnema/dumber/internal/ui/component"
 	"github.com/bnema/dumber/internal/ui/coordinator"
 	"github.com/bnema/dumber/internal/ui/focus"
@@ -343,13 +345,26 @@ func (a *App) deterministicBrowserWindowFallback() *browserWindow {
 func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
 	dispatch := a.dispatchOnMainThread
 	if dispatch == nil {
-		dispatch = func(fn func()) { fn() }
+		dispatch = func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			if fn != nil {
+				fn()
+			}
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchInline}
+		}
 	}
 
 	var openErr error
-	dispatch(func() {
+	result := dispatch("ui.open_fresh_window", func() {
 		openErr = a.openFreshWindow(ctx, url)
 	})
+	if !result.Completed() {
+		logging.FromContext(ctx).Warn().
+			Str("url", logging.TruncateURL(url, logging.PermissionLogURLMaxLen)).
+			Dur("elapsed", result.Elapsed).
+			Str("dispatch_status", string(result.Status)).
+			Msg("ui: open fresh window skipped after main-thread dispatch did not complete")
+		return fmt.Errorf("main thread dispatch did not complete: %s", result.Status)
+	}
 
 	return openErr
 }

--- a/internal/ui/browser_window_test.go
+++ b/internal/ui/browser_window_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
 	"github.com/bnema/dumber/internal/ui/component"
 	"github.com/bnema/dumber/internal/ui/focus"
 	"github.com/bnema/dumber/internal/ui/layout"
@@ -215,9 +216,13 @@ func TestOpenFreshWindow_DispatchesAndTracksBrowserWindow(t *testing.T) {
 
 	dispatched := false
 	createdURL := ""
-	app.dispatchOnMainThread = func(fn func()) {
+	app.dispatchOnMainThread = func(label string, fn func()) syncdispatch.SyncDispatchResult {
 		dispatched = true
+		if label != "ui.open_fresh_window" {
+			t.Fatalf("dispatch label = %q, want ui.open_fresh_window", label)
+		}
 		fn()
+		return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchCompleted}
 	}
 	app.browserWindowFactory = func(ctx context.Context, url string) (*browserWindow, error) {
 		createdURL = url
@@ -246,7 +251,10 @@ func TestOpenFreshWindow_DispatchesAndTracksBrowserWindow(t *testing.T) {
 
 func TestOpenFreshWindow_PropagatesFactoryError(t *testing.T) {
 	app := &App{browserWindows: make(map[string]*browserWindow)}
-	app.dispatchOnMainThread = func(fn func()) { fn() }
+	app.dispatchOnMainThread = func(label string, fn func()) syncdispatch.SyncDispatchResult {
+		fn()
+		return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchCompleted}
+	}
 	wantErr := errors.New("factory error")
 	app.browserWindowFactory = func(context.Context, string) (*browserWindow, error) {
 		return nil, wantErr

--- a/internal/ui/native_popup_window.go
+++ b/internal/ui/native_popup_window.go
@@ -110,19 +110,19 @@ func (a *App) openNativePopupWindow(ctx context.Context, input content.NativePop
 
 	if aborter, ok := input.PopupWebView.(port.NativePopupHostAbortCapable); ok {
 		aborter.SetNativePopupHostAbort(func() {
-			a.dispatchOnMainThread(func() {
+			a.dispatchNativePopupLifecycle("ui.native_popup.abort", popupID, func() {
 				a.releaseNativePopupWindow(popupID, true, false)
 			})
 		})
 	}
 	if lifecycle, ok := input.PopupWebView.(port.PopupLifecycleCapable); ok {
 		lifecycle.SetOnReadyToShow(func() {
-			a.dispatchOnMainThread(func() {
+			a.dispatchNativePopupLifecycle("ui.native_popup.ready_to_show", popupID, func() {
 				a.showNativePopupWindow(popupID)
 			})
 		})
 		lifecycle.SetOnClose(func() {
-			a.dispatchOnMainThread(func() {
+			a.dispatchNativePopupLifecycle("ui.native_popup.close", popupID, func() {
 				a.releaseNativePopupWindow(popupID, true, false)
 			})
 		})
@@ -131,7 +131,7 @@ func (a *App) openNativePopupWindow(ctx context.Context, input content.NativePop
 	}
 	if oauthWV, ok := input.PopupWebView.(port.OAuthCallbackCapable); ok {
 		oauthWV.AddCloseCallback(func() {
-			a.dispatchOnMainThread(func() {
+			a.dispatchNativePopupLifecycle("ui.native_popup.oauth_close", popupID, func() {
 				a.releaseNativePopupWindow(popupID, true, false)
 			})
 		})
@@ -146,6 +146,30 @@ func (a *App) openNativePopupWindow(ctx context.Context, input content.NativePop
 		Str("parent_pane_id", string(input.ParentPaneID)).
 		Msg("native popup host created")
 	return nil
+}
+
+func (a *App) dispatchNativePopupLifecycle(label string, popupID port.WebViewID, fn func()) {
+	if a == nil || fn == nil {
+		return
+	}
+	if a.dispatchOnMainThread == nil {
+		fn()
+		return
+	}
+	result := a.dispatchOnMainThread(label, fn)
+	if result.Completed() {
+		return
+	}
+	ctx := context.Background()
+	if a.deps != nil && a.deps.Ctx != nil {
+		ctx = a.deps.Ctx
+	}
+	logging.FromContext(ctx).Warn().
+		Uint64("popup_id", uint64(popupID)).
+		Str("dispatch_label", result.Label).
+		Dur("elapsed", result.Elapsed).
+		Str("dispatch_status", string(result.Status)).
+		Msg("native popup lifecycle dispatch did not complete")
 }
 
 func (a *App) showNativePopupWindow(popupID port.WebViewID) {

--- a/internal/ui/native_popup_window_test.go
+++ b/internal/ui/native_popup_window_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
 	portmocks "github.com/bnema/dumber/internal/application/port/mocks"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
 	"github.com/bnema/dumber/internal/ui/coordinator/content"
 	layoutmocks "github.com/bnema/dumber/internal/ui/layout/mocks"
 	"github.com/bnema/dumber/internal/ui/window"
@@ -73,6 +75,33 @@ func TestDestroyFailedNativePopupSetup_DestroysWebViewAndShell(t *testing.T) {
 	destroyFailedNativePopupSetup(shell, wv)
 
 	assert.True(t, shell.destroyed)
+}
+
+func TestDispatchNativePopupLifecycleSkipsWorkWhenDispatchTimesOutBeforeStart(t *testing.T) {
+	var ran bool
+	app := &App{
+		dispatchOnMainThread: func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchTimedOut, Elapsed: 5 * time.Millisecond}
+		},
+	}
+
+	app.dispatchNativePopupLifecycle("ui.native_popup.close", port.WebViewID(99), func() { ran = true })
+
+	assert.False(t, ran)
+}
+
+func TestDispatchNativePopupLifecycleTreatsCompletedAfterTimeoutAsCompleted(t *testing.T) {
+	var ran bool
+	app := &App{
+		dispatchOnMainThread: func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			fn()
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchCompletedAfterTimeout, Elapsed: 10 * time.Millisecond}
+		},
+	}
+
+	app.dispatchNativePopupLifecycle("ui.native_popup.close", port.WebViewID(99), func() { ran = true })
+
+	assert.True(t, ran)
 }
 
 func TestReleaseNativePopupWindow_DestroysWebViewAndRemovesState(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup creation reliability by enforcing dispatch timeouts and blocking timed-out popups
  * Window snapshot capture now gracefully handles unavailable snapshot state
  * More reliable pending-navigation handling to avoid premature clears during redirects/replays

* **Refactor**
  * Hardening of browser/WebView initialization and teardown on failure
  * Reworked labeled synchronous main-thread dispatch with clearer completion/timeout semantics

* **Tests**
  * Added extensive tests covering dispatch timeouts, completion outcomes, and navigation timing scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->