### PR TITLE
feat(ui): eject panes to new windows

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -239,6 +239,7 @@ stack-pane = ["s"]
 close-pane = ["x"]
 move-pane-to-tab = ["m"]
 move-pane-to-next-tab = ["M", "shift+m"]
+eject-pane-to-window = ["w"]
 
 # Consume-or-expel (niri-style) - very alpha
 consume-or-expel-left = ["["]

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -13,6 +13,8 @@ Dumber uses modal keybindings inspired by Zellij. Press a mode activation key, t
 
 Press `Escape` or `Enter` to exit any mode.
 
+Keybinding tables use uppercase letters as visual labels for unshifted letter keys. In config, use lowercase (for example, `["w"]` for Pane Mode eject). Shifted keys are shown with an explicit `Shift+` prefix.
+
 ## Pane Mode (`Ctrl+P`)
 
 | Action | Keys |
@@ -25,6 +27,7 @@ Press `Escape` or `Enter` to exit any mode.
 | Close pane | `X` |
 | Move to tab | `M` |
 | Move to next tab | `Shift+M` |
+| Eject to window | `W` |
 | Focus right | `Shift+→`, `Shift+L` |
 | Focus left | `Shift+←`, `Shift+H` |
 | Focus up | `Shift+↑`, `Shift+K` |

--- a/internal/application/usecase/extract_pane_to_tab_list.go
+++ b/internal/application/usecase/extract_pane_to_tab_list.go
@@ -1,0 +1,86 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+// ExtractPaneToTabListUseCase moves a pane from a source tab list into a new
+// tab in a target tab list. It is pure domain manipulation and has no
+// knowledge of browser windows or UI objects.
+type ExtractPaneToTabListUseCase struct {
+	idGenerator IDGenerator
+}
+
+func NewExtractPaneToTabListUseCase(idGenerator IDGenerator) *ExtractPaneToTabListUseCase {
+	return &ExtractPaneToTabListUseCase{idGenerator: idGenerator}
+}
+
+type ExtractPaneToTabListInput struct {
+	SourceTabs   *entity.TabList
+	SourceTabID  entity.TabID
+	SourcePaneID entity.PaneID
+	TargetTabs   *entity.TabList
+}
+
+type ExtractPaneToTabListOutput struct {
+	NewTab          *entity.Tab
+	MovedPaneNode   *entity.PaneNode
+	SourceTabClosed bool
+}
+
+func (uc *ExtractPaneToTabListUseCase) Execute(input ExtractPaneToTabListInput) (*ExtractPaneToTabListOutput, error) {
+	if err := validateExtractPaneToTabListInput(uc, input); err != nil {
+		return nil, err
+	}
+
+	sourceTab, err := findSourceTab(input.SourceTabs, input.SourceTabID)
+	if err != nil {
+		return nil, err
+	}
+
+	movedPane, sourceNode, err := findSourcePane(sourceTab.Workspace, input.SourcePaneID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := detachPaneFromWorkspace(sourceTab.Workspace, sourceNode); err != nil {
+		return nil, err
+	}
+
+	sourceTabClosed := closeSourceTabIfEmpty(input.SourceTabs, sourceTab)
+
+	tabID := entity.TabID(uc.idGenerator())
+	workspaceID := entity.WorkspaceID(uc.idGenerator())
+	newTab := entity.NewTab(tabID, workspaceID, movedPane)
+	input.TargetTabs.Add(newTab)
+
+	return &ExtractPaneToTabListOutput{
+		NewTab:          newTab,
+		MovedPaneNode:   newTab.Workspace.Root,
+		SourceTabClosed: sourceTabClosed,
+	}, nil
+}
+
+func validateExtractPaneToTabListInput(uc *ExtractPaneToTabListUseCase, input ExtractPaneToTabListInput) error {
+	if uc == nil {
+		return fmt.Errorf("extract pane to tab list use case is nil")
+	}
+	if input.SourceTabs == nil {
+		return fmt.Errorf("source tabs are required")
+	}
+	if input.TargetTabs == nil {
+		return fmt.Errorf("target tabs are required")
+	}
+	if input.SourceTabID == "" {
+		return fmt.Errorf("source tab id is required")
+	}
+	if input.SourcePaneID == "" {
+		return fmt.Errorf("source pane id is required")
+	}
+	if uc.idGenerator == nil {
+		return fmt.Errorf("id generator is required")
+	}
+	return nil
+}

--- a/internal/application/usecase/extract_pane_to_tab_list_test.go
+++ b/internal/application/usecase/extract_pane_to_tab_list_test.go
@@ -1,0 +1,225 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPaneToTabList_FromThreePaneStack(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	paneC := entity.NewPane(entity.PaneID("pC"))
+	sourceTab := newStackedTab("tA", "wA", paneA, paneB, paneC)
+	sourceTab.Workspace.ActivePaneID = paneB.ID
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneB.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.False(t, out.SourceTabClosed)
+	require.NotNil(t, out.NewTab)
+	require.NotNil(t, out.MovedPaneNode)
+
+	require.True(t, sourceTab.Workspace.Root.IsStacked)
+	require.Len(t, sourceTab.Workspace.Root.Children, 2)
+	require.Equal(t, paneA.ID, sourceTab.Workspace.Root.Children[0].Pane.ID)
+	require.Equal(t, paneC.ID, sourceTab.Workspace.Root.Children[1].Pane.ID)
+	require.Contains(t, []entity.PaneID{paneA.ID, paneC.ID}, sourceTab.Workspace.ActivePaneID)
+	require.Same(t, sourceTab.Workspace.Root, sourceTab.Workspace.Root.Children[0].Parent)
+	require.Same(t, sourceTab.Workspace.Root, sourceTab.Workspace.Root.Children[1].Parent)
+
+	require.Equal(t, 1, targetTabs.Count())
+	require.Same(t, out.NewTab, targetTabs.TabAt(0))
+	require.Same(t, paneB, out.NewTab.Workspace.Root.Pane)
+	require.Nil(t, out.NewTab.Workspace.Root.Parent)
+	require.Nil(t, out.MovedPaneNode.Parent)
+}
+
+func TestExtractPaneToTabList_FromTwoPaneStackDissolvesSource(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	sourceTab := newStackedTab("tA", "wA", paneA, paneB)
+	sourceTab.Workspace.ActivePaneID = paneB.ID
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneB.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.False(t, out.SourceTabClosed)
+
+	require.NotNil(t, sourceTab.Workspace.Root)
+	require.True(t, sourceTab.Workspace.Root.IsLeaf())
+	require.Same(t, paneA, sourceTab.Workspace.Root.Pane)
+	require.Nil(t, sourceTab.Workspace.Root.Parent)
+	require.Same(t, paneB, out.NewTab.Workspace.Root.Pane)
+	require.Nil(t, out.NewTab.Workspace.Root.Parent)
+	require.Nil(t, out.MovedPaneNode.Parent)
+}
+
+func TestExtractPaneToTabList_LastPaneClosesSourceTab(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	pane := entity.NewPane(entity.PaneID("pA"))
+	sourceTab := entity.NewTab(entity.TabID("tA"), entity.WorkspaceID("wA"), pane)
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: pane.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.True(t, out.SourceTabClosed)
+	require.Nil(t, sourceTabs.Find(sourceTab.ID))
+	require.Equal(t, 0, sourceTabs.Count())
+	require.Equal(t, 1, targetTabs.Count())
+	require.Same(t, pane, out.NewTab.Workspace.Root.Pane)
+}
+
+func TestExtractPaneToTabList_FromSplitSeversMovedNode(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	sourceTab := entity.NewTab(entity.TabID("tA"), entity.WorkspaceID("wA"), paneA)
+	removedSplit := &entity.PaneNode{ID: "split", SplitDir: entity.SplitHorizontal, SplitRatio: 0.5}
+	movedLeaf := &entity.PaneNode{ID: "pA", Pane: paneA, Parent: removedSplit}
+	otherLeaf := &entity.PaneNode{ID: "pB", Pane: paneB, Parent: removedSplit}
+	removedSplit.Children = []*entity.PaneNode{movedLeaf, otherLeaf}
+	sourceTab.Workspace.Root = removedSplit
+	sourceTab.Workspace.ActivePaneID = paneA.ID
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneA.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.False(t, out.SourceTabClosed)
+
+	require.Same(t, otherLeaf, sourceTab.Workspace.Root)
+	require.Nil(t, sourceTab.Workspace.Root.Parent)
+	require.Nil(t, out.MovedPaneNode.Parent)
+	require.Empty(t, removedSplit.Children)
+	assertParentPointers(t, sourceTab.Workspace.Root, nil)
+	assertParentPointers(t, out.NewTab.Workspace.Root, nil)
+}
+
+func TestExtractPaneToTabList_InvalidSourceTabID(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	sourceTabs.Add(entity.NewTab("source-tab", "source-ws", entity.NewPane("pane-a")))
+
+	_, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  "missing-tab",
+		SourcePaneID: "pane-a",
+		TargetTabs:   entity.NewTabList(),
+	})
+	require.Error(t, err)
+}
+
+func TestExtractPaneToTabList_InvalidSourcePaneID(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	sourceTab := entity.NewTab("source-tab", "source-ws", entity.NewPane("pane-a"))
+	sourceTabs.Add(sourceTab)
+
+	_, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: "missing-pane",
+		TargetTabs:   entity.NewTabList(),
+	})
+	require.Error(t, err)
+}
+
+func TestExtractPaneToTabList_NilInputs(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+
+	_, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabID:  "source-tab",
+		SourcePaneID: "pane-a",
+		TargetTabs:   entity.NewTabList(),
+	})
+	require.Error(t, err)
+
+	_, err = uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   entity.NewTabList(),
+		SourceTabID:  "source-tab",
+		SourcePaneID: "pane-a",
+	})
+	require.Error(t, err)
+}
+
+func TestExtractPaneToTabList_ParentPointerTreeIntegrity(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	paneC := entity.NewPane(entity.PaneID("pC"))
+	sourceTab := newStackedTab("tA", "wA", paneA, paneB, paneC)
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneB.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+
+	assertParentPointers(t, sourceTab.Workspace.Root, nil)
+	assertParentPointers(t, out.NewTab.Workspace.Root, nil)
+	require.Nil(t, out.MovedPaneNode.Parent)
+}
+
+func newStackedTab(tabID entity.TabID, workspaceID entity.WorkspaceID, panes ...*entity.Pane) *entity.Tab {
+	tab := entity.NewTab(tabID, workspaceID, panes[0])
+	stack := &entity.PaneNode{ID: "stack", IsStacked: true, ActiveStackIndex: 0}
+	for _, pane := range panes {
+		child := &entity.PaneNode{ID: string(pane.ID), Pane: pane, Parent: stack}
+		stack.Children = append(stack.Children, child)
+	}
+	tab.Workspace.Root = stack
+	tab.Workspace.ActivePaneID = panes[0].ID
+	return tab
+}
+
+func assertParentPointers(t *testing.T, node, wantParent *entity.PaneNode) {
+	t.Helper()
+	if node == nil {
+		return
+	}
+	require.Same(t, wantParent, node.Parent)
+	for _, child := range node.Children {
+		assertParentPointers(t, child, node)
+	}
+}

