### PR TITLE
fix(idle): avoid portal signal cleanup crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Syu --noconfirm
-          pacman -S --noconfirm git go webkitgtk-6.0 gtk4 libadwaita gobject-introspection base-devel brotli
+          pacman -S --noconfirm git go webkitgtk-6.0 gtk4 libadwaita gobject-introspection base-devel brotli dbus
       - uses: actions/checkout@v6
       - name: Cache Go modules
         uses: actions/cache@v5

--- a/internal/infrastructure/idle/portal_inhibitor.go
+++ b/internal/infrastructure/idle/portal_inhibitor.go
@@ -135,7 +135,10 @@ func (p *PortalInhibitor) Inhibit(ctx context.Context, reason string) error {
 func (p *PortalInhibitor) watchForResponse(ctx context.Context, handlePath dbus.ObjectPath) {
 	log := logging.FromContext(ctx)
 
-	if p.conn == nil {
+	p.mu.Lock()
+	conn := p.conn
+	p.mu.Unlock()
+	if conn == nil {
 		return
 	}
 
@@ -145,18 +148,18 @@ func (p *PortalInhibitor) watchForResponse(ctx context.Context, handlePath dbus.
 		requestIface, handlePath,
 	)
 
-	if err := p.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, matchRule).Err; err != nil {
+	if err := conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, matchRule).Err; err != nil {
 		log.Debug().Err(err).Msg("idle inhibitor: failed to add signal match")
 		return
 	}
 
 	// Create a channel to receive signals
 	signals := make(chan *dbus.Signal, 1)
-	p.conn.Signal(signals)
+	conn.Signal(signals)
 
 	defer func() {
-		p.conn.RemoveSignal(signals)
-		_ = p.conn.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, matchRule).Err
+		conn.RemoveSignal(signals)
+		_ = conn.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, matchRule).Err
 	}()
 
 	// Wait for either a Response signal or context cancellation

--- a/internal/infrastructure/idle/portal_inhibitor_test.go
+++ b/internal/infrastructure/idle/portal_inhibitor_test.go
@@ -1,0 +1,104 @@
+package idle
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func TestWatchForResponseCleanupSurvivesConnFieldCleared(t *testing.T) {
+	// clearConnOnDoneContext clears inhibitor.conn after watchForResponse has
+	// installed its cleanup defer; the test fails if cleanup dereferences the
+	// mutable field instead of the D-Bus connection snapshot.
+	conn := connectPrivateSessionBus(t)
+	defer conn.Close()
+
+	inhibitor := &PortalInhibitor{conn: conn}
+	ctx := &clearConnOnDoneContext{
+		Context: context.Background(),
+		done:    closedDoneChannel(),
+		clear: func() {
+			inhibitor.mu.Lock()
+			inhibitor.conn = nil
+			inhibitor.mu.Unlock()
+		},
+	}
+
+	inhibitor.watchForResponse(ctx, "/org/freedesktop/portal/desktop/request/dumber/test")
+
+	inhibitor.mu.Lock()
+	connCleared := inhibitor.conn == nil
+	inhibitor.mu.Unlock()
+	if !connCleared {
+		t.Fatal("watchForResponse returned before observing context cancellation")
+	}
+}
+
+func connectPrivateSessionBus(t *testing.T) *dbus.Conn {
+	t.Helper()
+
+	address := startPrivateSessionBus(t)
+	conn, err := dbus.Connect(address)
+	if err != nil {
+		t.Fatalf("connect to private D-Bus session bus: %v", err)
+	}
+	return conn
+}
+
+func startPrivateSessionBus(t *testing.T) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("dbus-daemon"); err != nil {
+		t.Skipf("dbus-daemon unavailable: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.Command("dbus-daemon", "--session", "--nofork", "--print-address=1")
+	cmd.Stderr = &stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("open dbus-daemon stdout: %v", err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("start dbus-daemon: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	address, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read dbus-daemon address: %v; stderr: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(address)
+}
+
+type clearConnOnDoneContext struct {
+	context.Context
+	done  <-chan struct{}
+	once  sync.Once
+	clear func()
+}
+
+func (c *clearConnOnDoneContext) Done() <-chan struct{} {
+	c.once.Do(c.clear)
+	return c.done
+}
+
+func closedDoneChannel() <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}


### PR DESCRIPTION
## Summary
- Fix a SIGSEGV in `PortalInhibitor.watchForResponse` by snapshotting the D-Bus connection before deferred signal cleanup.
- Add regression coverage for cleanup after `inhibitor.conn` is cleared.
- Document the race scenario exercised by the test.

## Test Plan
- [x] `go test ./internal/infrastructure/idle -count=1`
- [x] `go test -race ./internal/infrastructure/idle -count=1`
- [x] `go test ./...`
- [x] `make lint`
- [x] `make check`
- [x] CodeRabbit CLI: 0 findings after amend
- [x] Wrap-up review: no additional review jobs needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race in the idle inhibitor that could occur when system connections are closed during signal registration and cleanup.

* **Tests**
  * Added a test to ensure the idle inhibitor cleanup safely handles concurrent connection changes.

* **Chores**
  * CI updated to install the dbus package required for the new test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->