### PR TITLE
feat(theme): follow Noctalia external palettes

### DIFF
--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -249,6 +249,7 @@ func runGUI(cfg *config.Config) int {
 
 	ctx, browserSession, sessionCleanup := initBrowserSession(ctx, cfg, repos, bootstrapLog)
 	defer sessionCleanup()
+	bootstrap.LogResolvedTheme(ctx, initResult.ResolvedTheme)
 	timer.Mark("session")
 
 	log := logging.FromContext(ctx)
@@ -326,6 +327,9 @@ func runStandaloneOmnibox() int {
 		cfg,
 		initResult.RuntimeProfile,
 		initResult.ThemeManager,
+		initResult.ResolveThemeUC,
+		initResult.ExternalThemeSource,
+		initResult.ExternalThemeWatcher,
 		initResult.ColorResolver,
 		initResult.AdwaitaDetector,
 		nil,
@@ -471,7 +475,8 @@ func buildAndConfigureApp(
 ) (*ui.App, error) {
 	uiDeps, err := buildUIDependencies(
 		ctx, cfg, initResult.RuntimeProfile, initResult.ThemeManager,
-		initResult.ColorResolver, initResult.AdwaitaDetector,
+		initResult.ResolveThemeUC, initResult.ExternalThemeSource,
+		initResult.ExternalThemeWatcher, initResult.ColorResolver, initResult.AdwaitaDetector,
 		engine, repos, useCases, idleInhibitor, browserSession.Session.ID, browserSession.CrashReports(),
 	)
 	if err != nil {
@@ -506,11 +511,12 @@ func initStackAndRepos(
 	if needsEagerDB {
 		// Parallel phase 2: Database + engine initialize concurrently
 		dbEngine, err := bootstrap.RunParallelDBEngine(bootstrap.ParallelDBEngineInput{
-			Ctx:            ctx,
-			Config:         cfg,
-			RuntimeProfile: initResult.RuntimeProfile,
-			ThemeManager:   initResult.ThemeManager,
-			ColorResolver:  initResult.ColorResolver,
+			Ctx:                 ctx,
+			Config:              cfg,
+			RuntimeProfile:      initResult.RuntimeProfile,
+			ThemeManager:        initResult.ThemeManager,
+			ExternalThemeSource: initResult.ExternalThemeSource,
+			ColorResolver:       initResult.ColorResolver,
 		})
 		if err != nil {
 			return nil, nil, nil, err
@@ -520,12 +526,13 @@ func initStackAndRepos(
 
 	log := logging.FromContext(ctx)
 	engine, err := bootstrap.BuildEngine(bootstrap.EngineInput{
-		Ctx:            ctx,
-		Config:         cfg,
-		RuntimeProfile: initResult.RuntimeProfile,
-		ThemeManager:   initResult.ThemeManager,
-		ColorResolver:  initResult.ColorResolver,
-		Logger:         *log,
+		Ctx:                 ctx,
+		Config:              cfg,
+		RuntimeProfile:      initResult.RuntimeProfile,
+		ThemeManager:        initResult.ThemeManager,
+		ExternalThemeSource: initResult.ExternalThemeSource,
+		ColorResolver:       initResult.ColorResolver,
+		Logger:              *log,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -834,6 +841,9 @@ func buildUIDependencies(
 	cfg *config.Config,
 	runtimeProfile runtimeprofile.Profile,
 	themeManager *theme.Manager,
+	resolveThemeUC *usecase.ResolveThemeUseCase,
+	externalThemeSource port.ConfigurableExternalThemeSource,
+	externalThemeWatcher port.ExternalThemeWatcher,
 	colorResolver port.ColorSchemeResolver,
 	adwaitaDetector port.ToolkitAvailabilityNotifier,
 	engine port.Engine,
@@ -857,14 +867,17 @@ func buildUIDependencies(
 	browserLauncher := desktop.NewBrowserLauncher(browserLaunchRelay)
 
 	uiDeps := &ui.Dependencies{
-		Ctx:                 ctx,
-		Config:              cfg,
-		InitialURL:          initialURL,
-		RestoreSessionID:    restoreSessionID,
-		StartupCrashReports: startupCrashReports,
-		Theme:               themeManager,
-		ColorResolver:       colorResolver,
-		AdwaitaDetector:     adwaitaDetector,
+		Ctx:                  ctx,
+		Config:               cfg,
+		InitialURL:           initialURL,
+		RestoreSessionID:     restoreSessionID,
+		StartupCrashReports:  startupCrashReports,
+		Theme:                themeManager,
+		ResolveThemeUC:       resolveThemeUC,
+		ExternalThemeSource:  externalThemeSource,
+		ExternalThemeWatcher: externalThemeWatcher,
+		ColorResolver:        colorResolver,
+		AdwaitaDetector:      adwaitaDetector,
 		XDG: xdg.New(
 			runtimeProfile.Mode == runtimeprofile.ModeDev,
 			bootstrap.ResolveXDGRuntimeDir(runtimeProfile),

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -141,6 +141,10 @@ auto_open_on_new_pane = false
 | `appearance.monospace_font` | string | `"Fira Code"` | Monospace font |
 | `appearance.default_font_size` | int | `16` | Font size in points |
 | `appearance.color_scheme` | string | `"default"` | `prefer-dark`, `prefer-light`, `default` |
+| `appearance.external_theme.enabled` | bool | `false` | Enable an external palette source |
+| `appearance.external_theme.provider` | string | `"noctalia"` | External provider. Only `noctalia` is supported |
+| `appearance.external_theme.format` | string | `"colors-json"` | External file format: `colors-json` or `dumber-json` |
+| `appearance.external_theme.path` | string | `$XDG_CONFIG_HOME/noctalia/colors.json` | Path to the external theme JSON file |
 
 ### Color Palettes
 
@@ -167,6 +171,70 @@ muted = "#848484"
 accent = "#a8a8a8"
 border = "#363636"
 ```
+
+### External Theme: Noctalia
+
+Dumber can follow Noctalia by reading the native Noctalia palette file directly. No user template is required for the default integration.
+
+```toml
+[appearance.external_theme]
+enabled = true
+provider = "noctalia"
+format = "colors-json" # default
+# Optional. Defaults to $XDG_CONFIG_HOME/noctalia/colors.json.
+path = "~/.config/noctalia/colors.json"
+```
+
+The external file overrides palette colors only. Fonts, UI scale, pane-mode colors, and other appearance settings still come from Dumber config.
+
+#### `colors-json` contract
+
+`colors-json` reads Noctalia's active `colors.json` palette. Example file: [`docs/examples/noctalia-colors.json`](../examples/noctalia-colors.json).
+
+Dumber maps Noctalia roles like this:
+
+| Noctalia key | Dumber palette field |
+|--------------|----------------------|
+| `mShadow` | `background` when present, otherwise `mSurface` |
+| `mSurface` | `surface` |
+| `mHover` | `surface_variant` when present, otherwise `mSurfaceVariant` |
+| `mOnSurface` | `text` |
+| `mOnSurfaceVariant` | `muted` |
+| `mPrimary` | `accent` |
+| `mOutline` | `border` |
+
+Every mapped value must be a CSS-safe 6-digit hex color such as `#AABBCC`. `mShadow` and `mHover` are optional nuance roles; when they are present they are validated and used to preserve Dumber's background/surface/input contrast. Because Noctalia's native file contains the active palette only, Dumber applies that mapped palette to both resolved light and dark palettes so the app follows the file immediately.
+
+#### Advanced: `dumber-json` user template
+
+`dumber-json` remains supported for an explicit Dumber-specific Noctalia user template:
+
+```toml
+[appearance.external_theme]
+enabled = true
+provider = "noctalia"
+format = "dumber-json"
+# Optional for dumber-json. Defaults to $XDG_CONFIG_HOME/dumber/noctalia-theme.json.
+path = "~/.config/dumber/noctalia-theme.json"
+```
+
+The file must be JSON with root `light` and `dark` objects. Optional `source`, `name`, and `mode` metadata fields are accepted; `name` or `source` is used only as source metadata. Dumber chooses the active palette from `appearance.color_scheme` and the system color-scheme preference.
+
+Supported palette fields are:
+
+- `background`
+- `surface`
+- `surface_variant`
+- `text`
+- `muted`
+- `accent`
+- `border`
+
+Each non-empty palette value must be a CSS-safe 6-digit hex color such as `#AABBCC`. Empty or omitted palette fields inherit from the configured Dumber palette for that mode.
+
+Example rendered file: [`docs/examples/noctalia-dumber-theme.json`](../examples/noctalia-dumber-theme.json). Example template: [`docs/examples/noctalia-dumber-theme.template.json`](../examples/noctalia-dumber-theme.template.json).
+
+When Noctalia rewrites the watched file, Dumber reapplies the same resolved theme path used by config reloads. A malformed or temporarily missing file keeps the last valid external palette when one exists; disabling `appearance.external_theme.enabled` clears that last-good external palette and returns to Dumber's configured palettes.
 
 ## Debug Options
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -144,7 +144,7 @@ auto_open_on_new_pane = false
 | `appearance.external_theme.enabled` | bool | `false` | Enable an external palette source |
 | `appearance.external_theme.provider` | string | `"noctalia"` | External provider. Only `noctalia` is supported |
 | `appearance.external_theme.format` | string | `"colors-json"` | External file format: `colors-json` or `dumber-json` |
-| `appearance.external_theme.path` | string | `$XDG_CONFIG_HOME/noctalia/colors.json` | Path to the external theme JSON file |
+| `appearance.external_theme.path` | string | `$XDG_CONFIG_HOME/noctalia/colors.json` for `colors-json`; built-in dumber-json template path for `dumber-json` | Path to the external theme JSON file |
 
 ### Color Palettes
 
@@ -174,7 +174,7 @@ border = "#363636"
 
 ### External Theme: Noctalia
 
-Dumber can follow Noctalia by reading the native Noctalia palette file directly. No user template is required for the default integration.
+Dumber can integrate with Noctalia by reading the native Noctalia palette file directly. No user template is required for the default integration.
 
 ```toml
 [appearance.external_theme]
@@ -203,7 +203,11 @@ Dumber maps Noctalia roles like this:
 | `mPrimary` | `accent` |
 | `mOutline` | `border` |
 
-Every mapped value must be a CSS-safe 6-digit hex color such as `#AABBCC`. `mShadow` and `mHover` are optional nuance roles; when they are present they are validated and used to preserve Dumber's background/surface/input contrast. Because Noctalia's native file contains the active palette only, Dumber applies that mapped palette to both resolved light and dark palettes so the app follows the file immediately.
+Every mapped value must be a CSS-safe 6-digit hex color such as `#aabbcc`.
+
+`mShadow` and `mHover` are optional nuance roles. When present, they are validated and used to preserve Dumber's background/surface/input contrast.
+
+Because Noctalia's native file contains the active palette only, Dumber applies that mapped palette to both resolved light and dark palettes so the app follows the file immediately.
 
 #### Advanced: `dumber-json` user template
 

--- a/docs/examples/noctalia-colors.json
+++ b/docs/examples/noctalia-colors.json
@@ -1,0 +1,18 @@
+{
+  "mError": "#ff8080",
+  "mHover": "#282828",
+  "mOnError": "#000000",
+  "mOnHover": "#ffffff",
+  "mOnPrimary": "#000000",
+  "mOnSecondary": "#000000",
+  "mOnSurface": "#ffffff",
+  "mOnSurfaceVariant": "#a0a0a0",
+  "mOnTertiary": "#000000",
+  "mOutline": "#505050",
+  "mPrimary": "#ffc799",
+  "mSecondary": "#99ffe4",
+  "mShadow": "#000000",
+  "mSurface": "#0c0c0c",
+  "mSurfaceVariant": "#1c1c1c",
+  "mTertiary": "#fbadff"
+}

--- a/docs/examples/noctalia-dumber-theme.json
+++ b/docs/examples/noctalia-dumber-theme.json
@@ -1,0 +1,22 @@
+{
+  "source": "noctalia-user-template",
+  "mode": "dark",
+  "light": {
+    "background": "#fbf8ff",
+    "surface": "#f4eff7",
+    "surface_variant": "#e7e0ec",
+    "text": "#1d1b20",
+    "muted": "#49454f",
+    "accent": "#6750a4",
+    "border": "#79747e"
+  },
+  "dark": {
+    "background": "#141218",
+    "surface": "#211f26",
+    "surface_variant": "#49454f",
+    "text": "#e6e0e9",
+    "muted": "#cac4d0",
+    "accent": "#d0bcff",
+    "border": "#938f99"
+  }
+}

--- a/docs/examples/noctalia-dumber-theme.template.json
+++ b/docs/examples/noctalia-dumber-theme.template.json
@@ -1,0 +1,22 @@
+{
+  "source": "noctalia-user-template",
+  "mode": "{{mode}}",
+  "light": {
+    "background": "{{colors.background.light.hex}}",
+    "surface": "{{colors.surface.light.hex}}",
+    "surface_variant": "{{colors.surface_variant.light.hex}}",
+    "text": "{{colors.on_surface.light.hex}}",
+    "muted": "{{colors.on_surface_variant.light.hex}}",
+    "accent": "{{colors.primary.light.hex}}",
+    "border": "{{colors.outline.light.hex}}"
+  },
+  "dark": {
+    "background": "{{colors.background.dark.hex}}",
+    "surface": "{{colors.surface.dark.hex}}",
+    "surface_variant": "{{colors.surface_variant.dark.hex}}",
+    "text": "{{colors.on_surface.dark.hex}}",
+    "muted": "{{colors.on_surface_variant.dark.hex}}",
+    "accent": "{{colors.primary.dark.hex}}",
+    "border": "{{colors.outline.dark.hex}}"
+  }
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,7 +36,7 @@
 | `appearance.external_theme.enabled` | bool | `false` | |
 | `appearance.external_theme.provider` | string | `noctalia` | `noctalia` |
 | `appearance.external_theme.format` | string | `colors-json` | `colors-json`, `dumber-json` |
-| `appearance.external_theme.path` | string | `$XDG_CONFIG_HOME/noctalia/colors.json` | path to Noctalia colors.json or explicit dumber-json |
+| `appearance.external_theme.path` | string | `$XDG_CONFIG_HOME/noctalia/colors.json` | path to Noctalia `colors.json` or a `dumber-json` theme file; when empty and `format = "dumber-json"`, dumber uses the built-in dumber-json template path |
 | `appearance.light_palette.background` | string | `#f8f8f8` | |
 | `appearance.light_palette.surface` | string | `#f2f2f2` | |
 | `appearance.light_palette.surface_variant` | string | `#ececec` | |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,6 +33,10 @@
 | `appearance.monospace_font` | string | `Fira Code` | |
 | `appearance.default_font_size` | int | `16` | |
 | `appearance.color_scheme` | string | `default` | `prefer-dark`, `prefer-light`, `default` |
+| `appearance.external_theme.enabled` | bool | `false` | |
+| `appearance.external_theme.provider` | string | `noctalia` | `noctalia` |
+| `appearance.external_theme.format` | string | `colors-json` | `colors-json`, `dumber-json` |
+| `appearance.external_theme.path` | string | `$XDG_CONFIG_HOME/noctalia/colors.json` | path to Noctalia colors.json or explicit dumber-json |
 | `appearance.light_palette.background` | string | `#f8f8f8` | |
 | `appearance.light_palette.surface` | string | `#f2f2f2` | |
 | `appearance.light_palette.surface_variant` | string | `#ececec` | |

--- a/internal/application/dto/webui_config.go
+++ b/internal/application/dto/webui_config.go
@@ -1,5 +1,7 @@
 package dto
 
+import "github.com/bnema/dumber/internal/domain/entity"
+
 // WebUIConfig represents the subset of configuration editable in dumb://config.
 type WebUIConfig struct {
 	Appearance          WebUIAppearanceConfig     `json:"appearance"`
@@ -43,7 +45,11 @@ type SystemviewPerformancePayload struct {
 
 // SystemviewConfigPayload is the full JSON shape expected by dumb://config.
 type SystemviewConfigPayload struct {
-	Appearance          WebUIAppearanceConfig        `json:"appearance"`
+	// Appearance is the editable config snapshot.
+	Appearance WebUIAppearanceConfig `json:"appearance"`
+	// ResolvedAppearance is optional, display-only appearance resolved from config
+	// plus external theme sources. Forms must save Appearance, never this field.
+	ResolvedAppearance  *WebUIAppearanceConfig       `json:"resolved_appearance,omitempty"`
 	Performance         SystemviewPerformancePayload `json:"performance"`
 	DefaultUIScale      float64                      `json:"default_ui_scale"`
 	DefaultSearchEngine string                       `json:"default_search_engine"`
@@ -66,28 +72,27 @@ type WebUICustomPerformanceConfig struct {
 	WebViewPoolPrewarm     int `json:"webview_pool_prewarm"`
 }
 
-type WebUIAppearanceConfig struct {
-	SansFont        string       `json:"sans_font"`
-	SerifFont       string       `json:"serif_font"`
-	MonospaceFont   string       `json:"monospace_font"`
-	GtkFont         string       `json:"gtk_font"`
-	DefaultFontSize int          `json:"default_font_size"`
-	ColorScheme     string       `json:"color_scheme"`
-	LightPalette    ColorPalette `json:"light_palette"`
-	DarkPalette     ColorPalette `json:"dark_palette"`
-}
+type WebUIAppearanceConfig = entity.AppearanceConfig
 
-type ColorPalette struct {
-	Background     string `json:"background"`
-	Surface        string `json:"surface"`
-	SurfaceVariant string `json:"surface_variant"`
-	Text           string `json:"text"`
-	Muted          string `json:"muted"`
-	Accent         string `json:"accent"`
-	Border         string `json:"border"`
-}
+type WebUIExternalThemeConfig = entity.ExternalThemeConfig
+
+type ColorPalette = entity.ColorPalette
 
 type SearchShortcut struct {
 	URL         string `json:"url"`
 	Description string `json:"description"`
+}
+
+// WebUIAppearanceWithResolvedTheme builds a display-only appearance payload from
+// resolved theme values while preserving fields that are not theme-resolution
+// outputs, such as ColorScheme and ExternalTheme.
+func WebUIAppearanceWithResolvedTheme(base WebUIAppearanceConfig, resolved entity.ResolvedTheme) WebUIAppearanceConfig {
+	base.SansFont = resolved.Fonts.SansFont
+	base.SerifFont = resolved.Fonts.SerifFont
+	base.MonospaceFont = resolved.Fonts.MonospaceFont
+	base.GtkFont = resolved.Fonts.GtkFont
+	base.DefaultFontSize = resolved.Fonts.DefaultSize
+	base.LightPalette = resolved.LightPalette
+	base.DarkPalette = resolved.DarkPalette
+	return base
 }

--- a/internal/application/dto/webui_config_test.go
+++ b/internal/application/dto/webui_config_test.go
@@ -1,0 +1,46 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+func TestWebUIAppearanceWithResolvedThemePreservesColorSchemeAndUsesResolvedValues(t *testing.T) {
+	base := WebUIAppearanceConfig{
+		ColorScheme: "prefer-dark",
+		ExternalTheme: WebUIExternalThemeConfig{
+			Enabled:  true,
+			Provider: "noctalia",
+			Format:   "dumber-json",
+			Path:     "/tmp/theme.json",
+		},
+	}
+	resolved := entity.ResolvedTheme{
+		Fonts: entity.ThemeFonts{
+			SansFont:      "Inter",
+			SerifFont:     "Georgia",
+			MonospaceFont: "JetBrains Mono",
+			GtkFont:       "Adwaita Sans",
+			DefaultSize:   18,
+		},
+		LightPalette: entity.ColorPalette{Background: "#ffffff", Accent: "#0055ff"},
+		DarkPalette:  entity.ColorPalette{Background: "#111111", Accent: "#66aaff"},
+	}
+
+	got := WebUIAppearanceWithResolvedTheme(base, resolved)
+
+	require.Equal(t, "prefer-dark", got.ColorScheme)
+	require.Equal(t, base.ExternalTheme, got.ExternalTheme)
+	require.Equal(t, "Inter", got.SansFont)
+	require.Equal(t, "Georgia", got.SerifFont)
+	require.Equal(t, "JetBrains Mono", got.MonospaceFont)
+	require.Equal(t, "Adwaita Sans", got.GtkFont)
+	require.Equal(t, 18, got.DefaultFontSize)
+	require.Equal(t, "#ffffff", got.LightPalette.Background)
+	require.Equal(t, "#0055ff", got.LightPalette.Accent)
+	require.Equal(t, "#111111", got.DarkPalette.Background)
+	require.Equal(t, "#66aaff", got.DarkPalette.Accent)
+}

--- a/internal/application/port/external_theme.go
+++ b/internal/application/port/external_theme.go
@@ -1,0 +1,41 @@
+package port
+
+import (
+	"context"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+// ExternalThemeSource provides access to an external theme provider (e.g., Noctalia).
+// It must not import GTK, WebKit, CEF, lipgloss, fsnotify, Viper, or infrastructure config.
+type ExternalThemeSource interface {
+	// Get returns the current external theme, or nil if no external theme is available.
+	// An error indicates a transient I/O problem (e.g., connection lost).
+	// A nil theme with nil error means the source is enabled but has no theme data yet.
+	Get(ctx context.Context) (*entity.ExternalTheme, error)
+
+	// IsEnabled returns true if the external theme source is enabled.
+	// When disabled, the usecase should fall back to config/default palettes.
+	IsEnabled() bool
+}
+
+// ExternalThemeIdentityProvider exposes a stable source identity for last-good cache invalidation.
+// Implementations should change this value when the configured provider/format/path changes.
+type ExternalThemeIdentityProvider interface {
+	ExternalThemeIdentity() string
+}
+
+// ConfigurableExternalThemeSource is an external source whose settings can be
+// updated from a new config snapshot without replacing the ResolveThemeUseCase.
+type ConfigurableExternalThemeSource interface {
+	ExternalThemeSource
+	ExternalThemeIdentityProvider
+	Configure(entity.ExternalThemeConfig)
+}
+
+// ExternalThemeWatcher watches an external theme source and notifies callers
+// when they should refresh the resolved theme through the shared apply path.
+type ExternalThemeWatcher interface {
+	Start(ctx context.Context, cfg entity.ExternalThemeConfig, onChange func()) error
+	Stop() error
+}

--- a/internal/application/port/external_theme_test.go
+++ b/internal/application/port/external_theme_test.go
@@ -1,0 +1,51 @@
+package port
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+// compileCheckExternalThemeSource ensures the ExternalThemeSource interface
+// is defined and can be implemented by test mocks.
+func TestCompileCheckExternalThemeSource(_ *testing.T) {
+	var _ ExternalThemeSource = (*mockExternalThemeSource)(nil)
+	var _ ConfigurableExternalThemeSource = (*mockExternalThemeSource)(nil)
+	var _ ExternalThemeWatcher = (*mockExternalThemeWatcher)(nil)
+}
+
+// mockExternalThemeSource is a test-only implementation of ExternalThemeSource.
+type mockExternalThemeSource struct {
+	theme    *entity.ExternalTheme
+	err      error
+	enabled  bool
+	identity string
+}
+
+func (m *mockExternalThemeSource) Get(_ context.Context) (*entity.ExternalTheme, error) {
+	return m.theme, m.err
+}
+
+func (m *mockExternalThemeSource) IsEnabled() bool {
+	return m.enabled
+}
+
+func (m *mockExternalThemeSource) Configure(cfg entity.ExternalThemeConfig) {
+	m.enabled = cfg.Enabled
+	m.identity = cfg.Provider + "|" + cfg.Format + "|" + cfg.Path
+}
+
+func (m *mockExternalThemeSource) ExternalThemeIdentity() string {
+	return m.identity
+}
+
+type mockExternalThemeWatcher struct{}
+
+func (*mockExternalThemeWatcher) Start(context.Context, entity.ExternalThemeConfig, func()) error {
+	return nil
+}
+
+func (*mockExternalThemeWatcher) Stop() error {
+	return nil
+}

--- a/internal/application/usecase/read_systemview_config.go
+++ b/internal/application/usecase/read_systemview_config.go
@@ -6,19 +6,53 @@ import (
 
 	"github.com/bnema/dumber/internal/application/dto"
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/entity"
 )
 
 // ReadSystemviewConfigUseCase exposes read-side systemview config payloads.
 type ReadSystemviewConfigUseCase struct {
-	reader port.SystemviewConfigReader
+	reader             port.SystemviewConfigReader
+	resolvedAppearance *systemviewResolvedAppearanceResolver
+}
+
+type systemviewResolvedAppearanceResolver struct {
+	externalTheme port.ExternalThemeSource
+	colorResolver port.ColorSchemeResolver
+	prefersDark   func() bool
+}
+
+// ReadSystemviewConfigOption customizes ReadSystemviewConfigUseCase behavior.
+type ReadSystemviewConfigOption func(*ReadSystemviewConfigUseCase)
+
+// WithSystemviewResolvedAppearance overlays the current config payload with a display-only
+// resolved appearance snapshot. It uses an isolated theme resolver per read so opening
+// dumb://config cannot mutate the live browser theme resolver's last-good cache.
+func WithSystemviewResolvedAppearance(
+	externalTheme port.ExternalThemeSource,
+	colorResolver port.ColorSchemeResolver,
+	prefersDark func() bool,
+) ReadSystemviewConfigOption {
+	return func(uc *ReadSystemviewConfigUseCase) {
+		uc.resolvedAppearance = &systemviewResolvedAppearanceResolver{
+			externalTheme: externalTheme,
+			colorResolver: colorResolver,
+			prefersDark:   prefersDark,
+		}
+	}
 }
 
 // NewReadSystemviewConfigUseCase creates a new read systemview config use case.
-func NewReadSystemviewConfigUseCase(reader port.SystemviewConfigReader) *ReadSystemviewConfigUseCase {
+func NewReadSystemviewConfigUseCase(reader port.SystemviewConfigReader, opts ...ReadSystemviewConfigOption) *ReadSystemviewConfigUseCase {
 	if reader == nil {
 		panic("NewReadSystemviewConfigUseCase: reader is nil")
 	}
-	return &ReadSystemviewConfigUseCase{reader: reader}
+	uc := &ReadSystemviewConfigUseCase{reader: reader}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(uc)
+		}
+	}
+	return uc
 }
 
 // ErrNilSystemviewConfigReader is returned when the config reader dependency is nil.
@@ -29,7 +63,11 @@ func (uc *ReadSystemviewConfigUseCase) Current(ctx context.Context) (dto.Systemv
 	if uc == nil || uc.reader == nil {
 		return dto.SystemviewConfigPayload{}, ErrNilSystemviewConfigReader
 	}
-	return uc.reader.Current(ctx)
+	payload, err := uc.reader.Current(ctx)
+	if err != nil {
+		return dto.SystemviewConfigPayload{}, err
+	}
+	return uc.withResolvedAppearance(ctx, payload), nil
 }
 
 // Default returns the default systemview config payload.
@@ -38,4 +76,50 @@ func (uc *ReadSystemviewConfigUseCase) Default(ctx context.Context) (dto.Systemv
 		return dto.SystemviewConfigPayload{}, ErrNilSystemviewConfigReader
 	}
 	return uc.reader.Default(ctx)
+}
+
+func (uc *ReadSystemviewConfigUseCase) withResolvedAppearance(
+	ctx context.Context,
+	payload dto.SystemviewConfigPayload,
+) dto.SystemviewConfigPayload {
+	if uc == nil || uc.resolvedAppearance == nil {
+		return payload
+	}
+	resolved, ok := uc.resolvedAppearance.resolve(ctx, payload)
+	if !ok {
+		return payload
+	}
+	appearance := dto.WebUIAppearanceWithResolvedTheme(payload.Appearance, resolved)
+	payload.ResolvedAppearance = &appearance
+	return payload
+}
+
+func (r *systemviewResolvedAppearanceResolver) resolve(
+	ctx context.Context,
+	payload dto.SystemviewConfigPayload,
+) (entity.ResolvedTheme, bool) {
+	if r == nil {
+		return entity.ResolvedTheme{}, false
+	}
+	resolver := NewResolveThemeUseCase(r.externalTheme)
+	out, err := resolver.Execute(ctx, ResolveThemeInputFromConfig(
+		&payload.Appearance,
+		payload.DefaultUIScale,
+		nil,
+		r.preference(payload.Appearance.ColorScheme),
+	))
+	if err != nil {
+		return entity.ResolvedTheme{}, false
+	}
+	return out.Theme, true
+}
+
+func (r *systemviewResolvedAppearanceResolver) preference(colorScheme string) port.ColorSchemePreference {
+	fallback := port.ColorSchemePreference{PrefersDark: true, Source: "systemviews"}
+	if r.colorResolver != nil {
+		fallback = r.colorResolver.Resolve()
+	} else if r.prefersDark != nil {
+		fallback.PrefersDark = r.prefersDark()
+	}
+	return ColorSchemePreferenceFromConfig(colorScheme, fallback)
 }

--- a/internal/application/usecase/read_systemview_config_theme_test.go
+++ b/internal/application/usecase/read_systemview_config_theme_test.go
@@ -1,0 +1,129 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/application/dto"
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+type systemviewConfigReaderStub struct {
+	current dto.SystemviewConfigPayload
+	def     dto.SystemviewConfigPayload
+}
+
+func (s systemviewConfigReaderStub) Current(context.Context) (dto.SystemviewConfigPayload, error) {
+	return s.current, nil
+}
+
+func (s systemviewConfigReaderStub) Default(context.Context) (dto.SystemviewConfigPayload, error) {
+	return s.def, nil
+}
+
+type systemviewExternalThemeSource struct {
+	theme   *entity.ExternalTheme
+	enabled bool
+}
+
+func (s systemviewExternalThemeSource) Get(context.Context) (*entity.ExternalTheme, error) {
+	return s.theme, nil
+}
+
+func (s systemviewExternalThemeSource) IsEnabled() bool {
+	return s.enabled
+}
+
+func TestReadSystemviewConfigUseCase_CurrentResolvedAppearanceUsesPayloadSnapshot(t *testing.T) {
+	payload := systemviewThemePayload("prefer-light")
+	uc := NewReadSystemviewConfigUseCase(
+		systemviewConfigReaderStub{current: payload},
+		WithSystemviewResolvedAppearance(nil, nil, func() bool { return true }),
+	)
+
+	got, err := uc.Current(context.Background())
+	require.NoError(t, err)
+
+	require.NotNil(t, got.ResolvedAppearance)
+	require.NotEmpty(t, got.ResolvedAppearance.ColorScheme, "resolved appearance should preserve color scheme metadata")
+	require.Equal(t, "prefer-light", got.ResolvedAppearance.ColorScheme)
+	require.Equal(t, "#ffffff", got.ResolvedAppearance.LightPalette.Background)
+	require.Equal(t, "Inter", got.ResolvedAppearance.SansFont)
+	require.Equal(t, 18, got.ResolvedAppearance.DefaultFontSize)
+}
+
+func TestReadSystemviewConfigUseCase_CurrentResolvedAppearanceKeepsEditableAppearanceUnchanged(t *testing.T) {
+	payload := systemviewThemePayload("prefer-dark")
+	external := &entity.ExternalTheme{
+		Name:     "Noctalia",
+		Provider: "noctalia",
+		LightPalette: &entity.ColorPalette{
+			Background: "#eeeeee",
+			Accent:     "#112233",
+		},
+		DarkPalette: &entity.ColorPalette{
+			Background: "#000000",
+			Accent:     "#445566",
+		},
+	}
+	uc := NewReadSystemviewConfigUseCase(
+		systemviewConfigReaderStub{current: payload},
+		WithSystemviewResolvedAppearance(systemviewExternalThemeSource{theme: external, enabled: true}, nil, nil),
+	)
+
+	got, err := uc.Current(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, "#111111", got.Appearance.DarkPalette.Background)
+	require.Equal(t, "#66aaff", got.Appearance.DarkPalette.Accent)
+	require.NotNil(t, got.ResolvedAppearance)
+	require.Equal(t, "#000000", got.ResolvedAppearance.DarkPalette.Background)
+	require.Equal(t, "#445566", got.ResolvedAppearance.DarkPalette.Accent)
+	require.Equal(t, got.Appearance.ExternalTheme, got.ResolvedAppearance.ExternalTheme)
+}
+
+func TestReadSystemviewConfigUseCase_DefaultDoesNotOverlayResolvedAppearance(t *testing.T) {
+	payload := systemviewThemePayload("prefer-dark")
+	uc := NewReadSystemviewConfigUseCase(
+		systemviewConfigReaderStub{def: payload},
+		WithSystemviewResolvedAppearance(systemviewExternalThemeSource{theme: validExternalTheme(), enabled: true}, nil, nil),
+	)
+
+	got, err := uc.Default(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, got.ResolvedAppearance)
+}
+
+func systemviewThemePayload(colorScheme string) dto.SystemviewConfigPayload {
+	return dto.SystemviewConfigPayload{
+		DefaultUIScale: 1.25,
+		Appearance: dto.WebUIAppearanceConfig{
+			ColorScheme:     colorScheme,
+			SansFont:        "Inter",
+			SerifFont:       "Georgia",
+			MonospaceFont:   "JetBrains Mono",
+			GtkFont:         "Adwaita Sans",
+			DefaultFontSize: 18,
+			LightPalette: dto.ColorPalette{
+				Background:     "#ffffff",
+				Surface:        "#f8f8f8",
+				SurfaceVariant: "#eeeeee",
+				Text:           "#111111",
+				Muted:          "#666666",
+				Accent:         "#0055ff",
+				Border:         "#dddddd",
+			},
+			DarkPalette: dto.ColorPalette{
+				Background:     "#111111",
+				Surface:        "#1a1a1a",
+				SurfaceVariant: "#2a2a2a",
+				Text:           "#f5f5f5",
+				Muted:          "#a0a0a0",
+				Accent:         "#66aaff",
+				Border:         "#333333",
+			},
+		},
+	}
+}

--- a/internal/application/usecase/resolve_theme.go
+++ b/internal/application/usecase/resolve_theme.go
@@ -1,0 +1,436 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+// ResolveThemeInput contains the inputs needed to resolve the active theme.
+// It accepts config-level overrides and delegates to external sources via port.
+type ResolveThemeInput struct {
+	// ColorScheme is the user-configured color scheme preference.
+	// Values: "default", "prefer-dark", "prefer-light", "dark", "light".
+	// Phase 2 expects callers to resolve this into PrefersDark before invoking the usecase.
+	ColorScheme string
+
+	// PrefersDark is the detected system color scheme preference.
+	PrefersDark bool
+
+	// ColorSchemeSource identifies which detector provided the color scheme preference.
+	// Examples: "config", "adwaita", "gsettings", "env", "fallback".
+	ColorSchemeSource string
+
+	// LightPalette from user config (may be empty/nil).
+	LightPalette *entity.ColorPalette
+
+	// DarkPalette from user config (may be empty/nil).
+	DarkPalette *entity.ColorPalette
+
+	// Fonts from user config (may be nil for defaults).
+	Fonts *entity.ThemeFonts
+
+	// UIScale from GTK/display settings.
+	UIScale float64
+
+	// ModeColors from user config (may be nil for defaults).
+	ModeColors *entity.ThemeModeColors
+}
+
+// ResolveThemeOutput is the result of theme resolution.
+type ResolveThemeOutput struct {
+	// Theme is the resolved theme.
+	Theme entity.ResolvedTheme
+}
+
+// ResolveThemeUseCase resolves the active theme by merging config defaults,
+// user configuration, and an optional external theme source.
+//
+// Resolution precedence (locked contract):
+//   - External disabled -> config/default palettes
+//   - Valid external -> external palettes override palette colors only
+//   - Malformed/missing external at startup -> config/default palettes + warning
+//   - Malformed after valid external -> keep last-good external + warning/source metadata
+//   - Disabling external after valid -> clear last-good and use config/defaults
+//
+// CSS generation is NOT part of this usecase.
+// This usecase must NOT import GTK, WebKit, CEF, lipgloss, fsnotify, Viper, or infrastructure config.
+type ResolveThemeUseCase struct {
+	external port.ExternalThemeSource
+	mu       sync.Mutex
+
+	// lastGoodExternal holds the most recent fully-resolved valid external palette.
+	// Used for the "malformed after valid" -> keep last-good contract.
+	lastGoodExternal *entity.ExternalTheme
+
+	// lastExternalIdentity tracks the configured external source identity that produced lastGoodExternal.
+	// If the enabled provider/format/path changes, last-good is invalidated before resolving.
+	lastExternalIdentity string
+}
+
+// NewResolveThemeUseCase creates a new ResolveThemeUseCase.
+// external may be nil if no external theme source is available.
+func NewResolveThemeUseCase(external port.ExternalThemeSource) *ResolveThemeUseCase {
+	return &ResolveThemeUseCase{external: external}
+}
+
+// ResolveThemeInputFromConfig maps domain config shapes plus a detected color-scheme
+// preference into the application usecase input. It performs no precedence/fallback
+// resolution; Execute/Refresh owns that business logic.
+func ResolveThemeInputFromConfig(
+	appearance *entity.AppearanceConfig,
+	uiScale float64,
+	styling *entity.WorkspaceStylingConfig,
+	preference port.ColorSchemePreference,
+) ResolveThemeInput {
+	input := ResolveThemeInput{
+		PrefersDark:       preference.PrefersDark,
+		ColorSchemeSource: preference.Source,
+		UIScale:           uiScale,
+	}
+
+	if appearance != nil {
+		lightPalette := appearance.LightPalette
+		darkPalette := appearance.DarkPalette
+		fonts := entity.ThemeFonts{
+			SansFont:      appearance.SansFont,
+			SerifFont:     appearance.SerifFont,
+			MonospaceFont: appearance.MonospaceFont,
+			GtkFont:       appearance.GtkFont,
+			DefaultSize:   appearance.DefaultFontSize,
+		}
+		input.ColorScheme = appearance.ColorScheme
+		input.LightPalette = &lightPalette
+		input.DarkPalette = &darkPalette
+		input.Fonts = &fonts
+	}
+
+	if styling != nil {
+		modeColors := entity.ThemeModeColors{
+			PaneMode:    styling.PaneModeColor,
+			TabMode:     styling.TabModeColor,
+			SessionMode: styling.SessionModeColor,
+			ResizeMode:  styling.ResizeModeColor,
+		}
+		input.ModeColors = &modeColors
+	}
+
+	return input
+}
+
+// ColorSchemePreferenceFromConfig converts explicit config color-scheme values into
+// a resolver preference, falling back when config asks for the default/system value.
+func ColorSchemePreferenceFromConfig(colorScheme string, fallback port.ColorSchemePreference) port.ColorSchemePreference {
+	switch strings.ToLower(strings.TrimSpace(colorScheme)) {
+	case "prefer-dark", "dark":
+		return port.ColorSchemePreference{PrefersDark: true, Source: "config"}
+	case "prefer-light", "light":
+		return port.ColorSchemePreference{PrefersDark: false, Source: "config"}
+	default:
+		return fallback
+	}
+}
+
+// Refresh resolves the active theme for config reloads and future external-theme reloads.
+func (uc *ResolveThemeUseCase) Refresh(ctx context.Context, input ResolveThemeInput) (ResolveThemeOutput, error) {
+	return uc.Execute(ctx, input)
+}
+
+// Execute resolves the active theme.
+func (uc *ResolveThemeUseCase) Execute(ctx context.Context, input ResolveThemeInput) (ResolveThemeOutput, error) {
+	uc.mu.Lock()
+	defer uc.mu.Unlock()
+
+	base := uc.resolveBase(input)
+	lightPalette := base.lightPalette
+	darkPalette := base.darkPalette
+	warnings := base.warnings
+	themeSource := base.themeSource
+
+	if uc.external != nil && uc.external.IsEnabled() {
+		uc.syncExternalIdentity(externalThemeIdentity(uc.external))
+		ext, err := uc.external.Get(ctx)
+		if err != nil {
+			lightPalette, darkPalette, themeSource, warnings = uc.handleExternalError(err, lightPalette, darkPalette, themeSource, warnings)
+		} else if ext != nil {
+			lightPalette, darkPalette, themeSource, warnings = uc.applyExternalTheme(ext, lightPalette, darkPalette, themeSource, warnings)
+		} else {
+			lightPalette, darkPalette, themeSource, warnings = uc.handleMissingExternalTheme(lightPalette, darkPalette, themeSource, warnings)
+		}
+	} else {
+		uc.clearLastGoodExternal()
+	}
+
+	return ResolveThemeOutput{
+		Theme: buildResolvedTheme(input, lightPalette, darkPalette, base.fonts, base.modeColors, base.uiScale, themeSource, warnings),
+	}, nil
+}
+
+type resolvedThemeBase struct {
+	lightPalette entity.ColorPalette
+	darkPalette  entity.ColorPalette
+	fonts        entity.ThemeFonts
+	modeColors   entity.ThemeModeColors
+	uiScale      float64
+	themeSource  entity.ThemeSourceMetadata
+	warnings     []entity.ThemeWarning
+}
+
+func (*ResolveThemeUseCase) resolveBase(input ResolveThemeInput) resolvedThemeBase {
+	lightDefault := entity.DefaultLightPalette()
+	darkDefault := entity.DefaultDarkPalette()
+	lightPalette := entity.MergePalette(input.LightPalette, &lightDefault)
+	darkPalette := entity.MergePalette(input.DarkPalette, &darkDefault)
+
+	fonts := entity.MergeFonts(input.Fonts, entity.DefaultThemeFonts())
+	modeColors := entity.MergeModeColors(input.ModeColors, entity.DefaultThemeModeColors())
+	uiScale := input.UIScale
+	if uiScale <= 0 {
+		uiScale = 1.0
+	}
+
+	themeSourceKind := entity.ThemeSourceConfig
+	if input.LightPalette == nil && input.DarkPalette == nil {
+		themeSourceKind = entity.ThemeSourceDefault
+	}
+
+	return resolvedThemeBase{
+		lightPalette: lightPalette,
+		darkPalette:  darkPalette,
+		fonts:        fonts,
+		modeColors:   modeColors,
+		uiScale:      uiScale,
+		themeSource: entity.ThemeSourceMetadata{
+			Kind: themeSourceKind,
+		},
+	}
+}
+
+func (uc *ResolveThemeUseCase) clearLastGoodExternal() {
+	uc.lastGoodExternal = nil
+	uc.lastExternalIdentity = ""
+}
+
+func (uc *ResolveThemeUseCase) syncExternalIdentity(identity string) {
+	if identity == "" {
+		return
+	}
+	if uc.lastExternalIdentity != "" && uc.lastExternalIdentity != identity {
+		uc.lastGoodExternal = nil
+	}
+	uc.lastExternalIdentity = identity
+}
+
+func externalThemeIdentity(source port.ExternalThemeSource) string {
+	identityProvider, ok := source.(port.ExternalThemeIdentityProvider)
+	if !ok {
+		return ""
+	}
+	return identityProvider.ExternalThemeIdentity()
+}
+
+func (uc *ResolveThemeUseCase) handleMissingExternalTheme(
+	lightPalette, darkPalette entity.ColorPalette,
+	themeSource entity.ThemeSourceMetadata,
+	warnings []entity.ThemeWarning,
+) (entity.ColorPalette, entity.ColorPalette, entity.ThemeSourceMetadata, []entity.ThemeWarning) {
+	if uc.lastGoodExternal != nil {
+		warnings = append(warnings, entity.ThemeWarning{
+			Field:   "external",
+			Message: "external theme is missing, using last-good",
+		})
+		return uc.lastGoodPalettes(themeSource, warnings)
+	}
+
+	warnings = append(warnings, entity.ThemeWarning{
+		Field:   "external",
+		Message: "external theme is missing, using config/defaults",
+	})
+	return lightPalette, darkPalette, themeSource, warnings
+}
+
+func (uc *ResolveThemeUseCase) handleExternalError(
+	err error,
+	lightPalette, darkPalette entity.ColorPalette,
+	themeSource entity.ThemeSourceMetadata,
+	warnings []entity.ThemeWarning,
+) (entity.ColorPalette, entity.ColorPalette, entity.ThemeSourceMetadata, []entity.ThemeWarning) {
+	if uc.lastGoodExternal != nil {
+		warnings = append(warnings, entity.ThemeWarning{
+			Field:   "external",
+			Message: "failed to fetch external theme: " + err.Error() + ", using last-good",
+		})
+		return uc.lastGoodPalettes(themeSource, warnings)
+	}
+
+	warnings = append(warnings, entity.ThemeWarning{
+		Field:   "external",
+		Message: "failed to fetch external theme: " + err.Error(),
+	})
+	return lightPalette, darkPalette, themeSource, warnings
+}
+
+func (uc *ResolveThemeUseCase) applyExternalTheme(
+	ext *entity.ExternalTheme,
+	lightPalette, darkPalette entity.ColorPalette,
+	themeSource entity.ThemeSourceMetadata,
+	warnings []entity.ThemeWarning,
+) (entity.ColorPalette, entity.ColorPalette, entity.ThemeSourceMetadata, []entity.ThemeWarning) {
+	validationWarnings := externalThemeWarnings(ext)
+	if len(validationWarnings) > 0 {
+		if uc.lastGoodExternal != nil {
+			warnings = append(warnings, entity.ThemeWarning{
+				Field:   "external",
+				Message: "malformed external theme update, keeping last-good",
+			})
+			warnings = append(warnings, validationWarnings...)
+			return uc.lastGoodPalettes(themeSource, warnings)
+		}
+
+		warnings = append(warnings, entity.ThemeWarning{
+			Field:   "external",
+			Message: "malformed external theme, using config/defaults",
+		})
+		warnings = append(warnings, validationWarnings...)
+		return lightPalette, darkPalette, themeSource, warnings
+	}
+
+	// External palettes are partial overrides. Empty fields fall back through a
+	// repaired config/default palette so one invalid config value cannot discard
+	// otherwise valid external overrides or poison the last-good cache.
+	lightPalette, warnings = paletteWithValidFallbackFields(lightPalette, entity.DefaultLightPalette(), "light_palette", warnings)
+	darkPalette, warnings = paletteWithValidFallbackFields(darkPalette, entity.DefaultDarkPalette(), "dark_palette", warnings)
+	resolvedLight := entity.MergePalette(ext.LightPalette, &lightPalette)
+	resolvedDark := entity.MergePalette(ext.DarkPalette, &darkPalette)
+
+	provider := ext.Provider
+	lightCopy := resolvedLight
+	darkCopy := resolvedDark
+	uc.lastGoodExternal = &entity.ExternalTheme{
+		Name:         ext.Name,
+		Provider:     provider,
+		LightPalette: &lightCopy,
+		DarkPalette:  &darkCopy,
+	}
+
+	return resolvedLight, resolvedDark, entity.ThemeSourceMetadata{
+		Kind:     entity.ThemeSourceExternal,
+		Provider: provider,
+		LastGood: false,
+	}, warnings
+}
+
+func externalThemeWarnings(ext *entity.ExternalTheme) []entity.ThemeWarning {
+	if ext == nil {
+		return []entity.ThemeWarning{{Field: "external", Message: "theme is nil"}}
+	}
+	var warnings []entity.ThemeWarning
+	warnings = append(warnings, entity.ValidatePaletteOverrideHex(ext.LightPalette, "external.light_palette")...)
+	warnings = append(warnings, entity.ValidatePaletteOverrideHex(ext.DarkPalette, "external.dark_palette")...)
+	return warnings
+}
+
+func paletteWithValidFallbackFields(
+	palette entity.ColorPalette,
+	fallback entity.ColorPalette,
+	fieldPrefix string,
+	warnings []entity.ThemeWarning,
+) (entity.ColorPalette, []entity.ThemeWarning) {
+	if entity.IsPaletteValid(&palette) {
+		return palette, warnings
+	}
+	warnings = append(warnings, entity.ThemeWarning{
+		Field:   fieldPrefix,
+		Message: "resolved config palette contained invalid colors, using built-in defaults for invalid fields",
+	})
+	if !entity.IsValidHex(palette.Background) {
+		palette.Background = fallback.Background
+	}
+	if !entity.IsValidHex(palette.Surface) {
+		palette.Surface = fallback.Surface
+	}
+	if !entity.IsValidHex(palette.SurfaceVariant) {
+		palette.SurfaceVariant = fallback.SurfaceVariant
+	}
+	if !entity.IsValidHex(palette.Text) {
+		palette.Text = fallback.Text
+	}
+	if !entity.IsValidHex(palette.Muted) {
+		palette.Muted = fallback.Muted
+	}
+	if !entity.IsValidHex(palette.Accent) {
+		palette.Accent = fallback.Accent
+	}
+	if !entity.IsValidHex(palette.Border) {
+		palette.Border = fallback.Border
+	}
+	return palette, warnings
+}
+
+func (uc *ResolveThemeUseCase) lastGoodPalettes(
+	fallback entity.ThemeSourceMetadata,
+	warnings []entity.ThemeWarning,
+) (entity.ColorPalette, entity.ColorPalette, entity.ThemeSourceMetadata, []entity.ThemeWarning) {
+	if uc.lastGoodExternal == nil || uc.lastGoodExternal.LightPalette == nil || uc.lastGoodExternal.DarkPalette == nil {
+		return entity.DefaultLightPalette(), entity.DefaultDarkPalette(), fallback, warnings
+	}
+
+	return *uc.lastGoodExternal.LightPalette, *uc.lastGoodExternal.DarkPalette, entity.ThemeSourceMetadata{
+		Kind:     entity.ThemeSourceExternal,
+		Provider: uc.lastGoodExternal.Provider,
+		LastGood: true,
+	}, warnings
+}
+
+func buildResolvedTheme(
+	input ResolveThemeInput,
+	lightPalette, darkPalette entity.ColorPalette,
+	fonts entity.ThemeFonts,
+	modeColors entity.ThemeModeColors,
+	uiScale float64,
+	themeSource entity.ThemeSourceMetadata,
+	warnings []entity.ThemeWarning,
+) entity.ResolvedTheme {
+	if !entity.IsPaletteValid(&lightPalette) {
+		warnings = append(warnings, entity.ThemeWarning{
+			Field:   "light_palette",
+			Message: "resolved light palette was invalid, using built-in default",
+		})
+		lightPalette = entity.DefaultLightPalette()
+	}
+	if !entity.IsPaletteValid(&darkPalette) {
+		warnings = append(warnings, entity.ThemeWarning{
+			Field:   "dark_palette",
+			Message: "resolved dark palette was invalid, using built-in default",
+		})
+		darkPalette = entity.DefaultDarkPalette()
+	}
+	if !entity.IsModeColorsValid(&modeColors) {
+		warnings = append(warnings, entity.ThemeWarning{
+			Field:   "mode_colors",
+			Message: "resolved mode colors were invalid, using built-in defaults",
+		})
+		modeColors = entity.DefaultThemeModeColors()
+	}
+
+	activePalette := lightPalette
+	if input.PrefersDark {
+		activePalette = darkPalette
+	}
+
+	return entity.ResolvedTheme{
+		LightPalette:      lightPalette,
+		DarkPalette:       darkPalette,
+		ActivePalette:     activePalette,
+		PrefersDark:       input.PrefersDark,
+		ColorSchemeSource: input.ColorSchemeSource,
+		ThemeSource:       themeSource,
+		Fonts:             fonts,
+		UIScale:           uiScale,
+		ModeColors:        modeColors,
+		Warnings:          warnings,
+	}
+}

--- a/internal/application/usecase/resolve_theme_test.go
+++ b/internal/application/usecase/resolve_theme_test.go
@@ -1,0 +1,1365 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+// assertNoWarnings fails the test if there are any warnings.
+func assertNoWarnings(t *testing.T, warnings []entity.ThemeWarning) {
+	t.Helper()
+	if len(warnings) > 0 {
+		var msgs []string
+		for _, w := range warnings {
+			msgs = append(msgs, fmt.Sprintf("%s: %s", w.Field, w.Message))
+		}
+		t.Errorf("unexpected warnings: %s", strings.Join(msgs, "; "))
+	}
+}
+
+// assertValidPaletteHex checks every color field in a palette is valid CSS-safe hex.
+func assertValidPaletteHex(t *testing.T, label string, p entity.ResolvedThemePalette) {
+	t.Helper()
+	fields := map[string]string{
+		"Background":     p.Background,
+		"Surface":        p.Surface,
+		"SurfaceVariant": p.SurfaceVariant,
+		"Text":           p.Text,
+		"Muted":          p.Muted,
+		"Accent":         p.Accent,
+		"Border":         p.Border,
+	}
+	for name, value := range fields {
+		if !entity.IsValidHex(value) {
+			t.Errorf("%s.%s = %q is not a valid CSS-safe hex color", label, name, value)
+		}
+	}
+}
+
+// newMockExternalSource creates a test double for the external theme source port.
+type newMockExternalSource struct {
+	theme    *entity.ExternalTheme
+	err      error
+	enabled  bool
+	identity string
+}
+
+func (m *newMockExternalSource) Get(_ context.Context) (*entity.ExternalTheme, error) {
+	return m.theme, m.err
+}
+
+func (m *newMockExternalSource) IsEnabled() bool {
+	return m.enabled
+}
+
+func (m *newMockExternalSource) ExternalThemeIdentity() string {
+	return m.identity
+}
+
+// configLightPalette returns a recognizable light palette for config.
+func configLightPalette() *entity.ColorPalette {
+	return &entity.ColorPalette{
+		Background:     "#fafafa",
+		Surface:        "#ffffff",
+		SurfaceVariant: "#f0f0f0",
+		Text:           "#1a1a1a",
+		Muted:          "#666666",
+		Accent:         "#22c55e",
+		Border:         "#dddddd",
+	}
+}
+
+// configDarkPalette returns a recognizable dark palette for config.
+func configDarkPalette() *entity.ColorPalette {
+	return &entity.ColorPalette{
+		Background:     "#0a0a0b",
+		Surface:        "#1a1a1b",
+		SurfaceVariant: "#2d2d2d",
+		Text:           "#ffffff",
+		Muted:          "#909090",
+		Accent:         "#4ade80",
+		Border:         "#333333",
+	}
+}
+
+// externalLightPalette returns a different light palette for external testing.
+func externalLightPalette() *entity.ColorPalette {
+	return &entity.ColorPalette{
+		Background:     "#fff8e7",
+		Surface:        "#fffef5",
+		SurfaceVariant: "#f5ecd7",
+		Text:           "#2d2a1e",
+		Muted:          "#8c876e",
+		Accent:         "#d4a017",
+		Border:         "#e0d8b0",
+	}
+}
+
+// externalDarkPalette returns a different dark palette for external testing.
+func externalDarkPalette() *entity.ColorPalette {
+	return &entity.ColorPalette{
+		Background:     "#1a1a2e",
+		Surface:        "#16213e",
+		SurfaceVariant: "#0f3460",
+		Text:           "#e0e0e0",
+		Muted:          "#a0a0a0",
+		Accent:         "#e94560",
+		Border:         "#533483",
+	}
+}
+
+// validExternalTheme returns a fully valid ExternalTheme for testing.
+func validExternalTheme() *entity.ExternalTheme {
+	return &entity.ExternalTheme{
+		Name:         "Noctalia Test",
+		Provider:     "noctalia",
+		LightPalette: externalLightPalette(),
+		DarkPalette:  externalDarkPalette(),
+	}
+}
+
+// ============================================================
+// Precedence: External disabled → config/default palettes
+// ============================================================
+
+// TestResolveTheme_ExternalDisabled_UsesConfigPalettes verifies that when the external
+// source is disabled, config palettes (or defaults) are used.
+func TestResolveTheme_ExternalDisabled_UsesConfigPalettes(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	light := configLightPalette()
+	dark := configDarkPalette()
+
+	input := ResolveThemeInput{
+		ColorScheme:       "default",
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      light,
+		DarkPalette:       dark,
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	assertValidPaletteHex(t, "ActivePalette", output.Theme.ActivePalette)
+
+	// With PrefersDark=true and no external, light palette should be config
+	if output.Theme.LightPalette.Background != light.Background {
+		t.Errorf("expected LightPalette.Background=%q, got %q", light.Background, output.Theme.LightPalette.Background)
+	}
+	// Active palette should be dark (PrefersDark=true)
+	if output.Theme.ActivePalette.Background != dark.Background {
+		t.Errorf("expected ActivePalette.Background=%q (dark), got %q", dark.Background, output.Theme.ActivePalette.Background)
+	}
+}
+
+// TestResolveTheme_NoConfig_UsesDefaults verifies that when neither config nor external
+// provide palettes, sensible defaults are returned.
+func TestResolveTheme_NoConfig_UsesDefaults(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	input := ResolveThemeInput{
+		ColorScheme:       "default",
+		PrefersDark:       true,
+		ColorSchemeSource: "fallback",
+		UIScale:           1.0,
+		// LightPalette and DarkPalette are nil (no config)
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	assertValidPaletteHex(t, "ActivePalette", output.Theme.ActivePalette)
+
+	// Defaults must be non-trivial (Background, Text non-empty)
+	if output.Theme.DarkPalette.Background == "" {
+		t.Error("expected non-empty DarkPalette.Background from defaults")
+	}
+	if output.Theme.DarkPalette.Text == "" {
+		t.Error("expected non-empty DarkPalette.Text from defaults")
+	}
+	if output.Theme.LightPalette.Background == "" {
+		t.Error("expected non-empty LightPalette.Background from defaults")
+	}
+}
+
+// ============================================================
+// Precedence: Valid external → external palettes override palette colors only
+// ============================================================
+
+// TestResolveTheme_ValidExternal_OverridesPaletteColors verifies that when a valid
+// external theme is available, its palette colors override config palette colors,
+// but other fields (fonts, mode colors, scale) come from config or defaults.
+func TestResolveTheme_ValidExternal_OverridesPaletteColors(t *testing.T) {
+	ext := validExternalTheme()
+	mock := &newMockExternalSource{
+		theme:   ext,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		ColorScheme:       "default",
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		Fonts: &entity.ThemeFonts{
+			SansFont: "config-sans",
+		},
+		UIScale: 1.5,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	assertValidPaletteHex(t, "ActivePalette", output.Theme.ActivePalette)
+
+	// External palette should override config palette
+	if output.Theme.DarkPalette.Background != ext.DarkPalette.Background {
+		t.Errorf("expected DarkPalette.Background from external (%q), got %q",
+			ext.DarkPalette.Background, output.Theme.DarkPalette.Background)
+	}
+	if output.Theme.DarkPalette.Accent != ext.DarkPalette.Accent {
+		t.Errorf("expected DarkPalette.Accent from external (%q), got %q",
+			ext.DarkPalette.Accent, output.Theme.DarkPalette.Accent)
+	}
+
+	// ThemeSource should indicate external
+	if output.Theme.ThemeSource.Kind != entity.ThemeSourceExternal {
+		t.Errorf("expected ThemeSource.Kind=external, got %q", output.Theme.ThemeSource.Kind)
+	}
+	if output.Theme.ThemeSource.Provider != "noctalia" {
+		t.Errorf("expected ThemeSource.Provider=noctalia, got %q", output.Theme.ThemeSource.Provider)
+	}
+	if output.Theme.ThemeSource.LastGood {
+		t.Error("expected ThemeSource.LastGood=false for fresh valid external theme")
+	}
+
+	// ColorSchemeSource should still reflect the detector
+	if output.Theme.ColorSchemeSource != "adwaita" {
+		t.Errorf("expected ColorSchemeSource='adwaita', got %q", output.Theme.ColorSchemeSource)
+	}
+}
+
+// TestResolveTheme_ValidExternal_DoesNotOverrideNonPaletteFields verifies that
+// external theme only overrides palette colors, not fonts, scale, or mode colors.
+func TestResolveTheme_ValidExternal_DoesNotOverrideNonPaletteFields(t *testing.T) {
+	ext := validExternalTheme()
+	mock := &newMockExternalSource{
+		theme:   ext,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		ColorScheme:       "default",
+		PrefersDark:       false,
+		ColorSchemeSource: "env",
+		Fonts: &entity.ThemeFonts{
+			SansFont:      "MyConfigSans",
+			SerifFont:     "MyConfigSerif",
+			MonospaceFont: "MyConfigMono",
+			GtkFont:       "MyConfigGtk",
+			DefaultSize:   14,
+		},
+		UIScale: 2.0,
+		ModeColors: &entity.ThemeModeColors{
+			PaneMode:    "#111111",
+			TabMode:     "#222222",
+			SessionMode: "#333333",
+			ResizeMode:  "#444444",
+		},
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Fonts should come from config, not external
+	if output.Theme.Fonts.SansFont != "MyConfigSans" {
+		t.Errorf("expected SansFont from config (%q), got %q",
+			"MyConfigSans", output.Theme.Fonts.SansFont)
+	}
+	if output.Theme.Fonts.DefaultSize != 14 {
+		t.Errorf("expected DefaultFontSize from config (14), got %d",
+			output.Theme.Fonts.DefaultSize)
+	}
+
+	// UI scale should come from config
+	if output.Theme.UIScale != 2.0 {
+		t.Errorf("expected UIScale=2.0 from config, got %f", output.Theme.UIScale)
+	}
+
+	// Mode colors should come from config
+	if output.Theme.ModeColors.PaneMode != "#111111" {
+		t.Errorf("expected PaneMode from config (#111111), got %q",
+			output.Theme.ModeColors.PaneMode)
+	}
+}
+
+// TestResolveTheme_PartialExternal_MergesOverConfig verifies that empty external
+// fields are treated as "inherit" rather than malformed.
+func TestResolveTheme_PartialExternal_MergesOverConfig(t *testing.T) {
+	partialLight := &entity.ColorPalette{
+		Accent: "#123456",
+	}
+	partialDark := &entity.ColorPalette{
+		Background: "#010203",
+		Border:     "#abcdef",
+	}
+	mock := &newMockExternalSource{
+		theme: &entity.ExternalTheme{
+			Name:         "Partial Noctalia",
+			Provider:     "noctalia",
+			LightPalette: partialLight,
+			DarkPalette:  partialDark,
+		},
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	assertNoWarnings(t, output.Theme.Warnings)
+
+	if output.Theme.LightPalette.Accent != "#123456" {
+		t.Errorf("expected partial external light accent override, got %q", output.Theme.LightPalette.Accent)
+	}
+	if output.Theme.LightPalette.Background != configLightPalette().Background {
+		t.Errorf("expected empty external light background to inherit config value %q, got %q",
+			configLightPalette().Background, output.Theme.LightPalette.Background)
+	}
+	if output.Theme.DarkPalette.Background != "#010203" {
+		t.Errorf("expected partial external dark background override, got %q", output.Theme.DarkPalette.Background)
+	}
+	if output.Theme.DarkPalette.Text != configDarkPalette().Text {
+		t.Errorf("expected empty external dark text to inherit config value %q, got %q",
+			configDarkPalette().Text, output.Theme.DarkPalette.Text)
+	}
+	if output.Theme.ThemeSource.Kind != entity.ThemeSourceExternal || output.Theme.ThemeSource.Provider != "noctalia" {
+		t.Errorf("expected noctalia external source metadata, got %+v", output.Theme.ThemeSource)
+	}
+}
+
+// TestResolveTheme_PartialExternal_MergesOverDefaults verifies partial external
+// palettes also merge over built-in defaults when config palettes are absent.
+func TestResolveTheme_PartialExternal_MergesOverDefaults(t *testing.T) {
+	mock := &newMockExternalSource{
+		theme: &entity.ExternalTheme{
+			Name: "Partial Defaults",
+			LightPalette: &entity.ColorPalette{
+				Accent: "#112233",
+			},
+			DarkPalette: &entity.ColorPalette{
+				Accent: "#445566",
+			},
+		},
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	output, err := uc.Execute(context.Background(), ResolveThemeInput{PrefersDark: false})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	if output.Theme.LightPalette.Accent != "#112233" {
+		t.Errorf("expected external light accent, got %q", output.Theme.LightPalette.Accent)
+	}
+	if output.Theme.LightPalette.Background != entity.DefaultLightPalette().Background {
+		t.Errorf("expected light background to inherit default %q, got %q",
+			entity.DefaultLightPalette().Background, output.Theme.LightPalette.Background)
+	}
+	if output.Theme.DarkPalette.Accent != "#445566" {
+		t.Errorf("expected external dark accent, got %q", output.Theme.DarkPalette.Accent)
+	}
+}
+
+func TestResolveTheme_PartialExternal_RepairsInvalidConfigFallbackFields(t *testing.T) {
+	partialLight := &entity.ColorPalette{Accent: "#112233"}
+	partialDark := &entity.ColorPalette{Background: "#445566"}
+	mock := &newMockExternalSource{
+		theme: &entity.ExternalTheme{
+			Name:         "Partial With Invalid Config",
+			Provider:     "noctalia",
+			LightPalette: partialLight,
+			DarkPalette:  partialDark,
+		},
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+	invalidLight := *configLightPalette()
+	invalidLight.Background = "not-a-hex"
+	invalidDark := *configDarkPalette()
+	invalidDark.Text = "also-invalid"
+
+	output, err := uc.Execute(context.Background(), ResolveThemeInput{
+		PrefersDark:  true,
+		LightPalette: &invalidLight,
+		DarkPalette:  &invalidDark,
+		UIScale:      1.0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	if output.Theme.LightPalette.Accent != "#112233" {
+		t.Fatalf("expected valid external light accent to survive invalid config fallback, got %q", output.Theme.LightPalette.Accent)
+	}
+	if output.Theme.LightPalette.Background != entity.DefaultLightPalette().Background {
+		t.Fatalf("expected invalid config light background to be repaired from defaults, got %q", output.Theme.LightPalette.Background)
+	}
+	if output.Theme.DarkPalette.Background != "#445566" {
+		t.Fatalf("expected valid external dark background to survive invalid config fallback, got %q", output.Theme.DarkPalette.Background)
+	}
+	if output.Theme.DarkPalette.Text != entity.DefaultDarkPalette().Text {
+		t.Fatalf("expected invalid config dark text to be repaired from defaults, got %q", output.Theme.DarkPalette.Text)
+	}
+	if output.Theme.ThemeSource.Kind != entity.ThemeSourceExternal || output.Theme.ThemeSource.LastGood {
+		t.Fatalf("expected fresh external source metadata, got %+v", output.Theme.ThemeSource)
+	}
+}
+
+// ============================================================
+// PrefersDark selects ActivePalette
+// ============================================================
+
+// TestResolveTheme_PrefersDark_SelectsDarkPalette verifies that when PrefersDark=true,
+// ActivePalette is the dark palette.
+func TestResolveTheme_PrefersDark_SelectsDarkPalette(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "config",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.Theme.ActivePalette.Background != configDarkPalette().Background {
+		t.Errorf("expected ActivePalette to be dark palette, got Background=%q",
+			output.Theme.ActivePalette.Background)
+	}
+	if !output.Theme.PrefersDark {
+		t.Error("expected PrefersDark=true in output")
+	}
+}
+
+// TestResolveTheme_PrefersLight_SelectsLightPalette verifies that when PrefersDark=false,
+// ActivePalette is the light palette.
+func TestResolveTheme_PrefersLight_SelectsLightPalette(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	input := ResolveThemeInput{
+		PrefersDark:       false,
+		ColorSchemeSource: "config",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.Theme.ActivePalette.Background != configLightPalette().Background {
+		t.Errorf("expected ActivePalette to be light palette, got Background=%q",
+			output.Theme.ActivePalette.Background)
+	}
+	if output.Theme.PrefersDark {
+		t.Error("expected PrefersDark=false in output")
+	}
+}
+
+// ============================================================
+// Malformed external at startup → config/default palettes + warning
+// ============================================================
+
+// TestResolveTheme_MalformedExternalAtStartup_FallsBackToConfig tests that when the
+// external theme has malformed palette colors on first resolution, the usecase falls
+// back to config/defaults and includes a warning.
+func TestResolveTheme_MalformedExternalAtStartup_FallsBackToConfig(t *testing.T) {
+	malformed := &entity.ExternalTheme{
+		Name: "Malformed Theme",
+		LightPalette: &entity.ColorPalette{
+			Background: "rgb(0,0,0)", // not hex
+			Text:       "#ffffff",
+		},
+		DarkPalette: &entity.ColorPalette{
+			Background: "#hijklm", // invalid hex
+			Text:       "#ffffff",
+		},
+	}
+	mock := &newMockExternalSource{
+		theme:   malformed,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	assertValidPaletteHex(t, "ActivePalette", output.Theme.ActivePalette)
+
+	// Should fall back to config palette (not the malformed external)
+	if output.Theme.DarkPalette.Background != configDarkPalette().Background {
+		t.Errorf("expected fallback to config dark palette (%q), got %q",
+			configDarkPalette().Background, output.Theme.DarkPalette.Background)
+	}
+
+	// Should have at least one warning about the malformed external
+	if len(output.Theme.Warnings) == 0 {
+		t.Error("expected at least one warning for malformed external theme")
+	}
+}
+
+// TestResolveTheme_MissingExternalAtStartup_FallsBackWithWarning verifies that enabled
+// external sources returning nil data are treated as missing, not silently ignored.
+func TestResolveTheme_MissingExternalAtStartup_FallsBackWithWarning(t *testing.T) {
+	mock := &newMockExternalSource{
+		theme:   nil,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.Theme.DarkPalette.Background != configDarkPalette().Background {
+		t.Errorf("expected missing external startup fallback to config dark palette %q, got %q",
+			configDarkPalette().Background, output.Theme.DarkPalette.Background)
+	}
+	if len(output.Theme.Warnings) == 0 {
+		t.Fatal("expected warning for missing external theme")
+	}
+	if output.Theme.ThemeSource.Kind == entity.ThemeSourceExternal {
+		t.Errorf("expected non-external source for startup missing external, got %+v", output.Theme.ThemeSource)
+	}
+}
+
+func TestResolveTheme_ReadErrorAtStartup_FallsBackWithWarning(t *testing.T) {
+	mock := &newMockExternalSource{
+		err:      errors.New("read failed"),
+		enabled:  true,
+		identity: "noctalia|colors-json|/tmp/theme-a.json",
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.Theme.DarkPalette.Background != configDarkPalette().Background {
+		t.Errorf("expected read-error startup fallback to config dark palette %q, got %q",
+			configDarkPalette().Background, output.Theme.DarkPalette.Background)
+	}
+	if output.Theme.ThemeSource.Kind == entity.ThemeSourceExternal {
+		t.Errorf("expected non-external source for startup read error, got %+v", output.Theme.ThemeSource)
+	}
+	if len(output.Theme.Warnings) == 0 {
+		t.Fatal("expected warning for external read error")
+	}
+}
+
+func TestResolveTheme_ReadErrorAfterValid_KeepsLastGoodForSameIdentity(t *testing.T) {
+	ext := validExternalTheme()
+	mock := &newMockExternalSource{
+		theme:    ext,
+		enabled:  true,
+		identity: "noctalia|colors-json|/tmp/theme-a.json",
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	first, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first resolution error: %v", err)
+	}
+	mock.theme = nil
+	mock.err = errors.New("temporary read failure")
+
+	second, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second resolution error: %v", err)
+	}
+	if second.Theme.DarkPalette.Background != first.Theme.DarkPalette.Background {
+		t.Errorf("expected same-identity read error to keep last-good dark background %q, got %q",
+			first.Theme.DarkPalette.Background, second.Theme.DarkPalette.Background)
+	}
+	if !second.Theme.ThemeSource.LastGood {
+		t.Fatal("expected LastGood=true for same-identity read error after valid external")
+	}
+}
+
+func TestResolveTheme_ExternalIdentityChangeClearsLastGoodBeforeReadError(t *testing.T) {
+	ext := validExternalTheme()
+	mock := &newMockExternalSource{
+		theme:    ext,
+		enabled:  true,
+		identity: "noctalia|colors-json|/tmp/theme-a.json",
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	first, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first resolution error: %v", err)
+	}
+	if first.Theme.DarkPalette.Background == configDarkPalette().Background {
+		t.Fatal("first resolution should use external palette, not config")
+	}
+
+	mock.theme = nil
+	mock.err = errors.New("new path missing")
+	mock.identity = "noctalia|colors-json|/tmp/theme-b.json"
+
+	second, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second resolution error: %v", err)
+	}
+	if second.Theme.DarkPalette.Background != configDarkPalette().Background {
+		t.Errorf("expected changed-identity read error to fall back to config dark background %q, got %q",
+			configDarkPalette().Background, second.Theme.DarkPalette.Background)
+	}
+	if second.Theme.ThemeSource.LastGood {
+		t.Fatal("expected LastGood=false after external identity changed")
+	}
+	if second.Theme.ThemeSource.Kind == entity.ThemeSourceExternal {
+		t.Errorf("expected non-external source after changed-identity read error, got %+v", second.Theme.ThemeSource)
+	}
+}
+
+// TestResolveTheme_MissingExternalAfterValid_KeepsLastGood verifies missing nil data
+// after a valid external theme keeps last-good with warning metadata.
+func TestResolveTheme_MissingExternalAfterValid_KeepsLastGood(t *testing.T) {
+	ext := validExternalTheme()
+	mock := &newMockExternalSource{
+		theme:   ext,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	first, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first resolution error: %v", err)
+	}
+	mock.theme = nil
+
+	second, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second resolution error: %v", err)
+	}
+
+	if second.Theme.DarkPalette.Background != first.Theme.DarkPalette.Background {
+		t.Errorf("expected last-good dark background %q, got %q",
+			first.Theme.DarkPalette.Background, second.Theme.DarkPalette.Background)
+	}
+	if !second.Theme.ThemeSource.LastGood {
+		t.Error("expected LastGood=true when missing external follows valid external")
+	}
+	if second.Theme.ThemeSource.Provider != "noctalia" {
+		t.Errorf("expected provider noctalia, got %q", second.Theme.ThemeSource.Provider)
+	}
+	if len(second.Theme.Warnings) == 0 {
+		t.Fatal("expected warning for missing external after valid")
+	}
+}
+
+// TestResolveTheme_MalformedExternalMissingPalette_FallsBack verifies fallback
+// when the external theme has nil palettes.
+func TestResolveTheme_MalformedExternalMissingPalette_FallsBack(t *testing.T) {
+	malformed := &entity.ExternalTheme{
+		Name:         "Missing Palettes",
+		LightPalette: nil,
+		DarkPalette:  nil,
+	}
+	mock := &newMockExternalSource{
+		theme:   malformed,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+
+	// Should have warnings about missing palettes
+	if len(output.Theme.Warnings) == 0 {
+		t.Error("expected warnings for external theme with nil palettes")
+	}
+}
+
+// ============================================================
+// Malformed after valid external → keep last-good external + warning
+// ============================================================
+
+// TestResolveTheme_MalformedAfterValid_KeepsLastGood tests the "last-good" contract:
+// when an external theme becomes malformed after previously being valid, the usecase
+// keeps the last-good external palette colors and emits a warning.
+func TestResolveTheme_MalformedAfterValid_KeepsLastGood(t *testing.T) {
+	// Step 1: First resolution with valid external
+	ext := validExternalTheme()
+	mock := &newMockExternalSource{
+		theme:   ext,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output1, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first resolution error: %v", err)
+	}
+
+	firstDarkBg := output1.Theme.DarkPalette.Background
+	// Verify first resolution uses external palette
+	if firstDarkBg != ext.DarkPalette.Background {
+		t.Fatalf("expected first resolution to use external dark palette (%q), got %q",
+			ext.DarkPalette.Background, firstDarkBg)
+	}
+
+	// Step 2: External becomes malformed
+	malformed := &entity.ExternalTheme{
+		Name: "Now Malformed",
+		LightPalette: &entity.ColorPalette{
+			Background: "bad-color",
+			Text:       "#ffffff",
+		},
+		DarkPalette: nil, // missing palette
+	}
+	mock.theme = malformed
+
+	output2, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second resolution error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "DarkPalette", output2.Theme.DarkPalette)
+	assertValidPaletteHex(t, "ActivePalette", output2.Theme.ActivePalette)
+
+	// Should keep last-good colors (from first resolution)
+	if output2.Theme.DarkPalette.Background != firstDarkBg {
+		t.Errorf("expected to keep last-good dark palette background (%q), got %q",
+			firstDarkBg, output2.Theme.DarkPalette.Background)
+	}
+
+	// Should have warnings about the malformed update
+	if len(output2.Theme.Warnings) == 0 {
+		t.Error("expected warnings when external becomes malformed after being valid")
+	}
+
+	// ThemeSource should still indicate external (last-good)
+	if output2.Theme.ThemeSource.Kind != entity.ThemeSourceExternal {
+		t.Errorf("expected ThemeSource.Kind='external' for last-good, got %q", output2.Theme.ThemeSource.Kind)
+	}
+	if output2.Theme.ThemeSource.Provider != "noctalia" {
+		t.Errorf("expected ThemeSource.Provider='noctalia' for last-good, got %q", output2.Theme.ThemeSource.Provider)
+	}
+	if !output2.Theme.ThemeSource.LastGood {
+		t.Error("expected ThemeSource.LastGood=true for last-good external palette")
+	}
+}
+
+// ============================================================
+// Disabling external after valid → clear last-good and use config/defaults
+// ============================================================
+
+// TestResolveTheme_DisablingExternalAfterValid_ClearsLastGood verifies that when the
+// external source is disabled after having provided a valid theme, last-good is cleared
+// and config/defaults are used instead.
+func TestResolveTheme_DisablingExternalAfterValid_ClearsLastGood(t *testing.T) {
+	// Step 1: First resolution with valid external
+	ext := validExternalTheme()
+	mock := &newMockExternalSource{
+		theme:   ext,
+		enabled: true,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output1, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first resolution error: %v", err)
+	}
+
+	// Verify first resolution uses external palette
+	if output1.Theme.DarkPalette.Background == configDarkPalette().Background {
+		t.Fatal("first resolution should use external palette, not config")
+	}
+
+	// Step 2: External becomes disabled
+	mock.theme = nil
+	mock.enabled = false
+
+	output2, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second resolution error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "DarkPalette", output2.Theme.DarkPalette)
+
+	// Should fall back to config palette (NOT keep last-good)
+	if output2.Theme.DarkPalette.Background != configDarkPalette().Background {
+		t.Errorf("expected fallback to config dark palette (%q) after external disabled, got %q",
+			configDarkPalette().Background, output2.Theme.DarkPalette.Background)
+	}
+
+	// ThemeSource should indicate config or default
+	if output2.Theme.ThemeSource.Kind == entity.ThemeSourceExternal {
+		t.Error("expected ThemeSource.Kind NOT to be 'external' after external is disabled")
+	}
+	if output2.Theme.ThemeSource.LastGood {
+		t.Error("expected ThemeSource.LastGood=false after external is disabled")
+	}
+}
+
+// TestResolveTheme_DisablingExternalTwice_Noop verifies that disabling external
+// when it was already disabled is a no-op (no warnings, uses config).
+func TestResolveTheme_DisablingExternalTwice_Noop(t *testing.T) {
+	// External already disabled from start
+	mock := &newMockExternalSource{
+		enabled: false,
+	}
+	uc := NewResolveThemeUseCase(mock)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.0,
+	}
+
+	output1, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first resolution error: %v", err)
+	}
+
+	// Should use config
+	if output1.Theme.DarkPalette.Background != configDarkPalette().Background {
+		t.Errorf("expected config dark palette, got %q", output1.Theme.DarkPalette.Background)
+	}
+
+	// Second resolution with same disabled state — should behave identically
+	output2, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second resolution error: %v", err)
+	}
+
+	if output2.Theme.DarkPalette.Background != configDarkPalette().Background {
+		t.Errorf("expected config dark palette on second call, got %q", output2.Theme.DarkPalette.Background)
+	}
+
+	assertNoWarnings(t, output2.Theme.Warnings)
+}
+
+// ============================================================
+// Output completeness: all ResolvedTheme fields
+// ============================================================
+
+// TestResolveTheme_OutputContainsAllFields verifies that every field of
+// ResolvedTheme is populated in the output (no zero-value surprises).
+func TestResolveTheme_OutputContainsAllFields(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	fonts := entity.ThemeFonts{
+		SansFont:      "config-sans",
+		SerifFont:     "config-serif",
+		MonospaceFont: "config-mono",
+		GtkFont:       "config-gtk",
+		DefaultSize:   12,
+	}
+	modeColors := entity.ThemeModeColors{
+		PaneMode:    "#111111",
+		TabMode:     "#222222",
+		SessionMode: "#333333",
+		ResizeMode:  "#444444",
+	}
+
+	input := ResolveThemeInput{
+		ColorScheme:       "prefer-dark",
+		PrefersDark:       true,
+		ColorSchemeSource: "config",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		Fonts:             &fonts,
+		UIScale:           1.25,
+		ModeColors:        &modeColors,
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rt := output.Theme
+
+	// LightPalette must be valid
+	assertValidPaletteHex(t, "LightPalette", rt.LightPalette)
+	// DarkPalette must be valid
+	assertValidPaletteHex(t, "DarkPalette", rt.DarkPalette)
+	// ActivePalette must be valid
+	assertValidPaletteHex(t, "ActivePalette", rt.ActivePalette)
+	// PrefersDark
+	if !rt.PrefersDark {
+		t.Error("expected PrefersDark=true")
+	}
+	// ColorSchemeSource
+	if rt.ColorSchemeSource != "config" {
+		t.Errorf("expected ColorSchemeSource='config', got %q", rt.ColorSchemeSource)
+	}
+	// ThemeSource
+	if rt.ThemeSource.Kind == "" {
+		t.Error("expected non-empty ThemeSource.Kind")
+	}
+	// Fonts
+	if rt.Fonts.SansFont == "" {
+		t.Error("expected non-empty Fonts.SansFont")
+	}
+	if rt.Fonts.SerifFont == "" {
+		t.Error("expected non-empty Fonts.SerifFont")
+	}
+	if rt.Fonts.DefaultSize <= 0 {
+		t.Errorf("expected positive Fonts.DefaultSize, got %d", rt.Fonts.DefaultSize)
+	}
+	// UIScale
+	if rt.UIScale <= 0 {
+		t.Errorf("expected positive UIScale, got %f", rt.UIScale)
+	}
+	// ModeColors
+	if rt.ModeColors.PaneMode == "" {
+		t.Error("expected non-empty ModeColors.PaneMode")
+	}
+	if rt.ModeColors.TabMode == "" {
+		t.Error("expected non-empty ModeColors.TabMode")
+	}
+	if rt.ModeColors.SessionMode == "" {
+		t.Error("expected non-empty ModeColors.SessionMode")
+	}
+	if rt.ModeColors.ResizeMode == "" {
+		t.Error("expected non-empty ModeColors.ResizeMode")
+	}
+}
+
+// ============================================================
+// All palette colors must be valid CSS-safe hex
+// ============================================================
+
+// TestResolveTheme_AllOutputPalettesAreCSSSafeHex is the contract test: every color
+// field in every palette of the output must be a valid #RRGGBB hex color.
+func TestResolveTheme_AllOutputPalettesAreCSSSafeHex(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	input := ResolveThemeInput{
+		PrefersDark:       false,
+		ColorSchemeSource: "fallback",
+		UIScale:           1.0,
+		// No config palettes — must get valid defaults
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertValidPaletteHex(t, "LightPalette", output.Theme.LightPalette)
+	assertValidPaletteHex(t, "DarkPalette", output.Theme.DarkPalette)
+	assertValidPaletteHex(t, "ActivePalette", output.Theme.ActivePalette)
+}
+
+// ============================================================
+// Font defaults are used when no config or external fonts provided
+// ============================================================
+
+// TestResolveTheme_NoConfigFonts_UsesDefaults verifies that when fonts are not
+// provided in config or external, sensible defaults are used.
+func TestResolveTheme_NoConfigFonts_UsesDefaults(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "fallback",
+		UIScale:           1.0,
+		// Fonts is nil
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defaults := entity.DefaultThemeFonts()
+
+	if output.Theme.Fonts.SansFont != defaults.SansFont {
+		t.Errorf("expected default SansFont (%q), got %q",
+			defaults.SansFont, output.Theme.Fonts.SansFont)
+	}
+	if output.Theme.Fonts.SerifFont != defaults.SerifFont {
+		t.Errorf("expected default SerifFont (%q), got %q",
+			defaults.SerifFont, output.Theme.Fonts.SerifFont)
+	}
+	if output.Theme.Fonts.DefaultSize != defaults.DefaultSize {
+		t.Errorf("expected default DefaultSize (%d), got %d",
+			defaults.DefaultSize, output.Theme.Fonts.DefaultSize)
+	}
+}
+
+// ============================================================
+// Mode color defaults are used when not provided
+// ============================================================
+
+// TestResolveTheme_NoConfigModeColors_UsesDefaults verifies that when mode colors
+// are not provided, sensible defaults are used.
+func TestResolveTheme_NoConfigModeColors_UsesDefaults(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "fallback",
+		UIScale:           1.0,
+		// ModeColors is nil
+	}
+
+	output, err := uc.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Mode colors must be valid CSS-safe hex
+	fields := map[string]string{
+		"PaneMode":    output.Theme.ModeColors.PaneMode,
+		"TabMode":     output.Theme.ModeColors.TabMode,
+		"SessionMode": output.Theme.ModeColors.SessionMode,
+		"ResizeMode":  output.Theme.ModeColors.ResizeMode,
+	}
+	for name, value := range fields {
+		if value == "" {
+			t.Errorf("expected non-empty ModeColors.%s", name)
+		}
+		if !entity.IsValidHex(value) {
+			t.Errorf("ModeColors.%s = %q is not valid CSS-safe hex", name, value)
+		}
+	}
+}
+
+// TestResolveTheme_InvalidModeColors_FallsBackToDefaults verifies invalid config mode
+// colors cannot pass through ResolvedTheme.
+func TestResolveTheme_InvalidModeColors_FallsBackToDefaults(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+	invalid := &entity.ThemeModeColors{
+		PaneMode:    "not-a-color",
+		TabMode:     "#222222",
+		SessionMode: "#333333",
+		ResizeMode:  "#444444",
+	}
+
+	output, err := uc.Execute(context.Background(), ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "config",
+		ModeColors:        invalid,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defaults := entity.DefaultThemeModeColors()
+	if output.Theme.ModeColors != defaults {
+		t.Errorf("expected invalid mode colors to fall back to defaults %+v, got %+v", defaults, output.Theme.ModeColors)
+	}
+	if len(output.Theme.Warnings) == 0 {
+		t.Fatal("expected warning for invalid mode colors")
+	}
+}
+
+// ============================================================
+// UIScale defaults
+// ============================================================
+
+// TestResolveTheme_UIScaleDefaultsToOne verifies that when UIScale is zero or negative,
+// it defaults to 1.0.
+func TestResolveTheme_UIScaleDefaultsToOne(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	tests := []struct {
+		name     string
+		uiScale  float64
+		expected float64
+	}{
+		{"zero", 0.0, 1.0},
+		{"negative", -0.5, 1.0},
+		{"positive", 1.25, 1.25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := ResolveThemeInput{
+				PrefersDark:       true,
+				ColorSchemeSource: "fallback",
+				UIScale:           tt.uiScale,
+			}
+
+			output, err := uc.Execute(context.Background(), input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if output.Theme.UIScale != tt.expected {
+				t.Errorf("expected UIScale=%f, got %f", tt.expected, output.Theme.UIScale)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Color scheme source is properly captured
+// ============================================================
+
+// TestResolveTheme_ColorSchemeSourceIsCaptured verifies that the color scheme
+// source string is passed through to the output.
+func TestResolveTheme_ColorSchemeSourceIsCaptured(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+
+	sources := []string{"config", "adwaita", "gsettings", "env", "fallback"}
+
+	for _, source := range sources {
+		input := ResolveThemeInput{
+			PrefersDark:       true,
+			ColorSchemeSource: source,
+			UIScale:           1.0,
+		}
+
+		output, err := uc.Execute(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error for source %q: %v", source, err)
+		}
+
+		if output.Theme.ColorSchemeSource != source {
+			t.Errorf("expected ColorSchemeSource=%q, got %q", source, output.Theme.ColorSchemeSource)
+		}
+	}
+}
+
+// ============================================================
+// Refresh API
+// ============================================================
+
+// TestResolveTheme_RefreshDelegatesToExecute verifies the refresh/update API returns
+// the same single result shape as Execute without adding CSS generation or I/O.
+func TestResolveTheme_RefreshDelegatesToExecute(t *testing.T) {
+	uc := NewResolveThemeUseCase(nil)
+	input := ResolveThemeInput{
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		LightPalette:      configLightPalette(),
+		DarkPalette:       configDarkPalette(),
+		UIScale:           1.25,
+	}
+
+	output, err := uc.Refresh(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !output.Theme.PrefersDark {
+		t.Error("expected refreshed theme to preserve PrefersDark")
+	}
+	if output.Theme.ActivePalette.Background != configDarkPalette().Background {
+		t.Errorf("expected refreshed active palette background %q, got %q",
+			configDarkPalette().Background, output.Theme.ActivePalette.Background)
+	}
+	if output.Theme.UIScale != 1.25 {
+		t.Errorf("expected refreshed UI scale 1.25, got %f", output.Theme.UIScale)
+	}
+}
+
+// ============================================================
+// Input mapping from domain config shapes
+// ============================================================
+
+// TestResolveThemeInputFromConfig_MapsAppearanceStylingAndPreference verifies
+// app/bootstrap callers can build usecase input without duplicating fallback logic.
+func TestResolveThemeInputFromConfig_MapsAppearanceStylingAndPreference(t *testing.T) {
+	appearance := &entity.AppearanceConfig{
+		SansFont:        "Inter",
+		SerifFont:       "Georgia",
+		MonospaceFont:   "JetBrains Mono",
+		GtkFont:         "Adwaita Sans",
+		DefaultFontSize: 18,
+		ColorScheme:     "prefer-dark",
+		LightPalette:    *configLightPalette(),
+		DarkPalette:     *configDarkPalette(),
+	}
+	styling := &entity.WorkspaceStylingConfig{
+		PaneModeColor:    "#111111",
+		TabModeColor:     "#222222",
+		SessionModeColor: "#333333",
+		ResizeModeColor:  "#444444",
+	}
+	preference := port.ColorSchemePreference{PrefersDark: true, Source: "adwaita"}
+
+	input := ResolveThemeInputFromConfig(appearance, 1.25, styling, preference)
+
+	if input.ColorScheme != "prefer-dark" {
+		t.Errorf("expected color scheme prefer-dark, got %q", input.ColorScheme)
+	}
+	if !input.PrefersDark || input.ColorSchemeSource != "adwaita" {
+		t.Errorf("expected preference from detector, got PrefersDark=%v Source=%q", input.PrefersDark, input.ColorSchemeSource)
+	}
+	if input.LightPalette == nil || input.LightPalette.Background != configLightPalette().Background {
+		t.Fatalf("expected light palette pointer from appearance, got %+v", input.LightPalette)
+	}
+	if input.DarkPalette == nil || input.DarkPalette.Background != configDarkPalette().Background {
+		t.Fatalf("expected dark palette pointer from appearance, got %+v", input.DarkPalette)
+	}
+	if input.Fonts == nil || input.Fonts.SansFont != "Inter" || input.Fonts.DefaultSize != 18 {
+		t.Fatalf("expected fonts from appearance, got %+v", input.Fonts)
+	}
+	if input.UIScale != 1.25 {
+		t.Errorf("expected UI scale 1.25, got %f", input.UIScale)
+	}
+	if input.ModeColors == nil || input.ModeColors.PaneMode != "#111111" || input.ModeColors.ResizeMode != "#444444" {
+		t.Fatalf("expected mode colors from styling, got %+v", input.ModeColors)
+	}
+}
+
+// TestResolveThemeInputFromConfig_AllowsNilConfig verifies callers can resolve defaults
+// when appearance/styling config is unavailable.
+func TestResolveThemeInputFromConfig_AllowsNilConfig(t *testing.T) {
+	preference := port.ColorSchemePreference{PrefersDark: false, Source: "fallback"}
+
+	input := ResolveThemeInputFromConfig(nil, 0, nil, preference)
+
+	if input.ColorScheme != "" {
+		t.Errorf("expected empty color scheme for nil appearance, got %q", input.ColorScheme)
+	}
+	if input.PrefersDark || input.ColorSchemeSource != "fallback" {
+		t.Errorf("expected fallback light preference, got PrefersDark=%v Source=%q", input.PrefersDark, input.ColorSchemeSource)
+	}
+	if input.LightPalette != nil || input.DarkPalette != nil || input.Fonts != nil || input.ModeColors != nil {
+		t.Fatalf("expected nil optional inputs, got light=%v dark=%v fonts=%v modes=%v",
+			input.LightPalette, input.DarkPalette, input.Fonts, input.ModeColors)
+	}
+}

--- a/internal/bootstrap/engine.go
+++ b/internal/bootstrap/engine.go
@@ -23,19 +23,27 @@ import (
 
 // EngineInput holds the input for BuildEngine.
 type EngineInput struct {
-	Ctx            context.Context
-	Config         *config.Config
-	RuntimeProfile runtimeprofile.Profile
-	ThemeManager   *theme.Manager
-	ColorResolver  port.ColorSchemeResolver
-	Logger         zerolog.Logger
+	Ctx                 context.Context
+	Config              *config.Config
+	RuntimeProfile      runtimeprofile.Profile
+	ThemeManager        *theme.Manager
+	ExternalThemeSource port.ExternalThemeSource
+	ColorResolver       port.ColorSchemeResolver
+	Logger              zerolog.Logger
 }
 
 // BuildEngine constructs a port.Engine for the engine type specified in cfg.Engine.Type.
 func BuildEngine(input EngineInput) (port.Engine, error) {
 	cfg := input.Config
 	systemviewReader := config.NewSystemviewConfigReader(env.NewHardwareSurveyor())
-	systemviewUC := usecase.NewReadSystemviewConfigUseCase(systemviewReader)
+	systemviewUC := usecase.NewReadSystemviewConfigUseCase(
+		systemviewReader,
+		usecase.WithSystemviewResolvedAppearance(
+			input.ExternalThemeSource,
+			input.ColorResolver,
+			prefersDarkProvider(input.ThemeManager),
+		),
+	)
 	buildConfigPayload := func(read func(context.Context) (dto.SystemviewConfigPayload, error)) func() ([]byte, error) {
 		return func() ([]byte, error) {
 			payload, err := read(input.Ctx)
@@ -117,6 +125,15 @@ func BuildEngine(input EngineInput) (port.Engine, error) {
 		}, cefCfg, audioFactory, deps)
 	default:
 		return nil, fmt.Errorf("unknown engine type: %q", engineType)
+	}
+}
+
+func prefersDarkProvider(manager *theme.Manager) func() bool {
+	return func() bool {
+		if manager == nil {
+			return true
+		}
+		return manager.PrefersDark()
 	}
 }
 

--- a/internal/bootstrap/gui.go
+++ b/internal/bootstrap/gui.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/bnema/dumber/internal/infrastructure/colorscheme"
 	"github.com/bnema/dumber/internal/infrastructure/config"
 	"github.com/bnema/dumber/internal/infrastructure/deps"
 	"github.com/bnema/dumber/internal/infrastructure/env"
+	"github.com/bnema/dumber/internal/infrastructure/externaltheme/noctalia"
 	"github.com/bnema/dumber/internal/infrastructure/media"
 	"github.com/bnema/dumber/internal/infrastructure/persistence/sqlite"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
@@ -30,11 +32,15 @@ type DatabaseResult struct {
 
 // ParallelInitResult holds the results of parallel initialization phase.
 type ParallelInitResult struct {
-	RuntimeProfile  runtimeprofile.Profile
-	ThemeManager    *theme.Manager
-	ColorResolver   port.ColorSchemeResolver
-	AdwaitaDetector *colorscheme.AdwaitaDetector
-	Duration        time.Duration
+	RuntimeProfile       runtimeprofile.Profile
+	ThemeManager         *theme.Manager
+	ResolvedTheme        entity.ResolvedTheme
+	ResolveThemeUC       *usecase.ResolveThemeUseCase
+	ExternalThemeSource  port.ConfigurableExternalThemeSource
+	ExternalThemeWatcher port.ExternalThemeWatcher
+	ColorResolver        port.ColorSchemeResolver
+	AdwaitaDetector      *colorscheme.AdwaitaDetector
+	Duration             time.Duration
 }
 
 // DeferredInitResult holds results from deferred initialization checks.
@@ -90,8 +96,9 @@ func (e *RuntimeRequirementsError) LogDetails(ctx context.Context) {
 // Returns the first fatal error encountered, or nil with the results.
 func RunParallelInit(input ParallelInitInput) (*ParallelInitResult, error) {
 	var (
-		dirsErr error
-		wg      sync.WaitGroup
+		dirsErr  error
+		themeErr error
+		wg       sync.WaitGroup
 	)
 
 	profile, err := ResolveRuntimeProfile(input.Config)
@@ -122,14 +129,28 @@ func RunParallelInit(input ParallelInitInput) (*ParallelInitResult, error) {
 		dirsErr = resolveWebKitDirs(profile)
 	}()
 
-	// Theme manager (CPU-bound, no I/O)
+	// Theme manager. External theme file reads, when enabled, are non-fatal
+	// and reported as theme warnings by the usecase.
+	externalThemeSource := noctalia.NewFileSourceFromConfig(input.Config.Appearance.ExternalTheme)
+	resolveThemeUC := usecase.NewResolveThemeUseCase(externalThemeSource)
 	var themeManager *theme.Manager
+	var resolvedTheme entity.ResolvedTheme
 	go func() {
 		defer wg.Done()
-		themeManager = theme.NewManager(
-			input.Ctx, &input.Config.Appearance, input.Config.DefaultUIScale,
-			&input.Config.Workspace.Styling, resolver,
-		)
+		preference := resolver.Resolve()
+		resolved, err := resolveThemeUC.Execute(input.Ctx, usecase.ResolveThemeInputFromConfig(
+			&input.Config.Appearance,
+			input.Config.DefaultUIScale,
+			&input.Config.Workspace.Styling,
+			preference,
+		))
+		if err != nil {
+			themeErr = err
+			return
+		}
+		LogResolvedTheme(input.Ctx, resolved.Theme)
+		resolvedTheme = resolved.Theme
+		themeManager = theme.NewManager(input.Ctx, resolved.Theme)
 	}()
 
 	wg.Wait()
@@ -139,14 +160,40 @@ func RunParallelInit(input ParallelInitInput) (*ParallelInitResult, error) {
 	if dirsErr != nil {
 		return nil, fmt.Errorf("resolve directories: %w", dirsErr)
 	}
+	if themeErr != nil {
+		return nil, fmt.Errorf("resolve theme: %w", themeErr)
+	}
 
 	return &ParallelInitResult{
-		RuntimeProfile:  profile,
-		ThemeManager:    themeManager,
-		ColorResolver:   resolver,
-		AdwaitaDetector: adwaitaDetector,
-		Duration:        duration,
+		RuntimeProfile:       profile,
+		ThemeManager:         themeManager,
+		ResolvedTheme:        resolvedTheme,
+		ResolveThemeUC:       resolveThemeUC,
+		ExternalThemeSource:  externalThemeSource,
+		ExternalThemeWatcher: noctalia.NewFileWatcher(),
+		ColorResolver:        resolver,
+		AdwaitaDetector:      adwaitaDetector,
+		Duration:             duration,
 	}, nil
+}
+
+// LogResolvedTheme writes a compact theme-source summary and non-fatal warnings.
+func LogResolvedTheme(ctx context.Context, resolved entity.ResolvedTheme) {
+	log := logging.FromContext(ctx)
+	for _, warning := range resolved.Warnings {
+		log.Warn().Str("field", warning.Field).Msg(warning.Message)
+	}
+	event := log.Info().
+		Str("theme_source", string(resolved.ThemeSource.Kind)).
+		Str("color_scheme_source", resolved.ColorSchemeSource).
+		Bool("prefers_dark", resolved.PrefersDark)
+	if resolved.ThemeSource.Provider != "" {
+		event = event.Str("provider", resolved.ThemeSource.Provider)
+	}
+	if resolved.ThemeSource.LastGood {
+		event = event.Bool("last_good", true)
+	}
+	event.Msg("theme resolved")
 }
 
 // RunDeferredInit runs deferred initialization checks off the critical path.
@@ -275,11 +322,12 @@ type ParallelDBEngineResult struct {
 
 // ParallelDBEngineInput holds inputs for parallel DB and engine initialization.
 type ParallelDBEngineInput struct {
-	Ctx            context.Context
-	Config         *config.Config
-	RuntimeProfile runtimeprofile.Profile
-	ThemeManager   *theme.Manager
-	ColorResolver  port.ColorSchemeResolver
+	Ctx                 context.Context
+	Config              *config.Config
+	RuntimeProfile      runtimeprofile.Profile
+	ThemeManager        *theme.Manager
+	ExternalThemeSource port.ExternalThemeSource
+	ColorResolver       port.ColorSchemeResolver
 }
 
 // Note: Database path is resolved via config.GetDatabaseFile() internally.
@@ -314,12 +362,13 @@ func RunParallelDBEngine(input ParallelDBEngineInput) (*ParallelDBEngineResult, 
 
 	// Engine on main thread (GTK requirement)
 	engine, err := BuildEngine(EngineInput{
-		Ctx:            input.Ctx,
-		Config:         input.Config,
-		RuntimeProfile: input.RuntimeProfile,
-		ThemeManager:   input.ThemeManager,
-		ColorResolver:  input.ColorResolver,
-		Logger:         *log,
+		Ctx:                 input.Ctx,
+		Config:              input.Config,
+		RuntimeProfile:      input.RuntimeProfile,
+		ThemeManager:        input.ThemeManager,
+		ExternalThemeSource: input.ExternalThemeSource,
+		ColorResolver:       input.ColorResolver,
+		Logger:              *log,
 	})
 	if err != nil {
 		dbRes := <-dbCh

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -13,8 +13,10 @@ import (
 	"github.com/bnema/dumber/internal/bootstrap"
 	"github.com/bnema/dumber/internal/cli/styles"
 	"github.com/bnema/dumber/internal/domain/build"
+	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/bnema/dumber/internal/domain/repository"
 	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/infrastructure/externaltheme/noctalia"
 	"github.com/bnema/dumber/internal/infrastructure/favicon"
 	infralogging "github.com/bnema/dumber/internal/infrastructure/logging"
 	"github.com/bnema/dumber/internal/infrastructure/persistence/sqlite"
@@ -56,8 +58,9 @@ func NewApp() (*App, error) {
 		return nil, fmt.Errorf("resolve runtime profile: %w", err)
 	}
 
-	// Create theme from config
-	theme := styles.NewTheme(cfg)
+	// Create theme through the shared resolver. CLI keeps the historical dark default
+	// unless config explicitly requests a light scheme.
+	theme := styles.NewThemeFromResolved(resolveCLITheme(cfg))
 
 	// Start with a quiet logger. If a browser session is active, we'll attach to it.
 	logLevel := cfg.Logging.Level
@@ -155,6 +158,42 @@ func (a *App) Close() error {
 		return a.db.Close()
 	}
 	return nil
+}
+
+func resolveCLITheme(cfg *config.Config) entity.ResolvedTheme {
+	colorScheme := ""
+	if cfg != nil {
+		colorScheme = cfg.Appearance.ColorScheme
+	}
+	preference := usecase.ColorSchemePreferenceFromConfig(colorScheme, port.ColorSchemePreference{
+		PrefersDark: true,
+		Source:      "cli",
+	})
+
+	var appearance *entity.AppearanceConfig
+	var styling *entity.WorkspaceStylingConfig
+	var uiScale float64
+	if cfg != nil {
+		appearance = &cfg.Appearance
+		styling = &cfg.Workspace.Styling
+		uiScale = cfg.DefaultUIScale
+	}
+
+	externalThemeSource := noctalia.NewFileSource(false, "")
+	if cfg != nil {
+		externalThemeSource.Configure(cfg.Appearance.ExternalTheme)
+	}
+	uc := usecase.NewResolveThemeUseCase(externalThemeSource)
+	out, err := uc.Execute(context.Background(), usecase.ResolveThemeInputFromConfig(
+		appearance,
+		uiScale,
+		styling,
+		preference,
+	))
+	if err != nil {
+		return entity.ResolvedTheme{ActivePalette: entity.DefaultDarkPalette()}
+	}
+	return out.Theme
 }
 
 // Ctx returns the application context with logger.

--- a/internal/cli/app_theme_test.go
+++ b/internal/cli/app_theme_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/infrastructure/config"
+)
+
+func TestResolveCLIThemePreservesDarkDefault(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ColorScheme = "default"
+
+	resolved := resolveCLITheme(cfg)
+
+	require.True(t, resolved.PrefersDark)
+	require.Equal(t, cfg.Appearance.DarkPalette.Background, resolved.ActivePalette.Background)
+}
+
+func TestResolveCLIThemeHonorsExplicitLightPreference(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ColorScheme = "prefer-light"
+
+	resolved := resolveCLITheme(cfg)
+
+	require.False(t, resolved.PrefersDark)
+	require.Equal(t, cfg.Appearance.LightPalette.Background, resolved.ActivePalette.Background)
+}
+
+func TestResolveCLIThemeUsesEnabledExternalTheme(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "theme.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+		"light":{"background":"#ffffff","accent":"#112233"},
+		"dark":{"background":"#000000","accent":"#445566"}
+	}`), 0o600))
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ExternalTheme.Enabled = true
+	cfg.Appearance.ExternalTheme.Provider = "noctalia"
+	cfg.Appearance.ExternalTheme.Format = "dumber-json"
+	cfg.Appearance.ExternalTheme.Path = path
+
+	resolved := resolveCLITheme(cfg)
+
+	require.True(t, resolved.PrefersDark)
+	require.Equal(t, "#000000", resolved.ActivePalette.Background)
+	require.Equal(t, "#445566", resolved.ActivePalette.Accent)
+	require.Equal(t, "external", string(resolved.ThemeSource.Kind))
+	require.Equal(t, "noctalia", resolved.ThemeSource.Provider)
+}

--- a/internal/cli/styles/theme.go
+++ b/internal/cli/styles/theme.go
@@ -4,6 +4,7 @@ package styles
 import (
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/bnema/dumber/internal/infrastructure/config"
 )
 
@@ -78,6 +79,18 @@ func NewTheme(cfg *config.Config) *Theme {
 		p = DefaultDarkPalette()
 	}
 
+	return NewThemeFromPalette(p)
+}
+
+// NewThemeFromResolved creates a Theme from the active resolved palette.
+func NewThemeFromResolved(resolved entity.ResolvedTheme) *Theme {
+	p := resolved.ActivePalette
+	if p == (entity.ColorPalette{}) {
+		p = resolved.DarkPalette
+	}
+	if p == (entity.ColorPalette{}) {
+		p = DefaultDarkPalette()
+	}
 	return NewThemeFromPalette(p)
 }
 

--- a/internal/cli/styles/theme_test.go
+++ b/internal/cli/styles/theme_test.go
@@ -48,3 +48,16 @@ func TestNewThemeFromResolvedFallsBackToDarkPalette(t *testing.T) {
 	require.Equal(t, lipgloss.Color("#111111"), theme.Background)
 	require.Equal(t, lipgloss.Color("#fedcba"), theme.Accent)
 }
+
+func TestNewThemeFromResolvedFallsBackToDefaultDarkPalette(t *testing.T) {
+	resolved := entity.ResolvedTheme{}
+	palette := styles.DefaultDarkPalette()
+
+	theme := styles.NewThemeFromResolved(resolved)
+
+	require.Equal(t, lipgloss.Color(palette.Background), theme.Background)
+	require.Equal(t, lipgloss.Color(palette.Surface), theme.Surface)
+	require.Equal(t, lipgloss.Color(palette.Text), theme.Text)
+	require.Equal(t, lipgloss.Color(palette.Accent), theme.Accent)
+	require.Equal(t, lipgloss.Color(palette.Accent), theme.Success)
+}

--- a/internal/cli/styles/theme_test.go
+++ b/internal/cli/styles/theme_test.go
@@ -1,0 +1,50 @@
+package styles_test
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/cli/styles"
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+func TestNewThemeFromResolvedUsesActivePalette(t *testing.T) {
+	resolved := entity.ResolvedTheme{
+		ActivePalette: entity.ColorPalette{
+			Background:     "#010101",
+			Surface:        "#020202",
+			SurfaceVariant: "#030303",
+			Text:           "#fefefe",
+			Muted:          "#999999",
+			Accent:         "#abcdef",
+			Border:         "#444444",
+		},
+	}
+
+	theme := styles.NewThemeFromResolved(resolved)
+
+	require.Equal(t, lipgloss.Color("#010101"), theme.Background)
+	require.Equal(t, lipgloss.Color("#abcdef"), theme.Accent)
+	require.Equal(t, lipgloss.Color("#abcdef"), theme.Success)
+}
+
+func TestNewThemeFromResolvedFallsBackToDarkPalette(t *testing.T) {
+	resolved := entity.ResolvedTheme{
+		DarkPalette: entity.ColorPalette{
+			Background:     "#111111",
+			Surface:        "#222222",
+			SurfaceVariant: "#333333",
+			Text:           "#eeeeee",
+			Muted:          "#888888",
+			Accent:         "#fedcba",
+			Border:         "#444444",
+		},
+	}
+
+	theme := styles.NewThemeFromResolved(resolved)
+
+	require.Equal(t, lipgloss.Color("#111111"), theme.Background)
+	require.Equal(t, lipgloss.Color("#fedcba"), theme.Accent)
+}

--- a/internal/domain/entity/config_types.go
+++ b/internal/domain/entity/config_types.go
@@ -6,14 +6,23 @@ package entity
 
 // AppearanceConfig holds visual appearance settings.
 type AppearanceConfig struct {
-	SansFont        string       `mapstructure:"sans_font" yaml:"sans_font" toml:"sans_font" json:"sans_font"`
-	SerifFont       string       `mapstructure:"serif_font" yaml:"serif_font" toml:"serif_font" json:"serif_font"`
-	MonospaceFont   string       `mapstructure:"monospace_font" yaml:"monospace_font" toml:"monospace_font" json:"monospace_font"`
-	GtkFont         string       `mapstructure:"gtk_font" yaml:"gtk_font" toml:"gtk_font" json:"gtk_font"`
-	DefaultFontSize int          `mapstructure:"default_font_size" yaml:"default_font_size" toml:"default_font_size" json:"default_font_size"`
-	LightPalette    ColorPalette `mapstructure:"light_palette" yaml:"light_palette" toml:"light_palette" json:"light_palette"`
-	DarkPalette     ColorPalette `mapstructure:"dark_palette" yaml:"dark_palette" toml:"dark_palette" json:"dark_palette"`
-	ColorScheme     string       `mapstructure:"color_scheme" yaml:"color_scheme" toml:"color_scheme" json:"color_scheme"`
+	SansFont        string              `mapstructure:"sans_font" yaml:"sans_font" toml:"sans_font" json:"sans_font"`
+	SerifFont       string              `mapstructure:"serif_font" yaml:"serif_font" toml:"serif_font" json:"serif_font"`
+	MonospaceFont   string              `mapstructure:"monospace_font" yaml:"monospace_font" toml:"monospace_font" json:"monospace_font"`
+	GtkFont         string              `mapstructure:"gtk_font" yaml:"gtk_font" toml:"gtk_font" json:"gtk_font"`
+	DefaultFontSize int                 `mapstructure:"default_font_size" yaml:"default_font_size" toml:"default_font_size" json:"default_font_size"` //nolint:lll // struct tags must stay on one line
+	LightPalette    ColorPalette        `mapstructure:"light_palette" yaml:"light_palette" toml:"light_palette" json:"light_palette"`
+	DarkPalette     ColorPalette        `mapstructure:"dark_palette" yaml:"dark_palette" toml:"dark_palette" json:"dark_palette"`
+	ColorScheme     string              `mapstructure:"color_scheme" yaml:"color_scheme" toml:"color_scheme" json:"color_scheme"`
+	ExternalTheme   ExternalThemeConfig `mapstructure:"external_theme" yaml:"external_theme" toml:"external_theme" json:"external_theme"`
+}
+
+// ExternalThemeConfig controls optional external theme loading.
+type ExternalThemeConfig struct {
+	Enabled  bool   `mapstructure:"enabled" yaml:"enabled" toml:"enabled" json:"enabled"`
+	Provider string `mapstructure:"provider" yaml:"provider" toml:"provider" json:"provider"`
+	Format   string `mapstructure:"format" yaml:"format" toml:"format" json:"format"`
+	Path     string `mapstructure:"path" yaml:"path" toml:"path" json:"path"`
 }
 
 // ColorPalette defines the color scheme for a theme variant (light/dark).

--- a/internal/domain/entity/theme.go
+++ b/internal/domain/entity/theme.go
@@ -1,0 +1,299 @@
+package entity
+
+import "regexp"
+
+// ThemeSourceKind describes where the resolved palette colors originated.
+type ThemeSourceKind string
+
+const (
+	// ThemeSourceDefault indicates palette colors come from built-in defaults.
+	ThemeSourceDefault ThemeSourceKind = "default"
+	// ThemeSourceConfig indicates palette colors come from user configuration.
+	ThemeSourceConfig ThemeSourceKind = "config"
+	// ThemeSourceExternal indicates palette colors come from an external theme source.
+	ThemeSourceExternal ThemeSourceKind = "external"
+)
+
+// ThemeSourceMetadata describes the palette source used for a resolved theme.
+type ThemeSourceMetadata struct {
+	Kind     ThemeSourceKind
+	Provider string
+	LastGood bool
+}
+
+// ThemeWarning represents a non-fatal issue encountered during theme resolution.
+type ThemeWarning struct {
+	Field   string
+	Message string
+}
+
+// ThemeFonts holds the resolved font families and default size.
+type ThemeFonts struct {
+	SansFont      string
+	SerifFont     string
+	MonospaceFont string
+	GtkFont       string
+	DefaultSize   int
+}
+
+// ThemeModeColors holds mode indicator colors.
+// All values must be CSS-safe hex colors (e.g., "#4A90E2").
+type ThemeModeColors struct {
+	PaneMode    string
+	TabMode     string
+	SessionMode string
+	ResizeMode  string
+}
+
+// ResolvedThemePalette is a CSS-safe hex color palette.
+// Alias for ColorPalette with the contract that all color strings
+// are valid CSS hex colors (validated during resolution).
+type ResolvedThemePalette = ColorPalette
+
+// ExternalTheme represents palette data from an external source (e.g., Noctalia).
+// External themes override palette colors only; fonts, UI scale, and mode colors stay in Dumber config.
+// It must not depend on GTK, WebKit, CEF, lipgloss, fsnotify, Viper, or infrastructure config.
+type ExternalTheme struct {
+	Name     string
+	Provider string
+
+	// LightPalette and DarkPalette may contain partial overrides.
+	// Nil palette pointers are malformed; empty fields mean "use the resolved config/default field".
+	LightPalette *ColorPalette
+	DarkPalette  *ColorPalette
+}
+
+// ResolvedTheme is the final resolved theme output.
+// It contains palettes, fonts, colors, scale, and metadata.
+// All palette colors are guaranteed to be CSS-safe hex colors.
+// CSS generation is NOT part of this core type — it is a separate adapter concern.
+type ResolvedTheme struct {
+	LightPalette      ResolvedThemePalette
+	DarkPalette       ResolvedThemePalette
+	ActivePalette     ResolvedThemePalette
+	PrefersDark       bool
+	ColorSchemeSource string
+	ThemeSource       ThemeSourceMetadata
+	Fonts             ThemeFonts
+	UIScale           float64
+	ModeColors        ThemeModeColors
+	Warnings          []ThemeWarning
+}
+
+// hexColorRegex matches valid CSS-safe #RRGGBB hex colors (strict).
+var hexColorRegex = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+
+// IsValidHex returns true if s is a valid CSS-safe hex color (#RRGGBB format only).
+func IsValidHex(s string) bool {
+	return hexColorRegex.MatchString(s)
+}
+
+// DefaultThemeFonts returns Dumber's appearance font defaults.
+func DefaultThemeFonts() ThemeFonts {
+	return ThemeFonts{
+		SansFont:      "Fira Sans",
+		SerifFont:     "Fira Sans",
+		MonospaceFont: "Fira Code",
+		GtkFont:       "Adwaita Sans",
+		DefaultSize:   16,
+	}
+}
+
+// DefaultThemeModeColors returns the default mode indicator colors.
+// These match the existing default mode colors from config/infrastructure.
+func DefaultThemeModeColors() ThemeModeColors {
+	return ThemeModeColors{
+		PaneMode:    "#4A90E2",
+		TabMode:     "#FFA500",
+		SessionMode: "#9B59B6",
+		ResizeMode:  "#00D4AA",
+	}
+}
+
+// DefaultDarkPalette returns the built-in dark theme palette.
+// These values mirror the config default dark palette.
+func DefaultDarkPalette() ColorPalette {
+	return ColorPalette{
+		Background:     "#0a0a0b",
+		Surface:        "#18181b",
+		SurfaceVariant: "#27272a",
+		Text:           "#fafafa",
+		Muted:          "#a1a1aa",
+		Accent:         "#4ade80",
+		Border:         "#3f3f46",
+	}
+}
+
+// DefaultLightPalette returns the built-in light theme palette.
+// These values mirror the config default light palette.
+func DefaultLightPalette() ColorPalette {
+	return ColorPalette{
+		Background:     "#fafafa",
+		Surface:        "#f4f4f5",
+		SurfaceVariant: "#e4e4e7",
+		Text:           "#18181b",
+		Muted:          "#71717a",
+		Accent:         "#22c55e",
+		Border:         "#d4d4d8",
+	}
+}
+
+// ValidatePaletteHex checks every field in the palette is a valid #RRGGBB hex color.
+// Returns a slice of warnings for each invalid field. Empty slice means valid.
+func ValidatePaletteHex(p *ColorPalette, prefix string) []ThemeWarning {
+	if p == nil {
+		return []ThemeWarning{{Field: prefix, Message: "palette is nil"}}
+	}
+	var warnings []ThemeWarning
+	checkRequiredHex(&warnings, prefix, "background", p.Background)
+	checkRequiredHex(&warnings, prefix, "surface", p.Surface)
+	checkRequiredHex(&warnings, prefix, "surface_variant", p.SurfaceVariant)
+	checkRequiredHex(&warnings, prefix, "text", p.Text)
+	checkRequiredHex(&warnings, prefix, "muted", p.Muted)
+	checkRequiredHex(&warnings, prefix, "accent", p.Accent)
+	checkRequiredHex(&warnings, prefix, "border", p.Border)
+	return warnings
+}
+
+// ValidatePaletteOverrideHex checks non-empty override fields are valid #RRGGBB hex colors.
+// Empty fields are accepted and mean "inherit from the fallback palette".
+func ValidatePaletteOverrideHex(p *ColorPalette, prefix string) []ThemeWarning {
+	if p == nil {
+		return []ThemeWarning{{Field: prefix, Message: "palette is nil"}}
+	}
+	var warnings []ThemeWarning
+	checkOptionalHex(&warnings, prefix, "background", p.Background)
+	checkOptionalHex(&warnings, prefix, "surface", p.Surface)
+	checkOptionalHex(&warnings, prefix, "surface_variant", p.SurfaceVariant)
+	checkOptionalHex(&warnings, prefix, "text", p.Text)
+	checkOptionalHex(&warnings, prefix, "muted", p.Muted)
+	checkOptionalHex(&warnings, prefix, "accent", p.Accent)
+	checkOptionalHex(&warnings, prefix, "border", p.Border)
+	return warnings
+}
+
+func checkRequiredHex(warnings *[]ThemeWarning, prefix, field, value string) {
+	if !IsValidHex(value) {
+		*warnings = append(*warnings, ThemeWarning{
+			Field:   prefix + "." + field,
+			Message: "not a valid CSS-safe hex color (#RRGGBB)",
+		})
+	}
+}
+
+func checkOptionalHex(warnings *[]ThemeWarning, prefix, field, value string) {
+	if value != "" && !IsValidHex(value) {
+		*warnings = append(*warnings, ThemeWarning{
+			Field:   prefix + "." + field,
+			Message: "not a valid CSS-safe hex color (#RRGGBB)",
+		})
+	}
+}
+
+// IsPaletteValid returns true if every field in the palette is a valid #RRGGBB hex color.
+func IsPaletteValid(p *ColorPalette) bool {
+	return len(ValidatePaletteHex(p, "palette")) == 0
+}
+
+// IsPaletteOverrideValid returns true if every non-empty field in the palette is a valid #RRGGBB hex color.
+func IsPaletteOverrideValid(p *ColorPalette) bool {
+	return len(ValidatePaletteOverrideHex(p, "palette")) == 0
+}
+
+// MergePalette returns a new ColorPalette where empty fields in src are filled from defaults.
+// Both src and defaults may be nil. Returns a copy, never mutates inputs.
+func MergePalette(src, defaults *ColorPalette) ColorPalette {
+	var d ColorPalette
+	if defaults != nil {
+		d = *defaults
+	}
+	if src == nil {
+		return d
+	}
+	result := *src
+	if result.Background == "" {
+		result.Background = d.Background
+	}
+	if result.Surface == "" {
+		result.Surface = d.Surface
+	}
+	if result.SurfaceVariant == "" {
+		result.SurfaceVariant = d.SurfaceVariant
+	}
+	if result.Text == "" {
+		result.Text = d.Text
+	}
+	if result.Muted == "" {
+		result.Muted = d.Muted
+	}
+	if result.Accent == "" {
+		result.Accent = d.Accent
+	}
+	if result.Border == "" {
+		result.Border = d.Border
+	}
+	return result
+}
+
+// MergeFonts returns a ThemeFonts where zero/empty fields in src are filled from defaults.
+func MergeFonts(src *ThemeFonts, defaults ThemeFonts) ThemeFonts {
+	if src == nil {
+		return defaults
+	}
+	result := *src
+	if result.SansFont == "" {
+		result.SansFont = defaults.SansFont
+	}
+	if result.SerifFont == "" {
+		result.SerifFont = defaults.SerifFont
+	}
+	if result.MonospaceFont == "" {
+		result.MonospaceFont = defaults.MonospaceFont
+	}
+	if result.GtkFont == "" {
+		result.GtkFont = defaults.GtkFont
+	}
+	if result.DefaultSize <= 0 {
+		result.DefaultSize = defaults.DefaultSize
+	}
+	return result
+}
+
+// ValidateModeColorsHex checks every mode color field is a valid #RRGGBB hex color.
+func ValidateModeColorsHex(colors *ThemeModeColors, prefix string) []ThemeWarning {
+	if colors == nil {
+		return []ThemeWarning{{Field: prefix, Message: "mode colors are nil"}}
+	}
+	var warnings []ThemeWarning
+	checkRequiredHex(&warnings, prefix, "pane_mode", colors.PaneMode)
+	checkRequiredHex(&warnings, prefix, "tab_mode", colors.TabMode)
+	checkRequiredHex(&warnings, prefix, "session_mode", colors.SessionMode)
+	checkRequiredHex(&warnings, prefix, "resize_mode", colors.ResizeMode)
+	return warnings
+}
+
+// IsModeColorsValid returns true when every mode color is a valid #RRGGBB hex color.
+func IsModeColorsValid(colors *ThemeModeColors) bool {
+	return len(ValidateModeColorsHex(colors, "mode_colors")) == 0
+}
+
+// MergeModeColors returns a ThemeModeColors where empty fields in src are filled from defaults.
+func MergeModeColors(src *ThemeModeColors, defaults ThemeModeColors) ThemeModeColors {
+	if src == nil {
+		return defaults
+	}
+	result := *src
+	if result.PaneMode == "" {
+		result.PaneMode = defaults.PaneMode
+	}
+	if result.TabMode == "" {
+		result.TabMode = defaults.TabMode
+	}
+	if result.SessionMode == "" {
+		result.SessionMode = defaults.SessionMode
+	}
+	if result.ResizeMode == "" {
+		result.ResizeMode = defaults.ResizeMode
+	}
+	return result
+}

--- a/internal/domain/entity/theme_test.go
+++ b/internal/domain/entity/theme_test.go
@@ -1,0 +1,528 @@
+package entity
+
+import (
+	"testing"
+)
+
+// TestValidateHexColor_ValidHex tests that standard hex colors are recognized.
+func TestValidateHexColor_ValidHex(t *testing.T) {
+	valid := []string{
+		"#000000",
+		"#ffffff",
+		"#0a0a0b",
+		"#4ade80",
+		"#4A90E2",
+		"#FFA500",
+		"#9B59B6",
+		"#00D4AA",
+	}
+
+	for _, hex := range valid {
+		if !IsValidHex(hex) {
+			t.Errorf("expected %q to be a valid hex color", hex)
+		}
+	}
+}
+
+// TestValidateHexColor_InvalidHex tests that non-hex or malformed strings are rejected.
+func TestValidateHexColor_InvalidHex(t *testing.T) {
+	invalid := []string{
+		"",
+		"rgb(0,0,0)",
+		"#FFF",      // 3-char shorthand
+		"#FFFFFFFF", // 8-char with alpha
+		"#GGGGGG",   // non-hex chars
+		"red",
+		"#12",         // too short
+		"#1234567",    // odd length
+		"  #ffffff  ", // whitespace
+		"#ffffff ",    // trailing space
+	}
+
+	for _, hex := range invalid {
+		if IsValidHex(hex) {
+			t.Errorf("expected %q to be invalid hex", hex)
+		}
+	}
+}
+
+// TestDefaultThemeFonts_ReturnsSaneDefaults verifies the default font configuration has non-empty,
+// sensible values.
+func TestDefaultThemeFonts_ReturnsSaneDefaults(t *testing.T) {
+	fonts := DefaultThemeFonts()
+
+	if fonts.SansFont != "Fira Sans" {
+		t.Errorf("expected SansFont Fira Sans, got %q", fonts.SansFont)
+	}
+	if fonts.SerifFont != "Fira Sans" {
+		t.Errorf("expected SerifFont Fira Sans, got %q", fonts.SerifFont)
+	}
+	if fonts.MonospaceFont != "Fira Code" {
+		t.Errorf("expected MonospaceFont Fira Code, got %q", fonts.MonospaceFont)
+	}
+	if fonts.GtkFont != "Adwaita Sans" {
+		t.Errorf("expected GtkFont Adwaita Sans, got %q", fonts.GtkFont)
+	}
+	if fonts.DefaultSize != 16 {
+		t.Errorf("expected DefaultSize 16, got %d", fonts.DefaultSize)
+	}
+}
+
+// TestResolvedThemePalette_MustBeCSSSafeHex ensures that every color field
+// in a ResolvedThemePalette passes hex validation.
+// This is the locked contract: all palette colors in ResolvedTheme are CSS-safe hex.
+func TestResolvedThemePalette_MustBeCSSSafeHex(t *testing.T) {
+	// A well-formed palette that SHOULD be produced by resolution.
+	validPalette := ResolvedThemePalette{
+		Background:     "#0a0a0b",
+		Surface:        "#1a1a1b",
+		SurfaceVariant: "#2d2d2d",
+		Text:           "#ffffff",
+		Muted:          "#909090",
+		Accent:         "#4ade80",
+		Border:         "#333333",
+	}
+
+	fields := map[string]string{
+		"Background":     validPalette.Background,
+		"Surface":        validPalette.Surface,
+		"SurfaceVariant": validPalette.SurfaceVariant,
+		"Text":           validPalette.Text,
+		"Muted":          validPalette.Muted,
+		"Accent":         validPalette.Accent,
+		"Border":         validPalette.Border,
+	}
+
+	for name, value := range fields {
+		if !IsValidHex(value) {
+			t.Errorf("ResolvedThemePalette.%s = %q is not a valid CSS-safe hex color", name, value)
+		}
+	}
+}
+
+// TestResolvedThemePalette_RejectsInvalidColors verifies that any non-hex color
+// in a palette is detectable by a validation helper.
+func TestResolvedThemePalette_RejectsInvalidColors(t *testing.T) {
+	invalidFields := []struct {
+		name  string
+		value string
+	}{
+		{"Background", "rgb(0,0,0)"},
+		{"Background", "#F"},
+		{"Surface", "white"},
+		{"Text", "#GGGGGG"},
+		{"Accent", "hsl(0,0%,0%)"},
+		{"Border", ""},
+	}
+
+	for _, tc := range invalidFields {
+		if IsValidHex(tc.value) {
+			t.Errorf("field %q value %q should be rejected as invalid hex", tc.name, tc.value)
+		}
+	}
+}
+
+// TestThemeModeColors_DefaultsAreCSSSafe ensures the default mode colors are valid hex.
+func TestThemeModeColors_DefaultsAreCSSSafe(t *testing.T) {
+	// Per the existing ui/theme palette: defaults are #4A90E2, #FFA500, #9B59B6, #00D4AA
+	defaults := ThemeModeColors{
+		PaneMode:    "#4A90E2",
+		TabMode:     "#FFA500",
+		SessionMode: "#9B59B6",
+		ResizeMode:  "#00D4AA",
+	}
+
+	fields := map[string]string{
+		"PaneMode":    defaults.PaneMode,
+		"TabMode":     defaults.TabMode,
+		"SessionMode": defaults.SessionMode,
+		"ResizeMode":  defaults.ResizeMode,
+	}
+
+	for name, value := range fields {
+		if !IsValidHex(value) {
+			t.Errorf("ThemeModeColors.%s = %q is not a valid CSS-safe hex color", name, value)
+		}
+	}
+}
+
+// TestResolvedTheme_StructFieldsExist is a compile-time guard and field-inspection test
+// to verify that the ResolvedTheme struct carries all required fields from the locked contract.
+func TestResolvedTheme_StructFieldsExist(t *testing.T) {
+	rt := ResolvedTheme{
+		LightPalette: ResolvedThemePalette{
+			Background: "#0a0a0b",
+			Surface:    "#1a1a1b",
+		},
+		DarkPalette: ResolvedThemePalette{
+			Background: "#fafafa",
+			Surface:    "#ffffff",
+		},
+		ActivePalette: ResolvedThemePalette{
+			Background: "#0a0a0b",
+		},
+		PrefersDark:       true,
+		ColorSchemeSource: "adwaita",
+		ThemeSource:       ThemeSourceMetadata{Kind: ThemeSourceConfig},
+		Fonts:             DefaultThemeFonts(),
+		UIScale:           1.0,
+		ModeColors: ThemeModeColors{
+			PaneMode:    "#4A90E2",
+			TabMode:     "#FFA500",
+			SessionMode: "#9B59B6",
+			ResizeMode:  "#00D4AA",
+		},
+		Warnings: []ThemeWarning{
+			{Field: "external", Message: "malformed external theme, using last-good"},
+		},
+	}
+
+	// Verify the struct can be constructed and fields are accessible.
+	if !rt.PrefersDark {
+		t.Error("expected PrefersDark to be true")
+	}
+	if rt.ColorSchemeSource != "adwaita" {
+		t.Errorf("expected ColorSchemeSource 'adwaita', got %q", rt.ColorSchemeSource)
+	}
+	if rt.ThemeSource.Kind != ThemeSourceConfig {
+		t.Errorf("expected ThemeSource.Kind 'config', got %q", rt.ThemeSource.Kind)
+	}
+	if rt.UIScale != 1.0 {
+		t.Errorf("expected UIScale 1.0, got %f", rt.UIScale)
+	}
+	if len(rt.Warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(rt.Warnings))
+	}
+	if rt.Fonts.DefaultSize != 16 {
+		t.Errorf("expected DefaultSize 16, got %d", rt.Fonts.DefaultSize)
+	}
+}
+
+// TestThemeSourceKind_ConstantsAreDistinct verifies the ThemeSourceKind constants
+// have unique values so that source metadata comparisons work correctly.
+func TestThemeSourceKind_ConstantsAreDistinct(t *testing.T) {
+	kinds := map[ThemeSourceKind]bool{
+		ThemeSourceDefault:  true,
+		ThemeSourceConfig:   true,
+		ThemeSourceExternal: true,
+	}
+
+	if len(kinds) != 3 {
+		t.Error("ThemeSourceKind constants must be distinct")
+	}
+
+	if ThemeSourceDefault == ThemeSourceExternal {
+		t.Error("ThemeSourceDefault must not equal ThemeSourceExternal")
+	}
+	if ThemeSourceDefault == ThemeSourceConfig {
+		t.Error("ThemeSourceDefault must not equal ThemeSourceConfig")
+	}
+}
+
+// TestThemeWarning_FieldsExist verifies ThemeWarning carries the expected shape.
+func TestThemeWarning_FieldsExist(t *testing.T) {
+	w := ThemeWarning{
+		Field:   "light_palette.background",
+		Message: "not a valid hex color",
+	}
+
+	if w.Field == "" {
+		t.Error("expected ThemeWarning.Field to be non-empty")
+	}
+	if w.Message == "" {
+		t.Error("expected ThemeWarning.Message to be non-empty")
+	}
+}
+
+// TestExternalTheme_IsDomainPure verifies ExternalTheme can be constructed without any
+// infrastructure imports (this is a compile-time contract via package structure).
+func TestExternalTheme_IsDomainPure(t *testing.T) {
+	light := ColorPalette{
+		Background: "#0a0a0b",
+		Surface:    "#1a1a1b",
+	}
+	dark := ColorPalette{
+		Background: "#fafafa",
+		Surface:    "#ffffff",
+	}
+
+	ext := ExternalTheme{
+		Name:         "Noctalia Dark",
+		Provider:     "noctalia",
+		LightPalette: &light,
+		DarkPalette:  &dark,
+	}
+
+	if ext.Name != "Noctalia Dark" {
+		t.Errorf("expected Name 'Noctalia Dark', got %q", ext.Name)
+	}
+	if ext.Provider != "noctalia" {
+		t.Errorf("expected Provider 'noctalia', got %q", ext.Provider)
+	}
+	if ext.LightPalette == nil || ext.DarkPalette == nil {
+		t.Error("expected non-nil palettes")
+	}
+}
+
+// TestDefaultThemeFonts_AllFieldsAreSet ensures no zero-value fields in the defaults.
+func TestDefaultThemeFonts_AllFieldsAreSet(t *testing.T) {
+	fonts := DefaultThemeFonts()
+
+	// Check that all string fields are non-empty
+	if fonts.SansFont == "" {
+		t.Error("SansFont should have a default value")
+	}
+	if fonts.SerifFont == "" {
+		t.Error("SerifFont should have a default value")
+	}
+	if fonts.MonospaceFont == "" {
+		t.Error("MonospaceFont should have a default value")
+	}
+	if fonts.GtkFont == "" {
+		t.Error("GtkFont should have a default value")
+	}
+	if fonts.DefaultSize <= 0 {
+		t.Errorf("DefaultSize should be positive, got %d", fonts.DefaultSize)
+	}
+}
+
+// TestDefaultThemeModeColors_ReturnsSaneDefaults verifies the default mode colors.
+func TestDefaultThemeModeColors_ReturnsSaneDefaults(t *testing.T) {
+	mc := DefaultThemeModeColors()
+
+	if mc.PaneMode != "#4A90E2" {
+		t.Errorf("expected PaneMode #4A90E2, got %q", mc.PaneMode)
+	}
+	if mc.TabMode != "#FFA500" {
+		t.Errorf("expected TabMode #FFA500, got %q", mc.TabMode)
+	}
+	if mc.SessionMode != "#9B59B6" {
+		t.Errorf("expected SessionMode #9B59B6, got %q", mc.SessionMode)
+	}
+	if mc.ResizeMode != "#00D4AA" {
+		t.Errorf("expected ResizeMode #00D4AA, got %q", mc.ResizeMode)
+	}
+
+	// All must be valid hex
+	if !IsValidHex(mc.PaneMode) {
+		t.Error("default PaneMode should be valid hex")
+	}
+	if !IsValidHex(mc.TabMode) {
+		t.Error("default TabMode should be valid hex")
+	}
+	if !IsValidHex(mc.SessionMode) {
+		t.Error("default SessionMode should be valid hex")
+	}
+	if !IsValidHex(mc.ResizeMode) {
+		t.Error("default ResizeMode should be valid hex")
+	}
+}
+
+// TestDefaultDarkPalette_ReturnsValidHex verifies the default dark palette is all valid hex.
+func TestDefaultDarkPalette_ReturnsValidHex(t *testing.T) {
+	p := DefaultDarkPalette()
+
+	fields := map[string]string{
+		"Background":     p.Background,
+		"Surface":        p.Surface,
+		"SurfaceVariant": p.SurfaceVariant,
+		"Text":           p.Text,
+		"Muted":          p.Muted,
+		"Accent":         p.Accent,
+		"Border":         p.Border,
+	}
+	for name, value := range fields {
+		if value == "" {
+			t.Errorf("DefaultDarkPalette.%s should not be empty", name)
+		}
+		if !IsValidHex(value) {
+			t.Errorf("DefaultDarkPalette.%s = %q is not valid hex", name, value)
+		}
+	}
+}
+
+// TestDefaultLightPalette_ReturnsValidHex verifies the default light palette is all valid hex.
+func TestDefaultLightPalette_ReturnsValidHex(t *testing.T) {
+	p := DefaultLightPalette()
+
+	fields := map[string]string{
+		"Background":     p.Background,
+		"Surface":        p.Surface,
+		"SurfaceVariant": p.SurfaceVariant,
+		"Text":           p.Text,
+		"Muted":          p.Muted,
+		"Accent":         p.Accent,
+		"Border":         p.Border,
+	}
+	for name, value := range fields {
+		if value == "" {
+			t.Errorf("DefaultLightPalette.%s should not be empty", name)
+		}
+		if !IsValidHex(value) {
+			t.Errorf("DefaultLightPalette.%s = %q is not valid hex", name, value)
+		}
+	}
+}
+
+// TestValidatePaletteHex_Valid verifies ValidatePaletteHex returns no warnings for valid palettes.
+func TestValidatePaletteHex_Valid(t *testing.T) {
+	p := DefaultDarkPalette()
+	warnings := ValidatePaletteHex(&p, "dark")
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for valid palette, got %d: %v", len(warnings), warnings)
+	}
+}
+
+// TestValidatePaletteHex_Invalid verifies ValidatePaletteHex returns warnings for invalid palettes.
+func TestValidatePaletteHex_Invalid(t *testing.T) {
+	p := ColorPalette{
+		Background:     "rgb(0,0,0)", // invalid
+		Surface:        "#ffffff",
+		SurfaceVariant: "not-a-color",
+		Text:           "",        // invalid
+		Muted:          "#GGGGGG", // invalid
+		Accent:         "#123",    // 3-char shorthand, rejected
+		Border:         "#123456",
+	}
+	warnings := ValidatePaletteHex(&p, "test")
+	if len(warnings) == 0 {
+		t.Error("expected warnings for invalid palette, got none")
+	}
+}
+
+// TestValidatePaletteHex_Nil verifies ValidatePaletteHex handles nil.
+func TestValidatePaletteHex_Nil(t *testing.T) {
+	warnings := ValidatePaletteHex(nil, "ext")
+	if len(warnings) == 0 {
+		t.Error("expected warnings for nil palette")
+	}
+}
+
+// TestIsPaletteValid verifies IsPaletteValid returns correct truthiness.
+func TestIsPaletteValid_EdgeCases(t *testing.T) {
+	if IsPaletteValid(nil) {
+		t.Error("nil palette should not be valid")
+	}
+
+	valid := DefaultDarkPalette()
+	if !IsPaletteValid(&valid) {
+		t.Error("default dark palette should be valid")
+	}
+
+	partial := ColorPalette{
+		Background: "#000000",
+		Surface:    "#111111",
+		// missing fields are ""
+	}
+	if IsPaletteValid(&partial) {
+		t.Error("partial palette with empty fields should not be valid")
+	}
+}
+
+// TestMergePalette_FillsEmpties verifies MergePalette fills empty fields from defaults.
+func TestMergePalette_FillsEmpties(t *testing.T) {
+	src := &ColorPalette{
+		Background: "#000000",
+		Surface:    "", // should be filled
+		Text:       "#ffffff",
+	}
+	def := DefaultDarkPalette()
+	result := MergePalette(src, &def)
+
+	if result.Background != "#000000" {
+		t.Errorf("Background should be from src, got %q", result.Background)
+	}
+	if result.Surface != def.Surface {
+		t.Errorf("Surface should be filled from defaults, got %q", result.Surface)
+	}
+	if result.Text != "#ffffff" {
+		t.Errorf("Text should be from src, got %q", result.Text)
+	}
+}
+
+// TestMergePalette_NilSrc verifies MergePalette returns defaults when src is nil.
+func TestMergePalette_NilSrc(t *testing.T) {
+	def := DefaultDarkPalette()
+	result := MergePalette(nil, &def)
+
+	if result.Background != def.Background {
+		t.Errorf("expected default Background, got %q", result.Background)
+	}
+}
+
+// TestMergeFonts_FillsEmpties verifies MergeFonts fills zero fields from defaults.
+func TestMergeFonts_FillsEmpties(t *testing.T) {
+	src := &ThemeFonts{
+		SansFont: "Custom Sans",
+		// SerifFont empty
+		DefaultSize: 0, // zero
+	}
+	def := DefaultThemeFonts()
+	result := MergeFonts(src, def)
+
+	if result.SansFont != "Custom Sans" {
+		t.Errorf("SansFont should be from src, got %q", result.SansFont)
+	}
+	if result.SerifFont != def.SerifFont {
+		t.Errorf("SerifFont should be from defaults, got %q", result.SerifFont)
+	}
+	if result.DefaultSize != def.DefaultSize {
+		t.Errorf("DefaultSize should be from defaults, got %d", result.DefaultSize)
+	}
+}
+
+// TestMergeFonts_NilSrc verifies MergeFonts returns defaults when src is nil.
+func TestMergeFonts_NilSrc(t *testing.T) {
+	def := DefaultThemeFonts()
+	result := MergeFonts(nil, def)
+
+	if result.SansFont != def.SansFont {
+		t.Errorf("expected default SansFont, got %q", result.SansFont)
+	}
+}
+
+// TestMergeModeColors_FillsEmpties verifies mode color merging.
+func TestMergeModeColors_FillsEmpties(t *testing.T) {
+	src := &ThemeModeColors{
+		PaneMode: "#111111",
+		// TabMode empty
+	}
+	def := DefaultThemeModeColors()
+	result := MergeModeColors(src, def)
+
+	if result.PaneMode != "#111111" {
+		t.Errorf("PaneMode should be from src, got %q", result.PaneMode)
+	}
+	if result.TabMode != def.TabMode {
+		t.Errorf("TabMode should be from defaults, got %q", result.TabMode)
+	}
+}
+
+// TestValidateModeColorsHex_ReturnsWarnings verifies invalid mode colors are detected.
+func TestValidateModeColorsHex_ReturnsWarnings(t *testing.T) {
+	colors := &ThemeModeColors{
+		PaneMode:    "#111111",
+		TabMode:     "not-a-color",
+		SessionMode: "#333333",
+		ResizeMode:  "",
+	}
+
+	warnings := ValidateModeColorsHex(colors, "mode_colors")
+	if len(warnings) != 2 {
+		t.Fatalf("expected 2 invalid mode color warnings, got %d: %+v", len(warnings), warnings)
+	}
+	if IsModeColorsValid(colors) {
+		t.Error("expected invalid mode colors to be rejected")
+	}
+}
+
+// TestValidateModeColorsHex_DefaultsAreValid verifies default mode colors satisfy validation.
+func TestValidateModeColorsHex_DefaultsAreValid(t *testing.T) {
+	defaults := DefaultThemeModeColors()
+	if warnings := ValidateModeColorsHex(&defaults, "mode_colors"); len(warnings) != 0 {
+		t.Fatalf("expected default mode colors to be valid, got warnings: %+v", warnings)
+	}
+	if !IsModeColorsValid(&defaults) {
+		t.Error("expected default mode colors to be valid")
+	}
+}

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -1,5 +1,12 @@
 package config
 
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
 // Default configuration constants
 const (
 	// History defaults
@@ -14,7 +21,12 @@ const (
 	defaultMaxLogFiles   = 100 // session log files
 
 	// Appearance defaults
-	defaultFontSize = 16 // points
+	defaultFontSize                      = 16 // points
+	defaultExternalThemeProvider         = "noctalia"
+	defaultExternalThemeFormat           = "colors-json"
+	defaultExternalThemeColorsFilename   = "colors.json"
+	defaultExternalThemeTemplateFormat   = "dumber-json"
+	defaultExternalThemeTemplateFilename = "noctalia-theme.json"
 
 	// Workspace defaults
 	defaultNewPaneURL = "about:blank"
@@ -104,6 +116,36 @@ func getDefaultLogDir() string {
 	return logDir
 }
 
+// getDefaultExternalThemePath returns Noctalia's native colors.json path.
+func getDefaultExternalThemePath() string {
+	return getDefaultExternalThemePathForFormat(defaultExternalThemeFormat)
+}
+
+func getDefaultExternalThemePathForFormat(format string) string {
+	switch format {
+	case defaultExternalThemeTemplateFormat:
+		return getDefaultExternalThemeTemplatePath()
+	default:
+		return getDefaultNoctaliaColorsPath()
+	}
+}
+
+func getDefaultNoctaliaColorsPath() string {
+	configHome, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configHome, defaultExternalThemeProvider, defaultExternalThemeColorsFilename)
+}
+
+func getDefaultExternalThemeTemplatePath() string {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, defaultExternalThemeTemplateFilename)
+}
+
 // DefaultConfig returns the default configuration values for dumber.
 func DefaultConfig() *Config {
 	browsingContextDefaults := defaultBrowsingContextConfig()
@@ -164,6 +206,12 @@ func DefaultConfig() *Config {
 				Border:         "#3f3f46",
 			},
 			ColorScheme: "default", // default follows system theme
+			ExternalTheme: entity.ExternalThemeConfig{
+				Enabled:  false,
+				Provider: defaultExternalThemeProvider,
+				Format:   defaultExternalThemeFormat,
+				Path:     getDefaultExternalThemePath(),
+			},
 		},
 		Debug: DebugConfig{
 			EnableDevTools: true,

--- a/internal/infrastructure/config/external_theme_test.go
+++ b/internal/infrastructure/config/external_theme_test.go
@@ -1,0 +1,285 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/dto"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfig_ExternalThemeDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	require.False(t, cfg.Appearance.ExternalTheme.Enabled)
+	require.Equal(t, "noctalia", cfg.Appearance.ExternalTheme.Provider)
+	require.Equal(t, "colors-json", cfg.Appearance.ExternalTheme.Format)
+	require.Equal(t, filepath.Join("noctalia", "colors.json"), lastPathElements(cfg.Appearance.ExternalTheme.Path, 2))
+}
+
+func TestManagerSetDefaults_ExternalThemeViperDefaults(t *testing.T) {
+	mgr := &Manager{viper: viper.New()}
+	mgr.setDefaults()
+
+	require.False(t, mgr.viper.GetBool("appearance.external_theme.enabled"))
+	require.Equal(t, "noctalia", mgr.viper.GetString("appearance.external_theme.provider"))
+	require.Equal(t, "colors-json", mgr.viper.GetString("appearance.external_theme.format"))
+	require.Equal(t, filepath.Join("noctalia", "colors.json"), lastPathElements(
+		mgr.viper.GetString("appearance.external_theme.path"),
+		2,
+	))
+}
+
+func TestManagerLoad_ExternalThemeEnabledEmptyPathUsesDefaultColorsJSON(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("ENV", "")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	configDir := filepath.Join(configHome, appName)
+	require.NoError(t, os.MkdirAll(configDir, dirPerm))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`
+[appearance.external_theme]
+enabled = true
+provider = 'noctalia'
+path = ''
+`), filePerm))
+
+	mgr, err := NewManager()
+	require.NoError(t, err)
+	require.NoError(t, mgr.Load())
+
+	externalTheme := mgr.Get().Appearance.ExternalTheme
+	require.True(t, externalTheme.Enabled)
+	require.Equal(t, "noctalia", externalTheme.Provider)
+	require.Equal(t, "colors-json", externalTheme.Format)
+	require.Equal(t, filepath.Join(configHome, "noctalia", "colors.json"), externalTheme.Path)
+}
+
+func TestManagerLoad_ExternalThemeDumberJSONEmptyPathUsesTemplateDefault(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("ENV", "")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	configDir := filepath.Join(configHome, appName)
+	require.NoError(t, os.MkdirAll(configDir, dirPerm))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`
+[appearance.external_theme]
+enabled = true
+provider = 'noctalia'
+format = 'dumber-json'
+path = ''
+`), filePerm))
+
+	mgr, err := NewManager()
+	require.NoError(t, err)
+	require.NoError(t, mgr.Load())
+
+	externalTheme := mgr.Get().Appearance.ExternalTheme
+	require.True(t, externalTheme.Enabled)
+	require.Equal(t, "noctalia", externalTheme.Provider)
+	require.Equal(t, "dumber-json", externalTheme.Format)
+	require.Equal(t, filepath.Join(configDir, defaultExternalThemeTemplateFilename), externalTheme.Path)
+}
+
+func TestValidateConfig_ExternalTheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(*Config)
+		wantErr  bool
+		wantText string
+	}{
+		{
+			name: "disabled empty path validates",
+			mutate: func(cfg *Config) {
+				cfg.Appearance.ExternalTheme.Path = ""
+			},
+		},
+		{
+			name: "enabled colors-json with path validates",
+			mutate: func(cfg *Config) {
+				cfg.Appearance.ExternalTheme.Enabled = true
+				cfg.Appearance.ExternalTheme.Format = "colors-json"
+				cfg.Appearance.ExternalTheme.Path = "/tmp/colors.json"
+			},
+		},
+		{
+			name: "enabled dumber-json with path validates",
+			mutate: func(cfg *Config) {
+				cfg.Appearance.ExternalTheme.Enabled = true
+				cfg.Appearance.ExternalTheme.Format = "dumber-json"
+				cfg.Appearance.ExternalTheme.Path = "/tmp/theme.json"
+			},
+		},
+		{
+			name: "enabled empty path uses format-specific default",
+			mutate: func(cfg *Config) {
+				cfg.Appearance.ExternalTheme.Enabled = true
+				cfg.Appearance.ExternalTheme.Path = ""
+			},
+		},
+		{
+			name: "enabled rejects unsupported provider",
+			mutate: func(cfg *Config) {
+				cfg.Appearance.ExternalTheme.Enabled = true
+				cfg.Appearance.ExternalTheme.Provider = "other"
+				cfg.Appearance.ExternalTheme.Path = "/tmp/theme.json"
+			},
+			wantErr:  true,
+			wantText: "appearance.external_theme.provider",
+		},
+		{
+			name: "enabled rejects unsupported format",
+			mutate: func(cfg *Config) {
+				cfg.Appearance.ExternalTheme.Enabled = true
+				cfg.Appearance.ExternalTheme.Format = "toml"
+				cfg.Appearance.ExternalTheme.Path = "/tmp/theme.json"
+			},
+			wantErr:  true,
+			wantText: "appearance.external_theme.format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			tt.mutate(cfg)
+			normalizeConfig(cfg)
+
+			err := validateConfig(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantText)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNormalizeConfig_ExternalTheme(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Appearance.ExternalTheme.Provider = "  NOCTALIA  "
+	cfg.Appearance.ExternalTheme.Format = "  COLORS-JSON  "
+	cfg.Appearance.ExternalTheme.Path = "  /tmp/colors.json  "
+
+	normalizeConfig(cfg)
+
+	require.Equal(t, "noctalia", cfg.Appearance.ExternalTheme.Provider)
+	require.Equal(t, "colors-json", cfg.Appearance.ExternalTheme.Format)
+	require.Equal(t, "/tmp/colors.json", cfg.Appearance.ExternalTheme.Path)
+
+	cfg.Appearance.ExternalTheme.Provider = ""
+	cfg.Appearance.ExternalTheme.Format = ""
+	normalizeConfig(cfg)
+	require.Equal(t, "noctalia", cfg.Appearance.ExternalTheme.Provider)
+	require.Equal(t, "colors-json", cfg.Appearance.ExternalTheme.Format)
+}
+
+func TestSchemaProvider_ExternalThemeKeys(t *testing.T) {
+	keys := NewSchemaProvider().GetSchema()
+	byKey := map[string]bool{}
+	for _, key := range keys {
+		if key.Key == "appearance.external_theme.provider" {
+			require.Equal(t, SectionAppearance, key.Section)
+			require.Equal(t, "noctalia", key.Default)
+			require.Equal(t, []string{"noctalia"}, key.Values)
+		}
+		if key.Key == "appearance.external_theme.format" {
+			require.Equal(t, SectionAppearance, key.Section)
+			require.Equal(t, "colors-json", key.Default)
+			require.Equal(t, []string{"colors-json", "dumber-json"}, key.Values)
+		}
+		if key.Key == "appearance.external_theme.path" {
+			require.Equal(t, filepath.Join("noctalia", "colors.json"), lastPathElements(key.Default, 2))
+		}
+		byKey[key.Key] = true
+	}
+
+	for _, key := range []string{
+		"appearance.external_theme.enabled",
+		"appearance.external_theme.provider",
+		"appearance.external_theme.format",
+		"appearance.external_theme.path",
+	} {
+		require.True(t, byKey[key], "missing schema key %s", key)
+	}
+}
+
+func TestWriteConfigOrdered_IncludesExternalThemeTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := DefaultConfig()
+
+	require.NoError(t, WriteConfigOrdered(cfg, path))
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "[appearance.external_theme]")
+	require.Contains(t, string(content), "enabled = false")
+	require.Contains(t, string(content), "provider = 'noctalia'")
+	require.Contains(t, string(content), "format = 'colors-json'")
+	require.Contains(t, string(content), "colors.json")
+}
+
+func TestBuildSystemviewConfigPayload_ProjectsExternalTheme(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Appearance.ExternalTheme.Enabled = true
+	cfg.Appearance.ExternalTheme.Path = "/tmp/colors.json"
+
+	payload := BuildSystemviewConfigPayload(cfg, nil)
+
+	require.True(t, payload.Appearance.ExternalTheme.Enabled)
+	require.Equal(t, "noctalia", payload.Appearance.ExternalTheme.Provider)
+	require.Equal(t, "colors-json", payload.Appearance.ExternalTheme.Format)
+	require.Equal(t, "/tmp/colors.json", payload.Appearance.ExternalTheme.Path)
+}
+
+func lastPathElements(path string, count int) string {
+	cleaned := filepath.Clean(path)
+	parts := make([]string, 0, count)
+	for len(parts) < count && cleaned != "." && cleaned != string(filepath.Separator) {
+		parts = append([]string{filepath.Base(cleaned)}, parts...)
+		cleaned = filepath.Dir(cleaned)
+	}
+	return filepath.Join(parts...)
+}
+
+func TestWebUIConfigGatewaySaveWebUIConfig_ExternalThemeRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(""), 0o644))
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	require.NoError(t, v.ReadInConfig())
+
+	previousGlobal := globalManager
+	defer func() { globalManager = previousGlobal }()
+
+	mgr := &Manager{config: DefaultConfig(), viper: v}
+	globalManager = mgr
+
+	webCfg := dto.WebUIConfig{
+		Appearance: buildSystemviewAppearancePayload(DefaultConfig().Appearance),
+	}
+	webCfg.Appearance.ExternalTheme = dto.WebUIExternalThemeConfig{
+		Enabled:  true,
+		Provider: " NOCTALIA ",
+		Format:   " COLORS-JSON ",
+		Path:     " /tmp/colors.json ",
+	}
+	webCfg.DefaultUIScale = DefaultConfig().DefaultUIScale
+	webCfg.DefaultSearchEngine = DefaultConfig().DefaultSearchEngine
+	webCfg.SearchShortcuts = map[string]dto.SearchShortcut{}
+	for key, shortcut := range DefaultConfig().SearchShortcuts {
+		webCfg.SearchShortcuts[key] = dto.SearchShortcut{URL: shortcut.URL, Description: shortcut.Description}
+	}
+
+	require.NoError(t, NewWebUIConfigGateway(mgr).SaveWebUIConfig(context.Background(), webCfg))
+
+	saved := mgr.Get()
+	require.True(t, saved.Appearance.ExternalTheme.Enabled)
+	require.Equal(t, "noctalia", saved.Appearance.ExternalTheme.Provider)
+	require.Equal(t, "colors-json", saved.Appearance.ExternalTheme.Format)
+	require.Equal(t, "/tmp/colors.json", saved.Appearance.ExternalTheme.Path)
+}

--- a/internal/infrastructure/config/external_theme_test.go
+++ b/internal/infrastructure/config/external_theme_test.go
@@ -27,10 +27,7 @@ func TestManagerSetDefaults_ExternalThemeViperDefaults(t *testing.T) {
 	require.False(t, mgr.viper.GetBool("appearance.external_theme.enabled"))
 	require.Equal(t, "noctalia", mgr.viper.GetString("appearance.external_theme.provider"))
 	require.Equal(t, "colors-json", mgr.viper.GetString("appearance.external_theme.format"))
-	require.Equal(t, filepath.Join("noctalia", "colors.json"), lastPathElements(
-		mgr.viper.GetString("appearance.external_theme.path"),
-		2,
-	))
+	require.Empty(t, mgr.viper.GetString("appearance.external_theme.path"))
 }
 
 func TestManagerLoad_ExternalThemeEnabledEmptyPathUsesDefaultColorsJSON(t *testing.T) {
@@ -71,6 +68,31 @@ enabled = true
 provider = 'noctalia'
 format = 'dumber-json'
 path = ''
+`), filePerm))
+
+	mgr, err := NewManager()
+	require.NoError(t, err)
+	require.NoError(t, mgr.Load())
+
+	externalTheme := mgr.Get().Appearance.ExternalTheme
+	require.True(t, externalTheme.Enabled)
+	require.Equal(t, "noctalia", externalTheme.Provider)
+	require.Equal(t, "dumber-json", externalTheme.Format)
+	require.Equal(t, filepath.Join(configDir, defaultExternalThemeTemplateFilename), externalTheme.Path)
+}
+
+func TestManagerLoad_ExternalThemeDumberJSONOmittedPathUsesTemplateDefault(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("ENV", "")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	configDir := filepath.Join(configHome, appName)
+	require.NoError(t, os.MkdirAll(configDir, dirPerm))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`
+[appearance.external_theme]
+enabled = true
+provider = 'noctalia'
+format = 'dumber-json'
 `), filePerm))
 
 	mgr, err := NewManager()

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -659,7 +659,6 @@ func (m *Manager) setAppearanceDefaults(defaults *Config) {
 	m.viper.SetDefault("appearance.external_theme.enabled", defaults.Appearance.ExternalTheme.Enabled)
 	m.viper.SetDefault("appearance.external_theme.provider", defaults.Appearance.ExternalTheme.Provider)
 	m.viper.SetDefault("appearance.external_theme.format", defaults.Appearance.ExternalTheme.Format)
-	m.viper.SetDefault("appearance.external_theme.path", defaults.Appearance.ExternalTheme.Path)
 }
 
 func (m *Manager) setZoomAndScaleDefaults(defaults *Config) {

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -429,6 +429,22 @@ func normalizeEngineConfig(config *Config) {
 }
 
 func normalizeAppearance(config *Config) {
+	config.Appearance.ExternalTheme.Provider = strings.ToLower(strings.TrimSpace(config.Appearance.ExternalTheme.Provider))
+	config.Appearance.ExternalTheme.Format = strings.ToLower(strings.TrimSpace(config.Appearance.ExternalTheme.Format))
+	config.Appearance.ExternalTheme.Path = strings.TrimSpace(config.Appearance.ExternalTheme.Path)
+	if config.Appearance.ExternalTheme.Provider == "" {
+		config.Appearance.ExternalTheme.Provider = defaultExternalThemeProvider
+	}
+	if config.Appearance.ExternalTheme.Format == "" {
+		config.Appearance.ExternalTheme.Format = defaultExternalThemeFormat
+	}
+	if config.Appearance.ExternalTheme.Enabled &&
+		config.Appearance.ExternalTheme.Provider == defaultExternalThemeProvider &&
+		isSupportedExternalThemeFormat(config.Appearance.ExternalTheme.Format) &&
+		config.Appearance.ExternalTheme.Path == "" {
+		config.Appearance.ExternalTheme.Path = getDefaultExternalThemePathForFormat(config.Appearance.ExternalTheme.Format)
+	}
+
 	switch strings.ToLower(strings.TrimSpace(config.Appearance.ColorScheme)) {
 	case strings.ToLower(ThemePreferDark):
 		config.Appearance.ColorScheme = ThemePreferDark
@@ -640,6 +656,10 @@ func (m *Manager) setAppearanceDefaults(defaults *Config) {
 	m.viper.SetDefault("appearance.light_palette", defaults.Appearance.LightPalette)
 	m.viper.SetDefault("appearance.dark_palette", defaults.Appearance.DarkPalette)
 	m.viper.SetDefault("appearance.color_scheme", defaults.Appearance.ColorScheme)
+	m.viper.SetDefault("appearance.external_theme.enabled", defaults.Appearance.ExternalTheme.Enabled)
+	m.viper.SetDefault("appearance.external_theme.provider", defaults.Appearance.ExternalTheme.Provider)
+	m.viper.SetDefault("appearance.external_theme.format", defaults.Appearance.ExternalTheme.Format)
+	m.viper.SetDefault("appearance.external_theme.path", defaults.Appearance.ExternalTheme.Path)
 }
 
 func (m *Manager) setZoomAndScaleDefaults(defaults *Config) {

--- a/internal/infrastructure/config/schema_provider.go
+++ b/internal/infrastructure/config/schema_provider.go
@@ -175,6 +175,36 @@ func (*SchemaProvider) getAppearanceKeys(defaults *Config) []entity.ConfigKeyInf
 			Description: "Dark theme color palette (background, surface, surface_variant, text, muted, accent, border)",
 			Section:     SectionAppearance,
 		},
+		{
+			Key:         "appearance.external_theme.enabled",
+			Type:        "bool",
+			Default:     fmt.Sprintf("%t", defaults.Appearance.ExternalTheme.Enabled),
+			Description: "Enable loading theme settings from an external provider",
+			Section:     SectionAppearance,
+		},
+		{
+			Key:         "appearance.external_theme.provider",
+			Type:        "string",
+			Default:     defaults.Appearance.ExternalTheme.Provider,
+			Description: "External theme provider",
+			Values:      []string{"noctalia"},
+			Section:     SectionAppearance,
+		},
+		{
+			Key:         "appearance.external_theme.format",
+			Type:        "string",
+			Default:     defaults.Appearance.ExternalTheme.Format,
+			Description: "External theme file format",
+			Values:      []string{"colors-json", "dumber-json"},
+			Section:     SectionAppearance,
+		},
+		{
+			Key:         "appearance.external_theme.path",
+			Type:        "string",
+			Default:     defaults.Appearance.ExternalTheme.Path,
+			Description: "Path to the external theme file",
+			Section:     SectionAppearance,
+		},
 	}
 }
 

--- a/internal/infrastructure/config/validation.go
+++ b/internal/infrastructure/config/validation.go
@@ -104,7 +104,36 @@ func validateAppearance(config *Config) []string {
 	if config.DefaultUIScale < 0.5 || config.DefaultUIScale > 3.0 {
 		validationErrors = append(validationErrors, "default_ui_scale must be between 0.5 and 3.0")
 	}
+	validationErrors = append(validationErrors, validateExternalTheme(config)...)
 	return validationErrors
+}
+
+func validateExternalTheme(config *Config) []string {
+	externalTheme := config.Appearance.ExternalTheme
+	if !externalTheme.Enabled {
+		return nil
+	}
+
+	var validationErrors []string
+	if externalTheme.Provider != defaultExternalThemeProvider {
+		validationErrors = append(validationErrors, "appearance.external_theme.provider must be one of: noctalia")
+	}
+	if !isSupportedExternalThemeFormat(externalTheme.Format) {
+		validationErrors = append(validationErrors, "appearance.external_theme.format must be one of: colors-json, dumber-json")
+	}
+	if strings.TrimSpace(externalTheme.Path) == "" {
+		validationErrors = append(validationErrors, "appearance.external_theme.path is required when external_theme is enabled")
+	}
+	return validationErrors
+}
+
+func isSupportedExternalThemeFormat(format string) bool {
+	switch format {
+	case defaultExternalThemeFormat, defaultExternalThemeTemplateFormat:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateSearchEngine(config *Config) []string {

--- a/internal/infrastructure/config/webui_gateway.go
+++ b/internal/infrastructure/config/webui_gateway.go
@@ -64,10 +64,7 @@ func (g *WebUIConfigGateway) SaveWebUIConfig(ctx context.Context, cfg dto.WebUIC
 		Accent:         cfg.Appearance.DarkPalette.Accent,
 		Border:         cfg.Appearance.DarkPalette.Border,
 	}
-	current.Appearance.ExternalTheme.Enabled = cfg.Appearance.ExternalTheme.Enabled
-	current.Appearance.ExternalTheme.Provider = cfg.Appearance.ExternalTheme.Provider
-	current.Appearance.ExternalTheme.Format = cfg.Appearance.ExternalTheme.Format
-	current.Appearance.ExternalTheme.Path = cfg.Appearance.ExternalTheme.Path
+	current.Appearance.ExternalTheme = cfg.Appearance.ExternalTheme
 	current.DefaultUIScale = cfg.DefaultUIScale
 	current.DefaultSearchEngine = cfg.DefaultSearchEngine
 	if len(cfg.SearchShortcuts) == 0 {

--- a/internal/infrastructure/config/webui_gateway.go
+++ b/internal/infrastructure/config/webui_gateway.go
@@ -64,6 +64,10 @@ func (g *WebUIConfigGateway) SaveWebUIConfig(ctx context.Context, cfg dto.WebUIC
 		Accent:         cfg.Appearance.DarkPalette.Accent,
 		Border:         cfg.Appearance.DarkPalette.Border,
 	}
+	current.Appearance.ExternalTheme.Enabled = cfg.Appearance.ExternalTheme.Enabled
+	current.Appearance.ExternalTheme.Provider = cfg.Appearance.ExternalTheme.Provider
+	current.Appearance.ExternalTheme.Format = cfg.Appearance.ExternalTheme.Format
+	current.Appearance.ExternalTheme.Path = cfg.Appearance.ExternalTheme.Path
 	current.DefaultUIScale = cfg.DefaultUIScale
 	current.DefaultSearchEngine = cfg.DefaultSearchEngine
 	if len(cfg.SearchShortcuts) == 0 {

--- a/internal/infrastructure/config/webui_payload.go
+++ b/internal/infrastructure/config/webui_payload.go
@@ -58,6 +58,12 @@ func buildSystemviewAppearancePayload(appearance AppearanceConfig) dto.WebUIAppe
 		ColorScheme:     appearance.ColorScheme,
 		LightPalette:    buildSystemviewPalettePayload(appearance.LightPalette, defaults.LightPalette),
 		DarkPalette:     buildSystemviewPalettePayload(appearance.DarkPalette, defaults.DarkPalette),
+		ExternalTheme: dto.WebUIExternalThemeConfig{
+			Enabled:  appearance.ExternalTheme.Enabled,
+			Provider: appearance.ExternalTheme.Provider,
+			Format:   appearance.ExternalTheme.Format,
+			Path:     appearance.ExternalTheme.Path,
+		},
 	}
 }
 

--- a/internal/infrastructure/externaltheme/noctalia/source.go
+++ b/internal/infrastructure/externaltheme/noctalia/source.go
@@ -63,13 +63,17 @@ func (s *FileSource) Configure(cfg entity.ExternalThemeConfig) {
 	provider, format := normalizeProviderAndFormat(cfg.Provider, cfg.Format)
 	enabled := cfg.Enabled && provider == providerName && isSupportedFormat(format)
 	path := strings.TrimSpace(cfg.Path)
+	identityPath := path
+	if expandedPath, err := ExpandPath(path); err == nil {
+		identityPath = expandedPath
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.enabled = enabled
 	s.path = path
 	s.format = format
-	s.identity = externalThemeIdentity(enabled, provider, format, path)
+	s.identity = externalThemeIdentity(enabled, provider, format, identityPath)
 }
 
 // ExternalThemeIdentity returns the current normalized external theme identity.

--- a/internal/infrastructure/externaltheme/noctalia/source.go
+++ b/internal/infrastructure/externaltheme/noctalia/source.go
@@ -1,0 +1,364 @@
+package noctalia
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+const (
+	providerName     = "noctalia"
+	formatName       = formatColorsJSON
+	formatColorsJSON = "colors-json"
+	formatDumberJSON = "dumber-json"
+	colorsJSONName   = "Noctalia colors.json"
+	dumberJSONName   = "Noctalia Dumber JSON"
+)
+
+var _ port.ExternalThemeSource = (*FileSource)(nil)
+
+// FileSource reads a Noctalia external theme file.
+//
+// The default colors-json format reads Noctalia's native colors.json directly.
+// The dumber-json format remains available for explicit Dumber-specific user templates.
+type FileSource struct {
+	mu       sync.RWMutex
+	enabled  bool
+	path     string
+	format   string
+	identity string
+}
+
+// NewFileSource creates a Noctalia colors-json file source.
+func NewFileSource(enabled bool, path string) *FileSource {
+	source := &FileSource{}
+	source.Configure(entity.ExternalThemeConfig{
+		Enabled:  enabled,
+		Provider: providerName,
+		Format:   formatName,
+		Path:     path,
+	})
+	return source
+}
+
+// NewFileSourceFromConfig creates a file source from external theme config.
+func NewFileSourceFromConfig(cfg entity.ExternalThemeConfig) *FileSource {
+	source := &FileSource{}
+	source.Configure(cfg)
+	return source
+}
+
+// Configure updates the source from a normalized or raw external theme config snapshot.
+func (s *FileSource) Configure(cfg entity.ExternalThemeConfig) {
+	provider, format := normalizeProviderAndFormat(cfg.Provider, cfg.Format)
+	enabled := cfg.Enabled && provider == providerName && isSupportedFormat(format)
+	path := strings.TrimSpace(cfg.Path)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.enabled = enabled
+	s.path = path
+	s.format = format
+	s.identity = externalThemeIdentity(enabled, provider, format, path)
+}
+
+// ExternalThemeIdentity returns the current normalized external theme identity.
+func (s *FileSource) ExternalThemeIdentity() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.identity
+}
+
+// IsEnabled returns whether this source should be used.
+func (s *FileSource) IsEnabled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.enabled
+}
+
+// Get reads and parses the configured Noctalia theme file.
+func (s *FileSource) Get(ctx context.Context) (*entity.ExternalTheme, error) {
+	s.mu.RLock()
+	enabled := s.enabled
+	pathConfig := s.path
+	format := s.format
+	s.mu.RUnlock()
+
+	if !enabled {
+		return nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	path, err := ExpandPath(pathConfig)
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, errors.New("noctalia theme path is empty")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read noctalia theme file: %w", err)
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+
+	switch format {
+	case formatColorsJSON:
+		return ParseColorsJSON(data)
+	case formatDumberJSON:
+		return ParseDumberJSON(data)
+	default:
+		return nil, fmt.Errorf("unsupported noctalia theme format %q", format)
+	}
+}
+
+// ExpandPath expands environment variables, leading ~, and cleans the path.
+func ExpandPath(path string) (string, error) {
+	expanded := os.ExpandEnv(strings.TrimSpace(path))
+	if expanded == "" {
+		return "", nil
+	}
+	if expanded == "~" || strings.HasPrefix(expanded, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expand home directory: %w", err)
+		}
+		if expanded == "~" {
+			expanded = home
+		} else {
+			expanded = filepath.Join(home, expanded[2:])
+		}
+	}
+	return filepath.Clean(expanded), nil
+}
+
+// ParseColorsJSON parses Noctalia's native colors.json file.
+//
+// Noctalia colors.json represents the active palette only, so Dumber applies the
+// mapped palette to both light and dark resolved palettes. The mapper uses
+// optional mShadow/mHover roles when present to preserve background/surface/input
+// contrast, while falling back to older required roles for compatibility.
+func ParseColorsJSON(data []byte) (*entity.ExternalTheme, error) {
+	var raw colorsThemeJSON
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("parse noctalia colors json: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("parse noctalia colors json: trailing data")
+	}
+
+	palette, err := raw.toPalette()
+	if err != nil {
+		return nil, err
+	}
+	light := palette
+	dark := palette
+	return &entity.ExternalTheme{
+		Name:         colorsJSONName,
+		Provider:     providerName,
+		LightPalette: &light,
+		DarkPalette:  &dark,
+	}, nil
+}
+
+// ParseDumberJSON parses Noctalia user-template-generated Dumber JSON.
+func ParseDumberJSON(data []byte) (*entity.ExternalTheme, error) {
+	var raw dumberThemeJSON
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("parse noctalia dumber json: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("parse noctalia dumber json: trailing data")
+	}
+	if raw.Light == nil {
+		return nil, errors.New("parse noctalia dumber json: missing light palette")
+	}
+	if raw.Dark == nil {
+		return nil, errors.New("parse noctalia dumber json: missing dark palette")
+	}
+
+	light := raw.Light.toEntity()
+	dark := raw.Dark.toEntity()
+	if err := validatePalette(&light, "light"); err != nil {
+		return nil, err
+	}
+	if err := validatePalette(&dark, "dark"); err != nil {
+		return nil, err
+	}
+
+	return &entity.ExternalTheme{
+		Name:         firstNonEmpty(raw.Name, raw.Source, dumberJSONName),
+		Provider:     providerName,
+		LightPalette: &light,
+		DarkPalette:  &dark,
+	}, nil
+}
+
+type colorsThemeJSON struct {
+	MPrimary          *string `json:"mPrimary"`
+	MSurface          *string `json:"mSurface"`
+	MOnSurface        *string `json:"mOnSurface"`
+	MSurfaceVariant   *string `json:"mSurfaceVariant"`
+	MOnSurfaceVariant *string `json:"mOnSurfaceVariant"`
+	MOutline          *string `json:"mOutline"`
+	MShadow           *string `json:"mShadow"`
+	MHover            *string `json:"mHover"`
+}
+
+func (raw colorsThemeJSON) toPalette() (entity.ColorPalette, error) {
+	surface, err := requiredColorsHex("mSurface", raw.MSurface)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+	surfaceVariantBase, err := requiredColorsHex("mSurfaceVariant", raw.MSurfaceVariant)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+	text, err := requiredColorsHex("mOnSurface", raw.MOnSurface)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+	muted, err := requiredColorsHex("mOnSurfaceVariant", raw.MOnSurfaceVariant)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+	accent, err := requiredColorsHex("mPrimary", raw.MPrimary)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+	border, err := requiredColorsHex("mOutline", raw.MOutline)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+	background, err := optionalColorsHex("mShadow", raw.MShadow, surface)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+	surfaceVariant, err := optionalColorsHex("mHover", raw.MHover, surfaceVariantBase)
+	if err != nil {
+		return entity.ColorPalette{}, err
+	}
+
+	return entity.ColorPalette{
+		Background:     background,
+		Surface:        surface,
+		SurfaceVariant: surfaceVariant,
+		Text:           text,
+		Muted:          muted,
+		Accent:         accent,
+		Border:         border,
+	}, nil
+}
+
+func requiredColorsHex(field string, value *string) (string, error) {
+	if value == nil || *value == "" {
+		return "", fmt.Errorf("parse noctalia colors json: missing %s", field)
+	}
+	return validateColorsHex(field, *value)
+}
+
+func optionalColorsHex(field string, value *string, fallback string) (string, error) {
+	if value == nil {
+		return fallback, nil
+	}
+	return validateColorsHex(field, *value)
+}
+
+func validateColorsHex(field, value string) (string, error) {
+	if !entity.IsValidHex(value) {
+		return "", fmt.Errorf("parse noctalia colors json: %s: not a valid CSS-safe hex color (#RRGGBB)", field)
+	}
+	return value, nil
+}
+
+type dumberThemeJSON struct {
+	Source string       `json:"source"`
+	Mode   string       `json:"mode"`
+	Name   string       `json:"name"`
+	Light  *paletteJSON `json:"light"`
+	Dark   *paletteJSON `json:"dark"`
+}
+
+type paletteJSON struct {
+	Background     string `json:"background"`
+	Surface        string `json:"surface"`
+	SurfaceVariant string `json:"surface_variant"`
+	Text           string `json:"text"`
+	Muted          string `json:"muted"`
+	Accent         string `json:"accent"`
+	Border         string `json:"border"`
+}
+
+func (p paletteJSON) toEntity() entity.ColorPalette {
+	return entity.ColorPalette{
+		Background:     p.Background,
+		Surface:        p.Surface,
+		SurfaceVariant: p.SurfaceVariant,
+		Text:           p.Text,
+		Muted:          p.Muted,
+		Accent:         p.Accent,
+		Border:         p.Border,
+	}
+}
+
+func validatePalette(p *entity.ColorPalette, prefix string) error {
+	warnings := entity.ValidatePaletteOverrideHex(p, prefix)
+	if len(warnings) == 0 {
+		return nil
+	}
+	return fmt.Errorf("parse noctalia dumber json: %s: %s", warnings[0].Field, warnings[0].Message)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizeProviderAndFormat(providerInput, formatInput string) (string, string) {
+	provider := strings.ToLower(strings.TrimSpace(providerInput))
+	if provider == "" {
+		provider = providerName
+	}
+	format := strings.ToLower(strings.TrimSpace(formatInput))
+	if format == "" {
+		format = formatName
+	}
+	return provider, format
+}
+
+func isSupportedFormat(format string) bool {
+	switch format {
+	case formatColorsJSON, formatDumberJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+func externalThemeIdentity(enabled bool, provider, format, path string) string {
+	if !enabled {
+		return ""
+	}
+	return provider + "\x00" + format + "\x00" + strings.TrimSpace(path)
+}

--- a/internal/infrastructure/externaltheme/noctalia/source_test.go
+++ b/internal/infrastructure/externaltheme/noctalia/source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/bnema/dumber/internal/domain/entity"
@@ -38,7 +39,7 @@ func TestParseColorsJSONValidActivePalette(t *testing.T) {
 }
 
 func TestParseColorsJSONDocsExample(t *testing.T) {
-	path := filepath.Join("..", "..", "..", "..", "docs", "examples", "noctalia-colors.json")
+	path := docsExamplePath(t, "noctalia-colors.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile(%q) error = %v", path, err)
@@ -48,7 +49,7 @@ func TestParseColorsJSONDocsExample(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseColorsJSON(docs example) error = %v", err)
 	}
-	if theme.Provider != "noctalia" || theme.DarkPalette.Accent == "" {
+	if theme == nil || theme.DarkPalette == nil || theme.Provider != "noctalia" || theme.DarkPalette.Accent == "" {
 		t.Fatalf("parsed docs example = %+v", theme)
 	}
 }
@@ -142,7 +143,7 @@ func TestParseDumberJSONValidFullPalette(t *testing.T) {
 }
 
 func TestParseDumberJSONDocsExample(t *testing.T) {
-	path := filepath.Join("..", "..", "..", "..", "docs", "examples", "noctalia-dumber-theme.json")
+	path := docsExamplePath(t, "noctalia-dumber-theme.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile(%q) error = %v", path, err)
@@ -152,7 +153,7 @@ func TestParseDumberJSONDocsExample(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseDumberJSON(docs example) error = %v", err)
 	}
-	if theme.Provider != "noctalia" || theme.LightPalette.Background == "" || theme.DarkPalette.Background == "" {
+	if theme == nil || theme.LightPalette == nil || theme.DarkPalette == nil || theme.Provider != "noctalia" || theme.LightPalette.Background == "" || theme.DarkPalette.Background == "" {
 		t.Fatalf("parsed docs example = %+v", theme)
 	}
 }
@@ -231,6 +232,30 @@ func TestExpandPath(t *testing.T) {
 	want := filepath.Join(home, "theme.json")
 	if got != want {
 		t.Fatalf("ExpandPath() = %q, want %q", got, want)
+	}
+}
+
+func TestFileSourceIdentityUsesExpandedPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := filepath.Join(home, ".config", "noctalia", "colors.json")
+	source := NewFileSourceFromConfig(entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "colors-json",
+		Path:     path,
+	})
+	absoluteIdentity := source.ExternalThemeIdentity()
+
+	source.Configure(entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "colors-json",
+		Path:     "~/.config/noctalia/colors.json",
+	})
+	if source.ExternalThemeIdentity() != absoluteIdentity {
+		t.Fatalf("ExternalThemeIdentity() = %q, want %q", source.ExternalThemeIdentity(), absoluteIdentity)
 	}
 }
 
@@ -333,6 +358,15 @@ func TestFileSourceConfigureUpdatesSettings(t *testing.T) {
 	if source.IsEnabled() {
 		t.Fatal("IsEnabled() = true for unsupported format, want false")
 	}
+}
+
+func docsExamplePath(t *testing.T, name string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "..", "..", "docs", "examples", name)
 }
 
 func noctaliaColorsJSON() []byte {

--- a/internal/infrastructure/externaltheme/noctalia/source_test.go
+++ b/internal/infrastructure/externaltheme/noctalia/source_test.go
@@ -1,0 +1,357 @@
+package noctalia
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+func TestParseColorsJSONValidActivePalette(t *testing.T) {
+	theme, err := ParseColorsJSON(noctaliaColorsJSON())
+	if err != nil {
+		t.Fatalf("ParseColorsJSON() error = %v", err)
+	}
+	if theme.Provider != "noctalia" {
+		t.Fatalf("Provider = %q, want noctalia", theme.Provider)
+	}
+	if theme.Name == "" {
+		t.Fatal("Name is empty, want source metadata")
+	}
+	want := entity.ColorPalette{
+		Background:     "#000000",
+		Surface:        "#0c0c0c",
+		SurfaceVariant: "#282828",
+		Text:           "#ffffff",
+		Muted:          "#a0a0a0",
+		Accent:         "#ffc799",
+		Border:         "#505050",
+	}
+	if theme.LightPalette == nil || *theme.LightPalette != want {
+		t.Fatalf("LightPalette = %+v, want %+v", theme.LightPalette, want)
+	}
+	if theme.DarkPalette == nil || *theme.DarkPalette != want {
+		t.Fatalf("DarkPalette = %+v, want active Noctalia palette %+v", theme.DarkPalette, want)
+	}
+}
+
+func TestParseColorsJSONDocsExample(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "..", "docs", "examples", "noctalia-colors.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	theme, err := ParseColorsJSON(data)
+	if err != nil {
+		t.Fatalf("ParseColorsJSON(docs example) error = %v", err)
+	}
+	if theme.Provider != "noctalia" || theme.DarkPalette.Accent == "" {
+		t.Fatalf("parsed docs example = %+v", theme)
+	}
+}
+
+func TestParseColorsJSONFallsBackWhenNuanceFieldsAreAbsent(t *testing.T) {
+	theme, err := ParseColorsJSON([]byte(`{
+		"mPrimary":"#ffc799",
+		"mSurface":"#0c0c0c",
+		"mOnSurface":"#ffffff",
+		"mSurfaceVariant":"#1c1c1c",
+		"mOnSurfaceVariant":"#a0a0a0",
+		"mOutline":"#505050"
+	}`))
+	if err != nil {
+		t.Fatalf("ParseColorsJSON() error = %v", err)
+	}
+	if theme.DarkPalette.Background != "#0c0c0c" {
+		t.Fatalf("Background = %q, want mSurface fallback", theme.DarkPalette.Background)
+	}
+	if theme.DarkPalette.SurfaceVariant != "#1c1c1c" {
+		t.Fatalf("SurfaceVariant = %q, want mSurfaceVariant fallback", theme.DarkPalette.SurfaceVariant)
+	}
+}
+
+func TestParseColorsJSONRequiresMappedFields(t *testing.T) {
+	cases := map[string]string{
+		"missing surface":         `{"mPrimary":"#111111","mOnSurface":"#222222","mSurfaceVariant":"#333333","mOnSurfaceVariant":"#444444","mOutline":"#555555"}`,
+		"missing surface variant": `{"mPrimary":"#111111","mSurface":"#222222","mOnSurface":"#333333","mOnSurfaceVariant":"#444444","mOutline":"#555555"}`,
+		"missing text":            `{"mPrimary":"#111111","mSurface":"#222222","mSurfaceVariant":"#333333","mOnSurfaceVariant":"#444444","mOutline":"#555555"}`,
+		"missing muted":           `{"mPrimary":"#111111","mSurface":"#222222","mOnSurface":"#333333","mSurfaceVariant":"#444444","mOutline":"#555555"}`,
+		"missing accent":          `{"mSurface":"#111111","mOnSurface":"#222222","mSurfaceVariant":"#333333","mOnSurfaceVariant":"#444444","mOutline":"#555555"}`,
+		"missing border":          `{"mPrimary":"#111111","mSurface":"#222222","mOnSurface":"#333333","mSurfaceVariant":"#444444","mOnSurfaceVariant":"#555555"}`,
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseColorsJSON([]byte(input)); err == nil {
+				t.Fatal("ParseColorsJSON() error = nil, want missing field error")
+			}
+		})
+	}
+}
+
+func TestParseColorsJSONInvalidHexRejection(t *testing.T) {
+	if _, err := ParseColorsJSON([]byte(`{"mPrimary":"ffc799","mSurface":"#0c0c0c","mOnSurface":"#ffffff","mSurfaceVariant":"#1c1c1c","mOnSurfaceVariant":"#a0a0a0","mOutline":"#505050"}`)); err == nil {
+		t.Fatal("ParseColorsJSON() error = nil, want invalid hex error")
+	}
+}
+
+func TestParseColorsJSONInvalidOptionalNuanceHexRejection(t *testing.T) {
+	cases := map[string]string{
+		"invalid shadow": `{"mPrimary":"#ffc799","mSurface":"#0c0c0c","mOnSurface":"#ffffff","mSurfaceVariant":"#1c1c1c","mOnSurfaceVariant":"#a0a0a0","mOutline":"#505050","mShadow":"000000"}`,
+		"invalid hover":  `{"mPrimary":"#ffc799","mSurface":"#0c0c0c","mOnSurface":"#ffffff","mSurfaceVariant":"#1c1c1c","mOnSurfaceVariant":"#a0a0a0","mOutline":"#505050","mHover":"282828"}`,
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseColorsJSON([]byte(input)); err == nil {
+				t.Fatal("ParseColorsJSON() error = nil, want optional hex validation error")
+			}
+		})
+	}
+}
+
+func TestParseColorsJSONRejectsTrailingTokens(t *testing.T) {
+	if _, err := ParseColorsJSON(append(noctaliaColorsJSON(), []byte(` {}`)...)); err == nil {
+		t.Fatal("ParseColorsJSON() error = nil, want trailing data error")
+	}
+}
+
+func TestParseDumberJSONValidFullPalette(t *testing.T) {
+	json := []byte(`{
+		"name":"Night Theme",
+		"source":"noctalia-template",
+		"mode":"dark",
+		"light":{"background":"#FFFFFF","surface":"#F0F0F0","surface_variant":"#E0E0E0","text":"#111111","muted":"#777777","accent":"#3366CC","border":"#CCCCCC"},
+		"dark":{"background":"#000000","surface":"#101010","surface_variant":"#202020","text":"#EEEEEE","muted":"#999999","accent":"#AABBCC","border":"#333333"}
+	}`)
+
+	theme, err := ParseDumberJSON(json)
+	if err != nil {
+		t.Fatalf("ParseDumberJSON() error = %v", err)
+	}
+	if theme.Provider != "noctalia" {
+		t.Fatalf("Provider = %q, want noctalia", theme.Provider)
+	}
+	if theme.Name != "Night Theme" {
+		t.Fatalf("Name = %q, want metadata name", theme.Name)
+	}
+	if theme.LightPalette.Background != "#FFFFFF" || theme.DarkPalette.Accent != "#AABBCC" {
+		t.Fatalf("parsed palettes = %+v / %+v", theme.LightPalette, theme.DarkPalette)
+	}
+}
+
+func TestParseDumberJSONDocsExample(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "..", "docs", "examples", "noctalia-dumber-theme.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	theme, err := ParseDumberJSON(data)
+	if err != nil {
+		t.Fatalf("ParseDumberJSON(docs example) error = %v", err)
+	}
+	if theme.Provider != "noctalia" || theme.LightPalette.Background == "" || theme.DarkPalette.Background == "" {
+		t.Fatalf("parsed docs example = %+v", theme)
+	}
+}
+
+func TestParseDumberJSONPartialPalette(t *testing.T) {
+	theme, err := ParseDumberJSON([]byte(`{
+		"light":{"background":"#FFFFFF","accent":"#112233"},
+		"dark":{"text":"#EEEEEE"}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseDumberJSON() error = %v", err)
+	}
+	if theme.LightPalette.Surface != "" || theme.DarkPalette.Background != "" {
+		t.Fatalf("missing fields should remain empty: %+v / %+v", theme.LightPalette, theme.DarkPalette)
+	}
+}
+
+func TestParseDumberJSONRequiresLightAndDarkObjects(t *testing.T) {
+	cases := map[string]string{
+		"missing light": `{"dark":{}}`,
+		"missing dark":  `{"light":{}}`,
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseDumberJSON([]byte(input)); err == nil {
+				t.Fatal("ParseDumberJSON() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestParseDumberJSONMetadataNameFallsBackToSource(t *testing.T) {
+	theme, err := ParseDumberJSON([]byte(`{"source":"noctalia-template","light":{},"dark":{}}`))
+	if err != nil {
+		t.Fatalf("ParseDumberJSON() error = %v", err)
+	}
+	if theme.Name != "noctalia-template" {
+		t.Fatalf("Name = %q, want source fallback", theme.Name)
+	}
+}
+
+func TestParseDumberJSONValidHexAcceptance(t *testing.T) {
+	_, err := ParseDumberJSON([]byte(`{"light":{"accent":"#aBc123"},"dark":{"accent":"#ABC123"}}`))
+	if err != nil {
+		t.Fatalf("ParseDumberJSON() error = %v", err)
+	}
+}
+
+func TestParseDumberJSONInvalidHexRejection(t *testing.T) {
+	if _, err := ParseDumberJSON([]byte(`{"light":{"accent":"ABC123"},"dark":{}}`)); err == nil {
+		t.Fatal("ParseDumberJSON() error = nil, want invalid hex error")
+	}
+}
+
+func TestParseDumberJSONMalformedRejection(t *testing.T) {
+	if _, err := ParseDumberJSON([]byte(`{"light":`)); err == nil {
+		t.Fatal("ParseDumberJSON() error = nil, want malformed JSON error")
+	}
+}
+
+func TestParseDumberJSONRejectsTrailingTokens(t *testing.T) {
+	if _, err := ParseDumberJSON([]byte(`{"light":{},"dark":{}} {}`)); err == nil {
+		t.Fatal("ParseDumberJSON() error = nil, want trailing data error")
+	}
+}
+
+func TestExpandPath(t *testing.T) {
+	t.Setenv("NOCTALIA_THEME_TEST", "theme.json")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := ExpandPath("~/$NOCTALIA_THEME_TEST")
+	if err != nil {
+		t.Fatalf("ExpandPath() error = %v", err)
+	}
+	want := filepath.Join(home, "theme.json")
+	if got != want {
+		t.Fatalf("ExpandPath() = %q, want %q", got, want)
+	}
+}
+
+func TestFileSourceDisabledBehavior(t *testing.T) {
+	source := NewFileSource(false, "/does/not/exist")
+	if source.IsEnabled() {
+		t.Fatal("IsEnabled() = true, want false")
+	}
+	theme, err := source.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if theme != nil {
+		t.Fatalf("Get() theme = %+v, want nil", theme)
+	}
+}
+
+func TestFileSourceReadsColorsJSONByDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "colors.json")
+	if err := os.WriteFile(path, noctaliaColorsJSON(), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	theme, err := NewFileSource(true, path).Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if theme.LightPalette.Accent != "#ffc799" || theme.DarkPalette.Background != "#000000" || theme.DarkPalette.SurfaceVariant != "#282828" {
+		t.Fatalf("Get() palettes = %+v / %+v", theme.LightPalette, theme.DarkPalette)
+	}
+}
+
+func TestFileSourceReadsDumberJSONWhenConfigured(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "theme.json")
+	if err := os.WriteFile(path, []byte(`{"light":{"background":"#FFFFFF"},"dark":{"background":"#000000"}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	source := NewFileSourceFromConfig(entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "dumber-json",
+		Path:     path,
+	})
+	theme, err := source.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if theme.LightPalette.Background != "#FFFFFF" || theme.DarkPalette.Background != "#000000" {
+		t.Fatalf("Get() palettes = %+v / %+v", theme.LightPalette, theme.DarkPalette)
+	}
+}
+
+func TestFileSourceConfigureUpdatesSettings(t *testing.T) {
+	colorsPath := filepath.Join(t.TempDir(), "colors.json")
+	if err := os.WriteFile(colorsPath, noctaliaColorsJSON(), 0o600); err != nil {
+		t.Fatalf("WriteFile(colors) error = %v", err)
+	}
+	dumberPath := filepath.Join(t.TempDir(), "theme.json")
+	if err := os.WriteFile(dumberPath, []byte(`{"light":{"background":"#FFFFFF"},"dark":{"background":"#000000"}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(dumber) error = %v", err)
+	}
+
+	source := NewFileSourceFromConfig(entity.ExternalThemeConfig{})
+	if source.IsEnabled() {
+		t.Fatal("IsEnabled() = true, want false")
+	}
+
+	source.Configure(entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: " NOCTALIA ",
+		Format:   " COLORS-JSON ",
+		Path:     colorsPath,
+	})
+	if !source.IsEnabled() {
+		t.Fatal("IsEnabled() = false for colors-json, want true")
+	}
+	if _, err := source.Get(context.Background()); err != nil {
+		t.Fatalf("Get() colors-json after Configure error = %v", err)
+	}
+
+	source.Configure(entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "dumber-json",
+		Path:     dumberPath,
+	})
+	if !source.IsEnabled() {
+		t.Fatal("IsEnabled() = false for dumber-json, want true")
+	}
+	if _, err := source.Get(context.Background()); err != nil {
+		t.Fatalf("Get() dumber-json after Configure error = %v", err)
+	}
+
+	source.Configure(entity.ExternalThemeConfig{Enabled: true, Provider: "other", Format: "colors-json", Path: colorsPath})
+	if source.IsEnabled() {
+		t.Fatal("IsEnabled() = true for unsupported provider, want false")
+	}
+	source.Configure(entity.ExternalThemeConfig{Enabled: true, Provider: "noctalia", Format: "toml", Path: colorsPath})
+	if source.IsEnabled() {
+		t.Fatal("IsEnabled() = true for unsupported format, want false")
+	}
+}
+
+func noctaliaColorsJSON() []byte {
+	return []byte(`{
+		"mError": "#ff8080",
+		"mHover": "#282828",
+		"mOnError": "#000000",
+		"mOnHover": "#ffffff",
+		"mOnPrimary": "#000000",
+		"mOnSecondary": "#000000",
+		"mOnSurface": "#ffffff",
+		"mOnSurfaceVariant": "#a0a0a0",
+		"mOnTertiary": "#000000",
+		"mOutline": "#505050",
+		"mPrimary": "#ffc799",
+		"mSecondary": "#99ffe4",
+		"mShadow": "#000000",
+		"mSurface": "#0c0c0c",
+		"mSurfaceVariant": "#1c1c1c",
+		"mTertiary": "#fbadff"
+	}`)
+}

--- a/internal/infrastructure/externaltheme/noctalia/watcher.go
+++ b/internal/infrastructure/externaltheme/noctalia/watcher.go
@@ -43,7 +43,9 @@ func NewFileWatcher() *FileWatcher {
 func (w *FileWatcher) Start(ctx context.Context, cfg entity.ExternalThemeConfig, onChange func()) error {
 	path, enabled, err := watchPathFromConfig(cfg)
 	if err != nil {
-		_ = w.Stop()
+		if stopErr := w.Stop(); stopErr != nil {
+			return errors.Join(err, fmt.Errorf("stop noctalia theme watcher: %w", stopErr))
+		}
 		return err
 	}
 	if !enabled || path == "" {
@@ -75,7 +77,12 @@ func (w *FileWatcher) Start(ctx context.Context, cfg entity.ExternalThemeConfig,
 		return fmt.Errorf("create noctalia theme watcher: %w", err)
 	}
 	if err := watcher.Add(parent); err != nil {
-		_ = watcher.Close()
+		if closeErr := watcher.Close(); closeErr != nil {
+			return errors.Join(
+				fmt.Errorf("watch noctalia theme parent directory: %w", err),
+				fmt.Errorf("close noctalia theme watcher after add failure: %w", closeErr),
+			)
+		}
 		return fmt.Errorf("watch noctalia theme parent directory: %w", err)
 	}
 

--- a/internal/infrastructure/externaltheme/noctalia/watcher.go
+++ b/internal/infrastructure/externaltheme/noctalia/watcher.go
@@ -1,0 +1,190 @@
+package noctalia
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/fsnotify/fsnotify"
+)
+
+const defaultDebounceDelay = 75 * time.Millisecond
+
+// FileWatcher watches one Noctalia external theme file.
+//
+// It watches the file's parent directory so atomic writes and renames are
+// observed, then filters events to the configured file path.
+type FileWatcher struct {
+	mu       sync.Mutex
+	delay    time.Duration
+	watcher  *fsnotify.Watcher
+	path     string
+	stopCtx  context.Context
+	stopFunc context.CancelFunc
+	running  bool
+}
+
+// NewFileWatcher creates a file watcher with the default debounce delay.
+func NewFileWatcher() *FileWatcher {
+	return &FileWatcher{delay: defaultDebounceDelay}
+}
+
+// Start starts watching the configured external theme path.
+//
+// Calling Start with the same enabled path while already running is a no-op.
+// Calling Start with a different enabled path restarts the underlying watcher.
+// Disabled, unsupported, or empty-path config stops any existing watcher.
+func (w *FileWatcher) Start(ctx context.Context, cfg entity.ExternalThemeConfig, onChange func()) error {
+	path, enabled, err := watchPathFromConfig(cfg)
+	if err != nil {
+		_ = w.Stop()
+		return err
+	}
+	if !enabled || path == "" {
+		return w.Stop()
+	}
+	if onChange == nil {
+		return errors.New("noctalia file watcher callback is nil")
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.running && w.path == path {
+		return nil
+	}
+	if stopErr := w.stopLocked(); stopErr != nil {
+		return fmt.Errorf("stop previous noctalia theme watcher: %w", stopErr)
+	}
+
+	parent := filepath.Dir(path)
+	info, statErr := os.Stat(parent)
+	if statErr != nil {
+		return fmt.Errorf("watch noctalia theme parent directory: %w", statErr)
+	} else if !info.IsDir() {
+		return fmt.Errorf("watch noctalia theme parent directory: %s is not a directory", parent)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("create noctalia theme watcher: %w", err)
+	}
+	if err := watcher.Add(parent); err != nil {
+		_ = watcher.Close()
+		return fmt.Errorf("watch noctalia theme parent directory: %w", err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	w.watcher = watcher
+	w.path = path
+	w.stopCtx = runCtx
+	w.stopFunc = cancel
+	w.running = true
+
+	go w.run(runCtx, watcher, path, onChange)
+	return nil
+}
+
+// Stop stops the current watcher. It is safe to call repeatedly.
+func (w *FileWatcher) Stop() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.stopLocked()
+}
+
+func (w *FileWatcher) stopLocked() error {
+	if !w.running {
+		return nil
+	}
+	if w.stopFunc != nil {
+		w.stopFunc()
+	}
+	err := w.watcher.Close()
+	w.watcher = nil
+	w.path = ""
+	w.stopCtx = nil
+	w.stopFunc = nil
+	w.running = false
+	return err
+}
+
+func (w *FileWatcher) run(ctx context.Context, watcher *fsnotify.Watcher, path string, onChange func()) {
+	var timer *time.Timer
+	var timerC <-chan time.Time
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+		w.mu.Lock()
+		if w.watcher == watcher {
+			_ = w.stopLocked()
+		}
+		w.mu.Unlock()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if !isRelevantFileEvent(event, path) {
+				continue
+			}
+			if timer == nil {
+				timer = time.NewTimer(w.delay)
+				timerC = timer.C
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(w.delay)
+				timerC = timer.C
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			slog.Warn("noctalia theme watcher error", "error", err)
+		case <-timerC:
+			timerC = nil
+			onChange()
+		}
+	}
+}
+
+func watchPathFromConfig(cfg entity.ExternalThemeConfig) (string, bool, error) {
+	provider, format := normalizeProviderAndFormat(cfg.Provider, cfg.Format)
+	enabled := cfg.Enabled && provider == providerName && isSupportedFormat(format)
+	if !enabled {
+		return "", false, nil
+	}
+	path, err := ExpandPath(cfg.Path)
+	if err != nil {
+		return "", false, err
+	}
+	return path, path != "", nil
+}
+
+func isRelevantFileEvent(event fsnotify.Event, path string) bool {
+	if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename|fsnotify.Remove) == 0 {
+		return false
+	}
+	return filepath.Clean(event.Name) == path
+}
+
+func (w *FileWatcher) isRunningForTest() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running
+}

--- a/internal/infrastructure/externaltheme/noctalia/watcher_test.go
+++ b/internal/infrastructure/externaltheme/noctalia/watcher_test.go
@@ -1,0 +1,263 @@
+package noctalia
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+func TestFileWatcherStartStopAndContextCancellation(t *testing.T) {
+	path := writeThemeFile(t, t.TempDir(), "theme.json")
+	watcher := newFastWatcher()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := watcher.Start(ctx, watcherConfig(path), func() {}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if !watcher.isRunningForTest() {
+		t.Fatal("watcher is not running after Start")
+	}
+	if err := watcher.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if err := watcher.Stop(); err != nil {
+		t.Fatalf("second Stop() error = %v", err)
+	}
+
+	if err := watcher.Start(ctx, watcherConfig(path), func() {}); err != nil {
+		t.Fatalf("Start() after Stop error = %v", err)
+	}
+	cancel()
+	waitUntil(t, func() bool { return !watcher.isRunningForTest() })
+}
+
+func TestFileWatcherStartSamePathDoesNotDuplicateWatcher(t *testing.T) {
+	dir := t.TempDir()
+	path := writeThemeFile(t, dir, "theme.json")
+	watcher := newFastWatcher()
+	changes := make(chan struct{}, 4)
+
+	if err := watcher.Start(context.Background(), watcherConfig(path), func() { changes <- struct{}{} }); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := watcher.Start(context.Background(), watcherConfig(path), func() { changes <- struct{}{} }); err != nil {
+		t.Fatalf("second Start() same path error = %v", err)
+	}
+
+	writeThemeFile(t, dir, "theme.json")
+	waitForChange(t, changes)
+	assertNoChange(t, changes, 60*time.Millisecond)
+}
+
+func TestFileWatcherPathChangeRestartsAndDisabledStops(t *testing.T) {
+	dir := t.TempDir()
+	first := writeThemeFile(t, dir, "first.json")
+	second := writeThemeFile(t, dir, "second.json")
+	watcher := newFastWatcher()
+	changes := make(chan string, 8)
+
+	if err := watcher.Start(context.Background(), watcherConfig(first), func() { changes <- "first" }); err != nil {
+		t.Fatalf("Start(first) error = %v", err)
+	}
+	if err := watcher.Start(context.Background(), watcherConfig(second), func() { changes <- "second" }); err != nil {
+		t.Fatalf("Start(second) error = %v", err)
+	}
+
+	writeThemeFile(t, dir, "first.json")
+	assertNoStringChange(t, changes, 80*time.Millisecond)
+	writeThemeFile(t, dir, "second.json")
+	if got := waitForStringChange(t, changes); got != "second" {
+		t.Fatalf("callback = %q, want second", got)
+	}
+
+	cfg := watcherConfig(second)
+	cfg.Enabled = false
+	if err := watcher.Start(context.Background(), cfg, func() { changes <- "disabled" }); err != nil {
+		t.Fatalf("Start(disabled) error = %v", err)
+	}
+	if watcher.isRunningForTest() {
+		t.Fatal("watcher running after disabled config")
+	}
+	writeThemeFile(t, dir, "second.json")
+	assertNoStringChange(t, changes, 80*time.Millisecond)
+}
+
+func TestFileWatcherDebouncesBurstToOneCallback(t *testing.T) {
+	dir := t.TempDir()
+	path := writeThemeFile(t, dir, "theme.json")
+	watcher := newFastWatcher()
+	changes := make(chan struct{}, 8)
+
+	if err := watcher.Start(context.Background(), watcherConfig(path), func() { changes <- struct{}{} }); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	for range 5 {
+		writeThemeFile(t, dir, "theme.json")
+	}
+
+	waitForChange(t, changes)
+	assertNoChange(t, changes, 80*time.Millisecond)
+}
+
+func TestFileWatcherAtomicRenameWriteEmitsCallback(t *testing.T) {
+	dir := t.TempDir()
+	path := writeThemeFile(t, dir, "theme.json")
+	watcher := newFastWatcher()
+	changes := make(chan struct{}, 4)
+
+	if err := watcher.Start(context.Background(), watcherConfig(path), func() { changes <- struct{}{} }); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	tmp := filepath.Join(dir, "theme.json.tmp")
+	if err := os.WriteFile(tmp, []byte(`{"light":{},"dark":{}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(tmp) error = %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	waitForChange(t, changes)
+}
+
+func TestFileWatcherInvalidOrEmptyPathBehavior(t *testing.T) {
+	watcher := newFastWatcher()
+	if err := watcher.Start(context.Background(), watcherConfig(""), nil); err != nil {
+		t.Fatalf("Start(empty path) error = %v", err)
+	}
+	if watcher.isRunningForTest() {
+		t.Fatal("watcher running for empty path")
+	}
+	missingParent := filepath.Join(t.TempDir(), "missing", "theme.json")
+	if err := watcher.Start(context.Background(), watcherConfig(missingParent), func() {}); err == nil {
+		t.Fatal("Start(missing parent) error = nil, want error")
+	}
+}
+
+func TestWatchPathFromConfigSupportsNoctaliaFormats(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "theme.json")
+	for _, format := range []string{"colors-json", "dumber-json"} {
+		t.Run(format, func(t *testing.T) {
+			got, enabled, err := watchPathFromConfig(entity.ExternalThemeConfig{
+				Enabled:  true,
+				Provider: " NOCTALIA ",
+				Format:   " " + format + " ",
+				Path:     path,
+			})
+			if err != nil {
+				t.Fatalf("watchPathFromConfig() error = %v", err)
+			}
+			if !enabled {
+				t.Fatal("enabled = false, want true")
+			}
+			if got != path {
+				t.Fatalf("path = %q, want %q", got, path)
+			}
+		})
+	}
+
+	_, enabled, err := watchPathFromConfig(entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "toml",
+		Path:     path,
+	})
+	if err != nil {
+		t.Fatalf("watchPathFromConfig(unsupported) error = %v", err)
+	}
+	if enabled {
+		t.Fatal("enabled = true for unsupported format, want false")
+	}
+}
+
+func TestFileWatcherInvalidPathStopsPreviousWatcher(t *testing.T) {
+	dir := t.TempDir()
+	path := writeThemeFile(t, dir, "theme.json")
+	watcher := newFastWatcher()
+	changes := make(chan struct{}, 4)
+
+	if err := watcher.Start(context.Background(), watcherConfig(path), func() { changes <- struct{}{} }); err != nil {
+		t.Fatalf("Start(valid) error = %v", err)
+	}
+	missingParent := filepath.Join(dir, "missing", "theme.json")
+	if err := watcher.Start(context.Background(), watcherConfig(missingParent), func() { changes <- struct{}{} }); err == nil {
+		t.Fatal("Start(missing parent) error = nil, want error")
+	}
+	if watcher.isRunningForTest() {
+		t.Fatal("watcher running after invalid path")
+	}
+	writeThemeFile(t, dir, "theme.json")
+	assertNoChange(t, changes, 80*time.Millisecond)
+}
+
+func newFastWatcher() *FileWatcher {
+	watcher := NewFileWatcher()
+	watcher.delay = 20 * time.Millisecond
+	return watcher
+}
+
+func watcherConfig(path string) entity.ExternalThemeConfig {
+	return entity.ExternalThemeConfig{Enabled: true, Provider: providerName, Format: formatName, Path: path}
+}
+
+func writeThemeFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(`{"light":{},"dark":{}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", name, err)
+	}
+	return path
+}
+
+func waitForChange(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for callback")
+	}
+}
+
+func assertNoChange(t *testing.T, ch <-chan struct{}, d time.Duration) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal("unexpected callback")
+	case <-time.After(d):
+	}
+}
+
+func waitForStringChange(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case got := <-ch:
+		return got
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for callback")
+	}
+	return ""
+}
+
+func assertNoStringChange(t *testing.T, ch <-chan string, d time.Duration) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		t.Fatalf("unexpected callback %q", got)
+	case <-time.After(d):
+	}
+}
+
+func waitUntil(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
+}

--- a/internal/infrastructure/externaltheme/noctalia/watcher_test.go
+++ b/internal/infrastructure/externaltheme/noctalia/watcher_test.go
@@ -238,7 +238,7 @@ func waitForStringChange(t *testing.T, ch <-chan string) string {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timed out waiting for callback")
 	}
-	return ""
+	panic("unreachable")
 }
 
 func assertNoStringChange(t *testing.T, ch <-chan string, d time.Duration) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3072,6 +3072,11 @@ func (a *App) onShutdown(ctx context.Context) {
 
 	// Stop accepting relaunches before teardown starts.
 	a.closeBrowserLaunchRelayListener()
+	if a.deps != nil && a.deps.ExternalThemeWatcher != nil {
+		if err := a.deps.ExternalThemeWatcher.Stop(); err != nil {
+			log.Warn().Err(err).Msg("failed to stop external theme watcher")
+		}
+	}
 
 	// Cancel context to signal all goroutines
 	a.cancel(errors.New("application shutdown"))
@@ -5001,12 +5006,14 @@ func (a *App) UpdateOmniboxZoom(factor float64) {
 func (a *App) initConfigWatcher(ctx context.Context) {
 	log := logging.FromContext(ctx)
 
+	a.syncExternalThemeWatcher(ctx)
+
 	if a.deps.WatchConfig == nil || a.deps.OnConfigChange == nil {
-		log.Debug().Msg("no config watcher available, skipping")
+		log.Debug().Msg("no config watcher available, skipping config file watcher")
 		return
 	}
 
-	// Start viper watcher
+	// Start viper watcher.
 	if err := a.deps.WatchConfig(); err != nil {
 		log.Warn().Err(err).Msg("failed to start config watcher")
 		return
@@ -5016,6 +5023,7 @@ func (a *App) initConfigWatcher(ctx context.Context) {
 	// deps.Config is updated in-place before this callback fires.
 	a.deps.OnConfigChange(func() {
 		cb := glib.SourceFunc(func(_ uintptr) bool {
+			a.syncExternalThemeWatcher(ctx)
 			a.applyAppearanceConfig(ctx)
 			for _, bw := range a.browserWindows {
 				if bw == nil {
@@ -5034,6 +5042,21 @@ func (a *App) initConfigWatcher(ctx context.Context) {
 	})
 
 	log.Debug().Msg("config watcher initialized")
+}
+
+func (a *App) syncExternalThemeWatcher(ctx context.Context) {
+	if a == nil || a.deps == nil || a.deps.Config == nil || a.deps.ExternalThemeWatcher == nil {
+		return
+	}
+	log := logging.FromContext(ctx)
+	cfg := a.deps.Config.Appearance.ExternalTheme
+	if err := a.deps.ExternalThemeWatcher.Start(ctx, cfg, func() {
+		a.dispatchOnMainThread("ui.external_theme_reload", func() {
+			a.applyAppearanceConfig(ctx)
+		})
+	}); err != nil {
+		log.Warn().Err(err).Msg("failed to start external theme watcher")
+	}
 }
 
 func (a *App) applyAppearanceConfig(ctx context.Context) {
@@ -5057,43 +5080,92 @@ func (a *App) applyAppearanceConfig(ctx context.Context) {
 		a.contentCoord.ApplySettingsToAll(ctx)
 	}
 
-	// Update GTK theme and injected WebUI theme vars
-	if a.deps.Theme != nil {
-		var display *gdk.Display
-		if a.mainWindow != nil && a.mainWindow.Window() != nil {
-			display = a.mainWindow.Window().GetDisplay()
-		}
-		a.deps.Theme.UpdateFromConfig(ctx, &cfg.Appearance, cfg.DefaultUIScale, &cfg.Workspace.Styling, display)
+	a.applyThemeAppearance(ctx)
 
-		var inj port.ContentInjector
-		if a.engine != nil {
-			inj = a.engine.ContentInjector()
-		}
+	log.Info().Msg("appearance config updated")
+}
 
-		if inj != nil {
-			findCSS := theme.GenerateFindHighlightCSS(a.deps.Theme.GetCurrentPalette())
-			if err := inj.InjectFindHighlightCSS(ctx, findCSS); err != nil {
-				log.Warn().Err(err).Msg("failed to update find highlight CSS")
-			}
-		}
+func (a *App) applyThemeAppearance(ctx context.Context) {
+	log := logging.FromContext(ctx)
+	if a.deps == nil || a.deps.Config == nil || a.deps.Theme == nil {
+		return
+	}
+	cfg := a.deps.Config
 
-		prepareThemeUC := usecase.NewPrepareWebUIThemeUseCase(inj)
-		cssText := a.deps.Theme.GetWebUIThemeCSS()
-		if err := prepareThemeUC.Execute(ctx, usecase.PrepareWebUIThemeInput{CSSVars: cssText}); err != nil {
-			log.Warn().Err(err).Msg("failed to update WebUI theme CSS")
-		}
+	var display *gdk.Display
+	if a.mainWindow != nil && a.mainWindow.Window() != nil {
+		display = a.mainWindow.Window().GetDisplay()
+	}
 
-		if a.contentCoord != nil && inj != nil {
-			a.contentCoord.RefreshInjectedScriptsToAll(ctx)
-		}
+	preference := port.ColorSchemePreference{PrefersDark: a.deps.Theme.PrefersDark(), Source: "theme"}
+	if a.deps.ColorResolver != nil {
+		preference = a.deps.ColorResolver.Refresh()
+	}
+	if a.deps.ExternalThemeSource != nil {
+		a.deps.ExternalThemeSource.Configure(cfg.Appearance.ExternalTheme)
+	}
+	resolveThemeUC := a.deps.ResolveThemeUC
+	if resolveThemeUC == nil {
+		resolveThemeUC = usecase.NewResolveThemeUseCase(a.deps.ExternalThemeSource)
+	}
+	resolved, err := resolveThemeUC.Refresh(ctx, usecase.ResolveThemeInputFromConfig(
+		&cfg.Appearance,
+		cfg.DefaultUIScale,
+		&cfg.Workspace.Styling,
+		preference,
+	))
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to resolve theme")
+	} else {
+		logThemeResolution(ctx, resolved.Theme)
+		a.deps.Theme.UpdateFromResolved(ctx, resolved.Theme, display)
+		a.setupPoolBackgroundColor(ctx)
+	}
 
-		// Apply WebUI theme to already-loaded dumb:// pages
-		if a.contentCoord != nil {
-			a.contentCoord.ApplyWebUIThemeToAll(ctx, a.deps.Theme.PrefersDark(), cssText)
+	var inj port.ContentInjector
+	if a.engine != nil {
+		inj = a.engine.ContentInjector()
+	}
+
+	if inj != nil {
+		findCSS := theme.GenerateFindHighlightCSS(a.deps.Theme.GetCurrentPalette())
+		if err := inj.InjectFindHighlightCSS(ctx, findCSS); err != nil {
+			log.Warn().Err(err).Msg("failed to update find highlight CSS")
 		}
 	}
 
-	log.Info().Msg("appearance config updated")
+	prepareThemeUC := usecase.NewPrepareWebUIThemeUseCase(inj)
+	cssText := a.deps.Theme.GetWebUIThemeCSS()
+	if err := prepareThemeUC.Execute(ctx, usecase.PrepareWebUIThemeInput{CSSVars: cssText}); err != nil {
+		log.Warn().Err(err).Msg("failed to update WebUI theme CSS")
+	}
+
+	if a.contentCoord != nil && inj != nil {
+		a.contentCoord.RefreshInjectedScriptsToAll(ctx)
+	}
+
+	// Apply WebUI theme to already-loaded dumb:// pages
+	if a.contentCoord != nil {
+		a.contentCoord.ApplyWebUIThemeToAll(ctx, a.deps.Theme.PrefersDark(), cssText)
+	}
+}
+
+func logThemeResolution(ctx context.Context, resolved entity.ResolvedTheme) {
+	log := logging.FromContext(ctx)
+	for _, warning := range resolved.Warnings {
+		log.Warn().Str("field", warning.Field).Msg(warning.Message)
+	}
+	event := log.Info().
+		Str("theme_source", string(resolved.ThemeSource.Kind)).
+		Str("color_scheme_source", resolved.ColorSchemeSource).
+		Bool("prefers_dark", resolved.PrefersDark)
+	if resolved.ThemeSource.Provider != "" {
+		event = event.Str("provider", resolved.ThemeSource.Provider)
+	}
+	if resolved.ThemeSource.LastGood {
+		event = event.Bool("last_good", true)
+	}
+	event.Msg("theme resolved")
 }
 
 func (a *App) initFilteringAsync(ctx context.Context) {

--- a/internal/ui/deps.go
+++ b/internal/ui/deps.go
@@ -28,9 +28,12 @@ type Dependencies struct {
 	OnCrashReportsDetected func([]string)
 
 	// Theme and color scheme management
-	Theme           *theme.Manager
-	ColorResolver   port.ColorSchemeResolver
-	AdwaitaDetector port.ToolkitAvailabilityNotifier
+	Theme                *theme.Manager
+	ResolveThemeUC       *usecase.ResolveThemeUseCase
+	ExternalThemeSource  port.ConfigurableExternalThemeSource
+	ExternalThemeWatcher port.ExternalThemeWatcher
+	ColorResolver        port.ColorSchemeResolver
+	AdwaitaDetector      port.ToolkitAvailabilityNotifier
 
 	// XDG paths
 	XDG port.XDGPaths

--- a/internal/ui/external_theme_reload_test.go
+++ b/internal/ui/external_theme_reload_test.go
@@ -1,0 +1,270 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	portmocks "github.com/bnema/dumber/internal/application/port/mocks"
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
+	uitheme "github.com/bnema/dumber/internal/ui/theme"
+)
+
+type recordingExternalThemeWatcher struct {
+	starts  int
+	stops   int
+	cfg     entity.ExternalThemeConfig
+	trigger func()
+}
+
+func (w *recordingExternalThemeWatcher) Start(_ context.Context, cfg entity.ExternalThemeConfig, onChange func()) error {
+	w.starts++
+	w.cfg = cfg
+	w.trigger = onChange
+	return nil
+}
+
+func (w *recordingExternalThemeWatcher) Stop() error {
+	w.stops++
+	return nil
+}
+
+type mutableExternalThemeSource struct {
+	cfg   entity.ExternalThemeConfig
+	theme *entity.ExternalTheme
+	err   error
+}
+
+func (s *mutableExternalThemeSource) Configure(cfg entity.ExternalThemeConfig) {
+	s.cfg = cfg
+}
+
+func (s *mutableExternalThemeSource) ExternalThemeIdentity() string {
+	if !s.cfg.Enabled {
+		return ""
+	}
+	return s.cfg.Provider + "|" + s.cfg.Format + "|" + s.cfg.Path
+}
+
+func (s *mutableExternalThemeSource) IsEnabled() bool {
+	return s.cfg.Enabled
+}
+
+func (s *mutableExternalThemeSource) Get(context.Context) (*entity.ExternalTheme, error) {
+	if !s.IsEnabled() {
+		return nil, nil
+	}
+	return s.theme, s.err
+}
+
+func immediateDispatchForExternalThemeTest(label string, fn func()) syncdispatch.SyncDispatchResult {
+	fn()
+	return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchCompleted}
+}
+
+func TestExternalThemeWatcherCallbackAppliesThemeThroughSharedPath(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ColorScheme = "prefer-dark"
+	cfg.Appearance.ExternalTheme = entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "dumber-json",
+		Path:     "/tmp/theme.json",
+	}
+	source := &mutableExternalThemeSource{theme: externalThemeWithDarkBackground("#000000")}
+	watcher := &recordingExternalThemeWatcher{}
+	manager := uitheme.NewManager(ctx, resolvedThemeForUITest(cfg.Appearance.LightPalette, cfg.Appearance.DarkPalette))
+	engine := portmocks.NewMockEngine(t)
+	var backgroundUpdated bool
+	engine.EXPECT().UpdateSettings(mock.Anything, mock.Anything).Return(nil).Once()
+	engine.EXPECT().UpdateAppearance(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, r, g, b, alpha float64) {
+			backgroundUpdated = true
+			require.InDelta(t, 0.0, r, 0.000001)
+			require.InDelta(t, 0.0, g, 0.000001)
+			require.InDelta(t, 0.0, b, 0.000001)
+			require.InDelta(t, 1.0, alpha, 0.000001)
+		}).
+		Return(nil).
+		Once()
+	engine.EXPECT().ContentInjector().Return(nil).Once()
+	app := &App{
+		deps: &Dependencies{
+			Config:               cfg,
+			Theme:                manager,
+			ResolveThemeUC:       usecase.NewResolveThemeUseCase(source),
+			ExternalThemeSource:  source,
+			ExternalThemeWatcher: watcher,
+		},
+		dispatchOnMainThread: immediateDispatchForExternalThemeTest,
+		engine:               engine,
+	}
+
+	app.syncExternalThemeWatcher(ctx)
+	require.Equal(t, 1, watcher.starts)
+	require.Equal(t, cfg.Appearance.ExternalTheme, watcher.cfg)
+	require.NotNil(t, watcher.trigger)
+
+	watcher.trigger()
+
+	require.Equal(t, "#000000", app.deps.Theme.GetCurrentPalette().Background)
+	require.True(t, backgroundUpdated, "theme reload should refresh engine background color")
+}
+
+func TestExternalThemeReloadKeepsLastGoodAndDisablingClearsIt(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ColorScheme = "prefer-dark"
+	cfg.Appearance.ExternalTheme = entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "dumber-json",
+		Path:     "/tmp/theme.json",
+	}
+	source := &mutableExternalThemeSource{theme: externalThemeWithDarkBackground("#000000")}
+	manager := uitheme.NewManager(ctx, resolvedThemeForUITest(cfg.Appearance.LightPalette, cfg.Appearance.DarkPalette))
+	app := &App{
+		deps: &Dependencies{
+			Config:              cfg,
+			Theme:               manager,
+			ResolveThemeUC:      usecase.NewResolveThemeUseCase(source),
+			ExternalThemeSource: source,
+		},
+		dispatchOnMainThread: immediateDispatchForExternalThemeTest,
+	}
+
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, "#000000", app.deps.Theme.GetCurrentPalette().Background)
+
+	source.theme = &entity.ExternalTheme{
+		Name:         "broken",
+		Provider:     "noctalia",
+		LightPalette: &entity.ColorPalette{Accent: "not-a-hex"},
+		DarkPalette:  &entity.ColorPalette{Background: "also-bad"},
+	}
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, "#000000", app.deps.Theme.GetCurrentPalette().Background)
+
+	cfg.Appearance.ExternalTheme.Enabled = false
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, cfg.Appearance.DarkPalette.Background, app.deps.Theme.GetCurrentPalette().Background)
+}
+
+func TestExternalThemeReloadKeepsLastGoodOnReadError(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ColorScheme = "prefer-dark"
+	cfg.Appearance.ExternalTheme = entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "dumber-json",
+		Path:     "/tmp/theme.json",
+	}
+	source := &mutableExternalThemeSource{theme: externalThemeWithDarkBackground("#000000")}
+	manager := uitheme.NewManager(ctx, resolvedThemeForUITest(cfg.Appearance.LightPalette, cfg.Appearance.DarkPalette))
+	app := &App{
+		deps: &Dependencies{
+			Config:              cfg,
+			Theme:               manager,
+			ResolveThemeUC:      usecase.NewResolveThemeUseCase(source),
+			ExternalThemeSource: source,
+		},
+		dispatchOnMainThread: immediateDispatchForExternalThemeTest,
+	}
+
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, "#000000", app.deps.Theme.GetCurrentPalette().Background)
+
+	source.theme = nil
+	source.err = errors.New("temporary read failure")
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, "#000000", app.deps.Theme.GetCurrentPalette().Background)
+}
+
+func TestExternalThemeReloadRecoversAfterMalformedUpdate(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ColorScheme = "prefer-dark"
+	cfg.Appearance.ExternalTheme = entity.ExternalThemeConfig{
+		Enabled:  true,
+		Provider: "noctalia",
+		Format:   "dumber-json",
+		Path:     "/tmp/theme.json",
+	}
+	source := &mutableExternalThemeSource{theme: externalThemeWithDarkBackground("#000000")}
+	manager := uitheme.NewManager(ctx, resolvedThemeForUITest(cfg.Appearance.LightPalette, cfg.Appearance.DarkPalette))
+	app := &App{
+		deps: &Dependencies{
+			Config:              cfg,
+			Theme:               manager,
+			ResolveThemeUC:      usecase.NewResolveThemeUseCase(source),
+			ExternalThemeSource: source,
+		},
+		dispatchOnMainThread: immediateDispatchForExternalThemeTest,
+	}
+
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, "#000000", app.deps.Theme.GetCurrentPalette().Background)
+
+	source.theme = &entity.ExternalTheme{
+		Name:         "broken",
+		Provider:     "noctalia",
+		LightPalette: &entity.ColorPalette{Accent: "not-a-hex"},
+		DarkPalette:  &entity.ColorPalette{Background: "also-bad"},
+	}
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, "#000000", app.deps.Theme.GetCurrentPalette().Background)
+
+	source.theme = externalThemeWithDarkBackground("#123456")
+	app.applyAppearanceConfig(ctx)
+	require.Equal(t, "#123456", app.deps.Theme.GetCurrentPalette().Background)
+}
+
+func TestOnShutdownStopsExternalThemeWatcher(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	watcher := &recordingExternalThemeWatcher{}
+	app := &App{
+		deps:   &Dependencies{ExternalThemeWatcher: watcher},
+		cancel: cancel,
+	}
+
+	app.onShutdown(ctx)
+
+	require.Equal(t, 1, watcher.stops)
+}
+
+func resolvedThemeForUITest(light, dark entity.ColorPalette) entity.ResolvedTheme {
+	return entity.ResolvedTheme{
+		LightPalette:      light,
+		DarkPalette:       dark,
+		ActivePalette:     dark,
+		PrefersDark:       true,
+		ColorSchemeSource: "test",
+		ThemeSource:       entity.ThemeSourceMetadata{Kind: entity.ThemeSourceConfig},
+		Fonts:             entity.DefaultThemeFonts(),
+		UIScale:           1,
+		ModeColors:        entity.DefaultThemeModeColors(),
+	}
+}
+
+func externalThemeWithDarkBackground(background string) *entity.ExternalTheme {
+	return &entity.ExternalTheme{
+		Name:     "Noctalia",
+		Provider: "noctalia",
+		LightPalette: &entity.ColorPalette{
+			Background: "#eeeeee",
+			Accent:     "#112233",
+		},
+		DarkPalette: &entity.ColorPalette{
+			Background: background,
+			Accent:     "#445566",
+		},
+	}
+}

--- a/internal/ui/systemviews/app.go
+++ b/internal/ui/systemviews/app.go
@@ -794,7 +794,11 @@ func (a *App) loadShellTheme(ctx context.Context) {
 
 	config, err := a.deps.Config.Current(ctx)
 	if err == nil {
-		a.shellTheme = resolveShellTheme(config.Appearance)
+		appearance := config.Appearance
+		if config.ResolvedAppearance != nil {
+			appearance = *config.ResolvedAppearance
+		}
+		a.shellTheme = resolveShellTheme(appearance)
 	}
 }
 

--- a/internal/ui/systemviews/app_test.go
+++ b/internal/ui/systemviews/app_test.go
@@ -642,6 +642,12 @@ func TestAppLoadInitialConfigRouteRendersData(t *testing.T) {
 				Accent:         "#66aaff",
 				Border:         "#333333",
 			},
+			ExternalTheme: dto.WebUIExternalThemeConfig{
+				Enabled:  true,
+				Provider: "noctalia",
+				Format:   "dumber-json",
+				Path:     "/tmp/noctalia-dumber.json",
+			},
 		},
 		Performance: dto.SystemviewPerformancePayload{
 			Profile: "balanced",
@@ -707,6 +713,13 @@ func TestAppLoadInitialConfigRouteRendersData(t *testing.T) {
 	assert.Contains(t, app.renderedHTML, "Inter")
 	assert.Contains(t, app.renderedHTML, "appearance.light_palette.background")
 	assert.Contains(t, app.renderedHTML, "#ffffff")
+	assert.Contains(t, app.renderedHTML, "appearance.external_theme.enabled")
+	assert.Contains(t, app.renderedHTML, "appearance.external_theme.provider")
+	assert.Contains(t, app.renderedHTML, "appearance.external_theme.format")
+	assert.Contains(t, app.renderedHTML, "appearance.external_theme.path")
+	assert.Contains(t, app.renderedHTML, "noctalia")
+	assert.Contains(t, app.renderedHTML, "dumber-json")
+	assert.Contains(t, app.renderedHTML, "/tmp/noctalia-dumber.json")
 	assert.Contains(t, app.renderedHTML, "performance.profile")
 	assert.Contains(t, app.renderedHTML, "balanced")
 	assert.Contains(t, app.renderedHTML, "performance.custom.skia_cpu_threads")
@@ -761,6 +774,13 @@ func TestAppLoadInitialConfigRouteRendersEditControls(t *testing.T) {
 	require.NoError(t, app.LoadInitial(context.Background()))
 	assert.Contains(t, app.renderedHTML, `data-sv-action="config.appearance.save"`)
 	assert.Contains(t, app.renderedHTML, `data-sv-action="config.appearance.reset"`)
+	assert.Contains(t, app.renderedHTML, `name="external_theme_enabled"`)
+	assert.Contains(t, app.renderedHTML, `name="external_theme_provider"`)
+	assert.Contains(t, app.renderedHTML, `name="external_theme_format"`)
+	assert.Contains(t, app.renderedHTML, `name="external_theme_path"`)
+	assert.Contains(t, app.renderedHTML, `value="noctalia"`)
+	assert.Contains(t, app.renderedHTML, `value="dumber-json"`)
+	assert.Contains(t, app.renderedHTML, `/tmp/noctalia-dumber.json`)
 	assert.Contains(t, app.renderedHTML, `data-sv-action="config.search.save"`)
 	assert.Contains(t, app.renderedHTML, `data-sv-action="config.searchShortcut.create"`)
 	assert.Contains(t, app.renderedHTML, `data-sv-action="config.searchShortcut.update"`)
@@ -796,6 +816,7 @@ func TestAppHandleConfigActionsRefreshesDOM(t *testing.T) {
 		Data: map[string]string{
 			"sans_font": "Inter", "serif_font": "Georgia", "monospace_font": "JetBrains Mono",
 			"default_font_size": "18", "default_ui_scale": "1.25", "color_scheme": "prefer-light",
+			"external_theme_enabled": "yes", "external_theme_provider": " noctalia ", "external_theme_format": " dumber-json ", "external_theme_path": " /tmp/noctalia-dumber.json ",
 			"light_background": "#ffffff", "light_surface": "#fafafa", "light_surface_variant": "#eeeeee", "light_text": "#111111", "light_muted": "#666666", "light_accent": "#0055ff", "light_border": "#dddddd",
 			"dark_background": "#111111", "dark_surface": "#1a1a1a", "dark_surface_variant": "#2a2a2a", "dark_text": "#f5f5f5", "dark_muted": "#a0a0a0", "dark_accent": "#66aaff", "dark_border": "#333333",
 		},
@@ -803,6 +824,10 @@ func TestAppHandleConfigActionsRefreshesDOM(t *testing.T) {
 	assert.True(t, service.calledSave)
 	assert.Equal(t, 18, service.savedConfig.Appearance.DefaultFontSize)
 	assert.InEpsilon(t, 1.25, service.savedConfig.DefaultUIScale, 0.001)
+	assert.True(t, service.savedConfig.Appearance.ExternalTheme.Enabled)
+	assert.Equal(t, "noctalia", service.savedConfig.Appearance.ExternalTheme.Provider)
+	assert.Equal(t, "dumber-json", service.savedConfig.Appearance.ExternalTheme.Format)
+	assert.Equal(t, "/tmp/noctalia-dumber.json", service.savedConfig.Appearance.ExternalTheme.Path)
 	assert.Contains(t, dom.HTML(), "Saved appearance settings")
 	assert.Contains(t, dom.HTML(), `class="sv-app sv-light"`)
 
@@ -876,6 +901,28 @@ func TestAppRejectsSearchURLsWithoutPlaceholder(t *testing.T) {
 	assert.False(t, service.calledSave)
 }
 
+func TestAppLoadInitialConfigRouteUsesResolvedAppearanceOnlyForShellTheme(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfigPayload()
+	resolved := cfg.Appearance
+	resolved.DarkPalette.Background = "#222222"
+	resolved.DarkPalette.SurfaceVariant = "#444444"
+	cfg.ResolvedAppearance = &resolved
+	service := &fakeConfigService{
+		current:     cfg,
+		keybindings: port.KeybindingsConfig{},
+	}
+
+	app := NewApp(Dependencies{Config: service, LocationURI: "dumb://config"})
+
+	require.NoError(t, app.LoadInitial(context.Background()))
+	assert.Contains(t, app.renderedHTML, `--sv-background: #222222;`)
+	assert.Contains(t, app.renderedHTML, `--sv-surface-variant: #444444;`)
+	assert.Contains(t, app.renderedHTML, `value="#111111"`)
+	assert.Contains(t, app.renderedHTML, `value="#2a2a2a"`)
+}
+
 func testConfigPayload() dto.SystemviewConfigPayload {
 	return dto.SystemviewConfigPayload{
 		EngineType: "webkit",
@@ -887,6 +934,7 @@ func testConfigPayload() dto.SystemviewConfigPayload {
 			DefaultFontSize: 16,
 			LightPalette:    dto.ColorPalette{Background: "#ffffff", Surface: "#fafafa", SurfaceVariant: "#eeeeee", Text: "#111111", Muted: "#666666", Accent: "#0055ff", Border: "#dddddd"},
 			DarkPalette:     dto.ColorPalette{Background: "#111111", Surface: "#1a1a1a", SurfaceVariant: "#2a2a2a", Text: "#f5f5f5", Muted: "#a0a0a0", Accent: "#66aaff", Border: "#333333"},
+			ExternalTheme:   dto.WebUIExternalThemeConfig{Enabled: true, Provider: "noctalia", Format: "dumber-json", Path: "/tmp/noctalia-dumber.json"},
 		},
 		DefaultUIScale:      1,
 		DefaultSearchEngine: "https://duckduckgo.com/?q=%s",

--- a/internal/ui/systemviews/config.templ
+++ b/internal/ui/systemviews/config.templ
@@ -39,6 +39,14 @@ templ AppearanceForm(config dto.SystemviewConfigPayload) {
 			<option value="prefer-light" selected?={ colorSchemeSelected(config.Appearance.ColorScheme, "prefer-light") }>Prefer light</option>
 			<option value="prefer-dark" selected?={ colorSchemeSelected(config.Appearance.ColorScheme, "prefer-dark") }>Prefer dark</option>
 		</select></label>
+		<fieldset class="sv-fieldset">
+			<legend>External theme</legend>
+			<p class="sv-meta">Provider noctalia supports colors-json (default Noctalia colors.json) and dumber-json (advanced user template).</p>
+			<label><span>Enable external theme</span><input name="external_theme_enabled" type="checkbox" checked?={ config.Appearance.ExternalTheme.Enabled }/></label>
+			<label><span>Provider</span><input name="external_theme_provider" type="text" value={ config.Appearance.ExternalTheme.Provider } placeholder="noctalia"/></label>
+			<label><span>Format</span><input name="external_theme_format" type="text" value={ config.Appearance.ExternalTheme.Format } placeholder="colors-json"/></label>
+			<label><span>Path</span><input name="external_theme_path" type="text" value={ config.Appearance.ExternalTheme.Path } placeholder="~/.config/noctalia/colors.json"/></label>
+		</fieldset>
 		@PaletteFields("Light palette", "light", config.Appearance.LightPalette)
 		@PaletteFields("Dark palette", "dark", config.Appearance.DarkPalette)
 		<div class="sv-button-row sv-form-actions">

--- a/internal/ui/systemviews/config_actions.go
+++ b/internal/ui/systemviews/config_actions.go
@@ -102,6 +102,10 @@ func (a *App) saveAppearanceConfig(ctx context.Context, data map[string]string) 
 	cfg.Appearance.GtkFont = strings.TrimSpace(data["gtk_font"])
 	cfg.Appearance.DefaultFontSize = fontSize
 	cfg.Appearance.ColorScheme = strings.TrimSpace(data["color_scheme"])
+	cfg.Appearance.ExternalTheme.Enabled = configCheckboxEnabled(data["external_theme_enabled"])
+	cfg.Appearance.ExternalTheme.Provider = strings.TrimSpace(data["external_theme_provider"])
+	cfg.Appearance.ExternalTheme.Format = strings.TrimSpace(data["external_theme_format"])
+	cfg.Appearance.ExternalTheme.Path = strings.TrimSpace(data["external_theme_path"])
 	cfg.Appearance.LightPalette = paletteFromForm(data, "light")
 	cfg.Appearance.DarkPalette = paletteFromForm(data, "dark")
 	cfg.DefaultUIScale = uiScale
@@ -111,6 +115,15 @@ func (a *App) saveAppearanceConfig(ctx context.Context, data map[string]string) 
 	}
 	a.configNotice = "Saved appearance settings"
 	return nil
+}
+
+func configCheckboxEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "on", "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *App) resetAppearanceConfig(ctx context.Context) error {

--- a/internal/ui/systemviews/config_templ.go
+++ b/internal/ui/systemviews/config_templ.go
@@ -292,7 +292,56 @@ func AppearanceForm(config dto.SystemviewConfigPayload) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, ">Prefer dark</option></select></label>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, ">Prefer dark</option></select></label><fieldset class=\"sv-fieldset\"><legend>External theme</legend><p class=\"sv-meta\">Provider noctalia supports colors-json (default Noctalia colors.json) and dumber-json (advanced user template).</p><label><span>Enable external theme</span><input name=\"external_theme_enabled\" type=\"checkbox\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if config.Appearance.ExternalTheme.Enabled {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " checked")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "></label> <label><span>Provider</span><input name=\"external_theme_provider\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(config.Appearance.ExternalTheme.Provider)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 46, Col: 129}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" placeholder=\"noctalia\"></label> <label><span>Format</span><input name=\"external_theme_format\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var15 string
+		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(config.Appearance.ExternalTheme.Format)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 47, Col: 123}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" placeholder=\"colors-json\"></label> <label><span>Path</span><input name=\"external_theme_path\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var16 string
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(config.Appearance.ExternalTheme.Path)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 48, Col: 117}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" placeholder=\"~/.config/noctalia/colors.json\"></label></fieldset>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -304,7 +353,7 @@ func AppearanceForm(config dto.SystemviewConfigPayload) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"sv-button-row sv-form-actions\"><button class=\"sv-button\" type=\"submit\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"sv-button-row sv-form-actions\"><button class=\"sv-button\" type=\"submit\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -312,7 +361,7 @@ func AppearanceForm(config dto.SystemviewConfigPayload) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</button> <button class=\"sv-button sv-button-secondary\" type=\"button\" data-sv-action=\"config.appearance.reset\" data-sv-confirm=\"Reset appearance settings to defaults?\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</button> <button class=\"sv-button sv-button-secondary\" type=\"button\" data-sv-action=\"config.appearance.reset\" data-sv-confirm=\"Reset appearance settings to defaults?\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -320,7 +369,7 @@ func AppearanceForm(config dto.SystemviewConfigPayload) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</button></div></form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</button></div></form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -344,207 +393,207 @@ func PaletteFields(title string, prefix string, palette dto.ColorPalette) templ.
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var14 == nil {
-			templ_7745c5c3_Var14 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<fieldset class=\"sv-fieldset\"><legend>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var15 string
-		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 53, Col: 17}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</legend> <label><span>Background</span><input name=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_background")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 54, Col: 68}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" type=\"text\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var17 string
-		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Background)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 54, Col: 109}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" required></label> <label><span>Surface</span><input name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<fieldset class=\"sv-fieldset\"><legend>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_surface")
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 55, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 61, Col: 17}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</legend> <label><span>Background</span><input name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var19 string
-		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Surface)
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_background")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 55, Col: 100}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 62, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" required></label> <label><span>Surface variant</span><input name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_surface_variant")
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Background)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 56, Col: 78}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 62, Col: 109}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" required></label> <label><span>Surface</span><input name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.SurfaceVariant)
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_surface")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 56, Col: 123}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 63, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" required></label> <label><span>Text</span><input name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_text")
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Surface)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 57, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 63, Col: 100}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" required></label> <label><span>Surface variant</span><input name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var23 string
-		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Text)
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_surface_variant")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 57, Col: 91}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 64, Col: 78}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" required></label> <label><span>Muted</span><input name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var24 string
-		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_muted")
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.SurfaceVariant)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 58, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 64, Col: 123}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" required></label> <label><span>Text</span><input name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var25 string
-		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Muted)
+		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_text")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 58, Col: 94}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 65, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" required></label> <label><span>Accent</span><input name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var26 string
-		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_accent")
+		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Text)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 59, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 65, Col: 91}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" required></label> <label><span>Muted</span><input name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Accent)
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_muted")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 59, Col: 97}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 66, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" required></label> <label><span>Border</span><input name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var28 string
-		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_border")
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Muted)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 60, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 66, Col: 94}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\" required></label> <label><span>Accent</span><input name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var29 string
-		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Border)
+		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_accent")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 60, Col: 97}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 67, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" required></label></fieldset>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var30 string
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Accent)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 67, Col: 97}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" required></label> <label><span>Border</span><input name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var31 string
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(prefix + "_border")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 68, Col: 60}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(palette.Border)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 68, Col: 97}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\" required></label></fieldset>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -568,25 +617,25 @@ func SearchSettings(config dto.SystemviewConfigPayload) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var30 == nil {
-			templ_7745c5c3_Var30 = templ.NopComponent
+		templ_7745c5c3_Var33 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var33 == nil {
+			templ_7745c5c3_Var33 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<form class=\"sv-card-form\" data-sv-action=\"config.search.save\"><label><span>Default search engine</span><input name=\"default_search_engine\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<form class=\"sv-card-form\" data-sv-action=\"config.search.save\"><label><span>Default search engine</span><input name=\"default_search_engine\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var31 string
-		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(config.DefaultSearchEngine)
+		var templ_7745c5c3_Var34 string
+		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(config.DefaultSearchEngine)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 66, Col: 125}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 74, Col: 125}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var34)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" placeholder=\"https://duckduckgo.com/?q=%s\" required></label> <button class=\"sv-button\" type=\"submit\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" placeholder=\"https://duckduckgo.com/?q=%s\" required></label> <button class=\"sv-button\" type=\"submit\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -594,7 +643,7 @@ func SearchSettings(config dto.SystemviewConfigPayload) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</button></form><div class=\"sv-group\"><div class=\"sv-group-header\"><h4>Search shortcuts</h4></div><p class=\"sv-meta\">Shortcut URLs must include the %s placeholder for the search query.</p><form class=\"sv-inline-form\" data-sv-action=\"config.searchShortcut.create\"><label><span>Key</span><input name=\"key\" type=\"text\" placeholder=\"ddg\" required></label> <label><span>URL</span><input name=\"url\" type=\"text\" placeholder=\"https://duckduckgo.com/?q=%s\" pattern=\".*%s.*\" required></label> <label><span>Description</span><input name=\"description\" type=\"text\" placeholder=\"DuckDuckGo\"></label> <button class=\"sv-button sv-button-secondary\" type=\"submit\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</button></form><div class=\"sv-group\"><div class=\"sv-group-header\"><h4>Search shortcuts</h4></div><p class=\"sv-meta\">Shortcut URLs must include the %s placeholder for the search query.</p><form class=\"sv-inline-form\" data-sv-action=\"config.searchShortcut.create\"><label><span>Key</span><input name=\"key\" type=\"text\" placeholder=\"ddg\" required></label> <label><span>URL</span><input name=\"url\" type=\"text\" placeholder=\"https://duckduckgo.com/?q=%s\" pattern=\".*%s.*\" required></label> <label><span>Description</span><input name=\"description\" type=\"text\" placeholder=\"DuckDuckGo\"></label> <button class=\"sv-button sv-button-secondary\" type=\"submit\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -602,7 +651,7 @@ func SearchSettings(config dto.SystemviewConfigPayload) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</button></form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</button></form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -613,7 +662,7 @@ func SearchSettings(config dto.SystemviewConfigPayload) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<ul class=\"sv-list\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<ul class=\"sv-list\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -623,12 +672,12 @@ func SearchSettings(config dto.SystemviewConfigPayload) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</ul>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</ul>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -652,64 +701,64 @@ func SearchShortcutItem(shortcut searchShortcutRow) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var32 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var32 == nil {
-			templ_7745c5c3_Var32 = templ.NopComponent
+		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var35 == nil {
+			templ_7745c5c3_Var35 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<li class=\"sv-list-row\"><form class=\"sv-inline-form\" data-sv-action=\"config.searchShortcut.update\"><input type=\"hidden\" name=\"key\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var33 string
-		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Key)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 94, Col: 55}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var33)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\"> <label><span>Key</span><input name=\"new_key\" type=\"text\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var34 string
-		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Key)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 95, Col: 80}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var34)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" required></label> <label><span>URL</span><input name=\"url\" type=\"text\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var35 string
-		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.URL)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 96, Col: 76}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var35)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" pattern=\".*%s.*\" required></label> <label><span>Description</span><input name=\"description\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<li class=\"sv-list-row\"><form class=\"sv-inline-form\" data-sv-action=\"config.searchShortcut.update\"><input type=\"hidden\" name=\"key\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var36 string
-		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Description)
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Key)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 97, Col: 100}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 102, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var36)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\"></label> <button class=\"sv-button sv-button-secondary\" type=\"submit\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\"> <label><span>Key</span><input name=\"new_key\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var37 string
+		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Key)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 103, Col: 80}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var37)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\" required></label> <label><span>URL</span><input name=\"url\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var38 string
+		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.URL)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 104, Col: 76}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var38)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" pattern=\".*%s.*\" required></label> <label><span>Description</span><input name=\"description\" type=\"text\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var39 string
+		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Description)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 105, Col: 100}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\"></label> <button class=\"sv-button sv-button-secondary\" type=\"submit\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -717,33 +766,33 @@ func SearchShortcutItem(shortcut searchShortcutRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</button> <button class=\"sv-button sv-button-secondary sv-button-danger sv-button-icon-only\" type=\"button\" data-sv-action=\"config.searchShortcut.delete\" data-key=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</button> <button class=\"sv-button sv-button-secondary sv-button-danger sv-button-icon-only\" type=\"button\" data-sv-action=\"config.searchShortcut.delete\" data-key=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var37 string
-		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Key)
+		var templ_7745c5c3_Var40 string
+		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.ResolveAttributeValue(shortcut.Key)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 99, Col: 169}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 107, Col: 169}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var37)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" data-sv-confirm=\"Delete this search shortcut?\" aria-label=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var40)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var38 string
-		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.ResolveAttributeValue("Delete search shortcut " + shortcut.Key)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 99, Col: 272}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var38)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\" data-sv-confirm=\"Delete this search shortcut?\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\">")
+		var templ_7745c5c3_Var41 string
+		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue("Delete search shortcut " + shortcut.Key)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 107, Col: 272}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -751,7 +800,7 @@ func SearchShortcutItem(shortcut searchShortcutRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</button></form></li>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</button></form></li>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -775,178 +824,178 @@ func PerformanceSettings(config dto.SystemviewConfigPayload) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var39 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var39 == nil {
-			templ_7745c5c3_Var39 = templ.NopComponent
+		templ_7745c5c3_Var42 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var42 == nil {
+			templ_7745c5c3_Var42 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		customProfile := performanceProfileSelected(config.Performance.Profile, "custom")
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<form class=\"sv-card-form sv-config-form\" data-sv-action=\"config.performance.save\" data-sv-performance-form><label><span>Profile</span><select name=\"profile\" data-sv-performance-profile><option value=\"default\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<form class=\"sv-card-form sv-config-form\" data-sv-action=\"config.performance.save\" data-sv-performance-form><label><span>Profile</span><select name=\"profile\" data-sv-performance-profile><option value=\"default\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if performanceProfileSelected(config.Performance.Profile, "default") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, " selected")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, " selected")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, ">Default</option> <option value=\"balanced\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, ">Default</option> <option value=\"balanced\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if performanceProfileSelected(config.Performance.Profile, "balanced") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, " selected")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, " selected")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, ">Balanced</option> <option value=\"lite\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, ">Balanced</option> <option value=\"lite\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if performanceProfileSelected(config.Performance.Profile, "lite") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, " selected")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, " selected")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, ">Lite</option> <option value=\"max\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, ">Lite</option> <option value=\"max\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if performanceProfileSelected(config.Performance.Profile, "max") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, " selected")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, " selected")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, ">Max</option> <option value=\"custom\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, ">Max</option> <option value=\"custom\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if performanceProfileSelected(config.Performance.Profile, "custom") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, " selected")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, " selected")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, ">Custom</option></select></label><p class=\"sv-meta\">Choose Custom to edit individual performance values.</p><label><span>Skia CPU threads</span><input name=\"skia_cpu_threads\" type=\"number\" min=\"0\" max=\"8\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var40 string
-		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.SkiaCPUThreads))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 115, Col: 164}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var40)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if !customProfile {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, " disabled")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, " data-sv-performance-custom></label> <label><span>Skia GPU threads</span><input name=\"skia_gpu_threads\" type=\"number\" min=\"-1\" max=\"8\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var41 string
-		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.SkiaGPUThreads))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 116, Col: 165}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if !customProfile {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, " disabled")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, " data-sv-performance-custom></label> <label><span>Web process memory MB</span><input name=\"web_process_memory_mb\" type=\"number\" min=\"0\" max=\"16384\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var42 string
-		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.WebProcessMemoryMB))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 117, Col: 182}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var42)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if !customProfile {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, " disabled")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, " data-sv-performance-custom></label> <label><span>Network process memory MB</span><input name=\"network_process_memory_mb\" type=\"number\" min=\"0\" max=\"4096\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, ">Custom</option></select></label><p class=\"sv-meta\">Choose Custom to edit individual performance values.</p><label><span>Skia CPU threads</span><input name=\"skia_cpu_threads\" type=\"number\" min=\"0\" max=\"8\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var43 string
-		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.NetworkProcessMemoryMB))
+		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.SkiaCPUThreads))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 118, Col: 193}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 123, Col: 164}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var43)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if !customProfile {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, " disabled")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, " disabled")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, " data-sv-performance-custom></label> <label><span>WebView pool prewarm</span><input name=\"webview_pool_prewarm\" type=\"number\" min=\"0\" max=\"20\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, " data-sv-performance-custom></label> <label><span>Skia GPU threads</span><input name=\"skia_gpu_threads\" type=\"number\" min=\"-1\" max=\"8\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var44 string
-		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.WebViewPoolPrewarm))
+		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.SkiaGPUThreads))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 119, Col: 177}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 124, Col: 165}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var44)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if !customProfile {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, " disabled")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, " disabled")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, " data-sv-performance-custom></label> <button class=\"sv-button\" type=\"submit\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, " data-sv-performance-custom></label> <label><span>Web process memory MB</span><input name=\"web_process_memory_mb\" type=\"number\" min=\"0\" max=\"16384\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var45 string
+		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.WebProcessMemoryMB))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 125, Col: 182}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var45)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if !customProfile {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, " disabled")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, " data-sv-performance-custom></label> <label><span>Network process memory MB</span><input name=\"network_process_memory_mb\" type=\"number\" min=\"0\" max=\"4096\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var46 string
+		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.NetworkProcessMemoryMB))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 126, Col: 193}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var46)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if !customProfile {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, " disabled")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, " data-sv-performance-custom></label> <label><span>WebView pool prewarm</span><input name=\"webview_pool_prewarm\" type=\"number\" min=\"0\" max=\"20\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var47 string
+		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue(formatConfigInt(config.Performance.Custom.WebViewPoolPrewarm))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 127, Col: 177}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var47)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if !customProfile {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, " disabled")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, " data-sv-performance-custom></label> <button class=\"sv-button\" type=\"submit\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -954,69 +1003,69 @@ func PerformanceSettings(config dto.SystemviewConfigPayload) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</button></form><div class=\"sv-stat-grid\"><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var45 string
-		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(formatConfigInt(config.Performance.Hardware.CPUThreads))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 123, Col: 113}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</span><span class=\"sv-stat-label\">CPU threads</span></div><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var46 string
-		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(formatConfigInt(config.Performance.Hardware.TotalRAMMB))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 124, Col: 113}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</span><span class=\"sv-stat-label\">RAM MB</span></div><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var47 string
-		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(config.Performance.Hardware.GPUName)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 125, Col: 93}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</span><span class=\"sv-stat-label\">GPU</span></div><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "</button></form><div class=\"sv-stat-grid\"><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var48 string
-		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(config.EngineType)
+		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(formatConfigInt(config.Performance.Hardware.CPUThreads))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 126, Col: 75}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 131, Col: 113}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</span><span class=\"sv-stat-label\">Engine</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</span><span class=\"sv-stat-label\">CPU threads</span></div><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var49 string
+		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(formatConfigInt(config.Performance.Hardware.TotalRAMMB))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 132, Col: 113}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</span><span class=\"sv-stat-label\">RAM MB</span></div><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var50 string
+		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(config.Performance.Hardware.GPUName)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 133, Col: 93}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</span><span class=\"sv-stat-label\">GPU</span></div><div class=\"sv-stat-card\"><span class=\"sv-stat-value\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var51 string
+		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(config.EngineType)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 134, Col: 75}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</span><span class=\"sv-stat-label\">Engine</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if !engineIsWebKit(config.EngineType) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "<p class=\"sv-meta\">Performance tuning applies only to the WebKit engine.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<p class=\"sv-meta\">Performance tuning applies only to the WebKit engine.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<p class=\"sv-meta\">Performance profile changes may require restarting the browser to affect existing engine processes.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<p class=\"sv-meta\">Performance profile changes may require restarting the browser to affect existing engine processes.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1041,9 +1090,9 @@ func ConfigKeybindings(keybindings port.KeybindingsConfig) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var49 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var49 == nil {
-			templ_7745c5c3_Var49 = templ.NopComponent
+		templ_7745c5c3_Var52 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var52 == nil {
+			templ_7745c5c3_Var52 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		groups := configKeybindingGroups(keybindings)
@@ -1058,7 +1107,7 @@ func ConfigKeybindings(keybindings port.KeybindingsConfig) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<div class=\"sv-button-row\"><button class=\"sv-button sv-button-secondary sv-button-danger\" type=\"button\" data-sv-action=\"config.keybinding.resetAll\" data-sv-confirm=\"Reset all keybindings to defaults?\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "<div class=\"sv-button-row\"><button class=\"sv-button sv-button-secondary sv-button-danger\" type=\"button\" data-sv-action=\"config.keybinding.resetAll\" data-sv-confirm=\"Reset all keybindings to defaults?\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1066,7 +1115,7 @@ func ConfigKeybindings(keybindings port.KeybindingsConfig) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1097,48 +1146,48 @@ func ConfigKeybindingGroup(group renderedKeybindingGroup) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var50 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var50 == nil {
-			templ_7745c5c3_Var50 = templ.NopComponent
+		templ_7745c5c3_Var53 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var53 == nil {
+			templ_7745c5c3_Var53 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<div class=\"sv-group\"><div class=\"sv-group-header\"><div><h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<div class=\"sv-group\"><div class=\"sv-group-header\"><div><h4>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var51 string
-		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingGroupTitle(group))
+		var templ_7745c5c3_Var54 string
+		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingGroupTitle(group))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 155, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 163, Col: 37}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</h4>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if keybindingGroupMeta(group) != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<p class=\"sv-meta\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<p class=\"sv-meta\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var52 string
-			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingGroupMeta(group))
+			var templ_7745c5c3_Var55 string
+			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingGroupMeta(group))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 157, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 165, Col: 52}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</div></div><div class=\"sv-group-body\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "</div></div><div class=\"sv-group-body\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1148,7 +1197,7 @@ func ConfigKeybindingGroup(group renderedKeybindingGroup) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<ul class=\"sv-list\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<ul class=\"sv-list\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1158,12 +1207,12 @@ func ConfigKeybindingGroup(group renderedKeybindingGroup) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</ul>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "</ul>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1187,38 +1236,38 @@ func ConfigKeybinding(group renderedKeybindingGroup, binding renderedKeybinding)
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var53 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var53 == nil {
-			templ_7745c5c3_Var53 = templ.NopComponent
+		templ_7745c5c3_Var56 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var56 == nil {
+			templ_7745c5c3_Var56 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "<li class=\"sv-list-row\"><div class=\"sv-keybinding-row\"><div><strong>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "<li class=\"sv-list-row\"><div class=\"sv-keybinding-row\"><div><strong>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var54 string
-		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingDescription(binding))
+		var templ_7745c5c3_Var57 string
+		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingDescription(binding))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 179, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 187, Col: 44}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "</strong><p class=\"sv-meta\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var55 string
-		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingAction(binding))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 180, Col: 50}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "</strong><p class=\"sv-meta\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</p><div class=\"sv-binding-keys\">")
+		var templ_7745c5c3_Var58 string
+		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingAction(binding))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 188, Col: 50}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "</p><div class=\"sv-binding-keys\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1226,25 +1275,25 @@ func ConfigKeybinding(group renderedKeybindingGroup, binding renderedKeybinding)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "<span class=\"sv-badge\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "<span class=\"sv-badge\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var56 string
-		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingStatus(binding))
+		var templ_7745c5c3_Var59 string
+		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(keybindingStatus(binding))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 183, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 191, Col: 55}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if keybindingIsCustom(binding) && len(binding.DefaultKeys) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "<span class=\"sv-meta\">default:</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "<span class=\"sv-meta\">default:</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1253,46 +1302,46 @@ func ConfigKeybinding(group renderedKeybindingGroup, binding renderedKeybinding)
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "</div></div><form class=\"sv-inline-form\" data-sv-action=\"config.keybinding.set\"><input type=\"hidden\" name=\"mode\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "</div></div><form class=\"sv-inline-form\" data-sv-action=\"config.keybinding.set\"><input type=\"hidden\" name=\"mode\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var57 string
-		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.ResolveAttributeValue(group.Mode)
+		var templ_7745c5c3_Var60 string
+		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.ResolveAttributeValue(group.Mode)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 191, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 199, Col: 55}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var57)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\"> <input type=\"hidden\" name=\"action\" value=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var60)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var58 string
-		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.ResolveAttributeValue(binding.Action)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 192, Col: 61}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var58)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "\"> <input type=\"hidden\" name=\"action\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\"> <label><span>Keys</span><input name=\"keys\" type=\"text\" value=\"")
+		var templ_7745c5c3_Var61 string
+		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.ResolveAttributeValue(binding.Action)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 200, Col: 61}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var61)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var59 string
-		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.ResolveAttributeValue(keybindingKeysValue(binding.Keys))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 193, Col: 100}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var59)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "\"> <label><span>Keys</span><input name=\"keys\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "\" placeholder=\"ctrl+h, ctrl+shift+h\" required></label> <button class=\"sv-button sv-button-secondary\" type=\"submit\">")
+		var templ_7745c5c3_Var62 string
+		templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.ResolveAttributeValue(keybindingKeysValue(binding.Keys))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 201, Col: 100}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var62)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "\" placeholder=\"ctrl+h, ctrl+shift+h\" required></label> <button class=\"sv-button sv-button-secondary\" type=\"submit\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1300,33 +1349,33 @@ func ConfigKeybinding(group renderedKeybindingGroup, binding renderedKeybinding)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "</button> <button class=\"sv-button sv-button-secondary\" type=\"button\" data-sv-action=\"config.keybinding.reset\" data-mode=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "</button> <button class=\"sv-button sv-button-secondary\" type=\"button\" data-sv-action=\"config.keybinding.reset\" data-mode=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var60 string
-		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.ResolveAttributeValue(group.Mode)
+		var templ_7745c5c3_Var63 string
+		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.ResolveAttributeValue(group.Mode)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 195, Col: 127}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 203, Col: 127}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var60)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "\" data-action=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var63)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var61 string
-		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.ResolveAttributeValue(binding.Action)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 195, Col: 158}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var61)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "\" data-action=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "\">")
+		var templ_7745c5c3_Var64 string
+		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.ResolveAttributeValue(binding.Action)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `config.templ`, Line: 203, Col: 158}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var64)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1334,7 +1383,7 @@ func ConfigKeybinding(group renderedKeybindingGroup, binding renderedKeybinding)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "</button></form></div></li>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "</button></form></div></li>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/ui/theme/css.go
+++ b/internal/ui/theme/css.go
@@ -256,7 +256,7 @@ window.standalone-omnibox-window {
 /* Search entry field */
 entry.omnibox-entry,
 entry.omnibox-entry > text {
-	background-color: alpha(var(--bg), 0.88);
+	background-color: var(--surface-variant);
 	background-image: none;
 	color: var(--text);
 	caret-color: var(--accent);
@@ -278,7 +278,7 @@ entry.omnibox-entry:focus > text,
 entry.omnibox-entry:focus-within > text,
 entry.omnibox-entry:focus-visible > text {
 	border-color: var(--accent);
-	background-color: shade(var(--bg), 1.05);
+	background-color: shade(var(--surface-variant), 1.08);
 	background-image: none;
 	outline-style: none;
 	outline-width: 0px;
@@ -463,7 +463,7 @@ entry.omnibox-entry.omnibox-entry-bang-active:focus > text,
 entry.omnibox-entry.omnibox-entry-bang-active:focus-within > text,
 entry.omnibox-entry.omnibox-entry-bang-active:focus-visible > text {
 	border-color: var(--accent);
-	background-color: shade(var(--bg), 1.05);
+	background-color: shade(var(--surface-variant), 1.08);
 	background-image: none;
 }
 

--- a/internal/ui/theme/css_test.go
+++ b/internal/ui/theme/css_test.go
@@ -101,20 +101,27 @@ func TestGenerateCSS_FavoriteRowsOnlyTintTrailingAffordance(t *testing.T) {
 	}
 }
 
-func TestGenerateCSS_OmniboxSearchAreaMatchesHeaderSurface(t *testing.T) {
+func TestGenerateCSS_OmniboxSearchEntryUsesControlSurface(t *testing.T) {
 	css := GenerateCSS(DefaultDarkPalette())
 
 	containerRe := regexp.MustCompile(`(?s)\.omnibox-container\s*\{[^}]*background-color:\s*var\(--surface\);`)
 	if !containerRe.MatchString(css) {
 		t.Fatalf("expected omnibox container to use the header surface color")
 	}
-	entryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry\s*,\s*entry\.omnibox-entry\s*>\s*text\s*\{[^}]*background-color:\s*alpha\(var\(--bg\),\s*0\.88\);[^}]*background-image:\s*none;`)
+	entryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry\s*,\s*entry\.omnibox-entry\s*>\s*text\s*\{[^}]*background-color:\s*var\(--surface-variant\);[^}]*background-image:\s*none;`)
 	if !entryRe.MatchString(css) {
-		t.Fatalf("expected omnibox entry and its text node to use the darker background fill")
+		t.Fatalf("expected omnibox entry and its text node to use the control surface fill")
 	}
-	focusedEntryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry:focus[^\{]*,\s*entry\.omnibox-entry:focus-within[^\{]*,\s*entry\.omnibox-entry:focus-visible[^\{]*,\s*entry\.omnibox-entry:focus\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-within\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-visible\s*>\s*text\s*\{[^}]*background-color:\s*shade\(var\(--bg\),\s*1\.05\);`)
+	focusedEntryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry:focus[^\{]*,\s*entry\.omnibox-entry:focus-within[^\{]*,\s*entry\.omnibox-entry:focus-visible[^\{]*,\s*entry\.omnibox-entry:focus\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-within\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-visible\s*>\s*text\s*\{[^}]*background-color:\s*shade\(var\(--surface-variant\),\s*1\.08\);`)
 	if !focusedEntryRe.MatchString(css) {
-		t.Fatalf("expected focused omnibox entry text node to keep the darker bg-based fill")
+		t.Fatalf("expected focused omnibox entry text node to keep a distinct control-surface fill")
+	}
+	bangActiveRe := regexp.MustCompile(`(?s)entry\.omnibox-entry\.omnibox-entry-bang-active[^\{]*\{[^}]*background-color:\s*shade\(var\(--surface-variant\),\s*1\.08\);`)
+	if !bangActiveRe.MatchString(css) {
+		t.Fatalf("expected bang-active omnibox entry to keep a distinct control-surface fill")
+	}
+	if strings.Contains(css, "background-color: alpha(var(--bg), 0.88);") || strings.Contains(css, "background-color: shade(var(--bg), 1.05);") {
+		t.Fatalf("expected omnibox entry fills not to derive from the page background")
 	}
 	scrolledRe := regexp.MustCompile(`(?s)\.omnibox-scrolled\s*\{[^}]*background-color:\s*var\(--surface\);`)
 	if !scrolledRe.MatchString(css) {

--- a/internal/ui/theme/manager.go
+++ b/internal/ui/theme/manager.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/gdk"
@@ -14,106 +13,51 @@ import (
 )
 
 // Manager handles theme state and CSS application.
+// Theme precedence and fallback are resolved before data reaches this adapter.
 type Manager struct {
-	scheme        string  // "light", "dark", "system"
-	prefersDark   bool    // Resolved dark mode preference
-	lightPalette  Palette // Light theme colors
-	darkPalette   Palette // Dark theme colors
-	uiScale       float64 // UI scaling factor (1.0 = 100%)
-	fonts         FontConfig
-	gtkFont       string
-	modeColors    ModeColors // Modal mode indicator colors
-	cssProvider   *gtk.CssProvider
-	appliedFont   string
-	colorResolver port.ColorSchemeResolver // Resolver for dynamic detection
+	prefersDark  bool    // Resolved dark mode preference
+	lightPalette Palette // Light theme colors
+	darkPalette  Palette // Dark theme colors
+	uiScale      float64 // UI scaling factor (1.0 = 100%)
+	fonts        FontConfig
+	gtkFont      string
+	modeColors   ModeColors // Modal mode indicator colors
+	cssProvider  *gtk.CssProvider
+	appliedFont  string
 }
 
-// NewManager creates a new theme manager from configuration.
-// The ColorSchemeResolver is required for proper color scheme detection.
-//
-// appearance controls fonts, palette overrides and color scheme.
-// uiScale is the GTK UI scale factor (0 or negative means use default 1.0).
-// styling controls mode indicator colors; may be nil to use defaults.
-func NewManager(
-	ctx context.Context,
-	appearance *entity.AppearanceConfig,
-	uiScale float64,
-	styling *entity.WorkspaceStylingConfig,
-	resolver port.ColorSchemeResolver,
-) *Manager {
+// NewManager creates a new theme manager from an already-resolved theme.
+func NewManager(ctx context.Context, resolved entity.ResolvedTheme) *Manager {
 	log := logging.FromContext(ctx)
 
-	// Determine color scheme preference
-	scheme := "system"
-	if appearance != nil && appearance.ColorScheme != "" {
-		scheme = appearance.ColorScheme
-	}
-
-	// Resolve whether we should use dark mode via resolver
-	pref := resolver.Resolve()
-	prefersDark := pref.PrefersDark
-
-	// Build palettes from config or defaults
-	var lightPalette, darkPalette Palette
-	if appearance != nil {
-		lightPalette = PaletteFromConfig(&appearance.LightPalette, false)
-		darkPalette = PaletteFromConfig(&appearance.DarkPalette, true)
-	} else {
-		lightPalette = DefaultLightPalette()
-		darkPalette = DefaultDarkPalette()
-	}
-
-	// Get UI scale factor (default to 1.0 if not set)
-	if uiScale <= 0 {
-		uiScale = 1.0
-	}
-
-	fonts := DefaultFontConfig()
-	gtkFont := DefaultGTKFont()
-	if appearance != nil {
-		fonts.SansFont = Coalesce(appearance.SansFont, fonts.SansFont)
-		fonts.MonospaceFont = Coalesce(appearance.MonospaceFont, fonts.MonospaceFont)
-		gtkFont = Coalesce(appearance.GtkFont, gtkFont)
-		fonts.GtkFont = gtkFont
-	}
-
-	// Build mode colors from config
-	modeColors := modeColorsFromStyling(styling)
+	m := &Manager{}
+	m.applyResolvedTheme(resolved)
 
 	log.Debug().
-		Str("scheme", scheme).
-		Bool("prefers_dark", prefersDark).
-		Float64("ui_scale", uiScale).
-		Str("sans_font", fonts.SansFont).
-		Str("monospace_font", fonts.MonospaceFont).
-		Str("gtk_font", gtkFont).
+		Bool("prefers_dark", m.prefersDark).
+		Float64("ui_scale", m.uiScale).
+		Str("sans_font", m.fonts.SansFont).
+		Str("monospace_font", m.fonts.MonospaceFont).
+		Str("gtk_font", m.gtkFont).
 		Msg("theme manager initialized")
 
-	return &Manager{
-		scheme:        scheme,
-		prefersDark:   prefersDark,
-		lightPalette:  lightPalette,
-		darkPalette:   darkPalette,
-		uiScale:       uiScale,
-		fonts:         fonts,
-		gtkFont:       gtkFont,
-		modeColors:    modeColors,
-		colorResolver: resolver,
-	}
+	return m
 }
 
-// modeColorsFromStyling extracts mode colors from styling config, using defaults for missing values.
-func modeColorsFromStyling(styling *entity.WorkspaceStylingConfig) ModeColors {
-	defaults := DefaultModeColors()
-	if styling == nil {
-		return defaults
+func (m *Manager) applyResolvedTheme(resolved entity.ResolvedTheme) {
+	m.prefersDark = resolved.PrefersDark
+	m.lightPalette = PaletteFromEntity(resolved.LightPalette, false)
+	m.darkPalette = PaletteFromEntity(resolved.DarkPalette, true)
+	m.uiScale = resolved.UIScale
+	if m.uiScale <= 0 {
+		m.uiScale = 1.0
 	}
-	return ModeColors{
-		PaneMode:    Coalesce(styling.PaneModeColor, defaults.PaneMode),
-		TabMode:     Coalesce(styling.TabModeColor, defaults.TabMode),
-		SessionMode: Coalesce(styling.SessionModeColor, defaults.SessionMode),
-		ResizeMode:  Coalesce(styling.ResizeModeColor, defaults.ResizeMode),
+	m.fonts = FontConfigFromEntity(resolved.Fonts)
+	if m.fonts.GtkFont == "" {
+		m.fonts.GtkFont = DefaultGTKFont()
 	}
+	m.gtkFont = m.fonts.GtkFont
+	m.modeColors = ModeColorsFromEntity(resolved.ModeColors)
 }
 
 // PrefersDark returns true if dark mode is active.
@@ -121,7 +65,7 @@ func (m *Manager) PrefersDark() bool {
 	return m.prefersDark
 }
 
-// GetCurrentPalette returns the active palette based on current scheme.
+// GetCurrentPalette returns the active palette based on current preference.
 func (m *Manager) GetCurrentPalette() Palette {
 	if m.prefersDark {
 		return m.darkPalette
@@ -230,83 +174,19 @@ func (m *Manager) ApplyToDisplay(ctx context.Context, display *gdk.Display) {
 		Msg("theme CSS applied to display")
 }
 
-// SetColorScheme changes the active color scheme at runtime.
-func (m *Manager) SetColorScheme(ctx context.Context, scheme string, display *gdk.Display) {
+// UpdateFromResolved updates the theme manager state from a resolved theme.
+func (m *Manager) UpdateFromResolved(ctx context.Context, resolved entity.ResolvedTheme, display *gdk.Display) {
 	log := logging.FromContext(ctx)
 
-	m.scheme = scheme
-	pref := m.colorResolver.Refresh()
-	m.prefersDark = pref.PrefersDark
+	m.applyResolvedTheme(resolved)
 
 	log.Info().
-		Str("scheme", scheme).
-		Bool("prefers_dark", m.prefersDark).
-		Str("source", pref.Source).
-		Msg("color scheme changed")
-
-	// Re-apply CSS if display is available
-	if display != nil {
-		m.ApplyToDisplay(ctx, display)
-	}
-}
-
-// UpdateFromConfig updates the theme manager state from new config values.
-//
-// appearance controls fonts, palette overrides and color scheme.
-// uiScale is the GTK UI scale factor (0 or negative means keep existing scale).
-// styling controls mode indicator colors; may be nil to keep existing colors.
-func (m *Manager) UpdateFromConfig(
-	ctx context.Context,
-	appearance *entity.AppearanceConfig,
-	uiScale float64,
-	styling *entity.WorkspaceStylingConfig,
-	display *gdk.Display,
-) {
-	log := logging.FromContext(ctx)
-
-	if appearance == nil {
-		return
-	}
-
-	// Update scheme and resolve prefersDark via resolver
-	scheme := "system"
-	if appearance.ColorScheme != "" {
-		scheme = appearance.ColorScheme
-	}
-	m.scheme = scheme
-	pref := m.colorResolver.Refresh()
-	m.prefersDark = pref.PrefersDark
-
-	// Update palettes
-	m.lightPalette = PaletteFromConfig(&appearance.LightPalette, false)
-	m.darkPalette = PaletteFromConfig(&appearance.DarkPalette, true)
-
-	// Update UI scale
-	if uiScale > 0 {
-		m.uiScale = uiScale
-	}
-
-	defaults := DefaultFontConfig()
-	m.gtkFont = Coalesce(appearance.GtkFont, DefaultGTKFont())
-	m.fonts = FontConfig{
-		SansFont:      Coalesce(appearance.SansFont, defaults.SansFont),
-		MonospaceFont: Coalesce(appearance.MonospaceFont, defaults.MonospaceFont),
-		GtkFont:       m.gtkFont,
-	}
-
-	// Update mode colors
-	if styling != nil {
-		m.modeColors = modeColorsFromStyling(styling)
-	}
-
-	log.Info().
-		Str("scheme", m.scheme).
 		Bool("prefers_dark", m.prefersDark).
 		Float64("ui_scale", m.uiScale).
 		Str("sans_font", m.fonts.SansFont).
 		Str("monospace_font", m.fonts.MonospaceFont).
 		Str("gtk_font", m.gtkFont).
-		Msg("theme manager updated from config")
+		Msg("theme manager updated from resolved theme")
 
 	// Re-apply CSS if display is available
 	if display != nil {

--- a/internal/ui/theme/manager_test.go
+++ b/internal/ui/theme/manager_test.go
@@ -4,315 +4,163 @@ import (
 	"context"
 	"testing"
 
-	"github.com/bnema/dumber/internal/application/port"
-	"github.com/bnema/dumber/internal/application/port/mocks"
 	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewManager_DarkMode(t *testing.T) {
-	ctx := context.Background()
-	appearance := &entity.AppearanceConfig{
-		ColorScheme: "default",
+func resolvedThemeFixture(prefersDark bool) entity.ResolvedTheme {
+	light := entity.ColorPalette{
+		Background:     "#ffffff",
+		Surface:        "#f8f8f8",
+		SurfaceVariant: "#eeeeee",
+		Text:           "#111111",
+		Muted:          "#666666",
+		Accent:         "#0055ff",
+		Border:         "#dddddd",
 	}
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, appearance, 1.0, nil, mockResolver)
-
-	assert.True(t, manager.PrefersDark())
-	assert.Equal(t, "default", manager.scheme)
+	dark := entity.ColorPalette{
+		Background:     "#101010",
+		Surface:        "#181818",
+		SurfaceVariant: "#242424",
+		Text:           "#f5f5f5",
+		Muted:          "#999999",
+		Accent:         "#66aaff",
+		Border:         "#333333",
+	}
+	active := light
+	if prefersDark {
+		active = dark
+	}
+	return entity.ResolvedTheme{
+		LightPalette:      light,
+		DarkPalette:       dark,
+		ActivePalette:     active,
+		PrefersDark:       prefersDark,
+		ColorSchemeSource: "test",
+		ThemeSource:       entity.ThemeSourceMetadata{Kind: entity.ThemeSourceConfig},
+		Fonts: entity.ThemeFonts{
+			SansFont:      "Inter",
+			SerifFont:     "Georgia",
+			MonospaceFont: "JetBrains Mono",
+			GtkFont:       "Adwaita Sans",
+			DefaultSize:   16,
+		},
+		UIScale: 1.5,
+		ModeColors: entity.ThemeModeColors{
+			PaneMode:    "#ff0000",
+			TabMode:     "#00ff00",
+			SessionMode: "#0000ff",
+			ResizeMode:  "#ffff00",
+		},
+	}
 }
 
-func TestNewManager_LightMode(t *testing.T) {
+func TestNewManager_UsesResolvedThemeFields(t *testing.T) {
 	ctx := context.Background()
-	appearance := &entity.AppearanceConfig{
-		ColorScheme: "default",
-	}
+	resolved := resolvedThemeFixture(true)
 
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: false,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, appearance, 1.0, nil, mockResolver)
-
-	assert.False(t, manager.PrefersDark())
-}
-
-func TestNewManager_WithNilConfig(t *testing.T) {
-	ctx := context.Background()
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "fallback",
-	})
-
-	manager := NewManager(ctx, nil, 0, nil, mockResolver)
+	manager := NewManager(ctx, resolved)
 
 	require.NotNil(t, manager)
 	assert.True(t, manager.PrefersDark())
-	assert.Equal(t, "system", manager.scheme)
+	assert.Equal(t, "#ffffff", manager.GetLightPalette().Background)
+	assert.Equal(t, "#101010", manager.GetDarkPalette().Background)
+	assert.Equal(t, manager.GetDarkPalette(), manager.GetCurrentPalette())
+	assert.Equal(t, "#ff0000", manager.GetModeColors().PaneMode)
+	assert.Equal(t, FontConfig{SansFont: "Inter", MonospaceFont: "JetBrains Mono", GtkFont: "Adwaita Sans"}, manager.fonts)
+	assert.Equal(t, "Adwaita Sans", manager.gtkFont)
+	assert.InDelta(t, 1.5, manager.uiScale, 0.000001)
 }
 
-func TestNewManager_UsesConfigScheme(t *testing.T) {
+func TestNewManager_DefaultsInvalidScaleToOne(t *testing.T) {
 	ctx := context.Background()
-	appearance := &entity.AppearanceConfig{
-		ColorScheme: "prefer-dark",
-	}
+	resolved := resolvedThemeFixture(true)
+	resolved.UIScale = 0
 
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "config",
-	})
+	manager := NewManager(ctx, resolved)
 
-	manager := NewManager(ctx, appearance, 1.0, nil, mockResolver)
-
-	assert.Equal(t, "prefer-dark", manager.scheme)
+	require.NotNil(t, manager)
+	assert.InDelta(t, 1.0, manager.uiScale, 0.000001)
 }
 
-func TestManager_GetCurrentPalette_Dark(t *testing.T) {
+func TestManager_UpdateFromResolvedReplacesResolvedValues(t *testing.T) {
 	ctx := context.Background()
+	manager := NewManager(ctx, resolvedThemeFixture(true))
+	updated := resolvedThemeFixture(false)
+	updated.LightPalette.Background = "#abcdef"
+	updated.DarkPalette.Background = "#123456"
+	updated.Fonts.SansFont = "Recursive"
+	updated.UIScale = 2.0
+	updated.ModeColors.PaneMode = "#654321"
 
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, nil, 0, nil, mockResolver)
-	palette := manager.GetCurrentPalette()
-
-	// Dark palette should be returned
-	assert.Equal(t, manager.GetDarkPalette(), palette)
-}
-
-func TestManager_GetCurrentPalette_Light(t *testing.T) {
-	ctx := context.Background()
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: false,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, nil, 0, nil, mockResolver)
-	palette := manager.GetCurrentPalette()
-
-	// Light palette should be returned
-	assert.Equal(t, manager.GetLightPalette(), palette)
-}
-
-func TestManager_SetColorScheme(t *testing.T) {
-	ctx := context.Background()
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	// Initial resolve call
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-	// Refresh call when SetColorScheme is called
-	mockResolver.EXPECT().Refresh().Return(port.ColorSchemePreference{
-		PrefersDark: false,
-		Source:      "config",
-	})
-
-	manager := NewManager(ctx, nil, 0, nil, mockResolver)
-	assert.True(t, manager.PrefersDark())
-
-	// Change scheme - this calls Refresh on resolver
-	manager.SetColorScheme(ctx, "prefer-light", nil)
+	manager.UpdateFromResolved(ctx, updated, nil)
 
 	assert.False(t, manager.PrefersDark())
-	assert.Equal(t, "prefer-light", manager.scheme)
-}
-
-func TestManager_UpdateFromConfig(t *testing.T) {
-	ctx := context.Background()
-	appearance := &entity.AppearanceConfig{
-		ColorScheme: "default",
-	}
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	// Initial resolve
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-	// Refresh when UpdateFromConfig is called
-	mockResolver.EXPECT().Refresh().Return(port.ColorSchemePreference{
-		PrefersDark: false,
-		Source:      "config",
-	})
-
-	manager := NewManager(ctx, appearance, 1.0, nil, mockResolver)
-	assert.True(t, manager.PrefersDark())
-
-	// Update with new config
-	newAppearance := &entity.AppearanceConfig{
-		ColorScheme: "prefer-light",
-	}
-	manager.UpdateFromConfig(ctx, newAppearance, 0, nil, nil)
-
-	assert.False(t, manager.PrefersDark())
-	assert.Equal(t, "prefer-light", manager.scheme)
-}
-
-func TestManager_UpdateFromConfig_NilConfig(t *testing.T) {
-	ctx := context.Background()
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, nil, 0, nil, mockResolver)
-	initialScheme := manager.scheme
-
-	// UpdateFromConfig with nil appearance should be a no-op
-	manager.UpdateFromConfig(ctx, nil, 0, nil, nil)
-
-	assert.Equal(t, initialScheme, manager.scheme)
+	assert.Equal(t, "#abcdef", manager.GetLightPalette().Background)
+	assert.Equal(t, "#123456", manager.GetDarkPalette().Background)
+	assert.Equal(t, manager.GetLightPalette(), manager.GetCurrentPalette())
+	assert.Equal(t, "Recursive", manager.fonts.SansFont)
+	assert.InDelta(t, 2.0, manager.uiScale, 0.000001)
+	assert.Equal(t, "#654321", manager.GetModeColors().PaneMode)
 }
 
 func TestManager_GetWebUIThemeCSS(t *testing.T) {
 	ctx := context.Background()
+	manager := NewManager(ctx, resolvedThemeFixture(true))
 
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, nil, 0, nil, mockResolver)
 	css := manager.GetWebUIThemeCSS()
 
-	// Should contain both light and dark variables
 	assert.Contains(t, css, ":root{")
 	assert.Contains(t, css, ".dark{")
+	assert.Contains(t, css, "--background: #ffffff")
+	assert.Contains(t, css, "--background: #101010")
 }
 
-func TestManager_GetBackgroundRGBA(t *testing.T) {
+func TestManager_GetBackgroundRGBAUsesCurrentPalette(t *testing.T) {
 	ctx := context.Background()
+	manager := NewManager(ctx, resolvedThemeFixture(true))
 
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, nil, 0, nil, mockResolver)
 	r, g, b, a := manager.GetBackgroundRGBA()
 
-	// Should return valid RGBA values (0-1 range)
-	assert.GreaterOrEqual(t, r, float32(0))
-	assert.LessOrEqual(t, r, float32(1))
-	assert.GreaterOrEqual(t, g, float32(0))
-	assert.LessOrEqual(t, g, float32(1))
-	assert.GreaterOrEqual(t, b, float32(0))
-	assert.LessOrEqual(t, b, float32(1))
-	assert.GreaterOrEqual(t, a, float32(0))
-	assert.LessOrEqual(t, a, float32(1))
+	assert.InDelta(t, float32(0x10)/255, r, 0.0001)
+	assert.InDelta(t, float32(0x10)/255, g, 0.0001)
+	assert.InDelta(t, float32(0x10)/255, b, 0.0001)
+	assert.InDelta(t, float32(1), a, 0.0001)
 }
 
-func TestManager_CustomPalettes(t *testing.T) {
-	ctx := context.Background()
-	appearance := &entity.AppearanceConfig{
-		LightPalette: entity.ColorPalette{
-			Background: "#ffffff",
-			Text:       "#000000",
-		},
-		DarkPalette: entity.ColorPalette{
-			Background: "#000000",
-			Text:       "#ffffff",
-		},
-	}
+func TestPaletteFromEntityAddsSemanticDefaults(t *testing.T) {
+	palette := PaletteFromEntity(entity.ColorPalette{Background: "#ffffff", Text: "#111111"}, false)
 
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
+	assert.Equal(t, "#ffffff", palette.Background)
+	assert.Equal(t, "#111111", palette.Text)
+	assert.Equal(t, DefaultLightPalette().Success, palette.Success)
+	assert.Equal(t, DefaultLightPalette().Warning, palette.Warning)
+	assert.Equal(t, DefaultLightPalette().Destructive, palette.Destructive)
+}
+
+func TestModeColorsFromEntity(t *testing.T) {
+	modeColors := ModeColorsFromEntity(entity.ThemeModeColors{
+		PaneMode:    "#111111",
+		TabMode:     "#222222",
+		SessionMode: "#333333",
+		ResizeMode:  "#444444",
 	})
 
-	manager := NewManager(ctx, appearance, 1.0, nil, mockResolver)
-
-	lightPalette := manager.GetLightPalette()
-	darkPalette := manager.GetDarkPalette()
-
-	assert.Equal(t, "#ffffff", lightPalette.Background)
-	assert.Equal(t, "#000000", lightPalette.Text)
-	assert.Equal(t, "#000000", darkPalette.Background)
-	assert.Equal(t, "#ffffff", darkPalette.Text)
+	assert.Equal(t, "#111111", modeColors.PaneMode)
+	assert.Equal(t, "#222222", modeColors.TabMode)
+	assert.Equal(t, "#333333", modeColors.SessionMode)
+	assert.Equal(t, "#444444", modeColors.ResizeMode)
 }
 
-func TestManager_UIScale(t *testing.T) {
-	ctx := context.Background()
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, nil, 1.5, nil, mockResolver)
-
-	// UI scale should be stored (we can't directly access it, but we can verify
-	// the manager was created without error)
-	require.NotNil(t, manager)
-}
-
-func TestManager_Fonts(t *testing.T) {
-	ctx := context.Background()
-	appearance := &entity.AppearanceConfig{
+func TestFontConfigFromEntity(t *testing.T) {
+	fonts := FontConfigFromEntity(entity.ThemeFonts{
 		SansFont:      "Inter",
 		MonospaceFont: "JetBrains Mono",
 		GtkFont:       "Adwaita Sans",
-	}
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
 	})
 
-	manager := NewManager(ctx, appearance, 1.0, nil, mockResolver)
-
-	// Fonts should be stored (manager creation should succeed)
-	require.NotNil(t, manager)
-}
-
-func TestManager_ModeColors(t *testing.T) {
-	ctx := context.Background()
-	styling := &entity.WorkspaceStylingConfig{
-		PaneModeColor:    "#ff0000",
-		TabModeColor:     "#00ff00",
-		SessionModeColor: "#0000ff",
-		ResizeModeColor:  "#ffff00",
-	}
-
-	mockResolver := mocks.NewMockColorSchemeResolver(t)
-	mockResolver.EXPECT().Resolve().Return(port.ColorSchemePreference{
-		PrefersDark: true,
-		Source:      "test",
-	})
-
-	manager := NewManager(ctx, nil, 1.0, styling, mockResolver)
-	modeColors := manager.GetModeColors()
-
-	assert.Equal(t, "#ff0000", modeColors.PaneMode)
-	assert.Equal(t, "#00ff00", modeColors.TabMode)
-	assert.Equal(t, "#0000ff", modeColors.SessionMode)
-	assert.Equal(t, "#ffff00", modeColors.ResizeMode)
+	assert.Equal(t, FontConfig{SansFont: "Inter", MonospaceFont: "JetBrains Mono", GtkFont: "Adwaita Sans"}, fonts)
 }
 
 func TestDefaultGTKFont(t *testing.T) {

--- a/internal/ui/theme/palette.go
+++ b/internal/ui/theme/palette.go
@@ -112,6 +112,47 @@ func PaletteFromConfig(cfg *entity.ColorPalette, isDark bool) Palette {
 	}
 }
 
+// PaletteFromEntity creates a CSS adapter palette from a resolved domain palette.
+// Resolved palettes already contain validated color tokens; this adapter only adds
+// semantic status colors used by GTK/WebUI CSS.
+func PaletteFromEntity(p entity.ColorPalette, isDark bool) Palette {
+	defaults := DefaultLightPalette()
+	if isDark {
+		defaults = DefaultDarkPalette()
+	}
+	return Palette{
+		Background:     p.Background,
+		Surface:        p.Surface,
+		SurfaceVariant: p.SurfaceVariant,
+		Text:           p.Text,
+		Muted:          p.Muted,
+		Accent:         p.Accent,
+		Border:         p.Border,
+		Success:        defaults.Success,
+		Warning:        defaults.Warning,
+		Destructive:    defaults.Destructive,
+	}
+}
+
+// ModeColorsFromEntity creates CSS adapter mode colors from resolved domain mode colors.
+func ModeColorsFromEntity(colors entity.ThemeModeColors) ModeColors {
+	return ModeColors{
+		PaneMode:    colors.PaneMode,
+		TabMode:     colors.TabMode,
+		SessionMode: colors.SessionMode,
+		ResizeMode:  colors.ResizeMode,
+	}
+}
+
+// FontConfigFromEntity creates CSS adapter font config from resolved domain fonts.
+func FontConfigFromEntity(fonts entity.ThemeFonts) FontConfig {
+	return FontConfig{
+		SansFont:      fonts.SansFont,
+		MonospaceFont: fonts.MonospaceFont,
+		GtkFont:       fonts.GtkFont,
+	}
+}
+
 // Coalesce returns the first non-empty string.
 func Coalesce(values ...string) string {
 	for _, v := range values {


### PR DESCRIPTION
## Summary
- add external theme resolution and Noctalia palette source/watcher support
- wire external theme reloads through UI appearance refresh
- document Noctalia config examples and expose resolved appearance in system config

## Verification
- go test ./internal/application/usecase ./internal/application/dto ./internal/cli ./internal/ui ./internal/ui/theme ./internal/bootstrap ./internal/infrastructure/externaltheme/noctalia ./internal/application/port
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External theme support (Noctalia provider) with live-reload watcher and last-good fallback; UI/CLI now use resolved themes and expose external-theme controls.
* **Documentation**
  * Added external-theme configuration guide and example theme files for supported formats.
* **Tests**
  * Extensive unit and integration tests covering theme resolution, parsing, watcher behavior, UI reloads, and config handling.
* **Bug Fixes**
  * Omnibox styling updated to use control-surface colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->