### PR TITLE
fix(cef): restore touchpad scroll and navigation

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -195,12 +195,12 @@ border = "#363636"
 | `engine.cef.windowless_frame_rate` | int32 | `0` | >= 0 | Explicit CEF OSR FPS cap; 0 uses adaptive mode if enabled, otherwise CEF default |
 | `engine.cef.windowless_frame_rate_max` | int32 | `240` | >= 0 | Hard cap for adaptive CEF OSR FPS; 0 falls back to the built-in default cap selected by Dumber/CEF |
 | `engine.cef.input.scroll_wheel_multiplier` | float | `1.0` | > 0 | Mouse wheel scroll sensitivity multiplier |
-| `engine.cef.input.scroll_touchpad_multiplier` | float | `0.35` | > 0 | Touchpad/smooth scroll sensitivity multiplier |
+| `engine.cef.input.scroll_precise_multiplier` | float | `2.5` | > 0 | Precise/surface scroll sensitivity multiplier |
 | `engine.cef.input.scroll_horizontal_multiplier` | float | `1.0` | > 0 | Horizontal scroll sensitivity multiplier |
 | `engine.cef.input.scroll_vertical_multiplier` | float | `1.0` | > 0 | Vertical scroll sensitivity multiplier |
 | `engine.cef.input.scroll_max_delta` | int32 | `0` | >= 0 | Maximum absolute scroll delta after scaling; 0 disables clamping |
 | `engine.cef.input.touchpad_navigation_enabled` | bool | `true` | - | Enable two-finger touchpad swipe back/forward navigation |
-| `engine.cef.input.touchpad_navigation_min_delta` | float | `80.0` | > 0 | Minimum accumulated horizontal swipe delta required for navigation |
+| `engine.cef.input.touchpad_navigation_min_delta` | float | `15.0` | > 0 | Minimum accumulated horizontal swipe delta required for navigation |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 | Maximum vertical-to-horizontal delta ratio allowed for navigation swipes |
 | `default_ui_scale` | float | `1.0` | > 0 | GTK widget UI scale (1.0=100%, 2.0=200%) |
 | `default_webpage_zoom` | float | `1.2` | > 0 | Default page zoom (1.0=100%, 1.2=120%) |

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -200,7 +200,7 @@ border = "#363636"
 | `engine.cef.input.scroll_vertical_multiplier` | float | `1.0` | > 0 | Vertical scroll sensitivity multiplier |
 | `engine.cef.input.scroll_max_delta` | int32 | `0` | >= 0 | Maximum absolute scroll delta after scaling; 0 disables clamping |
 | `engine.cef.input.touchpad_navigation_enabled` | bool | `true` | - | Enable two-finger touchpad swipe back/forward navigation |
-| `engine.cef.input.touchpad_navigation_min_delta` | float | `15.0` | > 0 | Minimum accumulated horizontal swipe delta required for navigation |
+| `engine.cef.input.touchpad_navigation_min_delta` | float | `180.0` | > 0 | Minimum accumulated horizontal swipe delta required for navigation |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 | Maximum vertical-to-horizontal delta ratio allowed for navigation swipes |
 | `default_ui_scale` | float | `1.0` | > 0 | GTK widget UI scale (1.0=100%, 2.0=200%) |
 | `default_webpage_zoom` | float | `1.2` | > 0 | Default page zoom (1.0=100%, 1.2=120%) |

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -200,7 +200,7 @@ border = "#363636"
 | `engine.cef.input.scroll_vertical_multiplier` | float | `1.0` | > 0 | Vertical scroll sensitivity multiplier |
 | `engine.cef.input.scroll_max_delta` | int32 | `0` | >= 0 | Maximum absolute scroll delta after scaling; 0 disables clamping |
 | `engine.cef.input.touchpad_navigation_enabled` | bool | `true` | - | Enable two-finger touchpad swipe back/forward navigation |
-| `engine.cef.input.touchpad_navigation_min_delta` | float | `180.0` | > 0 | Minimum accumulated horizontal swipe delta required for navigation |
+| `engine.cef.input.touchpad_navigation_min_delta` | float | `200.0` | > 0 | Minimum accumulated horizontal swipe delta required for navigation |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 | Maximum vertical-to-horizontal delta ratio allowed for navigation swipes |
 | `default_ui_scale` | float | `1.0` | > 0 | GTK widget UI scale (1.0=100%, 2.0=200%) |
 | `default_webpage_zoom` | float | `1.2` | > 0 | Default page zoom (1.0=100%, 1.2=120%) |

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -203,6 +203,8 @@ border = "#363636"
 | `engine.cef.input.touchpad_navigation_min_delta` | float | `200.0` | > 0 | Minimum accumulated horizontal swipe delta required for navigation |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 | Maximum vertical-to-horizontal delta ratio allowed for navigation swipes |
 | `default_ui_scale` | float | `1.0` | > 0 | GTK widget UI scale (1.0=100%, 2.0=200%) |
+
+`engine.cef.input.touchpad_navigation_min_delta` uses raw GTK touchpad surface units for back/forward gestures. The default `200.0` matches WebKit-style commit distance to reduce accidental navigation; raise or lower it in `config.toml` to tune gesture sensitivity.
 | `default_webpage_zoom` | float | `1.2` | > 0 | Default page zoom (1.0=100%, 1.2=120%) |
 
 ## Workspace Configuration

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -70,7 +70,7 @@
 | `engine.cef.input.scroll_vertical_multiplier` | float | `1.0` | > 0 |
 | `engine.cef.input.scroll_max_delta` | int32 | `0` | >= 0 |
 | `engine.cef.input.touchpad_navigation_enabled` | bool | `true` | |
