### PR TITLE
chore(logging): add window launch diagnostics

### DIFF
--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -315,21 +315,24 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 				Msg("browser launch relay accepted request without opener")
 			return
 		}
+		started := time.Now()
 		log.Debug().
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
-			Msg("browser launch relay opening fresh window")
+			Msg("browser launch relay calling browser window opener")
 		if err := opener.OpenFreshWindow(ctx, request.URL); err != nil {
 			log.Warn().Err(err).
 				Str("request_id", requestID).
 				Str("url_host", safeURLHost(request.URL)).
-				Msg("failed to open fresh browser window")
+				Dur("elapsed", time.Since(started)).
+				Msg("browser launch relay opener failed")
 			return
 		}
 		log.Debug().
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
-			Msg("browser launch relay opened fresh window")
+			Dur("elapsed", time.Since(started)).
+			Msg("browser launch relay opener returned success")
 	}()
 }
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"errors"
 	"io"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -247,4 +248,13 @@ func TruncateURL(url string, maxLen int) string {
 		return url
 	}
 	return url[:maxLen] + "..."
+}
+
+// SafeURLHost returns only the host portion of a URL for privacy-preserving diagnostics.
+func SafeURLHost(raw string) string {
+	parsed, err := neturl.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -6,6 +6,25 @@ import (
 	"testing"
 )
 
+func TestSafeURLHostDropsPathQueryAndFragment(t *testing.T) {
+	t.Parallel()
+
+	got := SafeURLHost("https://example.com/private/path?token=secret#frag")
+	if got != "example.com" {
+		t.Fatalf("SafeURLHost returned %q, want %q", got, "example.com")
+	}
+}
+
+func TestSafeURLHostReturnsEmptyForOpaqueOrInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"about:blank", "not a url"} {
+		if got := SafeURLHost(raw); got != "" {
+			t.Fatalf("SafeURLHost(%q) returned %q, want empty host", raw, got)
+		}
+	}
+}
+
 func TestSessionFileWriter_DropsWritesAfterClose(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -422,9 +422,19 @@ func (a *App) prewarmWebViewPoolAsync(ctx context.Context) {
 }
 
 func (a *App) createBrowserWindow(ctx context.Context, initialURL string) (*browserWindow, error) {
+	log := logging.FromContext(ctx)
+	log.Debug().
+		Str("url_host", logging.SafeURLHost(initialURL)).
+		Bool("using_factory", a.browserWindowFactory != nil).
+		Int("window_count_before", len(a.browserWindows)).
+		Msg("ui: create browser window started")
+
 	if a.browserWindowFactory != nil {
 		created, err := a.browserWindowFactory(ctx, initialURL)
 		if err != nil {
+			log.Warn().Err(err).
+				Str("url_host", logging.SafeURLHost(initialURL)).
+				Msg("ui: browser window factory failed")
 			return nil, err
 		}
 		created.ensureTabs()
@@ -433,9 +443,11 @@ func (a *App) createBrowserWindow(ctx context.Context, initialURL string) (*brow
 		return created, nil
 	}
 
-	log := logging.FromContext(ctx)
 	mainWindow, err := window.New(ctx, a.gtkApp, a.deps.Config.Workspace.TabBarPosition)
 	if err != nil {
+		log.Warn().Err(err).
+			Str("url_host", logging.SafeURLHost(initialURL)).
+			Msg("ui: GTK browser window shell creation failed")
 		return nil, err
 	}
 	browserWindow := &browserWindow{
@@ -496,6 +508,10 @@ func (a *App) createBrowserWindow(ctx context.Context, initialURL string) (*brow
 	if display := mainWindow.Window().GetDisplay(); display != nil {
 		a.deps.Theme.ApplyToDisplay(ctx, display)
 	}
+	log.Debug().
+		Str("window_id", browserWindow.id).
+		Str("url_host", logging.SafeURLHost(initialURL)).
+		Msg("ui: create browser window completed")
 	return browserWindow, nil
 }
 
@@ -767,49 +783,101 @@ func (a *App) closeBrowserLaunchRelayListener() {
 }
 
 func (a *App) openFreshWindow(ctx context.Context, url string) error {
+	log := logging.FromContext(ctx)
+	log.Debug().
+		Str("url_host", logging.SafeURLHost(url)).
+		Int("window_count_before", len(a.browserWindows)).
+		Bool("has_tab_coord", a.tabCoord != nil).
+		Bool("has_tabs_uc", a.tabsUC != nil).
+		Msg("ui: open fresh window started")
+
 	created, err := a.createBrowserWindow(ctx, url)
 	if err != nil {
+		log.Warn().Err(err).
+			Str("url_host", logging.SafeURLHost(url)).
+			Int("window_count_after", len(a.browserWindows)).
+			Msg("ui: open fresh window could not create browser window")
 		return err
 	}
+	log.Debug().
+		Str("window_id", created.id).
+		Str("url_host", logging.SafeURLHost(url)).
+		Msg("ui: open fresh window created browser window shell")
 	a.registerBrowserWindow(created)
+	log.Debug().
+		Str("window_id", created.id).
+		Int("window_count_after_register", len(a.browserWindows)).
+		Msg("ui: open fresh window registered browser window")
 
 	if len(a.browserWindows) == 1 {
+		log.Debug().Str("window_id", created.id).Msg("ui: activating first browser window")
 		a.activateBrowserWindow(created)
 		return nil
 	}
 
 	var openErr error
+	path := "tabs_uc"
 	if a.tabCoord != nil {
+		path = "tab_coord"
+		log.Debug().Str("window_id", created.id).Msg("ui: creating initial tab for fresh window via tab coordinator")
 		openErr = a.openFreshWindowWithTabCoord(ctx, url, created)
 	} else if a.tabsUC == nil {
+		log.Debug().Str("window_id", created.id).Msg("ui: activating fresh browser window without tab use case")
 		a.activateBrowserWindow(created)
 		return nil
 	} else {
+		log.Debug().Str("window_id", created.id).Msg("ui: creating initial tab for fresh window via tabs use case")
 		openErr = a.openFreshWindowWithTabsUC(ctx, url, created)
 	}
 	if openErr != nil {
+		log.Warn().Err(openErr).
+			Str("window_id", created.id).
+			Str("path", path).
+			Int("window_count_after", len(a.browserWindows)).
+			Msg("ui: open fresh window initial tab creation failed")
 		return openErr
 	}
+	log.Debug().
+		Str("window_id", created.id).
+		Str("path", path).
+		Msg("ui: activating fresh browser window after tab creation")
 	a.activateBrowserWindow(created)
 	return nil
 }
 
 func (a *App) openFreshWindowWithTabCoord(ctx context.Context, url string, created *browserWindow) error {
+	log := logging.FromContext(ctx)
 	previousTarget := a.tabCoord.CurrentTarget()
-	a.tabCoord.SetCurrentTarget(a.ensureTabTargetForBrowserWindow(created))
+	target := a.ensureTabTargetForBrowserWindow(created)
+	a.tabCoord.SetCurrentTarget(target)
 	defer func() {
 		a.tabCoord.SetCurrentTarget(previousTarget)
 	}()
 
-	createdTab, createErr := a.tabCoord.Create(ctx, a.ensureTabTargetForBrowserWindow(created), url)
+	log.Debug().
+		Str("window_id", created.id).
+		Str("url_host", logging.SafeURLHost(url)).
+		Msg("ui: tab coordinator create started for fresh window")
+	createdTab, createErr := a.tabCoord.Create(ctx, target, url)
 	if createErr != nil {
+		log.Warn().Err(createErr).
+			Str("window_id", created.id).
+			Msg("ui: tab coordinator create failed for fresh window; rolling back window")
 		a.removeBrowserWindow(created.id)
 		if created.mainWindow != nil {
 			created.mainWindow.Destroy()
 		}
 		return createErr
 	}
+	log.Debug().
+		Str("window_id", created.id).
+		Str("tab_id", string(createdTab.ID)).
+		Msg("ui: tab coordinator create completed for fresh window")
 	if a.workspaceViews[createdTab.ID] == nil {
+		log.Warn().
+			Str("window_id", created.id).
+			Str("tab_id", string(createdTab.ID)).
+			Msg("ui: fresh window tab has no workspace view; rolling back window")
 		if createdTabs := a.tabListForBrowserWindow(created); createdTabs != nil {
 			createdTabs.Remove(createdTab.ID)
 		}
@@ -837,17 +905,29 @@ func (a *App) openFreshWindowWithTabCoord(ctx context.Context, url string, creat
 }
 
 func (a *App) openFreshWindowWithTabsUC(ctx context.Context, url string, created *browserWindow) error {
+	log := logging.FromContext(ctx)
+	log.Debug().
+		Str("window_id", created.id).
+		Str("url_host", logging.SafeURLHost(url)).
+		Msg("ui: tabs use case create started for fresh window")
 	output, err := a.tabsUC.Create(ctx, usecase.CreateTabInput{
 		TabList:    a.tabs,
 		InitialURL: url,
 	})
 	if err != nil {
+		log.Warn().Err(err).
+			Str("window_id", created.id).
+			Msg("ui: tabs use case create failed for fresh window; rolling back window")
 		a.removeBrowserWindow(created.id)
 		if created.mainWindow != nil {
 			created.mainWindow.Destroy()
 		}
 		return err
 	}
+	log.Debug().
+		Str("window_id", created.id).
+		Str("tab_id", string(output.Tab.ID)).
+		Msg("ui: tabs use case create completed for fresh window")
 	a.setBrowserWindowForTab(output.Tab.ID, created)
 	// Mirror the tabsUC-created tab into the new browser window's tab list.
 	// This path uses the tabs usecase directly instead of tabCoord.Create,
@@ -858,6 +938,10 @@ func (a *App) openFreshWindowWithTabsUC(ctx context.Context, url string, created
 		a.switchWorkspaceView(ctx, output.Tab.ID)
 	}
 	if a.workspaceViews[output.Tab.ID] == nil {
+		log.Warn().
+			Str("window_id", created.id).
+			Str("tab_id", string(output.Tab.ID)).
+			Msg("ui: fresh window tabs use case tab has no workspace view; rolling back window")
 		if createdTabs := a.tabListForBrowserWindow(created); createdTabs != nil {
 			createdTabs.Remove(output.Tab.ID)
 		}

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -343,6 +343,11 @@ func (a *App) deterministicBrowserWindowFallback() *browserWindow {
 }
 
 func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
+	log := logging.FromContext(ctx)
+	log.Debug().
+		Str("url_host", logging.SafeURLHost(url)).
+		Msg("ui: open fresh window dispatch requested")
+
 	dispatch := a.dispatchOnMainThread
 	if dispatch == nil {
 		dispatch = func(label string, fn func()) syncdispatch.SyncDispatchResult {
@@ -354,17 +359,46 @@ func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
 	}
 
 	var openErr error
+	var windowCountBefore int
+	var windowCountAfter int
+	var hasTabCoord bool
+	var hasTabsUC bool
 	result := dispatch("ui.open_fresh_window", func() {
+		windowCountBefore = len(a.browserWindows)
+		hasTabCoord = a.tabCoord != nil
+		hasTabsUC = a.tabsUC != nil
+		log.Debug().
+			Str("url_host", logging.SafeURLHost(url)).
+			Int("window_count_before", windowCountBefore).
+			Bool("has_tab_coord", hasTabCoord).
+			Bool("has_tabs_uc", hasTabsUC).
+			Msg("ui: open fresh window main-thread work started")
 		openErr = a.openFreshWindow(ctx, url)
+		windowCountAfter = len(a.browserWindows)
 	})
 	if !result.Completed() {
-		logging.FromContext(ctx).Warn().
-			Str("url", logging.TruncateURL(url, logging.PermissionLogURLMaxLen)).
+		log.Warn().
+			Str("url_host", logging.SafeURLHost(url)).
 			Dur("elapsed", result.Elapsed).
 			Str("dispatch_status", string(result.Status)).
 			Msg("ui: open fresh window skipped after main-thread dispatch did not complete")
 		return fmt.Errorf("main thread dispatch did not complete: %s", result.Status)
 	}
+	if openErr != nil {
+		log.Warn().Err(openErr).
+			Str("url_host", logging.SafeURLHost(url)).
+			Dur("elapsed", result.Elapsed).
+			Str("dispatch_status", string(result.Status)).
+			Int("window_count_after", windowCountAfter).
+			Msg("ui: open fresh window failed")
+		return openErr
+	}
 
-	return openErr
+	log.Debug().
+		Str("url_host", logging.SafeURLHost(url)).
+		Dur("elapsed", result.Elapsed).
+		Str("dispatch_status", string(result.Status)).
+		Int("window_count_after", windowCountAfter).
+		Msg("ui: open fresh window completed")
+	return nil
 }


### PR DESCRIPTION
## Summary

- add low-noise diagnostics around external browser-launch handoff and fresh-window creation
- log privacy-preserving `url_host` instead of URL paths/query strings
- add `logging.SafeURLHost` coverage

## Verification

```bash
go test ./internal/logging ./internal/ui ./internal/infrastructure/desktop
```

## Context

These diagnostics are intended to make future native crashes during high-churn external-link launches easier to pinpoint without keeping verbose per-step instrumentation permanently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests to validate safe URL host extraction.

* **Chores**
  * Improved logging around browser-window creation and fresh-window opening, including timing and sanitized URL host info to aid diagnostics and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->