### PR TITLE
fix(favicon): reject placeholder conversions

### DIFF
--- a/internal/application/usecase/favicon_test.go
+++ b/internal/application/usecase/favicon_test.go
@@ -238,6 +238,36 @@ func TestFaviconRefreshFromIconURLsUsesPageURLKey(t *testing.T) {
 	}
 }
 
+func TestFaviconRefreshFromIconURLsSkipsUnsupportedCandidates(t *testing.T) {
+	fx := newFaviconFixture()
+	fx.fetcher.responses = map[string]fakeFetchedIcon{
+		"https://cdn.example.net/icon.svg": {bytes: []byte("svg"), contentType: "image/svg+xml"},
+		"https://cdn.example.net/icon.png": {bytes: []byte("png"), contentType: "image/png"},
+	}
+	fx.converter.errByContentType = map[string]error{"image/svg+xml": ErrFaviconMiss}
+
+	err := fx.uc.RefreshFromIconURLs(context.Background(), "https://docs.example.com/page", []string{
+		"https://cdn.example.net/icon.svg",
+		"https://cdn.example.net/icon.png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fx.fetcher.calls != 2 {
+		t.Fatalf("fetcher calls=%d, want 2", fx.fetcher.calls)
+	}
+	meta := fx.repo.byKey["docs.example.com"]
+	if meta == nil {
+		t.Fatalf("expected page URL key to be stored; keys=%v", fx.repo.byKey)
+	}
+	if meta.SourceURL != "https://cdn.example.net/icon.png" || meta.ContentType != "image/png" {
+		t.Fatalf("stored meta = %+v, want png candidate", meta)
+	}
+	if string(fx.blobs.original["docs.example.com"]) != "png" {
+		t.Fatalf("stored original = %q, want png", fx.blobs.original["docs.example.com"])
+	}
+}
+
 func TestFaviconObserveConversionErrorDoesNotMutateExistingAssets(t *testing.T) {
 	fx := newFaviconFixture()
 	fx.seedOriginal([]byte("old"))
@@ -462,14 +492,18 @@ func (b *fakeBlobStore) RemoveDerived(_ context.Context, key favicon.Key) error 
 }
 
 type fakeConverter struct {
-	calls int
-	err   error
+	calls            int
+	err              error
+	errByContentType map[string]error
 }
 
-func (c *fakeConverter) Convert(_ context.Context, original []byte, _ string, sizes []int) (*appport.ConvertedFavicon, error) {
+func (c *fakeConverter) Convert(_ context.Context, original []byte, contentType string, sizes []int) (*appport.ConvertedFavicon, error) {
 	c.calls++
 	if c.err != nil {
 		return nil, c.err
+	}
+	if err := c.errByContentType[contentType]; err != nil {
+		return nil, err
 	}
 	out := &appport.ConvertedFavicon{PNG: append([]byte("png:"), original...), SizedPNG: map[int][]byte{}}
 	for _, s := range sizes {
@@ -514,9 +548,15 @@ func (i *fakeInvalidators) InvalidateAll(_ context.Context, _ favicon.Key) error
 	return nil
 }
 
+type fakeFetchedIcon struct {
+	bytes       []byte
+	contentType string
+}
+
 type fakeFetcher struct {
-	calls int
-	err   error
+	calls     int
+	err       error
+	responses map[string]fakeFetchedIcon
 }
 
 func (f *fakeFetcher) Fetch(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
@@ -528,5 +568,9 @@ func (f *fakeFetcher) Fetch(_ context.Context, req appport.FaviconFetchRequest) 
 	if iconURL == "" {
 		iconURL = "https://example.com/favicon.ico"
 	}
-	return &appport.FaviconFetchedIcon{PageURL: req.PageURL, IconURL: iconURL, Bytes: []byte("fetched"), Source: favicon.SourceDuckDuckGo, ContentType: "image/png"}, nil
+	response := f.responses[iconURL]
+	if response.bytes == nil {
+		response = fakeFetchedIcon{bytes: []byte("fetched"), contentType: "image/png"}
+	}
+	return &appport.FaviconFetchedIcon{PageURL: req.PageURL, IconURL: iconURL, Bytes: response.bytes, Source: favicon.SourceDuckDuckGo, ContentType: response.contentType}, nil
 }

--- a/internal/infrastructure/favicon/converter.go
+++ b/internal/infrastructure/favicon/converter.go
@@ -9,8 +9,6 @@ import (
 	"image/color"
 	"image/png"
 	"mime"
-	"regexp"
-	"strconv"
 	"strings"
 
 	appport "github.com/bnema/dumber/internal/application/port"
@@ -53,7 +51,7 @@ func (*ImageConverter) Convert(ctx context.Context, original []byte, contentType
 func decodeFaviconImage(data []byte, ct string) (image.Image, error) {
 	switch ct {
 	case "image/svg+xml":
-		return renderSimpleSVG(data)
+		return nil, fmt.Errorf("%w: svg favicon conversion is disabled", appport.ErrFaviconMiss)
 	case "image/x-icon", "image/vnd.microsoft.icon", "image/ico":
 		img, err := decodeICO(data)
 		if err != nil {
@@ -61,7 +59,7 @@ func decodeFaviconImage(data []byte, ct string) (image.Image, error) {
 		}
 		return img, nil
 	case "image/webp":
-		return renderWEBPPlaceholder(data)
+		return nil, fmt.Errorf("%w: webp favicon conversion is disabled", appport.ErrFaviconMiss)
 	}
 	if ct != "" && ct != "image/png" && ct != "image/jpeg" && ct != "image/gif" && ct != "image/webp" {
 		return nil, fmt.Errorf("%w: unsupported favicon content type %s", appport.ErrFaviconMiss, ct)
@@ -208,54 +206,4 @@ func decodeICODIB(data []byte, bitCountHint int) (image.Image, error) {
 		}
 	}
 	return img, nil
-}
-
-var svgSizeRe = regexp.MustCompile(`(?i)\b(width|height)=["']?(\d+)`) // intentionally small safe subset
-var svgFillRe = regexp.MustCompile(`(?i)\bfill=["']#?([0-9a-f]{6})`)
-
-func renderWEBPPlaceholder(data []byte) (image.Image, error) {
-	if len(data) < 12 || !bytes.HasPrefix(data, []byte("RIFF")) || string(data[8:12]) != "WEBP" {
-		return nil, fmt.Errorf("%w: malformed webp", appport.ErrFaviconMiss)
-	}
-	return solidImage(64, color.RGBA{R: 128, G: 128, B: 128, A: 255}), nil
-}
-
-func renderSimpleSVG(data []byte) (image.Image, error) {
-	trimmed := bytes.TrimSpace(data)
-	if !bytes.Contains(trimmed, []byte("<svg")) {
-		return nil, fmt.Errorf("%w: malformed svg", appport.ErrFaviconMiss)
-	}
-	size := 64
-	for _, m := range svgSizeRe.FindAllSubmatch(trimmed, -1) {
-		if v, err := strconv.Atoi(string(m[2])); err == nil && v > 0 && v <= 1024 {
-			size = v
-			break
-		}
-	}
-	fill := color.RGBA{R: 128, G: 128, B: 128, A: 255}
-	if m := svgFillRe.FindSubmatch(trimmed); len(m) == 2 {
-		if parsed, ok := parseHexColor(string(m[1])); ok {
-			fill = parsed
-		}
-	}
-	return solidImage(size, fill), nil
-}
-
-func solidImage(size int, fill color.RGBA) image.Image {
-	img := image.NewRGBA(image.Rect(0, 0, size, size))
-	for y := 0; y < size; y++ {
-		for x := 0; x < size; x++ {
-			img.SetRGBA(x, y, fill)
-		}
-	}
-	return img
-}
-
-func parseHexColor(hex string) (color.RGBA, bool) {
-	v, err := strconv.ParseUint(hex, 16, 32)
-	if err != nil {
-		return color.RGBA{}, false
-	}
-	const greenShift = 8
-	return color.RGBA{R: uint8(v >> 16), G: uint8(v >> greenShift), B: uint8(v), A: 255}, true
 }

--- a/internal/infrastructure/favicon/converter_test.go
+++ b/internal/infrastructure/favicon/converter_test.go
@@ -39,8 +39,6 @@ func TestConverterAcceptedFaviconFormatsProducePNGs(t *testing.T) {
 		{"png", "image/png", testPNG(t, 16, 16)},
 		{"ico with png payload", "image/x-icon", testICOWithPNG(t, testPNG(t, 16, 16))},
 		{"ico with bitmap payload", "image/x-icon", testICOWithDIB(t)},
-		{"svg", "image/svg+xml", []byte(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="#ff0000"/></svg>`)},
-		{"webp placeholder", "image/webp", []byte("RIFF\x04\x00\x00\x00WEBPVP8 ")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := conv.Convert(context.Background(), tc.data, tc.ct, []int{32})
@@ -56,6 +54,23 @@ func TestConverterAcceptedFaviconFormatsProducePNGs(t *testing.T) {
 			}
 			if img.Bounds().Dx() != 32 || img.Bounds().Dy() != 32 {
 				t.Fatalf("size = %v", img.Bounds())
+			}
+		})
+	}
+}
+
+func TestConverterRejectsFormatsThatWouldProducePlaceholders(t *testing.T) {
+	conv := NewImageConverter()
+	for _, tc := range []struct {
+		name, ct string
+		data     []byte
+	}{
+		{"svg", "image/svg+xml", []byte(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="#ff0000"/></svg>`)},
+		{"webp", "image/webp", []byte("RIFF\x04\x00\x00\x00WEBPVP8 ")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := conv.Convert(context.Background(), tc.data, tc.ct, []int{32}); !errors.Is(err, appport.ErrFaviconMiss) {
+				t.Fatalf("err = %v, want favicon miss", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Reject SVG/WebP favicon conversion instead of generating solid placeholder PNGs.
- Preserve fallback behavior so unsupported favicon candidates are skipped in favor of later usable candidates.
- Add regression tests for placeholder rejection and favicon candidate fallback.

## Test Plan
- [x] rtk go test ./internal/infrastructure/favicon ./internal/application/usecase ./internal/infrastructure/cef ./internal/ui/adapter ./internal/ui/coordinator/content

## Review
- Wrap-up review triage found no extra review jobs needed.
- CodeRabbit reported raw URL debug logging concerns; the added debug logs were removed and tests were rerun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced favicon processing to properly reject unsupported image formats (SVG, WebP) that previously generated placeholders. The application now exclusively processes compatible favicon formats (PNG, ICO) when evaluating multiple icon candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->