-| `engine.cef.input.touchpad_navigation_min_delta` | float | `15.0` | > 0 |
+| `engine.cef.input.touchpad_navigation_min_delta` | float | `180.0` | > 0 |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 |
 | `default_ui_scale` | float | `1.0` | > 0 |
 | `default_webpage_zoom` | float | `1.2` | > 0 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -70,7 +70,7 @@
 | `engine.cef.input.scroll_vertical_multiplier` | float | `1.0` | > 0 |
 | `engine.cef.input.scroll_max_delta` | int32 | `0` | >= 0 |
 | `engine.cef.input.touchpad_navigation_enabled` | bool | `true` | |
-| `engine.cef.input.touchpad_navigation_min_delta` | float | `180.0` | > 0 |
+| `engine.cef.input.touchpad_navigation_min_delta` | float | `200.0` | > 0 |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 |
 | `default_ui_scale` | float | `1.0` | > 0 |
 | `default_webpage_zoom` | float | `1.2` | > 0 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,12 +65,12 @@
 | `engine.cef.windowless_frame_rate` | int32 | `0` | >= 0 |
 | `engine.cef.windowless_frame_rate_max` | int32 | `240` | >= 0 |
 | `engine.cef.input.scroll_wheel_multiplier` | float | `1.0` | > 0 |
-| `engine.cef.input.scroll_touchpad_multiplier` | float | `0.35` | > 0 |
+| `engine.cef.input.scroll_precise_multiplier` | float | `2.5` | > 0 |
 | `engine.cef.input.scroll_horizontal_multiplier` | float | `1.0` | > 0 |
 | `engine.cef.input.scroll_vertical_multiplier` | float | `1.0` | > 0 |
 | `engine.cef.input.scroll_max_delta` | int32 | `0` | >= 0 |
 | `engine.cef.input.touchpad_navigation_enabled` | bool | `true` | |
-| `engine.cef.input.touchpad_navigation_min_delta` | float | `80.0` | > 0 |
+| `engine.cef.input.touchpad_navigation_min_delta` | float | `15.0` | > 0 |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 |
 | `default_ui_scale` | float | `1.0` | > 0 |
 | `default_webpage_zoom` | float | `1.2` | > 0 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -73,6 +73,8 @@
 | `engine.cef.input.touchpad_navigation_min_delta` | float | `200.0` | > 0 |
 | `engine.cef.input.touchpad_navigation_max_vertical_ratio` | float | `0.5` | > 0 |
 | `default_ui_scale` | float | `1.0` | > 0 |
+
+`engine.cef.input.touchpad_navigation_min_delta` is measured in raw GTK touchpad surface units. The default `200.0` matches WebKit-style commit distance to reduce accidental back/forward navigation and can be overridden in `config.toml`.
 | `default_webpage_zoom` | float | `1.2` | > 0 |
 | `workspace.new_pane_url` | string | `about:blank` | |
 | `workspace.switch_to_tab_on_move` | bool | `true` | |

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.3
 	github.com/bnema/purego-cef v0.13.2
-	github.com/bnema/purego-cef2gtk v0.7.1-0.20260608204515-03f646765b43
+	github.com/bnema/purego-cef2gtk v0.7.1-0.20260608211859-4c1f24c5eed0
 	github.com/bnema/purego-pipewire v0.1.4
 	github.com/bnema/purego-sqlite v0.1.3
 	github.com/bnema/puregotk v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.3
 	github.com/bnema/purego-cef v0.13.2
-	github.com/bnema/purego-cef2gtk v0.7.1-0.20260608211859-4c1f24c5eed0
+	github.com/bnema/purego-cef2gtk v0.8.0
 	github.com/bnema/purego-pipewire v0.1.4
 	github.com/bnema/purego-sqlite v0.1.3
 	github.com/bnema/puregotk v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -83,3 +83,5 @@ require (
 )
 
 tool github.com/a-h/templ/cmd/templ
+
+replace github.com/bnema/purego-cef2gtk => ../purego-cef2gtk

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.3
 	github.com/bnema/purego-cef v0.13.2
-	github.com/bnema/purego-cef2gtk v0.7.0
+	github.com/bnema/purego-cef2gtk v0.7.1-0.20260608204515-03f646765b43
 	github.com/bnema/purego-pipewire v0.1.4
 	github.com/bnema/purego-sqlite v0.1.3
 	github.com/bnema/puregotk v0.6.0
@@ -83,5 +83,3 @@ require (
 )
 
 tool github.com/a-h/templ/cmd/templ
-
-replace github.com/bnema/purego-cef2gtk => ../purego-cef2gtk

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.3 h1:lpTXuapRIBH2OTgLJTjYlK1olHmZkEQLloqgP
 github.com/bnema/purego v0.11.0-bnema.3/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.13.2 h1:weSttuJVxjyzp/A5J15ZdzOAVWO/jvvd6nBf8/N4zsI=
 github.com/bnema/purego-cef v0.13.2/go.mod h1:Jbc4GgUvGakEOfbRnXJGYrDbXz03YEpVgTWKPk5ss9k=
-github.com/bnema/purego-cef2gtk v0.7.1-0.20260608204515-03f646765b43 h1:jlrtzP/TSXW867UqmwrIaSxqjWaUKyp92Ag6Y7ZAR7I=
-github.com/bnema/purego-cef2gtk v0.7.1-0.20260608204515-03f646765b43/go.mod h1:eLgf2GwRirBmRNzPWAp/VMHf4MyAN8xoWbdoUNgW48A=
+github.com/bnema/purego-cef2gtk v0.7.1-0.20260608211859-4c1f24c5eed0 h1:+EKdDahBLdcXQT/COkW99Ol+sry/6FrLDostRkgo6O0=
+github.com/bnema/purego-cef2gtk v0.7.1-0.20260608211859-4c1f24c5eed0/go.mod h1:eLgf2GwRirBmRNzPWAp/VMHf4MyAN8xoWbdoUNgW48A=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=
 github.com/bnema/purego-pipewire v0.1.4/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.3 h1:aXysq9+wuRkbFzlVe2oIiooYseFZFb6ArwbfDYYafvY=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.3 h1:lpTXuapRIBH2OTgLJTjYlK1olHmZkEQLloqgP
 github.com/bnema/purego v0.11.0-bnema.3/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.13.2 h1:weSttuJVxjyzp/A5J15ZdzOAVWO/jvvd6nBf8/N4zsI=
 github.com/bnema/purego-cef v0.13.2/go.mod h1:Jbc4GgUvGakEOfbRnXJGYrDbXz03YEpVgTWKPk5ss9k=
