### PR TITLE
docs: update source-build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Set `ENV=dev` to use `.dev/dumber/` for config/data instead of XDG paths.
 ### Build From Source
 
 **Prerequisites:**
-- Go 1.25+
-- Node.js 20+ (for frontend assets)
+- Go 1.26.3+
 - WebKitGTK 6.0 and GTK4 dev packages
+- `brotli` for compressed systemviews assets
 
 ```bash
 git clone https://github.com/bnema/dumber
@@ -116,8 +116,8 @@ make build
 
 | Target | Description |
 |--------|-------------|
-| `make build` | Build frontend + binary |
-| `make build-quick` | Build binary only (skip frontend) |
+| `make build` | Build systemviews assets and the browser binary |
+| `make build-quick` | Build the browser binary only (skip systemviews asset generation) |
 | `make dev` | Run with `go run` |
 | `make test` | Run tests |
 | `make lint` | Run golangci-lint |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,15 +23,17 @@ flatpak install dumber.flatpak
 ```bash
 git clone https://github.com/bnema/dumber
 cd dumber
-go build -o dumber ./cmd/dumber
+make build
+./dist/dumber browse
 ```
 
 ### Build Dependencies
 
-- Go 1.25+
+- Go 1.26.3+
 - GTK4 development libraries
 - WebKitGTK 2.42+ development libraries
 - GStreamer development libraries
+- `brotli` for compressed systemviews assets
 
 ## Post-Install
 


### PR DESCRIPTION
## Summary
- update source-build docs to match the Go 1.26.3 toolchain declared in `go.mod`
- remove the stale Node.js frontend prerequisite and rename the build targets around systemviews assets
- document `brotli` as a source-build dependency for compressed systemviews assets

Closes #293

## Validation
- `git diff --check`