--- a/internal/application/usecase/move_pane_to_tab.go
+++ b/internal/application/usecase/move_pane_to_tab.go
@@ -234,6 +234,7 @@ func detachFromStackIfNeeded(ws *entity.Workspace, leaf *entity.PaneNode) (bool,
 	}
 
 	stackNode.Children = append(stackNode.Children[:idx], stackNode.Children[idx+1:]...)
+	leaf.Parent = nil
 	if stackNode.ActiveStackIndex >= len(stackNode.Children) {
 		stackNode.ActiveStackIndex = len(stackNode.Children) - 1
 	}
@@ -248,6 +249,7 @@ func detachFromStackIfNeeded(ws *entity.Workspace, leaf *entity.PaneNode) (bool,
 		stackNode.Children = nil
 		stackNode.IsStacked = false
 		stackNode.ActiveStackIndex = 0
+		remaining.Parent = nil
 		if stackNode.Pane != nil {
 			ws.ActivePaneID = stackNode.Pane.ID
 		} else {
@@ -280,6 +282,8 @@ func detachLeafFromWorkspace(ws *entity.Workspace, leaf *entity.PaneNode) error 
 	}
 
 	promoteSibling(ws, parent, sibling)
+	leaf.Parent = nil
+	parent.Children = nil
 	ws.ActivePaneID = findFirstLeafPaneID(sibling)
 	return nil
 }

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -220,6 +220,7 @@ func DefaultConfig() *Config {
 					"close-pane":            {Keys: []string{"x"}, Desc: "Close current pane"},
 					"move-pane-to-tab":      {Keys: []string{"m"}, Desc: "Move pane to different tab"},
 					"move-pane-to-next-tab": {Keys: []string{"M", "shift+m"}, Desc: "Move pane to next tab"},
+					"eject-pane-to-window":  {Keys: []string{"w"}, Desc: "Eject active pane to a new window"},
 
 					"consume-or-expel-left":  {Keys: []string{"["}, Desc: "Consume/expel pane left"},
 					"consume-or-expel-right": {Keys: []string{"]"}, Desc: "Consume/expel pane right"},

--- a/internal/infrastructure/config/defaults_test.go
+++ b/internal/infrastructure/config/defaults_test.go
@@ -35,6 +35,10 @@ func TestDefaultConfig_CoreDefaults(t *testing.T) {
 	assert.InDelta(t, defaultCEFTouchpadNavigationRatio, cfg.Engine.CEF.Input.TouchpadNavigationMaxVerticalRatio, 0.001)
 	assert.True(t, cfg.Engine.WebKit.ITPEnabled)
 
+	// Pane mode actions.
+	requireActionBinding(t, cfg.Workspace.PaneMode.Actions, "eject-pane-to-window", []string{"w"})
+	assert.Equal(t, "Eject active pane to a new window", cfg.Workspace.PaneMode.Actions["eject-pane-to-window"].Desc)
+
 	// System view shortcuts are first-class global actions.
 	requireActionBinding(t, cfg.Workspace.Shortcuts.Actions, "toggle-history-systemview", []string{"ctrl+h"})
 	requireActionBinding(t, cfg.Workspace.Shortcuts.Actions, "toggle-favorites-systemview", []string{})

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -175,6 +175,10 @@ func (m *Manager) transformLegacyConfig() {
 		transformer.TransformLegacyPopupsToBrowsingContexts(rawConfig)
 	}
 
+	// Merge newly added default actions into in-memory config so existing persisted
+	// action maps keep working before the user writes a migrated config to disk.
+	configMigrator.mergeMissingDefaultActions(rawConfig)
+
 	// Apply transformed config back to viper
 	for key, value := range rawConfig {
 		m.viper.Set(key, value)

--- a/internal/infrastructure/config/loader_actions_test.go
+++ b/internal/infrastructure/config/loader_actions_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerLoad_MergesMissingPaneModeActionsInMemory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	configFile, err := GetConfigFile()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configFile), 0o755))
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+[workspace.pane_mode]
+activation_shortcut = "ctrl+p"
+timeout_ms = 3000
+
+[workspace.pane_mode.actions.stack-pane]
+keys = ["s"]
+desc = "Custom stack pane"
+`), 0o644))
+
+	mgr, err := NewManager()
+	require.NoError(t, err)
+	require.NoError(t, mgr.Load())
+
+	cfg := mgr.Get()
+	require.NotNil(t, cfg)
+
+	eject, ok := cfg.Workspace.PaneMode.Actions["eject-pane-to-window"]
+	require.True(t, ok)
+	assert.Equal(t, []string{"w"}, eject.Keys)
+
+	stack := cfg.Workspace.PaneMode.Actions["stack-pane"]
+	assert.Equal(t, "Custom stack pane", stack.Desc)
+}

--- a/internal/infrastructure/config/migrate.go
+++ b/internal/infrastructure/config/migrate.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/entity"
 )
 
 // Migrator implements port.ConfigMigrator for comparing and merging config files.
@@ -23,6 +24,11 @@ type Migrator struct {
 	// defaultConfig holds the default configuration.
 	defaultConfig *Config
 }
+
+// configMigrator reuses the default-action metadata needed during config load.
+// It is immutable after initialization; per-command migration still constructs
+// explicit Migrator instances when callers need independent state.
+var configMigrator = NewMigrator()
 
 // NewMigrator creates a new Migrator instance.
 func NewMigrator() *Migrator {
@@ -129,7 +135,7 @@ func (m *Migrator) DetectChanges() ([]port.KeyChange, error) {
 
 	// Find missing keys (in defaults but not in user config)
 	missingKeys := excludeKeys(m.findMissingKeys(defaultKeys, userKeySet), handledLegacyMissingKeys)
-	missingKeys = appendUniqueKeys(missingKeys, m.detectMissingWorkspaceShortcutActions(userKeysWithValues))
+	missingKeys = appendUniqueKeys(missingKeys, m.detectMissingDefaultActions(userKeysWithValues))
 
 	// Try to match deprecated keys with missing keys (detect renames)
 	renames, unmatchedDeprecated, unmatchedMissing := m.matchRenamedKeys(deprecatedKeys, missingKeys)
@@ -280,9 +286,23 @@ const (
 	configFormatTOML             = "toml"
 	configFormatYAML             = "yaml"
 	configFormatJSON             = "json"
-	databasePathKey              = "database.path"
-	workspaceShortcutsActionsKey = "workspace.shortcuts.actions"
+	databasePathKey = "database.path"
 )
+
+type defaultActionMap struct {
+	key     string
+	actions map[string]entity.ActionBinding
+}
+
+func (m *Migrator) defaultActionMaps() []defaultActionMap {
+	return []defaultActionMap{
+		{key: "workspace.shortcuts.actions", actions: m.defaultConfig.Workspace.Shortcuts.Actions},
+		{key: "workspace.pane_mode.actions", actions: m.defaultConfig.Workspace.PaneMode.Actions},
+		{key: "workspace.tab_mode.actions", actions: m.defaultConfig.Workspace.TabMode.Actions},
+		{key: "workspace.resize_mode.actions", actions: m.defaultConfig.Workspace.ResizeMode.Actions},
+		{key: "session.session_mode.actions", actions: m.defaultConfig.Session.SessionMode.Actions},
+	}
+}
 
 // typesAreCompatible checks if the default types for two keys are compatible.
 // This prevents matching int keys with string keys during rename detection.
@@ -430,7 +450,7 @@ func (m *Migrator) Migrate() ([]string, error) {
 	for key := range keysToRemove {
 		m.deleteNestedKey(rawConfig, key)
 	}
-	m.mergeMissingWorkspaceShortcutActions(rawConfig)
+	m.mergeMissingDefaultActions(rawConfig)
 
 	// Create a new Viper instance with defaults for added keys
 	userViper := viper.New()
@@ -631,10 +651,12 @@ func (m *Migrator) defaultValueForKey(key string) any {
 		return value
 	}
 
-	if strings.HasPrefix(key, workspaceShortcutsActionsKey+".") {
-		actionName := strings.TrimPrefix(key, workspaceShortcutsActionsKey+".")
-		if action, ok := m.defaultConfig.Workspace.Shortcuts.Actions[actionName]; ok {
-			return action
+	for _, actionMap := range m.defaultActionMaps() {
+		if strings.HasPrefix(key, actionMap.key+".") {
+			actionName := strings.TrimPrefix(key, actionMap.key+".")
+			if action, ok := actionMap.actions[actionName]; ok {
+				return action
+			}
 		}
 	}
 
@@ -811,68 +833,66 @@ func (*Migrator) isUserDataSection(keyPath string) bool {
 	return false
 }
 
-// detectMissingWorkspaceShortcutActions finds default global shortcut actions not present in user config.
-func (m *Migrator) detectMissingWorkspaceShortcutActions(userKeysWithValues map[string]any) []string {
+// detectMissingDefaultActions finds default shortcut/modal actions not present in user config.
+func (m *Migrator) detectMissingDefaultActions(userKeysWithValues map[string]any) []string {
 	if userKeysWithValues == nil {
 		return nil
 	}
 
-	userActionsValue, ok := userKeysWithValues[workspaceShortcutsActionsKey]
-	if !ok {
-		return nil
-	}
-
-	userActions, ok := m.toStringAnyMap(userActionsValue)
-	if !ok {
-		return nil
-	}
-
-	defaultActions := m.defaultConfig.Workspace.Shortcuts.Actions
-	if len(defaultActions) == 0 {
-		return nil
-	}
-
 	missing := make([]string, 0)
-	for actionName := range defaultActions {
-		if _, exists := userActions[actionName]; exists {
+	for _, actionMap := range m.defaultActionMaps() {
+		userActionsValue, ok := userKeysWithValues[actionMap.key]
+		if !ok {
 			continue
 		}
-		legacyActionName := strings.ReplaceAll(actionName, "-", "_")
-		if _, exists := userActions[legacyActionName]; exists {
+
+		userActions, ok := m.toStringAnyMap(userActionsValue)
+		if !ok || len(actionMap.actions) == 0 {
 			continue
 		}
-		missing = append(missing, workspaceShortcutsActionsKey+"."+actionName)
+
+		for actionName := range actionMap.actions {
+			if _, exists := userActions[actionName]; exists {
+				continue
+			}
+			legacyActionName := strings.ReplaceAll(actionName, "-", "_")
+			if _, exists := userActions[legacyActionName]; exists {
+				continue
+			}
+			missing = append(missing, actionMap.key+"."+actionName)
+		}
 	}
 
 	sort.Strings(missing)
 	return missing
 }
 
-// mergeMissingWorkspaceShortcutActions injects new default shortcut actions while preserving user overrides.
-func (m *Migrator) mergeMissingWorkspaceShortcutActions(rawConfig map[string]any) {
-	actionsValue := m.getNestedValue(rawConfig, workspaceShortcutsActionsKey)
-	if actionsValue == nil {
-		return
-	}
-
-	userActions, ok := m.toStringAnyMap(actionsValue)
-	if !ok {
-		return
-	}
-
-	defaultActions := m.defaultConfig.Workspace.Shortcuts.Actions
-	for actionName, defaultAction := range defaultActions {
-		if _, exists := userActions[actionName]; exists {
+// mergeMissingDefaultActions injects new default shortcut/modal actions while preserving user overrides.
+func (m *Migrator) mergeMissingDefaultActions(rawConfig map[string]any) {
+	for _, actionMap := range m.defaultActionMaps() {
+		actionsValue := m.getNestedValue(rawConfig, actionMap.key)
+		if actionsValue == nil {
 			continue
 		}
-		legacyActionName := strings.ReplaceAll(actionName, "-", "_")
-		if _, exists := userActions[legacyActionName]; exists {
+
+		userActions, ok := m.toStringAnyMap(actionsValue)
+		if !ok {
 			continue
 		}
-		userActions[actionName] = defaultAction
-	}
 
-	m.setNestedValue(rawConfig, workspaceShortcutsActionsKey, userActions)
+		for actionName, defaultAction := range actionMap.actions {
+			if _, exists := userActions[actionName]; exists {
+				continue
+			}
+			legacyActionName := strings.ReplaceAll(actionName, "-", "_")
+			if _, exists := userActions[legacyActionName]; exists {
+				continue
+			}
+			userActions[actionName] = defaultAction
+		}
+
+		m.setNestedValue(rawConfig, actionMap.key, userActions)
+	}
 }
 
 func appendUniqueKeys(base, extra []string) []string {

--- a/internal/infrastructure/config/migrate_test.go
+++ b/internal/infrastructure/config/migrate_test.go
@@ -689,24 +689,33 @@ func TestMigrator_GetConfigType(t *testing.T) {
 	}
 }
 
-func TestMigrator_DetectMissingWorkspaceShortcutActions(t *testing.T) {
+func TestMigrator_DetectMissingDefaultActions(t *testing.T) {
 	m := NewMigrator()
 
-	defaultActions := m.defaultConfig.Workspace.Shortcuts.Actions
-	userActions := make(map[string]any, len(defaultActions))
-	for actionName, value := range defaultActions {
-		userActions[actionName] = value
+	shortcutActions := make(map[string]any, len(m.defaultConfig.Workspace.Shortcuts.Actions))
+	for actionName, value := range m.defaultConfig.Workspace.Shortcuts.Actions {
+		shortcutActions[actionName] = value
 	}
-	delete(userActions, "toggle-floating-pane")
+	delete(shortcutActions, "toggle-floating-pane")
 
-	missing := m.detectMissingWorkspaceShortcutActions(map[string]any{
-		"workspace.shortcuts.actions": userActions,
+	paneActions := make(map[string]any, len(m.defaultConfig.Workspace.PaneMode.Actions))
+	for actionName, value := range m.defaultConfig.Workspace.PaneMode.Actions {
+		paneActions[actionName] = value
+	}
+	delete(paneActions, "eject-pane-to-window")
+
+	missing := m.detectMissingDefaultActions(map[string]any{
+		"workspace.shortcuts.actions": shortcutActions,
+		"workspace.pane_mode.actions": paneActions,
 	})
 
-	assert.Equal(t, []string{"workspace.shortcuts.actions.toggle-floating-pane"}, missing)
+	assert.Equal(t, []string{
+		"workspace.pane_mode.actions.eject-pane-to-window",
+		"workspace.shortcuts.actions.toggle-floating-pane",
+	}, missing)
 }
 
-func TestMigrator_MergeMissingWorkspaceShortcutActions(t *testing.T) {
+func TestMigrator_MergeMissingDefaultActions(t *testing.T) {
 	m := NewMigrator()
 
 	rawConfig := map[string]any{
@@ -746,7 +755,7 @@ func TestMigrator_MergeMissingWorkspaceShortcutActions(t *testing.T) {
 		},
 	}
 
-	m.mergeMissingWorkspaceShortcutActions(rawConfig)
+	m.mergeMissingDefaultActions(rawConfig)
 
 	actionsAny := m.getNestedValue(rawConfig, "workspace.shortcuts.actions")
 	actions, ok := actionsAny.(map[string]any)
@@ -770,6 +779,43 @@ func TestMigrator_MergeMissingWorkspaceShortcutActions(t *testing.T) {
 	assert.NotContains(t, actions, "consume-or-expel-down")
 }
 
+func TestMigrator_MergeMissingDefaultActions_PaneMode(t *testing.T) {
+	m := NewMigrator()
+
+	rawConfig := map[string]any{
+		"workspace": map[string]any{
+			"pane_mode": map[string]any{
+				"actions": map[string]any{
+					"stack-pane": map[string]any{
+						"keys": []string{"s"},
+						"desc": "Stack pane with sibling",
+					},
+					"move-pane-to-tab": map[string]any{
+						"keys": []string{"m"},
+						"desc": "Custom move pane",
+					},
+				},
+			},
+		},
+	}
+
+	m.mergeMissingDefaultActions(rawConfig)
+
+	actionsAny := m.getNestedValue(rawConfig, "workspace.pane_mode.actions")
+	actions, ok := actionsAny.(map[string]any)
+	require.True(t, ok)
+
+	ejectAny, hasEject := actions["eject-pane-to-window"]
+	assert.True(t, hasEject)
+	assert.NotNil(t, ejectAny)
+
+	moveAny, hasMove := actions["move-pane-to-tab"]
+	require.True(t, hasMove)
+	move, ok := moveAny.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Custom move pane", move["desc"])
+}
+
 func TestMigrator_DefaultValueForKey_WorkspaceShortcutAction(t *testing.T) {
 	m := NewMigrator()
 
@@ -778,6 +824,16 @@ func TestMigrator_DefaultValueForKey_WorkspaceShortcutAction(t *testing.T) {
 	action, ok := value.(ActionBinding)
 	require.True(t, ok)
 	assert.Equal(t, []string{"alt+f"}, action.Keys)
+}
+
+func TestMigrator_DefaultValueForKey_PaneModeAction(t *testing.T) {
+	m := NewMigrator()
+
+	value := m.defaultValueForKey("workspace.pane_mode.actions.eject-pane-to-window")
+
+	action, ok := value.(ActionBinding)
+	require.True(t, ok)
+	assert.Equal(t, []string{"w"}, action.Keys)
 }
 
 func TestMigrator_DefaultValueForKey_RegularKey(t *testing.T) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -100,8 +100,9 @@ type App struct {
 	panesUC        *usecase.ManagePanesUseCase
 	workspaceViews map[entity.TabID]*component.WorkspaceView
 	windowForTab   map[entity.TabID]*browserWindow
-	widgetFactory  layout.WidgetFactory
-	stackedPaneMgr *component.StackedPaneManager
+	widgetFactory                layout.WidgetFactory
+	workspaceViewCreateOverride func(context.Context, *entity.Tab) bool
+	stackedPaneMgr              *component.StackedPaneManager
 
 	// Input handling
 	keyboardHandler       *input.KeyboardHandler
@@ -137,7 +138,8 @@ type App struct {
 	windowIDMu            sync.Mutex
 	firstWebViewShownOnce sync.Once
 
-	movePaneToTabUC *usecase.MovePaneToTabUseCase
+	movePaneToTabUC        *usecase.MovePaneToTabUseCase
+	extractPaneToTabListUC *usecase.ExtractPaneToTabListUseCase
 
 	// Accent picker for dead keys support
 	accentFocusProvider port.FocusedInputProvider
@@ -1772,7 +1774,11 @@ func (a *App) ensureTargetTabUI(ctx context.Context, tab *entity.Tab, targetWind
 	if tabBar := a.tabBarForBrowserWindow(targetWindow); tabBar != nil {
 		tabBar.AddTab(tab)
 	}
-	a.createWorkspaceViewWithoutAttach(ctx, tab)
+	if a.workspaceViews[tab.ID] == nil {
+		if !a.createWorkspaceViewWithoutAttach(ctx, tab) {
+			return
+		}
+	}
 }
 
 func (a *App) rebuildAndAttachWorkspace(ctx context.Context, tabID entity.TabID, tab *entity.Tab) {
@@ -2834,7 +2840,9 @@ func (a *App) buildRestoredTabUI(ctx context.Context, bw *browserWindow, tabBar 
 	if tab == nil {
 		return
 	}
-	a.createWorkspaceViewWithoutAttach(ctx, tab)
+	if !a.createWorkspaceViewWithoutAttach(ctx, tab) {
+		return
+	}
 	wsView := a.workspaceViews[tab.ID]
 	if a.wsCoord != nil && wsView != nil {
 		a.wsCoord.SetupStackedPaneCallbacks(ctx, tab.Workspace, wsView)
@@ -3198,8 +3206,9 @@ func (a *App) initCoordinators(ctx context.Context) {
 	// Wire tabbed popup behavior to create new tabs in the originating window.
 	a.wsCoord.SetOnCreatePopupTab(a.createPopupTab)
 
-	// Move pane use case (cross-tab)
+	// Move pane use cases (cross-tab/cross-window)
 	a.movePaneToTabUC = usecase.NewMovePaneToTabUseCase(a.generateID)
+	a.extractPaneToTabListUC = usecase.NewExtractPaneToTabListUseCase(a.generateID)
 
 	// 4. Navigation Coordinator
 	a.navCoord = coordinator.NewNavigationCoordinator(
@@ -3371,6 +3380,12 @@ func (a *App) wireKeyboardActions() {
 			a.activateBrowserWindow(bw)
 		}
 		return a.HandleMovePaneToNextTab(ctx)
+	})
+	a.kbDispatcher.SetOnEjectPaneToWindow(func(ctx context.Context, paneID entity.PaneID) error {
+		if bw := a.ownerOrLastFocusedBrowserWindow("", paneID); bw != nil {
+			a.activateBrowserWindow(bw)
+		}
+		return a.EjectActivePaneToWindow(ctx, paneID)
 	})
 	a.kbDispatcher.SetOnToggleFloatingPane(func(ctx context.Context) error {
 		return a.ToggleFloatingPane(ctx)
@@ -3778,7 +3793,9 @@ func (a *App) applyResizeModeBorder(ctx context.Context, ws *entity.Workspace) {
 
 // createWorkspaceView creates a WorkspaceView for a tab and attaches it to the content area.
 func (a *App) createWorkspaceView(ctx context.Context, tab *entity.Tab) {
-	a.createWorkspaceViewWithoutAttach(ctx, tab)
+	if !a.createWorkspaceViewWithoutAttach(ctx, tab) {
+		return
+	}
 
 	target := a.browserWindowForTab(tab.ID)
 	if target != nil {
@@ -3800,19 +3817,23 @@ func (a *App) createWorkspaceView(ctx context.Context, tab *entity.Tab) {
 
 // createWorkspaceViewWithoutAttach creates a WorkspaceView for a tab without attaching to content area.
 // Used during session restoration where we create all views first, then attach only the active one.
-func (a *App) createWorkspaceViewWithoutAttach(ctx context.Context, tab *entity.Tab) {
+func (a *App) createWorkspaceViewWithoutAttach(ctx context.Context, tab *entity.Tab) bool {
+	if a.workspaceViewCreateOverride != nil {
+		return a.workspaceViewCreateOverride(ctx, tab)
+	}
+
 	log := logging.FromContext(ctx)
 
 	if a.widgetFactory == nil {
 		log.Error().Msg("widget factory not initialized")
-		return
+		return false
 	}
 
 	// Create workspace view
 	wsView := component.NewWorkspaceView(ctx, a.widgetFactory)
 	if wsView == nil {
 		log.Error().Msg("failed to create workspace view")
-		return
+		return false
 	}
 	a.installFloatingOverlayPositioning(tab.ID, wsView.WorkspaceOverlayWidget())
 	if a.contentCoord != nil {
@@ -3831,7 +3852,7 @@ func (a *App) createWorkspaceViewWithoutAttach(ctx context.Context, tab *entity.
 	// Set the workspace
 	if err := wsView.SetWorkspace(ctx, tab.Workspace); err != nil {
 		log.Error().Err(err).Msg("failed to set workspace in view")
-		return
+		return false
 	}
 
 	// Ensure WebViews are attached to panes
@@ -3883,6 +3904,7 @@ func (a *App) createWorkspaceViewWithoutAttach(ctx context.Context, tab *entity.
 	a.syncFloatingFocus()
 
 	log.Debug().Str("tab_id", string(tab.ID)).Msg("workspace view created")
+	return true
 }
 
 // activeWorkspace returns the workspace of the focused browser window's active tab.

--- a/internal/ui/app_eject_pane_to_window_test.go
+++ b/internal/ui/app_eject_pane_to_window_test.go
@@ -1,0 +1,295 @@
+package ui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/ui/component"
+)
+
+func TestApp_EjectActivePaneToWindowRegistersTargetOwnership(t *testing.T) {
+	app, sourceWindow, sourceTab := newEjectTestApp(t, stackedTab("source-tab-a", "source-ws-a", "pane-a", "pane-b", "pane-c"))
+	sourceTab.Workspace.ActivePaneID = "pane-b"
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	if got := len(app.browserWindows); got != 2 {
+		t.Fatalf("browserWindows length = %d, want 2", got)
+	}
+	if app.browserWindows[sourceWindow.id] == nil {
+		t.Fatal("source window should remain registered")
+	}
+	targetWindow := app.browserWindows["target-window"]
+	if targetWindow == nil {
+		t.Fatal("target window was not registered")
+	}
+	if got := targetWindow.tabs.Count(); got != 1 {
+		t.Fatalf("target tab count = %d, want 1", got)
+	}
+	newTab := targetWindow.tabs.Tabs[0]
+	if got := app.windowForTab[newTab.ID]; got != targetWindow {
+		t.Fatalf("windowForTab[%s] = %p, want target %p", newTab.ID, got, targetWindow)
+	}
+	if got := newTab.Workspace.ActivePaneID; got != entity.PaneID("pane-b") {
+		t.Fatalf("target active pane = %q, want pane-b", got)
+	}
+	if got := sourceTab.Workspace.FindPane("pane-b"); got != nil {
+		t.Fatal("source workspace still contains moved pane")
+	}
+	if got := app.lastFocusedWindowID; got != targetWindow.id {
+		t.Fatalf("lastFocusedWindowID = %q, want %q", got, targetWindow.id)
+	}
+}
+
+func TestApp_EjectActivePaneToWindowRetainsSourceWindowOnRemainingActiveTab(t *testing.T) {
+	sourceTab := entity.NewTab("source-tab", "source-ws", entity.NewPane("pane-a"))
+	otherTab := entity.NewTab("other-tab", "other-ws", entity.NewPane("pane-b"))
+	app, sourceWindow, _ := newEjectTestApp(t, sourceTab)
+	sourceWindow.tabs.Add(otherTab)
+	app.setBrowserWindowForTab(otherTab.ID, sourceWindow)
+	sourceWindow.tabs.SetActive(sourceTab.ID)
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	if app.browserWindows[sourceWindow.id] == nil {
+		t.Fatal("source window should remain registered when another tab remains")
+	}
+	if got := sourceWindow.tabs.ActiveTabID; got != otherTab.ID {
+		t.Fatalf("source active tab = %q, want %q", got, otherTab.ID)
+	}
+	if got := app.windowForTab[sourceTab.ID]; got != nil {
+		t.Fatalf("closed source tab ownership remained: %p", got)
+	}
+	if got := app.windowForTab[otherTab.ID]; got != sourceWindow {
+		t.Fatalf("remaining tab owner = %p, want source window %p", got, sourceWindow)
+	}
+}
+
+func TestApp_EjectActivePaneToWindowRemovesEmptySourceWindow(t *testing.T) {
+	sourceTab := entity.NewTab("source-tab", "source-ws", entity.NewPane("pane-a"))
+	app, sourceWindow, _ := newEjectTestApp(t, sourceTab)
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	if app.browserWindows[sourceWindow.id] != nil {
+		t.Fatal("empty source window should be removed")
+	}
+	if got := len(app.browserWindows); got != 1 {
+		t.Fatalf("browserWindows length = %d, want replacement target only", got)
+	}
+	if got := app.windowForTab[sourceTab.ID]; got != nil {
+		t.Fatalf("source tab ownership remained after source tab closed: %p", got)
+	}
+	for _, bw := range app.browserWindows {
+		if bw.tabs == nil || bw.tabs.Count() == 0 {
+			t.Fatalf("registered zero-tab window remains: %#v", bw)
+		}
+	}
+}
+
+func TestApp_EjectActivePaneToWindowSnapshotRetainsSourceWindowWhenTabsRemain(t *testing.T) {
+	app, sourceWindow, sourceTab := newEjectTestApp(t, stackedTab("source-tab", "source-ws", "pane-a", "pane-b", "pane-c"))
+	sourceTab.Workspace.ActivePaneID = "pane-b"
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	windows, activeWindowIndex := app.GetWindowSnapshotState()
+	if got := len(windows); got != 2 {
+		t.Fatalf("snapshot window count = %d, want 2", got)
+	}
+	if got := activeWindowIndex; got != 1 {
+		t.Fatalf("active window index = %d, want target index 1", got)
+	}
+	if got := windows[0].WindowID; got != entity.WindowID(sourceWindow.id) {
+		t.Fatalf("first snapshot window = %q, want source %q", got, sourceWindow.id)
+	}
+	if got := windows[0].Tabs.Count(); got != 1 {
+		t.Fatalf("source snapshot tab count = %d, want 1", got)
+	}
+	if windows[0].Tabs.Find(sourceTab.ID) == nil {
+		t.Fatalf("source snapshot missing retained tab %q", sourceTab.ID)
+	}
+	assertTargetSnapshotContainsPane(t, windows[1], "pane-b")
+}
+
+func TestApp_EjectActivePaneToWindowSnapshotReplacesEmptySourceWindow(t *testing.T) {
+	sourceTab := entity.NewTab("source-tab", "source-ws", entity.NewPane("pane-a"))
+	app, _, _ := newEjectTestApp(t, sourceTab)
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	windows, activeWindowIndex := app.GetWindowSnapshotState()
+	if got := len(windows); got != 1 {
+		t.Fatalf("snapshot window count = %d, want replacement target only", got)
+	}
+	if got := activeWindowIndex; got != 0 {
+		t.Fatalf("active window index = %d, want target index 0", got)
+	}
+	assertTargetSnapshotContainsPane(t, windows[0], "pane-a")
+}
+
+func TestApp_EjectActivePaneToWindowTargetUICreationFailureRestoresState(t *testing.T) {
+	app, sourceWindow, sourceTab := newEjectTestApp(t, stackedTab("source-tab", "source-ws", "pane-a", "pane-b"))
+	app.workspaceViewCreateOverride = nil
+	sourceTab.Workspace.ActivePaneID = "pane-b"
+
+	err := app.EjectActivePaneToWindow(context.Background(), "")
+	if err == nil {
+		t.Fatal("EjectActivePaneToWindow returned nil error, want target UI creation error")
+	}
+
+	if got := len(app.browserWindows); got != 1 {
+		t.Fatalf("browserWindows length = %d, want restored source only", got)
+	}
+	if app.browserWindows[sourceWindow.id] != sourceWindow {
+		t.Fatal("source window should remain registered after rollback")
+	}
+	if app.browserWindows["target-window"] != nil {
+		t.Fatal("target window should be removed after rollback")
+	}
+	if got := sourceWindow.tabs.Count(); got != 1 {
+		t.Fatalf("source tab count = %d, want restored source tab", got)
+	}
+	restoredTab := sourceWindow.tabs.Find(sourceTab.ID)
+	if restoredTab == nil {
+		t.Fatal("source tab missing after rollback")
+	}
+	if restoredTab.Workspace.FindPane("pane-a") == nil || restoredTab.Workspace.FindPane("pane-b") == nil {
+		t.Fatal("source workspace panes were not restored after rollback")
+	}
+	if got := app.windowForTab[sourceTab.ID]; got != sourceWindow {
+		t.Fatalf("source tab owner = %p, want source window %p", got, sourceWindow)
+	}
+	if got := app.windowForTabCount(); got != 1 {
+		t.Fatalf("windowForTab length = %d, want restored source only", got)
+	}
+}
+
+func TestApp_EjectActivePaneToWindowUsecaseFailureRollsBackTargetWindow(t *testing.T) {
+	app, _, sourceTab := newEjectTestApp(t, stackedTab("source-tab", "source-ws", "pane-a", "pane-b"))
+	sourceTab.Workspace.ActivePaneID = "missing-pane"
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	if got := len(app.browserWindows); got != 1 {
+		t.Fatalf("browserWindows length = %d, want unchanged source only", got)
+	}
+	if app.browserWindows["target-window"] != nil {
+		t.Fatal("target window should not be registered after failure/no-op")
+	}
+	if got := app.windowForTabCount(); got != 1 {
+		t.Fatalf("windowForTab length = %d, want unchanged source only", got)
+	}
+}
+
+func TestApp_EjectActivePaneToWindowNoopsWhenRequestedPaneIsNotActiveWorkspacePane(t *testing.T) {
+	app, _, sourceTab := newEjectTestApp(t, stackedTab("source-tab", "source-ws", "pane-a", "pane-b"))
+	sourceTab.Workspace.ActivePaneID = "pane-a"
+
+	if err := app.EjectActivePaneToWindow(context.Background(), "floating-pane:source-tab:default"); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	if got := len(app.browserWindows); got != 1 {
+		t.Fatalf("browserWindows length = %d, want unchanged source only", got)
+	}
+	if sourceTab.Workspace.FindPane("pane-a") == nil || sourceTab.Workspace.FindPane("pane-b") == nil {
+		t.Fatal("source workspace changed after mismatched requested pane no-op")
+	}
+}
+
+func TestApp_EjectActivePaneToWindowNoopsForInternalSystemPane(t *testing.T) {
+	pane := entity.NewPane("pane-a")
+	pane.URI = "dumb://history"
+	app, _, sourceTab := newEjectTestApp(t, entity.NewTab("source-tab", "source-ws", pane))
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	if got := len(app.browserWindows); got != 1 {
+		t.Fatalf("browserWindows length = %d, want unchanged source only", got)
+	}
+	if sourceTab.Workspace.FindPane("pane-a") == nil {
+		t.Fatal("source system pane was moved")
+	}
+}
+
+func newEjectTestApp(t *testing.T, sourceTab *entity.Tab) (*App, *browserWindow, *entity.Tab) {
+	t.Helper()
+	sourceTabs := entity.NewTabList()
+	sourceTabs.Add(sourceTab)
+	sourceWindow := &browserWindow{id: "source-window", tabs: sourceTabs}
+	ids := []string{"new-tab", "new-workspace"}
+	idIndex := 0
+	app := &App{
+		tabs:                entity.NewTabList(),
+		browserWindows:      map[string]*browserWindow{sourceWindow.id: sourceWindow},
+		browserWindowOrder:  []string{sourceWindow.id},
+		lastFocusedWindowID: sourceWindow.id,
+		windowForTab:        map[entity.TabID]*browserWindow{sourceTab.ID: sourceWindow},
+		workspaceViews:      map[entity.TabID]*component.WorkspaceView{},
+		extractPaneToTabListUC: usecase.NewExtractPaneToTabListUseCase(func() string {
+			if idIndex >= len(ids) {
+				return "extra-id"
+			}
+			id := ids[idIndex]
+			idIndex++
+			return id
+		}),
+		browserWindowFactory: func(context.Context, string) (*browserWindow, error) {
+			return &browserWindow{id: "target-window", tabs: entity.NewTabList()}, nil
+		},
+	}
+	app.workspaceViewCreateOverride = func(_ context.Context, tab *entity.Tab) bool {
+		if tab == nil {
+			return false
+		}
+		app.workspaceViews[tab.ID] = &component.WorkspaceView{}
+		return true
+	}
+	app.tabs.Add(sourceTab)
+	return app, sourceWindow, sourceTab
+}
+
+func stackedTab(tabID entity.TabID, workspaceID entity.WorkspaceID, paneIDs ...entity.PaneID) *entity.Tab {
+	children := make([]*entity.PaneNode, 0, len(paneIDs))
+	stack := &entity.PaneNode{ID: "stack", IsStacked: true}
+	for _, paneID := range paneIDs {
+		child := &entity.PaneNode{ID: string(paneID) + "-node", Pane: entity.NewPane(paneID), Parent: stack}
+		children = append(children, child)
+	}
+	stack.Children = children
+	workspace := &entity.Workspace{ID: workspaceID, Root: stack, ActivePaneID: paneIDs[0]}
+	return &entity.Tab{ID: tabID, Workspace: workspace}
+}
+
+func assertTargetSnapshotContainsPane(t *testing.T, window entity.WindowTabListState, paneID entity.PaneID) {
+	t.Helper()
+	if got := window.WindowID; got != entity.WindowID("target-window") {
+		t.Fatalf("target snapshot window ID = %q, want target-window", got)
+	}
+	if got := window.Tabs.Count(); got != 1 {
+		t.Fatalf("target snapshot tab count = %d, want 1", got)
+	}
+	newTab := window.Tabs.Tabs[0]
+	if newTab.Workspace == nil || newTab.Workspace.FindPane(paneID) == nil {
+		t.Fatalf("target snapshot missing moved pane %q", paneID)
+	}
+}
+
+func (a *App) windowForTabCount() int { return len(a.windowForTab) }

--- a/internal/ui/component/pane_view_test.go
+++ b/internal/ui/component/pane_view_test.go
@@ -226,6 +226,39 @@ func TestSetWebViewWidget_ReplacesWidget(t *testing.T) {
 	assert.Equal(t, mockNewWebView, pv.WebViewWidget())
 }
 
+func TestSetWebViewWidget_ReparentsWidgetWithExistingParent(t *testing.T) {
+	// Arrange
+	mockFactory := mocks.NewMockWidgetFactory(t)
+	mockOverlay := mocks.NewMockOverlayWidget(t)
+	mockBorderBox := mocks.NewMockBoxWidget(t)
+	mockOldWebView := mocks.NewMockWidget(t)
+	mockNewWebView := mocks.NewMockWidget(t)
+	mockParent := mocks.NewMockWidget(t)
+
+	setupPaneViewMocks(t, mockFactory, mockOverlay, mockBorderBox, mockOldWebView)
+
+	pv := component.NewPaneView(context.Background(), mockFactory, entity.PaneID("pane-1"), mockOldWebView)
+
+	mockOverlay.EXPECT().SetChild(nil).Once()
+	mockOverlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
+	mockOverlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
+	mockNewWebView.EXPECT().GetAllocatedWidth().Return(0).Twice()
+	mockNewWebView.EXPECT().GetAllocatedHeight().Return(0).Twice()
+	mockNewWebView.EXPECT().GetParent().Return(mockParent).Once()
+	mockNewWebView.EXPECT().IsVisible().Return(true).Once()
+	mockNewWebView.EXPECT().Unparent().Once()
+	mockOverlay.EXPECT().SetChild(mockNewWebView).Once()
+	mockNewWebView.EXPECT().SetVisible(true).Once()
+
+	// Loading skeleton is hidden immediately for a reparented, already-visible widget.
+
+	// Act
+	pv.SetWebViewWidget(mockNewWebView)
+
+	// Assert
+	assert.Equal(t, mockNewWebView, pv.WebViewWidget())
+}
+
 func TestSetWebViewWidget_FromNil(t *testing.T) {
 	// Arrange
 	mockFactory := mocks.NewMockWidgetFactory(t)
@@ -538,7 +571,7 @@ func setupLoadingSkeletonMocks(
 	mockLoadingContainer.EXPECT().SetCanFocus(false).Maybe()
 	mockLoadingContainer.EXPECT().SetCanTarget(false).Maybe()
 	mockLoadingContainer.EXPECT().AddCssClass("loading-skeleton").Maybe()
-	mockLoadingContainer.EXPECT().SetVisible(true).Maybe()
+	mockLoadingContainer.EXPECT().SetVisible(mock.Anything).Maybe()
 
 	mockFactory.EXPECT().NewBox(layout.OrientationVertical, 6).Return(mockLoadingContent).Once()
 	mockLoadingContent.EXPECT().SetHalign(mock.Anything).Maybe()
@@ -565,6 +598,7 @@ func setupLoadingSkeletonMocks(
 	mockLoadingSpinner.EXPECT().SetSizeRequest(32, 32).Maybe()
 	mockLoadingSpinner.EXPECT().AddCssClass("loading-skeleton-spinner").Maybe()
 	mockLoadingSpinner.EXPECT().Start().Maybe()
+	mockLoadingSpinner.EXPECT().Stop().Maybe()
 
 	mockFactory.EXPECT().NewLabel(mock.Anything).Return(mockLoadingVersion).Once()
 	mockLoadingVersion.EXPECT().SetHalign(mock.Anything).Maybe()

--- a/internal/ui/coordinator/content/lifecycle_test.go
+++ b/internal/ui/coordinator/content/lifecycle_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/port/mocks"
 	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/ui/component"
+	"github.com/bnema/dumber/internal/ui/layout"
+	layoutmocks "github.com/bnema/dumber/internal/ui/layout/mocks"
 )
 
 // newMinimalCoordinator returns a Coordinator with the maps required by
@@ -121,6 +124,53 @@ func TestLifecycle_EnsureWebView_ErrorWhenAcquireFails(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, acquireErr, err)
+}
+
+func TestLifecycle_AttachToWorkspace_ReusesRegisteredWebViewByPaneID(t *testing.T) {
+	t.Parallel()
+
+	paneID := entity.PaneID("pane-1")
+	wv := mocks.NewMockWebView(t)
+	wv.EXPECT().IsDestroyed().Return(false).Once()
+	wv.EXPECT().ID().Return(port.WebViewID(104)).Once()
+	wv.EXPECT().URI().Return("").Maybe()
+
+	pool := mocks.NewMockWebViewPool(t)
+	widgetFactory := layoutmocks.NewMockWidgetFactory(t)
+	ctx, wsView := newAttachWorkspaceView(t, widgetFactory)
+	workspace := &entity.Workspace{
+		ID:           "workspace-1",
+		Root:         &entity.PaneNode{ID: "node-1", Pane: entity.NewPane(paneID)},
+		ActivePaneID: paneID,
+	}
+
+	c := newMinimalCoordinator()
+	c.pool = pool
+	c.widgetFactory = widgetFactory
+	c.webViews[paneID] = wv
+
+	c.AttachToWorkspace(ctx, workspace, wsView)
+
+	assert.Same(t, wv, c.webViews[paneID])
+}
+
+func newAttachWorkspaceView(t *testing.T, factory *layoutmocks.MockWidgetFactory) (context.Context, *component.WorkspaceView) {
+	t.Helper()
+	ctx := context.Background()
+	container := layoutmocks.NewMockBoxWidget(t)
+	overlay := layoutmocks.NewMockOverlayWidget(t)
+
+	factory.EXPECT().NewBox(layout.OrientationVertical, 0).Return(container).Once()
+	container.EXPECT().SetHexpand(true).Once()
+	container.EXPECT().SetVexpand(true).Once()
+	container.EXPECT().SetVisible(true).Once()
+	factory.EXPECT().NewOverlay().Return(overlay).Once()
+	overlay.EXPECT().SetHexpand(true).Once()
+	overlay.EXPECT().SetVexpand(true).Once()
+	overlay.EXPECT().SetChild(container).Once()
+	overlay.EXPECT().SetVisible(true).Once()
+
+	return ctx, component.NewWorkspaceView(ctx, factory)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ui/dispatcher/keyboard.go
+++ b/internal/ui/dispatcher/keyboard.go
@@ -32,23 +32,24 @@ type KeyboardActions struct {
 
 // KeyboardDispatcher routes keyboard actions to appropriate coordinators.
 type KeyboardDispatcher struct {
-	actions          KeyboardActions
-	wsCoord          *coordinator.WorkspaceCoordinator
-	navCoord         *coordinator.NavigationCoordinator
-	zoomUC           *usecase.ManageZoomUseCase
-	copyURLUC        *usecase.CopyURLUseCase
-	actionHandlers   map[input.Action]func(ctx context.Context) error
-	onQuit           func()
-	onFindOpen       func(ctx context.Context) error
-	onFindNext       func(ctx context.Context) error
-	onFindPrev       func(ctx context.Context) error
-	onFindClose      func(ctx context.Context) error
-	activePaneID     func(ctx context.Context) entity.PaneID
-	onSessionOpen    func(ctx context.Context, paneID entity.PaneID) error
-	onMovePaneToTab  func(ctx context.Context, paneID entity.PaneID) error
-	onMovePaneToNext func(ctx context.Context, paneID entity.PaneID) error
-	onToggleFloating func(ctx context.Context) error
-	onOpenFloating   func(ctx context.Context, target input.FloatingProfileTarget) error
+	actions             KeyboardActions
+	wsCoord             *coordinator.WorkspaceCoordinator
+	navCoord            *coordinator.NavigationCoordinator
+	zoomUC              *usecase.ManageZoomUseCase
+	copyURLUC           *usecase.CopyURLUseCase
+	actionHandlers      map[input.Action]func(ctx context.Context) error
+	onQuit              func()
+	onFindOpen          func(ctx context.Context) error
+	onFindNext          func(ctx context.Context) error
+	onFindPrev          func(ctx context.Context) error
+	onFindClose         func(ctx context.Context) error
+	activePaneID        func(ctx context.Context) entity.PaneID
+	onSessionOpen       func(ctx context.Context, paneID entity.PaneID) error
+	onMovePaneToTab     func(ctx context.Context, paneID entity.PaneID) error
+	onMovePaneToNext    func(ctx context.Context, paneID entity.PaneID) error
+	onEjectPaneToWindow func(ctx context.Context, paneID entity.PaneID) error
+	onToggleFloating    func(ctx context.Context) error
+	onOpenFloating      func(ctx context.Context, target input.FloatingProfileTarget) error
 }
 
 // NewKeyboardDispatcher creates a new KeyboardDispatcher.
@@ -112,6 +113,10 @@ func (d *KeyboardDispatcher) SetOnMovePaneToTab(fn func(ctx context.Context, pan
 
 func (d *KeyboardDispatcher) SetOnMovePaneToNextTab(fn func(ctx context.Context, paneID entity.PaneID) error) {
 	d.onMovePaneToNext = fn
+}
+
+func (d *KeyboardDispatcher) SetOnEjectPaneToWindow(fn func(ctx context.Context, paneID entity.PaneID) error) {
+	d.onEjectPaneToWindow = fn
 }
 
 func (d *KeyboardDispatcher) SetOnToggleFloatingPane(fn func(ctx context.Context) error) {
@@ -181,6 +186,9 @@ func (d *KeyboardDispatcher) initActionHandlers() {
 		},
 		input.ActionMovePaneToNextTab: func(ctx context.Context) error {
 			return d.handleMovePaneToNextTab(ctx)
+		},
+		input.ActionEjectPaneToWindow: func(ctx context.Context) error {
+			return d.handleEjectPaneToWindow(ctx)
 		},
 		input.ActionConsumeOrExpelLeft: func(ctx context.Context) error {
 			return d.wsCoord.ConsumeOrExpelPane(ctx, usecase.ConsumeOrExpelLeft)
@@ -330,6 +338,14 @@ func (d *KeyboardDispatcher) handleMovePaneToNextTab(ctx context.Context) error 
 		return d.onMovePaneToNext(ctx, d.activePaneID(ctx))
 	}
 	logging.FromContext(ctx).Debug().Msg("move pane to next tab action (no handler)")
+	return nil
+}
+
+func (d *KeyboardDispatcher) handleEjectPaneToWindow(ctx context.Context) error {
+	if d.onEjectPaneToWindow != nil {
+		return d.onEjectPaneToWindow(ctx, d.activePaneID(ctx))
+	}
+	logging.FromContext(ctx).Debug().Msg("eject pane to window action (no handler)")
 	return nil
 }
 

--- a/internal/ui/dispatcher/keyboard_test.go
+++ b/internal/ui/dispatcher/keyboard_test.go
@@ -124,6 +124,11 @@ func TestKeyboardDispatcher_PassesActivePaneIDToShellCallbacks(t *testing.T) {
 			set:    d.SetOnMovePaneToNextTab,
 			invoke: d.handleMovePaneToNextTab,
 		},
+		{
+			name:   "eject pane to window",
+			set:    d.SetOnEjectPaneToWindow,
+			invoke: d.handleEjectPaneToWindow,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/ui/input/shortcuts.go
+++ b/internal/ui/input/shortcuts.go
@@ -137,6 +137,7 @@ const (
 
 	ActionMovePaneToTab     Action = "move_pane_to_tab"
 	ActionMovePaneToNextTab Action = "move_pane_to_next_tab"
+	ActionEjectPaneToWindow Action = "eject_pane_to_window"
 
 	ActionConsumeOrExpelLeft  Action = "consume_or_expel_left"
 	ActionConsumeOrExpelRight Action = "consume_or_expel_right"
@@ -601,6 +602,8 @@ var configActionToAction = map[string]Action{
 	"move-pane-to-tab":      ActionMovePaneToTab,
 	"move_pane_to_next_tab": ActionMovePaneToNextTab,
 	"move-pane-to-next-tab": ActionMovePaneToNextTab,
+	"eject_pane_to_window":  ActionEjectPaneToWindow,
+	"eject-pane-to-window":  ActionEjectPaneToWindow,
 
 	"consume_or_expel_left":  ActionConsumeOrExpelLeft,
 	"consume-or-expel-left":  ActionConsumeOrExpelLeft,
@@ -824,7 +827,7 @@ func ShouldAutoExitMode(action Action) bool {
 	case ActionNewTab, ActionCloseTab, ActionRenameTab,
 		ActionSplitRight, ActionSplitLeft, ActionSplitUp, ActionSplitDown,
 		ActionClosePane, ActionStackPane,
-		ActionMovePaneToTab, ActionMovePaneToNextTab,
+		ActionMovePaneToTab, ActionMovePaneToNextTab, ActionEjectPaneToWindow,
 		ActionConsumeOrExpelLeft, ActionConsumeOrExpelRight, ActionConsumeOrExpelUp, ActionConsumeOrExpelDown,
 		ActionOpenSessionManager:
 		return true

--- a/internal/ui/input/shortcuts_test.go
+++ b/internal/ui/input/shortcuts_test.go
@@ -351,6 +351,7 @@ func TestShouldAutoExitMode(t *testing.T) {
 		ActionStackPane,
 		ActionMovePaneToTab,
 		ActionMovePaneToNextTab,
+		ActionEjectPaneToWindow,
 	}
 
 	stayActions := []Action{
@@ -373,6 +374,17 @@ func TestShouldAutoExitMode(t *testing.T) {
 		if ShouldAutoExitMode(action) {
 			t.Errorf("ShouldAutoExitMode(%s) = true, want false", action)
 		}
+	}
+}
+
+func TestMapConfigAction_EjectPaneToWindowAliases(t *testing.T) {
+	tests := []string{"eject_pane_to_window", "eject-pane-to-window"}
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := mapConfigAction(name); got != ActionEjectPaneToWindow {
+				t.Fatalf("mapConfigAction(%s) = %s, want %s", name, got, ActionEjectPaneToWindow)
+			}
+		})
 	}
 }
 

--- a/internal/ui/pane_window_eject.go
+++ b/internal/ui/pane_window_eject.go
@@ -1,0 +1,255 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/ui/component"
+)
+
+func (a *App) createEmptyBrowserWindow(ctx context.Context) (*browserWindow, error) {
+	created, err := a.createBrowserWindow(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	a.registerBrowserWindow(created)
+	return created, nil
+}
+
+func (a *App) cleanupEjectTargetWindow(bw *browserWindow) {
+	if bw == nil {
+		return
+	}
+	if bw.tabs != nil {
+		for _, tab := range bw.tabs.Tabs {
+			if tab == nil {
+				continue
+			}
+			delete(a.windowForTab, tab.ID)
+			delete(a.workspaceViews, tab.ID)
+			if a.tabs != nil {
+				a.tabs.Remove(tab.ID)
+			}
+		}
+	}
+	a.removeBrowserWindow(bw.id)
+	if bw.mainWindow != nil {
+		bw.mainWindow.Destroy()
+	}
+}
+
+type ejectRollbackSnapshot struct {
+	sourceTabs     *entity.TabList
+	sourceSnapshot *entity.TabList
+	targetTabs     *entity.TabList
+	targetSnapshot *entity.TabList
+	globalSnapshot *entity.TabList
+	windowForTab   map[entity.TabID]*browserWindow
+	workspaceViews map[entity.TabID]*component.WorkspaceView
+}
+
+func (a *App) captureEjectRollbackSnapshot(sourceTabs, targetTabs *entity.TabList) ejectRollbackSnapshot {
+	return ejectRollbackSnapshot{
+		sourceTabs:     sourceTabs,
+		sourceSnapshot: sourceTabs.Snapshot(),
+		targetTabs:     targetTabs,
+		targetSnapshot: targetTabs.Snapshot(),
+		globalSnapshot: a.tabs.Snapshot(),
+		windowForTab:   cloneWindowForTabMap(a.windowForTab),
+		workspaceViews: cloneWorkspaceViewsMap(a.workspaceViews),
+	}
+}
+
+func (a *App) restoreEjectSnapshots(snapshot ejectRollbackSnapshot) {
+	if snapshot.sourceTabs != nil {
+		snapshot.sourceTabs.ReplaceFrom(snapshot.sourceSnapshot)
+	}
+	if snapshot.targetTabs != nil {
+		snapshot.targetTabs.ReplaceFrom(snapshot.targetSnapshot)
+	}
+	if a.tabs != nil {
+		a.tabs.ReplaceFrom(snapshot.globalSnapshot)
+	}
+	a.windowForTab = snapshot.windowForTab
+	a.workspaceViews = snapshot.workspaceViews
+}
+
+func (a *App) rollbackEjectTargetUIFailure(targetWindow *browserWindow, snapshot ejectRollbackSnapshot) error {
+	a.restoreEjectSnapshots(snapshot)
+	a.cleanupEjectTargetWindow(targetWindow)
+	return fmt.Errorf("failed to create target workspace view")
+}
+
+func cloneWindowForTabMap(source map[entity.TabID]*browserWindow) map[entity.TabID]*browserWindow {
+	cloned := make(map[entity.TabID]*browserWindow, len(source))
+	for tabID, bw := range source {
+		cloned[tabID] = bw
+	}
+	return cloned
+}
+
+func cloneWorkspaceViewsMap(source map[entity.TabID]*component.WorkspaceView) map[entity.TabID]*component.WorkspaceView {
+	cloned := make(map[entity.TabID]*component.WorkspaceView, len(source))
+	for tabID, wsView := range source {
+		cloned[tabID] = wsView
+	}
+	return cloned
+}
+
+func (a *App) activePaneEjectSource(requestedPaneID entity.PaneID) (*browserWindow, *entity.TabList, *entity.Tab, entity.PaneID) {
+	sourceWindow := a.lastFocusedBrowserWindow()
+	sourceTabs := a.tabListForBrowserWindow(sourceWindow)
+	sourceTab := a.activeTabForBrowserWindow(sourceWindow)
+	if sourceWindow == nil || sourceTabs == nil || sourceTab == nil || sourceTab.Workspace == nil {
+		return nil, nil, nil, ""
+	}
+	sourcePaneID := sourceTab.Workspace.ActivePaneID
+	if requestedPaneID != "" && requestedPaneID != sourcePaneID {
+		return nil, nil, nil, ""
+	}
+	sourceNode := sourceTab.Workspace.FindPane(sourcePaneID)
+	if sourcePaneID == "" || sourceNode == nil || sourceNode.Pane == nil || !isEjectableWorkspacePane(sourceNode.Pane) {
+		return nil, nil, nil, ""
+	}
+	return sourceWindow, sourceTabs, sourceTab, sourcePaneID
+}
+
+func isEjectableWorkspacePane(pane *entity.Pane) bool {
+	if pane == nil {
+		return false
+	}
+	return pane.WindowType == entity.WindowMain && !strings.HasPrefix(pane.URI, "dumb://")
+}
+
+func (a *App) EjectActivePaneToWindow(ctx context.Context, requestedPaneID entity.PaneID) error {
+	if a.extractPaneToTabListUC == nil {
+		return nil
+	}
+
+	sourceWindow, sourceTabs, sourceTab, sourcePaneID := a.activePaneEjectSource(requestedPaneID)
+	if sourceWindow == nil {
+		return nil
+	}
+
+	targetWindow, err := a.createEmptyBrowserWindow(ctx)
+	if err != nil {
+		return err
+	}
+	targetTabs := a.ensureTabListForBrowserWindow(targetWindow)
+	if targetTabs == nil {
+		a.cleanupEjectTargetWindow(targetWindow)
+		return fmt.Errorf("target tab list is required")
+	}
+
+	rollbackSnapshot := a.captureEjectRollbackSnapshot(sourceTabs, targetTabs)
+
+	out, err := a.extractPaneToTabListUC.Execute(usecase.ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: sourcePaneID,
+		TargetTabs:   targetTabs,
+	})
+	if err != nil {
+		a.cleanupEjectTargetWindow(targetWindow)
+		return err
+	}
+	if out == nil || out.NewTab == nil {
+		a.cleanupEjectTargetWindow(targetWindow)
+		return nil
+	}
+
+	a.setBrowserWindowForTab(out.NewTab.ID, targetWindow)
+	a.syncDerivedGlobalTabMirror(out.NewTab)
+	if a.tabs != nil {
+		a.tabs.SetActive(out.NewTab.ID)
+	}
+	a.ensureTargetTabUI(ctx, out.NewTab, targetWindow)
+	if a.workspaceViews[out.NewTab.ID] == nil {
+		return a.rollbackEjectTargetUIFailure(targetWindow, rollbackSnapshot)
+	}
+
+	if out.SourceTabClosed {
+		a.removeSourceTabUI(sourceTab.ID, sourceWindow)
+		delete(a.windowForTab, sourceTab.ID)
+		a.switchSourceWindowToActiveTab(ctx, sourceWindow, sourceTabs)
+	} else {
+		a.rebuildAndAttachWorkspace(ctx, sourceTab.ID, sourceTab)
+	}
+
+	a.rebuildAndAttachWorkspace(ctx, out.NewTab.ID, out.NewTab)
+	if a.contentCoord != nil && out.NewTab.Workspace != nil {
+		a.contentCoord.SyncWebViewViewport(ctx, out.NewTab.Workspace.ActivePaneID, "eject-pane-to-window")
+	}
+
+	a.updateEjectWindowChrome(ctx, sourceWindow, targetWindow, targetTabs, out.NewTab.ID)
+
+	if out.SourceTabClosed && sourceTabs.Count() == 0 {
+		a.removeEmptySourceBrowserWindow(sourceWindow)
+	}
+
+	targetWindows := a.orderedBrowserWindowsForSnapshot()
+	a.replaceGlobalTabsFromRuntimeWindows(targetWindows, targetWindow)
+
+	a.activateBrowserWindow(targetWindow)
+	a.switchWorkspaceView(ctx, out.NewTab.ID)
+	if targetWindow.mainWindow != nil {
+		targetWindow.mainWindow.Show()
+	}
+	a.MarkDirty()
+	return nil
+}
+
+func (a *App) updateEjectWindowChrome(
+	ctx context.Context,
+	sourceWindow, targetWindow *browserWindow,
+	targetTabs *entity.TabList,
+	newTabID entity.TabID,
+) {
+	targetTabs.SetActive(newTabID)
+	if tabBar := a.tabBarForBrowserWindow(targetWindow); tabBar != nil {
+		tabBar.SetActive(newTabID)
+	}
+	if a.tabCoord != nil {
+		a.tabCoord.UpdateBarVisibility(ctx, a.tabTargetForBrowserWindow(sourceWindow))
+		a.tabCoord.UpdateBarVisibility(ctx, a.tabTargetForBrowserWindow(targetWindow))
+	}
+	a.updateBrowserWindowTabBarVisibility(sourceWindow)
+	a.updateBrowserWindowTabBarVisibility(targetWindow)
+}
+
+func (a *App) switchSourceWindowToActiveTab(ctx context.Context, bw *browserWindow, tabs *entity.TabList) {
+	if bw == nil || tabs == nil || tabs.Count() == 0 {
+		return
+	}
+	activeTab := tabs.ActiveTab()
+	if activeTab == nil {
+		return
+	}
+	if tabBar := a.tabBarForBrowserWindow(bw); tabBar != nil {
+		tabBar.SetActive(activeTab.ID)
+	}
+	a.switchWorkspaceView(ctx, activeTab.ID)
+}
+
+func (a *App) removeEmptySourceBrowserWindow(bw *browserWindow) {
+	if bw == nil || a.tabCountForBrowserWindow(bw) != 0 {
+		return
+	}
+	a.removeBrowserWindow(bw.id)
+	if bw.mainWindow != nil {
+		bw.mainWindow.Destroy()
+	}
+}
+
+func (a *App) orderedBrowserWindowsForSnapshot() []*browserWindow {
+	windows := make([]*browserWindow, 0, len(a.browserWindows))
+	for _, id := range a.windowOrder() {
+		if bw := a.browserWindows[id]; bw != nil {
+			windows = append(windows, bw)
+		}
+	}
+	return windows
+}


### PR DESCRIPTION
## Summary
- Add Pane Mode `eject-pane-to-window` action for moving the active pane into a new browser window.
- Preserve clean architecture boundaries with a pure pane/tab-list extraction usecase and UI-owned window/WebView/focus orchestration.
- Merge missing default modal actions into persisted configs at migration time and runtime load so existing configs pick up the new binding.

## Test Plan
- `go test ./internal/application/usecase ./internal/infrastructure/config ./internal/ui/input ./internal/ui/dispatcher ./internal/ui`
- `make lint`
- `make check`
- CodeRabbit review against `main`: 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Eject pane to window" action (bound to `W` in pane mode) that moves the active pane into a new separate window.

* **Documentation**
  * Updated keybindings reference to document the new eject-pane-to-window action and clarified keybinding table rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->