-github.com/bnema/purego-cef2gtk v0.7.0 h1:sv8VUB8VIqwrwV9M5E2u6pZ24ly4+erCeooRyCMz1mc=
-github.com/bnema/purego-cef2gtk v0.7.0/go.mod h1:eLgf2GwRirBmRNzPWAp/VMHf4MyAN8xoWbdoUNgW48A=
+github.com/bnema/purego-cef2gtk v0.7.1-0.20260608204515-03f646765b43 h1:jlrtzP/TSXW867UqmwrIaSxqjWaUKyp92Ag6Y7ZAR7I=
+github.com/bnema/purego-cef2gtk v0.7.1-0.20260608204515-03f646765b43/go.mod h1:eLgf2GwRirBmRNzPWAp/VMHf4MyAN8xoWbdoUNgW48A=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=
 github.com/bnema/purego-pipewire v0.1.4/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.3 h1:aXysq9+wuRkbFzlVe2oIiooYseFZFb6ArwbfDYYafvY=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.3 h1:lpTXuapRIBH2OTgLJTjYlK1olHmZkEQLloqgP
 github.com/bnema/purego v0.11.0-bnema.3/go.mod h1:5BnOIUj+0fvk/vwv45iottFoGfkDT7cnLXnpM2s6Hng=
 github.com/bnema/purego-cef v0.13.2 h1:weSttuJVxjyzp/A5J15ZdzOAVWO/jvvd6nBf8/N4zsI=
 github.com/bnema/purego-cef v0.13.2/go.mod h1:Jbc4GgUvGakEOfbRnXJGYrDbXz03YEpVgTWKPk5ss9k=
-github.com/bnema/purego-cef2gtk v0.7.1-0.20260608211859-4c1f24c5eed0 h1:+EKdDahBLdcXQT/COkW99Ol+sry/6FrLDostRkgo6O0=
-github.com/bnema/purego-cef2gtk v0.7.1-0.20260608211859-4c1f24c5eed0/go.mod h1:eLgf2GwRirBmRNzPWAp/VMHf4MyAN8xoWbdoUNgW48A=
+github.com/bnema/purego-cef2gtk v0.8.0 h1:Fd1umUyyPuIqmqyg252dChcv6XJtYVsudleEZ7we9LY=
+github.com/bnema/purego-cef2gtk v0.8.0/go.mod h1:eLgf2GwRirBmRNzPWAp/VMHf4MyAN8xoWbdoUNgW48A=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=
 github.com/bnema/purego-pipewire v0.1.4/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.3 h1:aXysq9+wuRkbFzlVe2oIiooYseFZFb6ArwbfDYYafvY=

--- a/internal/bootstrap/engine.go
+++ b/internal/bootstrap/engine.go
@@ -86,7 +86,7 @@ func BuildEngine(input EngineInput) (port.Engine, error) {
 			WindowlessFrameRateMax:      cfg.Engine.CEF.CEFWindowlessFrameRateMax(),
 			Input: cef.RuntimeInputConfig{
 				ScrollWheelMultiplier:              cfg.Engine.CEF.Input.ScrollWheelMultiplier,
-				ScrollTouchpadMultiplier:           cfg.Engine.CEF.Input.ScrollTouchpadMultiplier,
+				ScrollPreciseMultiplier:            cfg.Engine.CEF.Input.ScrollPreciseMultiplier,
 				ScrollHorizontalMultiplier:         cfg.Engine.CEF.Input.ScrollHorizontalMultiplier,
 				ScrollVerticalMultiplier:           cfg.Engine.CEF.Input.ScrollVerticalMultiplier,
 				ScrollMaxDelta:                     cfg.Engine.CEF.Input.ScrollMaxDelta,

--- a/internal/infrastructure/cef/runtime_config.go
+++ b/internal/infrastructure/cef/runtime_config.go
@@ -30,7 +30,7 @@ type RuntimeConfig struct {
 
 type RuntimeInputConfig struct {
 	ScrollWheelMultiplier              float64
-	ScrollTouchpadMultiplier           float64
+	ScrollPreciseMultiplier            float64
 	ScrollHorizontalMultiplier         float64
 	ScrollVerticalMultiplier           float64
 	ScrollMaxDelta                     int32

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -1523,7 +1523,7 @@ func (wv *WebView) handleScrollInputDiagnostic(event cef2gtk.ScrollEvent) cef2gt
 	wv.inputDiagLastLog = now
 	wv.inputDiagMu.Unlock()
 
-	logging.FromContext(wv.ctx).Debug().
+	logging.FromContext(wv.ctx).Trace().
 		Uint64("webview_id", uint64(wv.id)).
 		Int("events", count).
 		Str("phase", fmt.Sprint(event.Phase)).
@@ -1544,20 +1544,22 @@ func (wv *WebView) handleScrollInputDiagnostic(event cef2gtk.ScrollEvent) cef2gt
 }
 
 func (wv *WebView) handleNavigationSwipeAction(action cef2gtk.NavigationSwipeAction) {
-	logging.FromContext(wv.ctx).Debug().
-		Uint64("webview_id", uint64(wv.id)).
-		Str("action", fmt.Sprint(action)).
-		Bool("can_go_back", wv.CanGoBack()).
-		Bool("can_go_forward", wv.CanGoForward()).
-		Msg("cef: touchpad navigation swipe recognized")
+	if wv.ctx != nil {
+		logging.FromContext(wv.ctx).Debug().
+			Uint64("webview_id", uint64(wv.id)).
+			Str("action", fmt.Sprint(action)).
+			Bool("can_go_back", wv.CanGoBack()).
+			Bool("can_go_forward", wv.CanGoForward()).
+			Msg("cef: touchpad navigation swipe recognized")
+	}
 
 	switch action {
 	case cef2gtk.NavigationSwipeBack:
-		if err := wv.GoBack(wv.ctx); err != nil {
+		if err := wv.GoBack(wv.ctx); err != nil && wv.ctx != nil {
 			logging.FromContext(wv.ctx).Warn().Err(err).Msg("touchpad back navigation failed")
 		}
 	case cef2gtk.NavigationSwipeForward:
-		if err := wv.GoForward(wv.ctx); err != nil {
+		if err := wv.GoForward(wv.ctx); err != nil && wv.ctx != nil {
 			logging.FromContext(wv.ctx).Warn().Err(err).Msg("touchpad forward navigation failed")
 		}
 	}

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -1534,6 +1534,8 @@ func (wv *WebView) handleScrollInputDiagnostic(event cef2gtk.ScrollEvent) cef2gt
 		Int64("cef_delta_x_sum", deltaX).
 		Int64("cef_delta_y_sum", deltaY).
 		Bool("nav_enabled", wv.inputConfig.TouchpadNavigationEnabled).
+		Float64("nav_min_delta", wv.inputConfig.TouchpadNavigationMinDelta).
+		Float64("nav_max_vertical_ratio", wv.inputConfig.TouchpadNavigationMaxVerticalRatio).
 		Bool("can_go_back", wv.CanGoBack()).
 		Bool("can_go_forward", wv.CanGoForward()).
 		Msg("cef: touchpad horizontal scroll diagnostic")

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -225,8 +225,16 @@ type WebView struct {
 	windowlessFrameRate int32
 	backgroundColor     uint32
 	inputConfig         RuntimeInputConfig
-	touchpadSwipeDX     float64
-	touchpadSwipeDY     float64
+
+	// Touchpad input diagnostics are debounced to avoid flooding logs while
+	// debugging continuous scroll streams.
+	inputDiagMu        sync.Mutex
+	inputDiagLastLog   time.Time
+	inputDiagEvents    int
+	inputDiagDX        float64
+	inputDiagDY        float64
+	inputDiagDeltaXSum int64
+	inputDiagDeltaYSum int64
 
 	// Audio output factory and active stream.
 	audioOutputFactory port.AudioOutputFactory
@@ -1462,7 +1470,7 @@ func (wv *WebView) bridgeInputOptions() cef2gtk.InputOptions {
 		Scale: 0,
 		Scroll: cef2gtk.ScrollOptions{
 			WheelMultiplier:      wv.inputConfig.ScrollWheelMultiplier,
-			TouchpadMultiplier:   wv.inputConfig.ScrollTouchpadMultiplier,
+			PreciseMultiplier:    wv.inputConfig.ScrollPreciseMultiplier,
 			HorizontalMultiplier: wv.inputConfig.ScrollHorizontalMultiplier,
 			VerticalMultiplier:   wv.inputConfig.ScrollVerticalMultiplier,
 			MaxDelta:             wv.inputConfig.ScrollMaxDelta,
@@ -1470,13 +1478,16 @@ func (wv *WebView) bridgeInputOptions() cef2gtk.InputOptions {
 		OnMiddleClick: func(_, _ float64) bool {
 			return wv.handleMiddleClickFromBridge()
 		},
-		OnTouchpadSwipe: func(event cef2gtk.TouchpadSwipeEvent) cef2gtk.TouchpadSwipeDecision {
-			if wv.handleTouchpadNavigationSwipe(event) {
-				return cef2gtk.TouchpadSwipeConsume
-			}
-			return cef2gtk.TouchpadSwipePassthrough
+		OnScroll: wv.handleScrollInputDiagnostic,
+		NavigationSwipe: cef2gtk.NavigationSwipeOptions{
+			Enabled:          wv.inputConfig.TouchpadNavigationEnabled,
+			MinDelta:         wv.inputConfig.TouchpadNavigationMinDelta,
+			MaxVerticalRatio: wv.inputConfig.TouchpadNavigationMaxVerticalRatio,
 		},
-		SelectionText: wv.selectedTextSnapshot,
+		CanNavigateBack:    wv.CanGoBack,
+		CanNavigateForward: wv.CanGoForward,
+		OnNavigateSwipe:    wv.handleNavigationSwipeAction,
+		SelectionText:      wv.selectedTextSnapshot,
 		OnClipboardShortcut: func(action, text string) {
 			if wv.engine != nil {
 				wv.engine.handleExplicitClipboardBridgeText(wv.id, action, text)
@@ -1485,95 +1496,69 @@ func (wv *WebView) bridgeInputOptions() cef2gtk.InputOptions {
 	}
 }
 
-type touchpadNavigationAction int
-
-const (
-	touchpadNavigationNone touchpadNavigationAction = iota
-	touchpadNavigationBack
-	touchpadNavigationForward
-)
-
-func (wv *WebView) handleTouchpadNavigationSwipe(event cef2gtk.TouchpadSwipeEvent) bool {
-	cfg := wv.inputConfig
-	if !cfg.TouchpadNavigationEnabled || event.Fingers != 2 {
-		wv.resetTouchpadNavigationSwipe()
-		return false
+func (wv *WebView) handleScrollInputDiagnostic(event cef2gtk.ScrollEvent) cef2gtk.ScrollDecision {
+	if event.Phase != cef2gtk.ScrollPhaseUpdate || math.Abs(event.DX) == 0 {
+		return cef2gtk.ScrollForwardToCEF
 	}
 
-	switch event.Phase {
-	case cef2gtk.TouchpadGesturePhaseBegin:
-		wv.resetTouchpadNavigationSwipe()
-		return false
-	case cef2gtk.TouchpadGesturePhaseUpdate:
-		wv.accumulateTouchpadNavigationSwipe(event.DX, event.DY)
-		return false
-	case cef2gtk.TouchpadGesturePhaseEnd:
-		dx, dy := wv.finishTouchpadNavigationSwipe()
-		switch chooseTouchpadNavigationAction(cfg, dx, dy, wv.CanGoBack(), wv.CanGoForward()) {
-		case touchpadNavigationBack:
-			if err := wv.GoBack(wv.ctx); err != nil {
-				logging.FromContext(wv.ctx).Warn().Err(err).Msg("touchpad back navigation failed")
-				return false
-			}
-			return true
-		case touchpadNavigationForward:
-			if err := wv.GoForward(wv.ctx); err != nil {
-				logging.FromContext(wv.ctx).Warn().Err(err).Msg("touchpad forward navigation failed")
-				return false
-			}
-			return true
-		default:
-			return false
+	wv.inputDiagMu.Lock()
+	wv.inputDiagEvents++
+	wv.inputDiagDX += event.DX
+	wv.inputDiagDY += event.DY
+	wv.inputDiagDeltaXSum += int64(event.DeltaX)
+	wv.inputDiagDeltaYSum += int64(event.DeltaY)
+	now := time.Now()
+	if !wv.inputDiagLastLog.IsZero() && now.Sub(wv.inputDiagLastLog) < time.Second {
+		wv.inputDiagMu.Unlock()
+		return cef2gtk.ScrollForwardToCEF
+	}
+	count := wv.inputDiagEvents
+	dx, dy := wv.inputDiagDX, wv.inputDiagDY
+	deltaX, deltaY := wv.inputDiagDeltaXSum, wv.inputDiagDeltaYSum
+	wv.inputDiagEvents = 0
+	wv.inputDiagDX = 0
+	wv.inputDiagDY = 0
+	wv.inputDiagDeltaXSum = 0
+	wv.inputDiagDeltaYSum = 0
+	wv.inputDiagLastLog = now
+	wv.inputDiagMu.Unlock()
+
+	logging.FromContext(wv.ctx).Debug().
+		Uint64("webview_id", uint64(wv.id)).
+		Int("events", count).
+		Str("phase", fmt.Sprint(event.Phase)).
+		Str("unit", fmt.Sprint(event.Unit)).
+		Bool("unit_known", event.UnitKnown).
+		Float64("dx_sum", dx).
+		Float64("dy_sum", dy).
+		Int64("cef_delta_x_sum", deltaX).
+		Int64("cef_delta_y_sum", deltaY).
+		Bool("nav_enabled", wv.inputConfig.TouchpadNavigationEnabled).
+		Bool("can_go_back", wv.CanGoBack()).
+		Bool("can_go_forward", wv.CanGoForward()).
+		Msg("cef: touchpad horizontal scroll diagnostic")
+
+	return cef2gtk.ScrollForwardToCEF
+}
+
+func (wv *WebView) handleNavigationSwipeAction(action cef2gtk.NavigationSwipeAction) {
+	logging.FromContext(wv.ctx).Debug().
+		Uint64("webview_id", uint64(wv.id)).
+		Str("action", fmt.Sprint(action)).
+		Bool("can_go_back", wv.CanGoBack()).
+		Bool("can_go_forward", wv.CanGoForward()).
+		Msg("cef: touchpad navigation swipe recognized")
+
+	switch action {
+	case cef2gtk.NavigationSwipeBack:
+		if err := wv.GoBack(wv.ctx); err != nil {
+			logging.FromContext(wv.ctx).Warn().Err(err).Msg("touchpad back navigation failed")
 		}
-	case cef2gtk.TouchpadGesturePhaseCancel:
-		wv.resetTouchpadNavigationSwipe()
-		return false
-	default:
-		return false
+	case cef2gtk.NavigationSwipeForward:
+		if err := wv.GoForward(wv.ctx); err != nil {
+			logging.FromContext(wv.ctx).Warn().Err(err).Msg("touchpad forward navigation failed")
+		}
 	}
-}
-
-func (wv *WebView) resetTouchpadNavigationSwipe() {
-	wv.mu.Lock()
-	wv.touchpadSwipeDX = 0
-	wv.touchpadSwipeDY = 0
-	wv.mu.Unlock()
-}
-
-func (wv *WebView) accumulateTouchpadNavigationSwipe(dx, dy float64) {
-	wv.mu.Lock()
-	wv.touchpadSwipeDX += dx
-	wv.touchpadSwipeDY += dy
-	wv.mu.Unlock()
-}
-
-func (wv *WebView) finishTouchpadNavigationSwipe() (float64, float64) {
-	wv.mu.Lock()
-	defer wv.mu.Unlock()
-	dx, dy := wv.touchpadSwipeDX, wv.touchpadSwipeDY
-	wv.touchpadSwipeDX = 0
-	wv.touchpadSwipeDY = 0
-	return dx, dy
-}
-
-func chooseTouchpadNavigationAction(cfg RuntimeInputConfig, dx, dy float64, canGoBack, canGoForward bool) touchpadNavigationAction {
-	if !cfg.TouchpadNavigationEnabled {
-		return touchpadNavigationNone
-	}
-	absDX, absDY := math.Abs(dx), math.Abs(dy)
-	if absDX < cfg.TouchpadNavigationMinDelta {
-		return touchpadNavigationNone
-	}
-	if absDY > absDX*cfg.TouchpadNavigationMaxVerticalRatio {
-		return touchpadNavigationNone
-	}
-	if dx > 0 && canGoBack {
-		return touchpadNavigationBack
-	}
-	if dx < 0 && canGoForward {
-		return touchpadNavigationForward
-	}
-	return touchpadNavigationNone
 }
 
 func (wv *WebView) viewBridgeScale() float64 {

--- a/internal/infrastructure/cef/webview_input_test.go
+++ b/internal/infrastructure/cef/webview_input_test.go
@@ -13,7 +13,7 @@ func TestWebViewBridgeInputOptions_LeavesTargetSelectionToAdapter(t *testing.T) 
 		nativeWidget: nativeWidget,
 		inputConfig: RuntimeInputConfig{
 			ScrollWheelMultiplier:              1.25,
-			ScrollTouchpadMultiplier:           0.35,
+			ScrollPreciseMultiplier:            2.5,
 			ScrollHorizontalMultiplier:         0.75,
 			ScrollVerticalMultiplier:           1.5,
 			ScrollMaxDelta:                     120,
@@ -27,50 +27,19 @@ func TestWebViewBridgeInputOptions_LeavesTargetSelectionToAdapter(t *testing.T) 
 
 	require.Zero(t, opts.Scale)
 	require.InDelta(t, 1.25, opts.Scroll.WheelMultiplier, 0.001)
-	require.InDelta(t, 0.35, opts.Scroll.TouchpadMultiplier, 0.001)
+	require.InDelta(t, 2.5, opts.Scroll.PreciseMultiplier, 0.001)
 	require.InDelta(t, 0.75, opts.Scroll.HorizontalMultiplier, 0.001)
 	require.InDelta(t, 1.5, opts.Scroll.VerticalMultiplier, 0.001)
 	require.Equal(t, int32(120), opts.Scroll.MaxDelta)
 	require.NotNil(t, opts.OnMiddleClick)
-	require.NotNil(t, opts.OnTouchpadSwipe)
+	require.NotNil(t, opts.OnScroll)
+	require.True(t, opts.NavigationSwipe.Enabled)
+	require.InDelta(t, 80.0, opts.NavigationSwipe.MinDelta, 0.001)
+	require.InDelta(t, 0.5, opts.NavigationSwipe.MaxVerticalRatio, 0.001)
+	require.NotNil(t, opts.CanNavigateBack)
+	require.NotNil(t, opts.CanNavigateForward)
+	require.NotNil(t, opts.OnNavigateSwipe)
 	require.NotNil(t, opts.SelectionText)
 	require.NotNil(t, opts.OnClipboardShortcut)
 	require.Same(t, nativeWidget, wv.nativeWidget)
-}
-
-func TestChooseTouchpadNavigationAction(t *testing.T) {
-	cfg := RuntimeInputConfig{
-		TouchpadNavigationEnabled:          true,
-		TouchpadNavigationMinDelta:         80,
-		TouchpadNavigationMaxVerticalRatio: 0.5,
-	}
-
-	tests := []struct {
-		name         string
-		cfg          *RuntimeInputConfig
-		dx, dy       float64
-		canGoBack    bool
-		canGoForward bool
-		want         touchpadNavigationAction
-	}{
-		{name: "right swipe goes back", dx: 100, dy: 10, canGoBack: true, want: touchpadNavigationBack},
-		{name: "left swipe goes forward", dx: -100, dy: 10, canGoForward: true, want: touchpadNavigationForward},
-		{name: "below threshold ignored", dx: 40, dy: 0, canGoBack: true, want: touchpadNavigationNone},
-		{name: "disabled ignored", cfg: &RuntimeInputConfig{TouchpadNavigationEnabled: false, TouchpadNavigationMinDelta: 80, TouchpadNavigationMaxVerticalRatio: 0.5}, dx: 100, dy: 0, canGoBack: true, want: touchpadNavigationNone},
-		{name: "exact threshold goes back", dx: 80, dy: 0, canGoBack: true, want: touchpadNavigationBack},
-		{name: "vertical diagonal ignored", dx: 100, dy: 80, canGoBack: true, want: touchpadNavigationNone},
-		{name: "unavailable back ignored", dx: 100, dy: 0, canGoBack: false, want: touchpadNavigationNone},
-		{name: "unavailable forward ignored", dx: -100, dy: 0, canGoForward: false, want: touchpadNavigationNone},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testCfg := cfg
-			if tt.cfg != nil {
-				testCfg = *tt.cfg
-			}
-			got := chooseTouchpadNavigationAction(testCfg, tt.dx, tt.dy, tt.canGoBack, tt.canGoForward)
-			require.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -75,7 +75,7 @@ const (
 	defaultCEFScrollPreciseMultiplier = 2.5
 	defaultCEFScrollMaxDelta          = 0
 	defaultCEFTouchpadNavigation      = true
-	defaultCEFTouchpadNavigationDelta = 180.0
+	defaultCEFTouchpadNavigationDelta = 200.0
 	defaultCEFTouchpadNavigationRatio = 0.5
 
 	// Skia threading defaults (0 = unset, -1 = unset for GPU threads)

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -75,7 +75,7 @@ const (
 	defaultCEFScrollPreciseMultiplier = 2.5
 	defaultCEFScrollMaxDelta          = 0
 	defaultCEFTouchpadNavigation      = true
-	defaultCEFTouchpadNavigationDelta = 15.0
+	defaultCEFTouchpadNavigationDelta = 180.0
 	defaultCEFTouchpadNavigationRatio = 0.5
 
 	// Skia threading defaults (0 = unset, -1 = unset for GPU threads)

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -67,16 +67,16 @@ const (
 	defaultUIScale            = 1.0 // UI scale multiplier (1.0 = 100%, 1.2 = 120%)
 
 	// Performance defaults
-	defaultZoomCacheSize               = 256 // domains to cache (~20KB memory)
-	defaultWebViewPoolPrewarmCount     = 4   // WebViews to pre-create at startup
-	defaultCEFWindowlessFrameRate      = 60  // static OSR frame rate when adaptive CEF pacing is disabled
-	defaultCEFWindowlessFrameRateMax   = 240 // adaptive OSR frame-rate hard cap
-	defaultCEFScrollMultiplier         = 1.0
-	defaultCEFScrollTouchpadMultiplier = 0.35
-	defaultCEFScrollMaxDelta           = 0
-	defaultCEFTouchpadNavigation       = true
-	defaultCEFTouchpadNavigationDelta  = 80.0
-	defaultCEFTouchpadNavigationRatio  = 0.5
+	defaultZoomCacheSize              = 256 // domains to cache (~20KB memory)
+	defaultWebViewPoolPrewarmCount    = 4   // WebViews to pre-create at startup
+	defaultCEFWindowlessFrameRate     = 60  // static OSR frame rate when adaptive CEF pacing is disabled
+	defaultCEFWindowlessFrameRateMax  = 240 // adaptive OSR frame-rate hard cap
+	defaultCEFScrollMultiplier        = 1.0
+	defaultCEFScrollPreciseMultiplier = 2.5
+	defaultCEFScrollMaxDelta          = 0
+	defaultCEFTouchpadNavigation      = true
+	defaultCEFTouchpadNavigationDelta = 15.0
+	defaultCEFTouchpadNavigationRatio = 0.5
 
 	// Skia threading defaults (0 = unset, -1 = unset for GPU threads)
 	defaultSkiaCPUPaintingThreads = 0
@@ -186,7 +186,7 @@ func DefaultConfig() *Config {
 				EnableAudioHandler:          true,
 				Input: CEFInputConfig{
 					ScrollWheelMultiplier:              defaultCEFScrollMultiplier,
-					ScrollTouchpadMultiplier:           defaultCEFScrollTouchpadMultiplier,
+					ScrollPreciseMultiplier:            defaultCEFScrollPreciseMultiplier,
 					ScrollHorizontalMultiplier:         defaultCEFScrollMultiplier,
 					ScrollVerticalMultiplier:           defaultCEFScrollMultiplier,
 					ScrollMaxDelta:                     defaultCEFScrollMaxDelta,

--- a/internal/infrastructure/config/defaults_test.go
+++ b/internal/infrastructure/config/defaults_test.go
@@ -26,7 +26,7 @@ func TestDefaultConfig_CoreDefaults(t *testing.T) {
 	assert.True(t, cfg.Engine.CEF.EnableAudioHandler)
 	assert.False(t, cfg.Engine.CEF.TraceHandlers)
 	assert.InDelta(t, defaultCEFScrollMultiplier, cfg.Engine.CEF.Input.ScrollWheelMultiplier, 0.001)
-	assert.InDelta(t, defaultCEFScrollTouchpadMultiplier, cfg.Engine.CEF.Input.ScrollTouchpadMultiplier, 0.001)
+	assert.InDelta(t, defaultCEFScrollPreciseMultiplier, cfg.Engine.CEF.Input.ScrollPreciseMultiplier, 0.001)
 	assert.InDelta(t, defaultCEFScrollMultiplier, cfg.Engine.CEF.Input.ScrollHorizontalMultiplier, 0.001)
 	assert.InDelta(t, defaultCEFScrollMultiplier, cfg.Engine.CEF.Input.ScrollVerticalMultiplier, 0.001)
 	assert.Equal(t, int32(defaultCEFScrollMaxDelta), cfg.Engine.CEF.Input.ScrollMaxDelta)

--- a/internal/infrastructure/config/engine.go
+++ b/internal/infrastructure/config/engine.go
@@ -121,7 +121,7 @@ type CEFEngineConfig struct {
 // CEFInputConfig holds CEF-specific input translation options.
 type CEFInputConfig struct {
 	ScrollWheelMultiplier              float64 `mapstructure:"scroll_wheel_multiplier" toml:"scroll_wheel_multiplier" yaml:"scroll_wheel_multiplier"`                                              //nolint:lll // struct tags exceed lll limit
-	ScrollTouchpadMultiplier           float64 `mapstructure:"scroll_touchpad_multiplier" toml:"scroll_touchpad_multiplier" yaml:"scroll_touchpad_multiplier"`                                     //nolint:lll // struct tags exceed lll limit
+	ScrollPreciseMultiplier            float64 `mapstructure:"scroll_precise_multiplier" toml:"scroll_precise_multiplier" yaml:"scroll_precise_multiplier"`                                        //nolint:lll // struct tags exceed lll limit
 	ScrollHorizontalMultiplier         float64 `mapstructure:"scroll_horizontal_multiplier" toml:"scroll_horizontal_multiplier" yaml:"scroll_horizontal_multiplier"`                               //nolint:lll // struct tags exceed lll limit
 	ScrollVerticalMultiplier           float64 `mapstructure:"scroll_vertical_multiplier" toml:"scroll_vertical_multiplier" yaml:"scroll_vertical_multiplier"`                                     //nolint:lll // struct tags exceed lll limit
 	ScrollMaxDelta                     int32   `mapstructure:"scroll_max_delta" toml:"scroll_max_delta" yaml:"scroll_max_delta"`                                                                   //nolint:lll // struct tags exceed lll limit

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -783,7 +783,7 @@ func (m *Manager) setEngineDefaults(defaults *Config) {
 
 func (m *Manager) setCEFInputDefaults(input CEFInputConfig) {
 	m.viper.SetDefault("engine.cef.input.scroll_wheel_multiplier", input.ScrollWheelMultiplier)
-	m.viper.SetDefault("engine.cef.input.scroll_touchpad_multiplier", input.ScrollTouchpadMultiplier)
+	m.viper.SetDefault("engine.cef.input.scroll_precise_multiplier", input.ScrollPreciseMultiplier)
 	m.viper.SetDefault("engine.cef.input.scroll_horizontal_multiplier", input.ScrollHorizontalMultiplier)
 	m.viper.SetDefault("engine.cef.input.scroll_vertical_multiplier", input.ScrollVerticalMultiplier)
 	m.viper.SetDefault("engine.cef.input.scroll_max_delta", input.ScrollMaxDelta)

--- a/internal/infrastructure/config/loader_test.go
+++ b/internal/infrastructure/config/loader_test.go
@@ -18,7 +18,7 @@ func TestSetEngineDefaults(t *testing.T) {
 	assert.Equal(t, 4, mgr.viper.GetInt("engine.pool_prewarm_count"))
 	assert.Equal(t, 256, mgr.viper.GetInt("engine.zoom_cache_size"))
 	assert.InDelta(t, defaultCEFScrollMultiplier, mgr.viper.GetFloat64("engine.cef.input.scroll_wheel_multiplier"), 0.001)
-	assert.InDelta(t, defaultCEFScrollTouchpadMultiplier, mgr.viper.GetFloat64("engine.cef.input.scroll_touchpad_multiplier"), 0.001)
+	assert.InDelta(t, defaultCEFScrollPreciseMultiplier, mgr.viper.GetFloat64("engine.cef.input.scroll_precise_multiplier"), 0.001)
 	assert.InDelta(t, defaultCEFScrollMultiplier, mgr.viper.GetFloat64("engine.cef.input.scroll_horizontal_multiplier"), 0.001)
 	assert.InDelta(t, defaultCEFScrollMultiplier, mgr.viper.GetFloat64("engine.cef.input.scroll_vertical_multiplier"), 0.001)
 	assert.Equal(t, defaultCEFScrollMaxDelta, mgr.viper.GetInt("engine.cef.input.scroll_max_delta"))

--- a/internal/infrastructure/config/schema_provider.go
+++ b/internal/infrastructure/config/schema_provider.go
@@ -971,10 +971,10 @@ func (*SchemaProvider) getPerformanceKeys(defaults *Config) []entity.ConfigKeyIn
 			Section:     SectionPerformance,
 		},
 		{
-			Key:         "engine.cef.input.scroll_touchpad_multiplier",
+			Key:         "engine.cef.input.scroll_precise_multiplier",
 			Type:        "float64",
-			Default:     fmt.Sprintf("%.2f", defaults.Engine.CEF.Input.ScrollTouchpadMultiplier),
-			Description: "CEF touchpad/smooth scroll delta multiplier",
+			Default:     fmt.Sprintf("%.2f", defaults.Engine.CEF.Input.ScrollPreciseMultiplier),
+			Description: "CEF precise/surface scroll delta multiplier",
 			Range:       ">0",
 			Section:     SectionPerformance,
 		},

--- a/internal/infrastructure/config/validation.go
+++ b/internal/infrastructure/config/validation.go
@@ -367,8 +367,8 @@ func validateCEF(config *Config) []string {
 	if invalidPositiveFloat(input.ScrollWheelMultiplier) {
 		validationErrors = append(validationErrors, "engine.cef.input.scroll_wheel_multiplier must be > 0")
 	}
-	if invalidPositiveFloat(input.ScrollTouchpadMultiplier) {
-		validationErrors = append(validationErrors, "engine.cef.input.scroll_touchpad_multiplier must be > 0")
+	if invalidPositiveFloat(input.ScrollPreciseMultiplier) {
+		validationErrors = append(validationErrors, "engine.cef.input.scroll_precise_multiplier must be > 0")
 	}
 	if invalidPositiveFloat(input.ScrollHorizontalMultiplier) {
 		validationErrors = append(validationErrors, "engine.cef.input.scroll_horizontal_multiplier must be > 0")

--- a/internal/infrastructure/config/validation_test.go
+++ b/internal/infrastructure/config/validation_test.go
@@ -81,12 +81,12 @@ func TestValidateConfig_CEFConfig(t *testing.T) {
 			wantText: "engine.cef.input.scroll_wheel_multiplier",
 		},
 		{
-			name: "negative touchpad multiplier",
+			name: "negative precise multiplier",
 			mutate: func(cfg *Config) {
-				cfg.Engine.CEF.Input.ScrollTouchpadMultiplier = -0.1
+				cfg.Engine.CEF.Input.ScrollPreciseMultiplier = -0.1
 			},
 			wantErr:  true,
-			wantText: "engine.cef.input.scroll_touchpad_multiplier",
+			wantText: "engine.cef.input.scroll_precise_multiplier",
 		},
 		{
 			name: "zero horizontal multiplier",


### PR DESCRIPTION
## Summary
- wire CEF input configuration through purego-cef2gtk touchpad scroll/navigation options
- enable WebKit-style two-finger back/forward navigation for CEF webviews
- tune navigation threshold to WebKit-style raw GTK surface-unit commit distance and keep trace-level diagnostics for future investigation
- remove the local purego-cef2gtk replace and depend on the PR branch pseudo-version

## Dependency
- Depends on purego-cef2gtk PR #14: https://github.com/bnema/purego-cef2gtk/pull/14

## Verification
- go test ./internal/infrastructure/config ./internal/infrastructure/cef
- go test ./...
- CodeRabbit CLI pass on purego-cef2gtk: 0 findings
- CodeRabbit CLI pass on dumber: 2 minor findings addressed

## Manual testing
- GLib scroll spam resolved
- vertical touchpad scrolling remains usable
- horizontal two-finger back navigation works
- accidental small horizontal drift no longer triggers navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guides and reference docs describing touchpad gesture navigation units and how to override defaults.

* **New Features**
  * Added engine.cef.input.scroll_precise_multiplier to tune scroll precision.

* **Changes**
  * Increased default touchpad gesture sensitivity (engine.cef.input.touchpad_navigation_min_delta) from 80.0 to 200.0.
  * Replaced engine.cef.input.scroll_touchpad_multiplier with the new precise multiplier setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->