### PR TITLE
fix(audit): harden local browser boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,10 @@ jobs:
             ${{ runner.os }}-go-build-
       - name: Build application and systemviews assets
         run: make build
+      - name: Verify generated systemviews artifacts
+        run: make verify-generated
       - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b /usr/local/bin latest
+        run: make install-golangci-lint TOOL_BIN_DIR=/usr/local/bin
       - name: Run golangci-lint
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -101,6 +102,8 @@ jobs:
             ${{ runner.os }}-go-build-
       - name: Build application and systemviews assets
         run: make build
+      - name: Verify generated systemviews artifacts
+        run: make verify-generated
       - name: Run tests
         env:
           GDK_BACKEND: wayland

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 gobject-introspection base-devel brotli
       - uses: actions/checkout@v6
+      - name: Set up pinned Go toolchain
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Cache Go modules
         uses: actions/cache@v5
         with:
@@ -88,6 +93,11 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 libadwaita gobject-introspection base-devel brotli dbus
       - uses: actions/checkout@v6
+      - name: Set up pinned Go toolchain
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Cache Go modules
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 gobject-introspection base-devel brotli
       - uses: actions/checkout@v6
       - name: Set up pinned Go toolchain
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
           cache: false
@@ -94,7 +94,7 @@ jobs:
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 libadwaita gobject-introspection base-devel brotli dbus
       - uses: actions/checkout@v6
       - name: Set up pinned Go toolchain
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 gobject-introspection base-devel brotli
       - uses: actions/checkout@v6
-      - name: Normalize checkout worktree
-        run: |
-          git reset --hard HEAD
-          git clean -ffdx
       - name: Set up pinned Go toolchain
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
@@ -97,10 +93,6 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 libadwaita gobject-introspection base-devel brotli dbus
       - uses: actions/checkout@v6
-      - name: Normalize checkout worktree
-        run: |
-          git reset --hard HEAD
-          git clean -ffdx
       - name: Set up pinned Go toolchain
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 gobject-introspection base-devel brotli
       - uses: actions/checkout@v6
+      - name: Allow git commands in container checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Set up pinned Go toolchain
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
@@ -77,9 +79,7 @@ jobs:
           make install-golangci-lint
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Run golangci-lint
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          golangci-lint run --timeout=20m
+        run: golangci-lint run --timeout=20m
 
   test:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
       - name: Verify generated systemviews artifacts
         run: make verify-generated
       - name: Install golangci-lint
-        run: make install-golangci-lint TOOL_BIN_DIR=/usr/local/bin
+        run: |
+          make install-golangci-lint
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Run golangci-lint
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -102,8 +104,6 @@ jobs:
             ${{ runner.os }}-go-build-
       - name: Build application and systemviews assets
         run: make build
-      - name: Verify generated systemviews artifacts
-        run: make verify-generated
       - name: Run tests
         env:
           GDK_BACKEND: wayland

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 gobject-introspection base-devel brotli
       - uses: actions/checkout@v6
+      - name: Normalize checkout worktree
+        run: |
+          git reset --hard HEAD
+          git clean -ffdx
       - name: Set up pinned Go toolchain
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
@@ -93,6 +97,10 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git go webkitgtk-6.0 gtk4 libadwaita gobject-introspection base-devel brotli dbus
       - uses: actions/checkout@v6
+      - name: Normalize checkout worktree
+        run: |
+          git reset --hard HEAD
+          git clean -ffdx
       - name: Set up pinned Go toolchain
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for dumber (Clean Architecture - puregotk)
 
-.PHONY: build build-systemviews generate-systemviews build-quick install-local test lint clean install-tools dev generate help init man flatpak-deps flatpak-build flatpak-install flatpak-run flatpak-clean stress-omnibox-callbacks verify-purego check
+.PHONY: build build-systemviews generate-systemviews build-quick install-local test lint staticcheck clean install-tools install-golangci-lint install-staticcheck dev generate help init man flatpak-deps flatpak-build flatpak-install flatpak-run flatpak-clean stress-omnibox-callbacks verify-purego verify-generated check
 
 # Load local overrides from .env.local if present (Makefile syntax)
 ifneq (,$(wildcard .env.local))
@@ -13,6 +13,9 @@ BINARY_NAME=dumber
 MAIN_PATH=./cmd/dumber
 DIST_DIR=dist
 LOCAL_BIN_DIR?=$(HOME)/.local/bin
+TOOL_BIN_DIR?=$(shell go env GOPATH)/bin
+GOLANGCI_LINT_VERSION?=v2.12.2
+STATICCHECK_VERSION?=v0.7.0
 
 # Detect number of CPU cores for parallel compilation
 NPROCS?=$(shell nproc 2>/dev/null || echo 1)
@@ -126,6 +129,13 @@ stress-omnibox-callbacks: ## Run placeholder omnibox callback stress harness
 verify-purego: ## Ensure callback path stays cgo/export free
 	bash ./scripts/verify_purego_only.sh
 
+verify-generated: ## Verify generated systemviews artifacts are committed
+	@echo "Verifying generated systemviews artifacts..."
+	@git diff --exit-code -- assets/systemviews internal/ui/systemviews || { \
+		echo "Generated systemviews artifacts are out of date. Run 'make build-systemviews' and commit the result."; \
+		exit 1; \
+	}
+
 # Linting
 lint: ## Run golangci-lint
 	@echo "Running golangci-lint..."
@@ -135,16 +145,28 @@ lint-fix: ## Run golangci-lint with --fix
 	@echo "Running golangci-lint with --fix..."
 	golangci-lint run --fix
 
+staticcheck: ## Run Staticcheck
+	@echo "Running staticcheck..."
+	staticcheck ./...
+
 # Format code
 fmt: ## Format Go code with gofmt
 	@echo "Formatting Go code..."
 	go fmt ./...
 
 # Tools installation
-install-tools: ## Install development tools
+install-golangci-lint: ## Install pinned golangci-lint
+	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(TOOL_BIN_DIR)..."
+	@mkdir -p $(TOOL_BIN_DIR)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(TOOL_BIN_DIR) $(GOLANGCI_LINT_VERSION)
+
+install-staticcheck: ## Install pinned Staticcheck with the active Go toolchain
+	@echo "Installing staticcheck $(STATICCHECK_VERSION)..."
+	go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
+
+install-tools: install-golangci-lint install-staticcheck ## Install development tools
 	@echo "Installing development tools..."
 	go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@echo "Tools installed successfully"
 
 # Cleanup

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ fmt: ## Format Go code with gofmt
 install-golangci-lint: ## Install pinned golangci-lint
 	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(TOOL_BIN_DIR)..."
 	@mkdir -p $(TOOL_BIN_DIR)
+	# Accepted trade-off: use the upstream installer entrypoint, but keep the
+	# requested golangci-lint version pinned in this repo for reproducible tool use.
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOL_BIN_DIR) $(GOLANGCI_LINT_VERSION)
 
 install-staticcheck: ## Install pinned Staticcheck with the active Go toolchain

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ fmt: ## Format Go code with gofmt
 install-golangci-lint: ## Install pinned golangci-lint
 	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(TOOL_BIN_DIR)..."
 	@mkdir -p $(TOOL_BIN_DIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(TOOL_BIN_DIR) $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOL_BIN_DIR) $(GOLANGCI_LINT_VERSION)
 
 install-staticcheck: ## Install pinned Staticcheck with the active Go toolchain
 	@echo "Installing staticcheck $(STATICCHECK_VERSION)..."

--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,10 @@ fmt: ## Format Go code with gofmt
 install-golangci-lint: ## Install pinned golangci-lint
 	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(TOOL_BIN_DIR)..."
 	@mkdir -p $(TOOL_BIN_DIR)
-	# Accepted trade-off: use the upstream installer entrypoint, but keep the
-	# requested golangci-lint version pinned in this repo for reproducible tool use.
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOL_BIN_DIR) $(GOLANGCI_LINT_VERSION)
+	# Build the pinned version with the active Go toolchain instead of using the
+	# upstream install.sh helper, which currently misidentifies release assets now
+	# that golangci-lint publishes sibling .sbom.json files for each tarball.
+	GOBIN=$(TOOL_BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 install-staticcheck: ## Install pinned Staticcheck with the active Go toolchain
 	@echo "Installing staticcheck $(STATICCHECK_VERSION)..."

--- a/README.md
+++ b/README.md
@@ -208,9 +208,11 @@ Set `ENV=dev` to use `.dev/dumber/` for config and data instead of XDG paths.
 
 **Prerequisites:**
 
-- Go 1.25+
-- Node.js 20+ for frontend assets
+- Go 1.26+
 - WebKitGTK 6.0 and GTK4 development packages
+- Brotli for compressed systemviews assets
+
+Systemviews assets are generated with `go tool templ` and Go's `js/wasm` toolchain; no root Node toolchain is required.
 
 ```bash
 git clone https://github.com/bnema/dumber
@@ -223,12 +225,16 @@ make build
 
 | Target | Description |
 |--------|-------------|
-| `make build` | Build frontend and binary |
-| `make build-quick` | Build binary only, skipping frontend |
+| `make build` | Build systemviews assets and binary |
+| `make build-quick` | Build binary only, skipping systemviews assets |
 | `make dev` | Run with `go run` |
 | `make test` | Run tests |
-| `make lint` | Run golangci-lint |
+| `make lint` | Run the pinned golangci-lint version |
+| `make staticcheck` | Run Staticcheck with the pinned tool version |
+| `make verify-generated` | Verify generated systemviews artifacts are committed |
 | `make flatpak-build` | Build Flatpak bundle |
+
+Development tool versions are pinned in `Makefile` (`GOLANGCI_LINT_VERSION`, `STATICCHECK_VERSION`). Bump those values intentionally when refreshing lint/static analysis tooling.
 
 ## Contributing
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,15 +43,19 @@ flatpak install dumber.flatpak
 ```bash
 git clone https://github.com/bnema/dumber
 cd dumber
-go build -o dumber ./cmd/dumber
+make build
+./dist/dumber browse
 ```
 
 ### Build Dependencies
 
-- Go 1.25+
+- Go 1.26+
 - GTK4 development libraries
-- WebKitGTK 2.42+ development libraries
+- WebKitGTK 6.0 development libraries
 - GStreamer development libraries
+- Brotli for compressed systemviews assets
+
+Systemviews assets are generated with `go tool templ` and Go's `js/wasm` toolchain; no root Node toolchain is required.
 
 ## Post-Install
 

--- a/internal/application/usecase/search_history.go
+++ b/internal/application/usecase/search_history.go
@@ -307,6 +307,10 @@ func (uc *SearchHistoryUseCase) GetDomainStats(ctx context.Context, limit int) (
 	return uc.historyRepo.GetDomainStats(ctx, limit)
 }
 
+// clampOptionalLimit normalizes an optional limit where zero remains a valid
+// "no limit" value, negatives fall back to defaultLimit, and values above
+// maxLimit are capped. Use clampPositiveLimit instead when zero should be
+// treated as invalid input.
 func clampOptionalLimit(limit, defaultLimit, maxLimit int) int {
 	if limit < 0 {
 		return defaultLimit
@@ -317,6 +321,11 @@ func clampOptionalLimit(limit, defaultLimit, maxLimit int) int {
 	return limit
 }
 
+// clampPositiveLimit normalizes a required positive limit. Values less than or
+// equal to zero fall back to defaultLimit, values above maxLimit are capped,
+// and the result stays within the expected positive range. Use this for
+// required limits like domain stats, and clampOptionalLimit when zero has its
+// own meaning.
 func clampPositiveLimit(limit, defaultLimit, maxLimit int) int {
 	if limit <= 0 {
 		return defaultLimit

--- a/internal/application/usecase/search_history.go
+++ b/internal/application/usecase/search_history.go
@@ -18,7 +18,16 @@ import (
 // Compile-time check: SearchHistoryUseCase must satisfy port.HomepageHistory.
 var _ port.HomepageHistory = (*SearchHistoryUseCase)(nil)
 
-const historyWindowDuration = 24 * time.Hour
+const (
+	historyWindowDuration = 24 * time.Hour
+
+	defaultHistoryPageLimit   = 50
+	maxHistoryPageLimit       = 500
+	defaultHistorySearchLimit = 20
+	maxHistorySearchLimit     = 100
+	defaultDomainStatsLimit   = 20
+	maxDomainStatsLimit       = 100
+)
 
 // SearchHistoryUseCase handles history search and retrieval operations.
 type SearchHistoryUseCase struct {
@@ -47,10 +56,7 @@ func (uc *SearchHistoryUseCase) Search(ctx context.Context, input SearchInput) (
 		return &SearchOutput{Matches: []entity.HistoryMatch{}}, nil
 	}
 
-	limit := input.Limit
-	if limit <= 0 {
-		limit = 20 // Default limit
-	}
+	limit := clampPositiveLimit(input.Limit, defaultHistorySearchLimit, maxHistorySearchLimit)
 
 	// Use repository's FTS5 search
 	matches, err := uc.historyRepo.Search(ctx, input.Query, limit)
@@ -67,11 +73,10 @@ func (uc *SearchHistoryUseCase) Search(ctx context.Context, input SearchInput) (
 }
 
 // GetRecent retrieves recent history entries. A zero limit means all entries;
-// negative limits retain the historical default page size.
+// negative limits retain the historical default page size. Positive limits are
+// capped to keep WebUI-originated queries bounded.
 func (uc *SearchHistoryUseCase) GetRecent(ctx context.Context, limit, offset int) ([]*entity.HistoryEntry, error) {
-	if limit < 0 {
-		limit = 50 // Default limit for invalid negative values.
-	}
+	limit = clampOptionalLimit(limit, defaultHistoryPageLimit, maxHistoryPageLimit)
 
 	entries, err := uc.historyRepo.GetRecent(ctx, limit, offset)
 	if err != nil {
@@ -82,11 +87,10 @@ func (uc *SearchHistoryUseCase) GetRecent(ctx context.Context, limit, offset int
 }
 
 // GetRecentByDomain retrieves recent history entries for a canonical domain. A
-// zero limit means all matching entries; negative limits use the default page size.
+// zero limit means all matching entries; negative limits use the default page
+// size. Positive limits are capped to keep WebUI-originated queries bounded.
 func (uc *SearchHistoryUseCase) GetRecentByDomain(ctx context.Context, domain string, limit, offset int) ([]*entity.HistoryEntry, error) {
-	if limit < 0 {
-		limit = 50
-	}
+	limit = clampOptionalLimit(limit, defaultHistoryPageLimit, maxHistoryPageLimit)
 	domain, err := canonicalHistoryDomain(domain)
 	if err != nil {
 		return nil, err
@@ -298,11 +302,29 @@ func (uc *SearchHistoryUseCase) GetDomainStats(ctx context.Context, limit int) (
 	log := logging.FromContext(ctx)
 	log.Debug().Int("limit", limit).Msg("getting domain stats")
 
-	if limit <= 0 {
-		limit = 20
-	}
+	limit = clampPositiveLimit(limit, defaultDomainStatsLimit, maxDomainStatsLimit)
 
 	return uc.historyRepo.GetDomainStats(ctx, limit)
+}
+
+func clampOptionalLimit(limit, defaultLimit, maxLimit int) int {
+	if limit < 0 {
+		return defaultLimit
+	}
+	if limit > maxLimit {
+		return maxLimit
+	}
+	return limit
+}
+
+func clampPositiveLimit(limit, defaultLimit, maxLimit int) int {
+	if limit <= 0 {
+		return defaultLimit
+	}
+	if limit > maxLimit {
+		return maxLimit
+	}
+	return limit
 }
 
 // GetStats retrieves lightweight aggregate history statistics.

--- a/internal/application/usecase/search_history_test.go
+++ b/internal/application/usecase/search_history_test.go
@@ -38,6 +38,31 @@ func TestSearchHistoryUseCase_GetRecent_NegativeLimitDefaultsToPageSize(t *testi
 	assert.Empty(t, result)
 }
 
+func TestSearchHistoryUseCase_GetRecent_ClampsOversizedLimit(t *testing.T) {
+	ctx := testContext()
+	historyRepo := repomocks.NewMockHistoryRepository(t)
+	historyRepo.EXPECT().GetRecent(mock.Anything, 500, 10).Return([]*entity.HistoryEntry{}, nil).Once()
+
+	uc := usecase.NewSearchHistoryUseCase(historyRepo)
+	result, err := uc.GetRecent(ctx, 10_000, 10)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestSearchHistoryUseCase_Search_ClampsOversizedLimit(t *testing.T) {
+	ctx := testContext()
+	historyRepo := repomocks.NewMockHistoryRepository(t)
+	historyRepo.EXPECT().Search(mock.Anything, "dumber", 100).Return([]entity.HistoryMatch{}, nil).Once()
+
+	uc := usecase.NewSearchHistoryUseCase(historyRepo)
+	result, err := uc.Search(ctx, usecase.SearchInput{Query: "dumber", Limit: 10_000})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Matches)
+}
+
 func TestSearchHistoryUseCase_GetRecentWindow_InvalidDomainReturnsValidationError(t *testing.T) {
 	ctx := testContext()
 	historyRepo := repomocks.NewMockHistoryRepository(t)
@@ -189,6 +214,18 @@ func TestSearchHistoryUseCase_GetMostVisited_ReturnsEmptyWhenNoHistory(t *testin
 	assert.Empty(t, result)
 }
 
+func TestSearchHistoryUseCase_GetDomainStats_ClampsOversizedLimit(t *testing.T) {
+	ctx := testContext()
+	historyRepo := repomocks.NewMockHistoryRepository(t)
+	historyRepo.EXPECT().GetDomainStats(mock.Anything, 100).Return([]*entity.DomainStat{}, nil).Once()
+
+	uc := usecase.NewSearchHistoryUseCase(historyRepo)
+	result, err := uc.GetDomainStats(ctx, 10_000)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
 func TestSearchHistoryUseCase_ClearRange_RecentRangeDeletesSinceCutoff(t *testing.T) {
 	ctx := testContext()
 	historyRepo := repomocks.NewMockHistoryRepository(t)
@@ -255,6 +292,18 @@ func TestSearchHistoryUseCase_GetRecentByDomainAllowsUnderscoreDomains(t *testin
 
 	require.NoError(t, err)
 	assert.Equal(t, want, result)
+}
+
+func TestSearchHistoryUseCase_GetRecentByDomain_ClampsOversizedLimit(t *testing.T) {
+	ctx := testContext()
+	historyRepo := repomocks.NewMockHistoryRepository(t)
+	historyRepo.EXPECT().GetRecentByDomain(mock.Anything, "example.com", 500, 25).Return([]*entity.HistoryEntry{}, nil).Once()
+	uc := usecase.NewSearchHistoryUseCase(historyRepo)
+
+	result, err := uc.GetRecentByDomain(ctx, "example.com", 10_000, 25)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
 }
 
 func TestSearchHistoryUseCase_DeleteByDomainAllowsUnderscoreDomains(t *testing.T) {

--- a/internal/infrastructure/externaltheme/noctalia/watcher_test.go
+++ b/internal/infrastructure/externaltheme/noctalia/watcher_test.go
@@ -89,7 +89,8 @@ func TestFileWatcherPathChangeRestartsAndDisabledStops(t *testing.T) {
 func TestFileWatcherDebouncesBurstToOneCallback(t *testing.T) {
 	dir := t.TempDir()
 	path := writeThemeFile(t, dir, "theme.json")
-	watcher := newFastWatcher()
+	watcher := NewFileWatcher()
+	watcher.delay = 100 * time.Millisecond
 	changes := make(chan struct{}, 8)
 
 	if err := watcher.Start(context.Background(), watcherConfig(path), func() { changes <- struct{}{} }); err != nil {
@@ -100,7 +101,7 @@ func TestFileWatcherDebouncesBurstToOneCallback(t *testing.T) {
 	}
 
 	waitForChange(t, changes)
-	assertNoChange(t, changes, 80*time.Millisecond)
+	assertNoChange(t, changes, 150*time.Millisecond)
 }
 
 func TestFileWatcherAtomicRenameWriteEmitsCallback(t *testing.T) {

--- a/internal/infrastructure/favicon/cache.go
+++ b/internal/infrastructure/favicon/cache.go
@@ -30,6 +30,7 @@ type Cache struct {
 	diskDir   string
 	writeChan chan diskWrite
 	closeOnce sync.Once
+	closed    bool
 	mu        sync.RWMutex
 }
 
@@ -100,8 +101,12 @@ func (c *Cache) Set(ctx context.Context, domain string, data []byte) {
 		Int("bytes", len(data)).
 		Msg("favicon: Cache.Set")
 
-	// Write to memory cache
+	// Write to memory cache unless the cache is already shutting down.
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
 	c.memCache[domain] = data
 	c.mu.Unlock()
 
@@ -228,6 +233,10 @@ func (c *Cache) HasOnDisk(domain string) bool {
 // Close shuts down the background writer goroutine.
 func (c *Cache) Close() {
 	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		c.closed = true
 		if c.writeChan != nil {
 			close(c.writeChan)
 		}
@@ -308,6 +317,13 @@ func (c *Cache) queueDiskWrite(domain string, data []byte) {
 	if c.diskDir == "" {
 		return
 	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.closed {
+		return
+	}
+
 	select {
 	case c.writeChan <- diskWrite{domain: domain, data: data}:
 		// queued successfully

--- a/internal/infrastructure/favicon/cache_test.go
+++ b/internal/infrastructure/favicon/cache_test.go
@@ -1,0 +1,21 @@
+package favicon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_SetAfterCloseIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	cache := NewCache(t.TempDir())
+	cache.Close()
+
+	require.NotPanics(t, func() {
+		cache.Set(ctx, "example.com", []byte("favicon"))
+	})
+
+	_, ok := cache.Get(ctx, "example.com")
+	require.False(t, ok)
+}

--- a/internal/infrastructure/filtering/downloader.go
+++ b/internal/infrastructure/filtering/downloader.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	pathpkg "path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -312,8 +312,8 @@ func validateFilterFilename(filename string) (string, error) {
 		}
 	}
 
-	clean := path.Clean(filename)
-	if path.Ext(clean) != ".json" {
+	clean := pathpkg.Clean(filename)
+	if pathpkg.Ext(clean) != ".json" {
 		return "", fmt.Errorf("invalid filter filename %q: expected .json extension", filename)
 	}
 

--- a/internal/infrastructure/filtering/downloader.go
+++ b/internal/infrastructure/filtering/downloader.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/bnema/dumber/internal/logging"
@@ -16,13 +18,34 @@ import (
 const (
 	cacheDirPerm     = 0o755
 	manifestFilePerm = 0o644
+
+	defaultMaxManifestBytes    int64 = 1 << 20 // 1 MiB
+	defaultMaxFilterFiles            = 128
+	defaultMaxFilterFileBytes  int64 = 64 << 20  // 64 MiB
+	defaultMaxTotalFilterBytes int64 = 512 << 20 // 512 MiB
 )
+
+// downloadLimits bounds remote filter metadata and payloads.
+type downloadLimits struct {
+	maxManifestBytes    int64
+	maxFilterFiles      int
+	maxFilterFileBytes  int64
+	maxTotalFilterBytes int64
+}
+
+var defaultDownloadLimits = downloadLimits{
+	maxManifestBytes:    defaultMaxManifestBytes,
+	maxFilterFiles:      defaultMaxFilterFiles,
+	maxFilterFileBytes:  defaultMaxFilterFileBytes,
+	maxTotalFilterBytes: defaultMaxTotalFilterBytes,
+}
 
 // Downloader handles downloading filter files from GitHub releases.
 type Downloader struct {
 	baseURL    string
 	cacheDir   string
 	httpClient *http.Client
+	limits     downloadLimits
 }
 
 // NewDownloader creates a new Downloader.
@@ -34,14 +57,15 @@ func NewDownloader(cacheDir string) *Downloader {
 		httpClient: &http.Client{
 			Timeout: 60 * time.Second,
 		},
+		limits: defaultDownloadLimits,
 	}
 }
 
 // GetCachedManifest reads the locally cached manifest.json.
 // Returns nil if no cached manifest exists.
 func (d *Downloader) GetCachedManifest() (*Manifest, error) {
-	path := filepath.Join(d.cacheDir, FilterFiles.Manifest)
-	data, err := os.ReadFile(path)
+	manifestPath := filepath.Join(d.cacheDir, FilterFiles.Manifest)
+	data, err := readLimitedFile(manifestPath, d.limits.maxManifestBytes, "cached manifest")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -52,6 +76,9 @@ func (d *Downloader) GetCachedManifest() (*Manifest, error) {
 	var manifest Manifest
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse cached manifest: %w", err)
+	}
+	if err := d.validateManifest(&manifest); err != nil {
+		return nil, fmt.Errorf("invalid cached manifest: %w", err)
 	}
 	return &manifest, nil
 }
@@ -84,7 +111,7 @@ func (d *Downloader) FetchManifest(ctx context.Context) (*Manifest, error) {
 		return nil, fmt.Errorf("manifest fetch failed with status %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := readLimitedResponseBody(resp, d.limits.maxManifestBytes, "manifest")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest body: %w", err)
 	}
@@ -92,6 +119,9 @@ func (d *Downloader) FetchManifest(ctx context.Context) (*Manifest, error) {
 	var manifest Manifest
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse manifest: %w", err)
+	}
+	if err := d.validateManifest(&manifest); err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
 	}
 
 	log.Debug().Str("version", manifest.Version).Msg("fetched manifest")
@@ -153,7 +183,12 @@ func (d *Downloader) DownloadFilters(ctx context.Context, onProgress func(Downlo
 			})
 		}
 
-		path, bytesDownloaded, err := d.downloadFile(ctx, filename)
+		remainingBytes := d.limits.maxTotalFilterBytes - totalBytes
+		if remainingBytes <= 0 {
+			return nil, fmt.Errorf("filter downloads exceed total size limit of %d bytes", d.limits.maxTotalFilterBytes)
+		}
+
+		path, bytesDownloaded, err := d.downloadFile(ctx, filename, minInt64(d.limits.maxFilterFileBytes, remainingBytes))
 		if err != nil {
 			log.Error().Err(err).Str("file", filename).Msg("failed to download filter file")
 			return nil, err
@@ -174,9 +209,13 @@ func (d *Downloader) DownloadFilters(ctx context.Context, onProgress func(Downlo
 }
 
 // downloadFile downloads a single file and returns its local path.
-func (d *Downloader) downloadFile(ctx context.Context, filename string) (string, int64, error) {
-	url := fmt.Sprintf("%s/%s", d.baseURL, filename)
-	localPath := filepath.Join(d.cacheDir, filename)
+func (d *Downloader) downloadFile(ctx context.Context, filename string, maxBytes int64) (string, int64, error) {
+	localPath, safeFilename, err := d.cachePathForFilterFile(filename)
+	if err != nil {
+		return "", 0, err
+	}
+
+	url := fmt.Sprintf("%s/%s", d.baseURL, safeFilename)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
@@ -197,25 +236,29 @@ func (d *Downloader) downloadFile(ctx context.Context, filename string) (string,
 		return "", 0, fmt.Errorf("download %s failed with status %d", filename, resp.StatusCode)
 	}
 
+	if resp.ContentLength > maxBytes {
+		return "", 0, fmt.Errorf("filter file %q too large: content length %d exceeds limit %d", safeFilename, resp.ContentLength, maxBytes)
+	}
+
 	// Write to temp file in cacheDir, then atomic rename into destination.
-	tmpFile, err := os.CreateTemp(d.cacheDir, filepath.Base(filename)+".*.tmp")
+	tmpFile, err := os.CreateTemp(d.cacheDir, filepath.Base(safeFilename)+".*.tmp")
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to create temp file: %w", err)
 	}
 	tmpPath := tmpFile.Name()
 
-	bytesWritten, err := io.Copy(tmpFile, resp.Body)
+	bytesWritten, err := copyLimited(tmpFile, resp.Body, maxBytes, fmt.Sprintf("filter file %q", safeFilename))
 	if err != nil {
 		_ = tmpFile.Close()
 		_ = os.Remove(tmpPath)
-		return "", 0, fmt.Errorf("failed to write %s: %w", filename, err)
+		return "", 0, fmt.Errorf("failed to write %s: %w", safeFilename, err)
 	}
 	if err := tmpFile.Close(); err != nil {
 		_ = os.Remove(tmpPath)
 		return "", 0, fmt.Errorf("failed to close temp file: %w", err)
 	}
 
-	if err := d.renameTempFile(tmpPath, localPath); err != nil {
+	if err := d.renameTempFile(tmpPath, safeFilename); err != nil {
 		_ = os.Remove(tmpPath)
 		return "", 0, err
 	}
@@ -223,14 +266,88 @@ func (d *Downloader) downloadFile(ctx context.Context, filename string) (string,
 	return localPath, bytesWritten, nil
 }
 
-func (*Downloader) renameTempFile(tmpPath, localPath string) error {
-	parentDir := filepath.Dir(localPath)
-
-	if err := os.MkdirAll(parentDir, cacheDirPerm); err != nil {
-		return fmt.Errorf("failed to create target dir: %w", err)
+func (d *Downloader) cachePathForFilterFile(filename string) (string, string, error) {
+	safeFilename, err := validateFilterFilename(filename)
+	if err != nil {
+		return "", "", err
 	}
 
-	if err := os.Rename(tmpPath, localPath); err != nil {
+	cacheDirAbs, err := filepath.Abs(d.cacheDir)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve cache dir: %w", err)
+	}
+	localPath := filepath.Join(d.cacheDir, filepath.FromSlash(safeFilename))
+	targetAbs, err := filepath.Abs(localPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve cache path: %w", err)
+	}
+	if err := ensurePathInside(cacheDirAbs, targetAbs); err != nil {
+		return "", "", fmt.Errorf("invalid filter filename %q: %w", filename, err)
+	}
+
+	return localPath, safeFilename, nil
+}
+
+func validateFilterFilename(filename string) (string, error) {
+	if filename == "" {
+		return "", fmt.Errorf("invalid filter filename: empty")
+	}
+	if strings.TrimSpace(filename) != filename {
+		return "", fmt.Errorf("invalid filter filename %q: surrounding whitespace is not allowed", filename)
+	}
+	if filepath.IsAbs(filename) || strings.HasPrefix(filename, "/") {
+		return "", fmt.Errorf("invalid filter filename %q: absolute paths are not allowed", filename)
+	}
+	if strings.Contains(filename, "\\") {
+		return "", fmt.Errorf("invalid filter filename %q: backslashes are not allowed", filename)
+	}
+	if strings.ContainsAny(filename, "?#") {
+		return "", fmt.Errorf("invalid filter filename %q: URL control characters are not allowed", filename)
+	}
+
+	parts := strings.Split(filename, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("invalid filter filename %q: path traversal components are not allowed", filename)
+		}
+	}
+
+	clean := path.Clean(filename)
+	if path.Ext(clean) != ".json" {
+		return "", fmt.Errorf("invalid filter filename %q: expected .json extension", filename)
+	}
+
+	return clean, nil
+}
+
+func ensurePathInside(baseAbs, targetAbs string) error {
+	rel, err := filepath.Rel(baseAbs, targetAbs)
+	if err != nil {
+		return fmt.Errorf("failed to compare with cache dir: %w", err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("resolved path escapes cache dir")
+	}
+	return nil
+}
+
+func (d *Downloader) renameTempFile(tmpPath, safeFilename string) error {
+	relTarget := filepath.FromSlash(safeFilename)
+	parentDir := filepath.Dir(relTarget)
+
+	root, err := os.OpenRoot(d.cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to open cache root: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	if parentDir != "." {
+		if err := root.MkdirAll(parentDir, cacheDirPerm); err != nil {
+			return fmt.Errorf("failed to create target dir: %w", err)
+		}
+	}
+
+	if err := root.Rename(filepath.Base(tmpPath), relTarget); err != nil {
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 
@@ -239,6 +356,10 @@ func (*Downloader) renameTempFile(tmpPath, localPath string) error {
 
 // cacheManifest writes an already-fetched manifest to disk.
 func (d *Downloader) cacheManifest(manifest *Manifest) error {
+	if err := d.validateManifest(manifest); err != nil {
+		return fmt.Errorf("invalid manifest: %w", err)
+	}
+
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
@@ -262,8 +383,11 @@ func (d *Downloader) GetCachedFilterPaths() []string {
 	}
 	paths := make([]string, 0, len(manifest.Combined.Files))
 	for _, filename := range manifest.Combined.Files {
-		path := filepath.Join(d.cacheDir, filename)
-		if _, err := os.Stat(path); err != nil {
+		path, safeFilename, err := d.cachePathForFilterFile(filename)
+		if err != nil {
+			return nil
+		}
+		if !d.hasCachedFilterFile(safeFilename) {
 			return nil
 		}
 		paths = append(paths, path)
@@ -312,6 +436,94 @@ func (d *Downloader) NeedsUpdate(ctx context.Context) (bool, error) {
 // ClearCache removes all cached filter files.
 func (d *Downloader) ClearCache() error {
 	return os.RemoveAll(d.cacheDir)
+}
+
+func (d *Downloader) hasCachedFilterFile(safeFilename string) bool {
+	root, err := os.OpenRoot(d.cacheDir)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = root.Close() }()
+
+	info, err := root.Stat(filepath.FromSlash(safeFilename))
+	return err == nil && !info.IsDir()
+}
+
+func (d *Downloader) validateManifest(manifest *Manifest) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is nil")
+	}
+	if len(manifest.Combined.Files) > d.limits.maxFilterFiles {
+		return fmt.Errorf("manifest lists %d combined filter files, limit is %d", len(manifest.Combined.Files), d.limits.maxFilterFiles)
+	}
+	for _, filename := range manifest.Combined.Files {
+		if _, _, err := d.cachePathForFilterFile(filename); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readLimitedFile(filename string, limit int64, label string) ([]byte, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > limit {
+		return nil, fmt.Errorf("%s too large: size %d exceeds limit %d", label, info.Size(), limit)
+	}
+
+	return readLimitedReader(file, limit, label)
+}
+
+func readLimitedResponseBody(resp *http.Response, limit int64, label string) ([]byte, error) {
+	if resp.ContentLength > limit {
+		return nil, fmt.Errorf("%s too large: content length %d exceeds limit %d", label, resp.ContentLength, limit)
+	}
+	return readLimitedReader(resp.Body, limit, label)
+}
+
+func readLimitedReader(r io.Reader, limit int64, label string) ([]byte, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("%s size limit must be positive", label)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%s too large: exceeds limit %d bytes", label, limit)
+	}
+	return data, nil
+}
+
+func copyLimited(dst io.Writer, src io.Reader, limit int64, label string) (int64, error) {
+	if limit <= 0 {
+		return 0, fmt.Errorf("%s size limit must be positive", label)
+	}
+
+	written, err := io.Copy(dst, io.LimitReader(src, limit+1))
+	if err != nil {
+		return written, err
+	}
+	if written > limit {
+		return written, fmt.Errorf("%s too large: exceeds limit %d bytes", label, limit)
+	}
+	return written, nil
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // IsCacheStale checks if the cached manifest is older than maxAge.

--- a/internal/infrastructure/filtering/downloader_test.go
+++ b/internal/infrastructure/filtering/downloader_test.go
@@ -122,7 +122,10 @@ func TestDownloader_DownloadFilters_AllowsSafeNestedManifestFilenames(t *testing
 
 func TestDownloader_FetchManifest_RejectsOversizedManifest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/"+FilterFiles.Manifest, r.URL.Path)
+		if r.URL.Path != "/"+FilterFiles.Manifest {
+			http.NotFound(w, r)
+			return
+		}
 		_, _ = io.WriteString(w, strings.Repeat("x", 17))
 	}))
 	defer server.Close()
@@ -148,7 +151,10 @@ func TestDownloader_FetchManifest_RejectsTooManyFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/"+FilterFiles.Manifest, r.URL.Path)
+		if r.URL.Path != "/"+FilterFiles.Manifest {
+			http.NotFound(w, r)
+			return
+		}
 		_, _ = w.Write(payload)
 	}))
 	defer server.Close()

--- a/internal/infrastructure/filtering/downloader_test.go
+++ b/internal/infrastructure/filtering/downloader_test.go
@@ -2,11 +2,13 @@ package filtering
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,7 +48,7 @@ func TestDownloader_DownloadFile_RecoversWhenTargetDirDeletedConcurrently(t *tes
 	}
 	resultCh := make(chan result, 1)
 	go func() {
-		path, n, err := d.downloadFile(context.Background(), filename)
+		path, n, err := d.downloadFile(context.Background(), filename, d.limits.maxFilterFileBytes)
 		resultCh <- result{path: path, n: n, err: err}
 	}()
 
@@ -64,6 +66,203 @@ func TestDownloader_DownloadFile_RecoversWhenTargetDirDeletedConcurrently(t *tes
 	require.Contains(t, string(content), "url-filter")
 }
 
+func TestDownloader_DownloadFilters_RejectsUnsafeManifestFilenames(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	requested := make([]string, 0, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		if r.URL.Path != "/"+FilterFiles.Manifest {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, `{"version":"test","combined":{"total_rules":1,"files":["../escape.json"]}}`)
+	}))
+	defer server.Close()
+
+	d := NewDownloader(cacheDir)
+	d.baseURL = server.URL
+
+	paths, err := d.DownloadFilters(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, paths)
+	require.Contains(t, err.Error(), "invalid manifest")
+	require.Equal(t, []string{"/" + FilterFiles.Manifest}, requested)
+}
+
+func TestDownloader_DownloadFilters_AllowsSafeNestedManifestFilenames(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	filename := "nested/combined-part1.json"
+	body := `[{"trigger":{"url-filter":"test"},"action":{"type":"block"}}]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + FilterFiles.Manifest:
+			_, _ = io.WriteString(w, `{"version":"test","combined":{"total_rules":1,"files":["`+filename+`"]}}`)
+		case "/" + filename:
+			_, _ = io.WriteString(w, body)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	d := NewDownloader(cacheDir)
+	d.baseURL = server.URL
+
+	paths, err := d.DownloadFilters(context.Background(), nil)
+	require.NoError(t, err)
+
+	wantPath := filepath.Join(cacheDir, "nested", "combined-part1.json")
+	require.Equal(t, []string{wantPath}, paths)
+	content, err := os.ReadFile(wantPath)
+	require.NoError(t, err)
+	require.Equal(t, body, string(content))
+}
+
+func TestDownloader_FetchManifest_RejectsOversizedManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/"+FilterFiles.Manifest, r.URL.Path)
+		_, _ = io.WriteString(w, strings.Repeat("x", 17))
+	}))
+	defer server.Close()
+
+	d := NewDownloader(t.TempDir())
+	d.baseURL = server.URL
+	d.limits.maxManifestBytes = 16
+
+	manifest, err := d.FetchManifest(context.Background())
+	require.Error(t, err)
+	require.Nil(t, manifest)
+	require.Contains(t, err.Error(), "manifest too large")
+}
+
+func TestDownloader_FetchManifest_RejectsTooManyFiles(t *testing.T) {
+	payload, err := json.Marshal(Manifest{
+		Version: "test",
+		Combined: CombinedInfo{
+			TotalRules: 3,
+			Files:      []string{"part1.json", "part2.json", "part3.json"},
+		},
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/"+FilterFiles.Manifest, r.URL.Path)
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	d := NewDownloader(t.TempDir())
+	d.baseURL = server.URL
+	d.limits.maxFilterFiles = 2
+
+	manifest, err := d.FetchManifest(context.Background())
+	require.Error(t, err)
+	require.Nil(t, manifest)
+	require.Contains(t, err.Error(), "limit is 2")
+}
+
+func TestDownloader_DownloadFilters_RejectsOversizedFilterFile(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	filename := "combined.json"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + FilterFiles.Manifest:
+			_, _ = io.WriteString(w, `{"version":"test","combined":{"total_rules":1,"files":["combined.json"]}}`)
+		case "/" + filename:
+			_, _ = io.WriteString(w, "12345")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	d := NewDownloader(cacheDir)
+	d.baseURL = server.URL
+	d.limits.maxFilterFileBytes = 4
+	d.limits.maxTotalFilterBytes = 32
+
+	paths, err := d.DownloadFilters(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, paths)
+	require.Contains(t, err.Error(), "too large")
+	require.NoFileExists(t, filepath.Join(cacheDir, filename))
+}
+
+func TestDownloader_DownloadFilters_EnforcesTotalDownloadLimit(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + FilterFiles.Manifest:
+			_, _ = io.WriteString(w, `{"version":"test","combined":{"total_rules":2,"files":["part1.json","part2.json"]}}`)
+		case "/part1.json", "/part2.json":
+			_, _ = io.WriteString(w, "12345")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	d := NewDownloader(cacheDir)
+	d.baseURL = server.URL
+	d.limits.maxFilterFileBytes = 8
+	d.limits.maxTotalFilterBytes = 8
+
+	paths, err := d.DownloadFilters(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, paths)
+	require.Contains(t, err.Error(), "too large")
+	require.FileExists(t, filepath.Join(cacheDir, "part1.json"))
+	require.NoFileExists(t, filepath.Join(cacheDir, "part2.json"))
+}
+
+func TestDownloader_DownloadFilters_RejectsSymlinkEscape(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	outsideDir := filepath.Join(t.TempDir(), "outside")
+	require.NoError(t, os.MkdirAll(cacheDir, cacheDirPerm))
+	require.NoError(t, os.MkdirAll(outsideDir, cacheDirPerm))
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(cacheDir, "nested")))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + FilterFiles.Manifest:
+			_, _ = io.WriteString(w, `{"version":"test","combined":{"total_rules":1,"files":["nested/combined.json"]}}`)
+		case "/nested/combined.json":
+			_, _ = io.WriteString(w, `[{"trigger":{"url-filter":"test"},"action":{"type":"block"}}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	d := NewDownloader(cacheDir)
+	d.baseURL = server.URL
+
+	paths, err := d.DownloadFilters(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, paths)
+	require.Contains(t, err.Error(), "failed to create target dir")
+	require.NoFileExists(t, filepath.Join(outsideDir, "combined.json"))
+}
+
+func TestDownloader_GetCachedFilterPaths_RejectsSymlinkEscape(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	outsideDir := filepath.Join(t.TempDir(), "outside")
+	require.NoError(t, os.MkdirAll(cacheDir, cacheDirPerm))
+	require.NoError(t, os.MkdirAll(outsideDir, cacheDirPerm))
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(cacheDir, "nested")))
+	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "combined.json"), []byte("[]"), manifestFilePerm))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cacheDir, FilterFiles.Manifest),
+		[]byte(`{"version":"test","combined":{"total_rules":1,"files":["nested/combined.json"]}}`),
+		manifestFilePerm,
+	))
+
+	d := NewDownloader(cacheDir)
+	require.Nil(t, d.GetCachedFilterPaths())
+}
+
 func TestDownloader_RenameTempFile_RequiresDirectoryParent(t *testing.T) {
 	t.Parallel()
 
@@ -78,7 +277,7 @@ func TestDownloader_RenameTempFile_RequiresDirectoryParent(t *testing.T) {
 
 	d := NewDownloader(cacheDir)
 
-	err := d.renameTempFile(tmpFile, filepath.Join(parentAsFile, "filter.json"))
+	err := d.renameTempFile(tmpFile, "target/filter.json")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not a directory")
+	require.Contains(t, err.Error(), "failed to create target dir")
 }

--- a/internal/infrastructure/webkit/messaging.go
+++ b/internal/infrastructure/webkit/messaging.go
@@ -198,15 +198,25 @@ func (r *MessageRouter) handleScriptMessage(senderUCM webkit.UserContentManager,
 		log.Warn().Err(err).Str("json", rawJSON).Msg("failed to unmarshal script message")
 		return
 	}
-	if msg.WebViewID == 0 && msg.WebViewIDAlt != 0 {
-		msg.WebViewID = msg.WebViewIDAlt
+
+	senderWV := lookupSenderWebView(senderUCM)
+	if senderWV == nil {
+		log.Warn().Msg("rejecting script message from unknown sender")
+		return
 	}
-	if msg.WebViewID == 0 {
-		if senderWV := lookupSenderWebView(senderUCM); senderWV != nil {
-			msg.WebViewID = uint64(senderWV.ID())
-			r.syncWebViewID(senderWV)
-		}
+	if !isTrustedBridgeWebView(senderWV) {
+		log.Warn().
+			Str("type", msg.Type).
+			Uint64("sender_webview_id", uint64(senderWV.ID())).
+			Str("uri", senderWV.URI()).
+			Msg("rejecting script message from untrusted page")
+		return
 	}
+
+	// Trust the sender WebView resolved from WebKit's UserContentManager, not a
+	// caller-provided webViewId field in page-controlled JSON.
+	msg.WebViewID = uint64(senderWV.ID())
+	r.syncWebViewID(senderWV)
 
 	if msg.Type == "" {
 		log.Warn().Msg("script message missing type")
@@ -260,6 +270,17 @@ func lookupSenderWebView(senderUCM webkit.UserContentManager) *WebView {
 		return nil
 	}
 	return LookupWebViewByUCMPointer(ptr)
+}
+
+func isTrustedBridgeWebView(wv *WebView) bool {
+	if wv == nil {
+		return false
+	}
+	return isTrustedBridgeURI(wv.URI())
+}
+
+func isTrustedBridgeURI(raw string) bool {
+	return isTrustedSystemviewURL(raw)
 }
 
 func (r *MessageRouter) syncWebViewID(wv *WebView) {

--- a/internal/infrastructure/webkit/messaging_test.go
+++ b/internal/infrastructure/webkit/messaging_test.go
@@ -1,0 +1,42 @@
+package webkit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTrustedBridgeURI(t *testing.T) {
+	t.Parallel()
+
+	trusted := []string{
+		"dumb://history",
+		"dumb://favorites",
+		"dumb://config",
+		"dumb://error",
+		"dumb://crash",
+		"dumb://history/path?cursor=1",
+	}
+	for _, raw := range trusted {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			require.True(t, isTrustedBridgeURI(raw))
+		})
+	}
+
+	untrusted := []string{
+		"",
+		"https://example.com",
+		"http://localhost",
+		"file:///tmp/history.html",
+		"dumb://evil/history",
+		"dumb://example.com",
+		"javascript:alert(1)",
+	}
+	for _, raw := range untrusted {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			require.False(t, isTrustedBridgeURI(raw))
+		})
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2808,7 +2808,11 @@ func (a *App) cleanupCreatedBrowserWindows(createdWindows []*browserWindow) {
 			continue
 		}
 		mainWindow := bw.mainWindow
-		a.removeBrowserWindow(bw.id)
+		if _, tracked := a.browserWindows[bw.id]; tracked {
+			a.removeBrowserWindow(bw.id)
+		} else {
+			a.cleanupTransientBrowserWindowForDestroy(bw)
+		}
 		if mainWindow != nil {
 			if a.mainWindow == mainWindow {
 				a.mainWindow = nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2838,10 +2838,14 @@ func (a *App) pruneStaleBrowserWindows(runtimeWindows []*browserWindow) {
 	}
 	for id, bw := range a.browserWindows {
 		if !runtimeSet[id] {
-			if bw != nil && bw.mainWindow != nil {
-				bw.mainWindow.Destroy()
+			var mainWindowToDestroy *window.MainWindow
+			if bw != nil {
+				mainWindowToDestroy = bw.mainWindow
 			}
 			a.removeBrowserWindow(id)
+			if mainWindowToDestroy != nil {
+				mainWindowToDestroy.Destroy()
+			}
 		}
 	}
 

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -51,6 +51,14 @@ func (bw *browserWindow) detachInputForDestroy() {
 	}
 }
 
+func (bw *browserWindow) teardownForDestroy() {
+	if bw == nil {
+		return
+	}
+	bw.detachInputForDestroy()
+	bw.clearShellState()
+}
+
 func (bw *browserWindow) clearShellState() {
 	if bw == nil {
 		return
@@ -299,8 +307,7 @@ func (a *App) removeBrowserWindow(id string) {
 		}
 	}
 	if removed != nil {
-		removed.detachInputForDestroy()
-		removed.clearShellState()
+		removed.teardownForDestroy()
 	}
 	if a.contentCoord != nil {
 		a.contentCoord.ClearPopupNamedContextsForWindow(id)
@@ -315,6 +322,38 @@ func (a *App) removeBrowserWindow(id string) {
 		}
 	}
 	if wasMainWindow {
+		a.clearResizeModeBorder()
+		if fallback != nil {
+			a.activateBrowserWindow(fallback)
+			return
+		}
+		a.lastFocusedWindowID = ""
+		a.mainWindow = nil
+		a.keyboardHandler = nil
+		a.globalShortcutHandler = nil
+		if a.tabCoord != nil {
+			a.tabCoord.SetCurrentTarget(coordinator.TabTarget{})
+		}
+	}
+}
+
+func (a *App) cleanupTransientBrowserWindowForDestroy(bw *browserWindow) {
+	if bw == nil {
+		return
+	}
+	bw.teardownForDestroy()
+	if a.contentCoord != nil {
+		a.contentCoord.ClearPopupNamedContextsForWindow(bw.id)
+	}
+	fallback := a.deterministicBrowserWindowFallback()
+	if a.lastFocusedWindowID == bw.id {
+		if fallback != nil {
+			a.lastFocusedWindowID = fallback.id
+		} else {
+			a.lastFocusedWindowID = ""
+		}
+	}
+	if bw.mainWindow == a.mainWindow {
 		a.clearResizeModeBorder()
 		if fallback != nil {
 			a.activateBrowserWindow(fallback)

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -39,15 +39,15 @@ type browserWindow struct {
 	webrtcIndicator       *component.WebRTCPermissionIndicator
 }
 
-func (bw *browserWindow) detachInput() {
+func (bw *browserWindow) detachInputForDestroy() {
 	if bw == nil {
 		return
 	}
 	if bw.keyboardHandler != nil {
-		bw.keyboardHandler.Detach()
+		bw.keyboardHandler.DetachForDestroy()
 	}
 	if bw.globalShortcutHandler != nil {
-		bw.globalShortcutHandler.Detach()
+		bw.globalShortcutHandler.DetachForDestroy()
 	}
 }
 
@@ -299,7 +299,7 @@ func (a *App) removeBrowserWindow(id string) {
 		}
 	}
 	if removed != nil {
-		removed.detachInput()
+		removed.detachInputForDestroy()
 		removed.clearShellState()
 	}
 	if a.contentCoord != nil {

--- a/internal/ui/browser_window_test.go
+++ b/internal/ui/browser_window_test.go
@@ -67,6 +67,40 @@ func TestBrowserWindow_RemoveBrowserWindowClearsShellState(t *testing.T) {
 	}
 }
 
+func TestApp_CleanupCreatedBrowserWindowsDetachesUnregisteredWindowBeforeDestroy(t *testing.T) {
+	transientMainWindow := &window.MainWindow{}
+	fallbackMainWindow := &window.MainWindow{}
+	transient := &browserWindow{id: "window-transient", mainWindow: transientMainWindow}
+	fallback := &browserWindow{id: "window-fallback", mainWindow: fallbackMainWindow}
+	app := &App{
+		mainWindow:          transientMainWindow,
+		browserWindows:      map[string]*browserWindow{fallback.id: fallback},
+		browserWindowOrder:  []string{fallback.id},
+		lastFocusedWindowID: transient.id,
+	}
+
+	setShellField(t, transient, "keyboardHandler", &input.KeyboardHandler{})
+	setShellField(t, transient, "globalShortcutHandler", &input.GlobalShortcutHandler{})
+	setShellField(t, transient, "accentPicker", &component.AccentPicker{})
+
+	app.cleanupCreatedBrowserWindows([]*browserWindow{transient})
+
+	for _, name := range []string{"keyboardHandler", "globalShortcutHandler", "accentPicker"} {
+		if !fieldIsZero(t, transient, name) {
+			t.Fatalf("transient browserWindow.%s was not cleared", name)
+		}
+	}
+	if app.mainWindow != fallbackMainWindow {
+		t.Fatalf("mainWindow = %p, want fallback main window %p", app.mainWindow, fallbackMainWindow)
+	}
+	if app.lastFocusedWindowID != fallback.id {
+		t.Fatalf("lastFocusedWindowID = %q, want %q", app.lastFocusedWindowID, fallback.id)
+	}
+	if got := app.browserWindows[fallback.id]; got != fallback {
+		t.Fatalf("fallback browser window changed during transient cleanup: got %p want %p", got, fallback)
+	}
+}
+
 func TestBrowserWindow_RemoveBrowserWindowCleansOwnedTabState(t *testing.T) {
 	ownedTab := entity.NewTab(entity.TabID("tab-owned"), entity.WorkspaceID("workspace-owned"), entity.NewPane(entity.PaneID("pane-owned")))
 	otherTab := entity.NewTab(entity.TabID("tab-other"), entity.WorkspaceID("workspace-other"), entity.NewPane(entity.PaneID("pane-other")))

--- a/internal/ui/input/gesture.go
+++ b/internal/ui/input/gesture.go
@@ -104,7 +104,7 @@ func (h *GestureHandler) AttachTo(widget *gtk.Widget) {
 	h.pressedHandlerID = h.clickGesture.ConnectPressed(&h.pressedCb)
 	h.widget = widget
 	h.destroyCb = func(_ gtk.Widget) {
-		h.Detach()
+		h.DetachForDestroy()
 	}
 	h.destroyHandlerID = widget.ConnectDestroy(&h.destroyCb)
 
@@ -182,8 +182,19 @@ func (h *GestureHandler) detachExistingAttachment() {
 	}
 }
 
-// Detach removes the gesture handler and disconnects its GTK signals.
+// Detach removes the gesture handler from a live widget and disconnects its
+// GTK signals.
 func (h *GestureHandler) Detach() {
+	h.detach(true)
+}
+
+// DetachForDestroy disconnects retained GTK callbacks during widget teardown
+// without mutating the widget's controller list while GTK is destroying it.
+func (h *GestureHandler) DetachForDestroy() {
+	h.detach(false)
+}
+
+func (h *GestureHandler) detach(removeController bool) {
 	if h == nil {
 		return
 	}
@@ -209,7 +220,7 @@ func (h *GestureHandler) Detach() {
 	if widget != nil && destroyHandlerID != 0 {
 		widget.DisconnectSignal(destroyHandlerID)
 	}
-	if widget != nil && clickGesture != nil {
+	if removeController && widget != nil && clickGesture != nil {
 		widget.RemoveController(&clickGesture.EventController)
 	}
 }

--- a/internal/ui/input/gesture_test.go
+++ b/internal/ui/input/gesture_test.go
@@ -50,3 +50,22 @@ func TestGestureHandlerDetachClearsRetainedCallbacksAndState(t *testing.T) {
 	assert.Nil(t, h.onAction)
 	assert.Nil(t, h.navigator)
 }
+
+func TestGestureHandlerDetachForDestroyClearsRetainedCallbacksAndState(t *testing.T) {
+	h := NewGestureHandler(context.Background())
+	h.pressedCb = func(gtk.GestureClick, int, float64, float64) {}
+	h.destroyCb = func(gtk.Widget) {}
+	h.pressedHandlerID = 1
+	h.destroyHandlerID = 2
+	h.onAction = func(context.Context, Action) error { return nil }
+	h.navigator = testGestureNavigator{}
+
+	h.DetachForDestroy()
+
+	assert.Nil(t, h.pressedCb)
+	assert.Nil(t, h.destroyCb)
+	assert.Zero(t, h.pressedHandlerID)
+	assert.Zero(t, h.destroyHandlerID)
+	assert.Nil(t, h.onAction)
+	assert.Nil(t, h.navigator)
+}

--- a/internal/ui/input/global_shortcuts.go
+++ b/internal/ui/input/global_shortcuts.go
@@ -579,24 +579,34 @@ func (h *GlobalShortcutHandler) ReloadShortcuts(ctx context.Context, workspace *
 		Msg("global shortcuts reloaded")
 }
 
-// Detach removes the global shortcut handler from the window.
-// Note: GTK handles cleanup when the widget is destroyed,
-// but we clear our references here.
+// Detach removes the global shortcut handler from a live GTK window.
+// Use DetachForDestroy when the window is already closing or being destroyed.
 func (h *GlobalShortcutHandler) Detach() {
+	h.detach(true)
+}
+
+// DetachForDestroy releases retained GTK callbacks during window teardown
+// without mutating the window's controller or action lists while GTK is
+// destroying them.
+func (h *GlobalShortcutHandler) DetachForDestroy() {
+	h.detach(false)
+}
+
+func (h *GlobalShortcutHandler) detach(removeFromWindow bool) {
 	h.generation++
-	if h.window != nil && h.controller != nil {
+	if removeFromWindow && h.window != nil && h.controller != nil {
 		h.window.RemoveController(&h.controller.EventController)
 	}
 	if h.releaseController != nil && h.keyReleasedHandlerID != 0 {
 		h.releaseController.DisconnectSignal(h.keyReleasedHandlerID)
 	}
-	if h.window != nil && h.releaseController != nil {
+	if removeFromWindow && h.window != nil && h.releaseController != nil {
 		h.window.RemoveController(&h.releaseController.EventController)
 	}
 	if h.globalAction != nil && h.globalActionHandlerID != 0 {
 		h.globalAction.DisconnectSignal(h.globalActionHandlerID)
 	}
-	if h.window != nil && h.globalAction != nil {
+	if removeFromWindow && h.window != nil && h.globalAction != nil {
 		h.window.RemoveAction(globalShortcutActionName)
 	}
 	h.controller = nil

--- a/internal/ui/input/global_shortcuts_test.go
+++ b/internal/ui/input/global_shortcuts_test.go
@@ -133,6 +133,58 @@ func TestGlobalShortcutHandlerSuppressesOneShotActionsAfterDetach(t *testing.T) 
 	}
 }
 
+func TestGlobalShortcutHandlerDetachForDestroyClearsRetainedState(t *testing.T) {
+	h := &GlobalShortcutHandler{
+		registered:            make(map[KeyBinding]Action),
+		shortcutRefs:          make(map[string]globalShortcutRegistration),
+		lastDispatchAt:        make(map[Action]time.Time),
+		heldShortcuts:         make(map[globalShortcutHoldKey]struct{}),
+		globalActionCb:        func(_ gio.SimpleAction, _ uintptr) {},
+		globalActionHandlerID: 1,
+		keyReleasedCb:         func(_ gtk.EventControllerKey, _ uint, _ uint, _ gdk.ModifierType) {},
+		keyReleasedHandlerID:  2,
+	}
+
+	h.DetachForDestroy()
+
+	if h.controller != nil {
+		t.Fatal("controller should be cleared during destroy detach")
+	}
+	if h.releaseController != nil {
+		t.Fatal("releaseController should be cleared during destroy detach")
+	}
+	if h.shortcutAction != nil {
+		t.Fatal("shortcutAction should be cleared during destroy detach")
+	}
+	if h.globalAction != nil {
+		t.Fatal("globalAction should be cleared during destroy detach")
+	}
+	if h.globalActionCb != nil {
+		t.Fatal("globalActionCb should be cleared during destroy detach")
+	}
+	if h.keyReleasedCb != nil {
+		t.Fatal("keyReleasedCb should be cleared during destroy detach")
+	}
+	if h.globalActionHandlerID != 0 {
+		t.Fatal("globalActionHandlerID should be reset during destroy detach")
+	}
+	if h.keyReleasedHandlerID != 0 {
+		t.Fatal("keyReleasedHandlerID should be reset during destroy detach")
+	}
+	if h.registered != nil {
+		t.Fatal("registered shortcuts should be cleared during destroy detach")
+	}
+	if h.shortcutRefs != nil {
+		t.Fatal("shortcut refs should be cleared during destroy detach")
+	}
+	if h.lastDispatchAt != nil {
+		t.Fatal("lastDispatchAt should be cleared during destroy detach")
+	}
+	if h.heldShortcuts != nil {
+		t.Fatal("heldShortcuts should be cleared during destroy detach")
+	}
+}
+
 func TestGlobalShortcutHandlerGenerationMarksOldCallbacksStale(t *testing.T) {
 	h := &GlobalShortcutHandler{}
 	generation := h.generation

--- a/internal/ui/input/keyboard.go
+++ b/internal/ui/input/keyboard.go
@@ -243,8 +243,20 @@ func (h *KeyboardHandler) AttachTo(window *gtk.ApplicationWindow) {
 	log.Debug().Msg("keyboard handler attached to window")
 }
 
-// Detach removes the keyboard handler and releases its GTK signal callbacks.
+// Detach removes the keyboard handler from a live GTK window and releases its
+// retained GTK signal callbacks.
 func (h *KeyboardHandler) Detach() {
+	h.detach(true)
+}
+
+// DetachForDestroy releases retained GTK signal callbacks during window
+// teardown without mutating the window's controller list while GTK is
+// destroying it.
+func (h *KeyboardHandler) DetachForDestroy() {
+	h.detach(false)
+}
+
+func (h *KeyboardHandler) detach(removeController bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.controller != nil && h.keyPressedHandlerID != 0 {
@@ -253,7 +265,7 @@ func (h *KeyboardHandler) Detach() {
 	if h.controller != nil && h.keyReleasedHandlerID != 0 {
 		h.controller.DisconnectSignal(h.keyReleasedHandlerID)
 	}
-	if h.window != nil && h.controller != nil {
+	if removeController && h.window != nil && h.controller != nil {
 		h.window.RemoveController(&h.controller.EventController)
 	}
 	h.controller = nil

--- a/internal/ui/input/keyboard_test.go
+++ b/internal/ui/input/keyboard_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bnema/dumber/internal/domain/entity"
 	"github.com/bnema/puregotk/v4/gdk"
+	"github.com/bnema/puregotk/v4/gtk"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -229,6 +230,25 @@ func TestHandleKeyPress_NoRouteCallback_DefaultsToShortcuts(t *testing.T) {
 	// 'z' is not a registered shortcut in ModeNormal, so returns false
 	result := h.handleKeyPress(uint('z'), 0, 0)
 	assert.False(t, result, "unregistered key in ModeNormal returns false")
+}
+
+func TestKeyboardHandlerDetachForDestroyClearsRetainedCallbacksAndState(t *testing.T) {
+	h := NewKeyboardHandler(context.Background(), newTestWorkspace(), newTestSession())
+	h.keyPressedCb = func(gtk.EventControllerKey, uint, uint, gdk.ModifierType) bool { return true }
+	h.keyReleasedCb = func(gtk.EventControllerKey, uint, uint, gdk.ModifierType) {}
+	h.keyPressedHandlerID = 1
+	h.keyReleasedHandlerID = 2
+	h.activePressedActions = map[Action]uint{ActionReload: 1}
+
+	h.DetachForDestroy()
+
+	assert.Nil(t, h.controller)
+	assert.Nil(t, h.window)
+	assert.Nil(t, h.keyPressedCb)
+	assert.Nil(t, h.keyReleasedCb)
+	assert.Zero(t, h.keyPressedHandlerID)
+	assert.Zero(t, h.keyReleasedHandlerID)
+	assert.Nil(t, h.activePressedActions)
 }
 
 func TestHandleKeyPress_SuppressesHeldHardwareFallbackTabSwitchUntilRelease(t *testing.T) {

--- a/internal/ui/systemviews/components_templ.go
+++ b/internal/ui/systemviews/components_templ.go
@@ -38,11 +38,11 @@ func appFrameComponent(page renderedPage, theme shellTheme, body templ.Component
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var2).String())
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var2).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -51,11 +51,11 @@ func appFrameComponent(page renderedPage, theme shellTheme, body templ.Component
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(string(page.route))
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(string(page.route))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 4, Col: 67}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -64,11 +64,11 @@ func appFrameComponent(page renderedPage, theme shellTheme, body templ.Component
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(pageDocumentTitle(page))
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(pageDocumentTitle(page))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 4, Col: 111}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -188,11 +188,11 @@ func Section(className string, title string) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var10).String())
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var10).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -425,11 +425,11 @@ func Alert(kind string, message string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 string
-			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var22).String())
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var22).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -438,11 +438,11 @@ func Alert(kind string, message string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var24 string
-			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(alertRole(kind))
+			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(alertRole(kind))
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 56, Col: 56}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -573,11 +573,11 @@ func Button(label string, action string, classes string, attrs templ.Attributes,
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var30 string
-		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var29).String())
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var29).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -586,11 +586,11 @@ func Button(label string, action string, classes string, attrs templ.Attributes,
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var31 string
-		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(action)
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(action)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components.templ`, Line: 73, Col: 77}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/ui/systemviews/favorites_templ.go
+++ b/internal/ui/systemviews/favorites_templ.go
@@ -285,11 +285,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var7).String())
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var7).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -298,11 +298,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%t", favoriteAllFilterActive(data)))
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%t", favoriteAllFilterActive(data)))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 71, Col: 149}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -320,11 +320,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var10).String())
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var10).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -333,11 +333,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%t", favoriteFolderFilterActive(data, entity.FolderID(0))))
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%t", favoriteFolderFilterActive(data, entity.FolderID(0))))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 72, Col: 195}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -357,11 +357,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var13).String())
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var13).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -370,11 +370,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var15 string
-				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%t", favoriteFolderFilterActive(data, folder.ID)))
+				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%t", favoriteFolderFilterActive(data, folder.ID)))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 75, Col: 179}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -383,11 +383,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var16 string
-				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", folder.ID))
+				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", folder.ID))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 75, Col: 266}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -426,11 +426,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var19 string
-				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var18).String())
+				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var18).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -439,11 +439,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var20 string
-				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%t", favoriteTagFilterActive(data, tag.ID)))
+				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%t", favoriteTagFilterActive(data, tag.ID)))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 83, Col: 167}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -452,11 +452,11 @@ func FavoritesControls(data favoritesRenderData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", tag.ID))
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", tag.ID))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 83, Col: 245}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -533,11 +533,11 @@ func FavoriteCreateTagPicker(tags []*entity.Tag) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var25 string
-					templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", tag.ID))
+					templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", tag.ID))
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 101, Col: 75}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -608,11 +608,11 @@ func FavoriteItem(favorite *entity.Favorite, folders []*entity.Folder, tags []*e
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var29 string
-		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", favorite.ID))
+		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", favorite.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 113, Col: 106}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -704,11 +704,11 @@ func FavoriteItem(favorite *entity.Favorite, folders []*entity.Folder, tags []*e
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var35 string
-		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", favorite.ID))
+		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", favorite.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 124, Col: 175}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var35)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -766,11 +766,11 @@ func FavoriteEditForm(favorite *entity.Favorite, folders []*entity.Folder) templ
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var37 string
-		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", favorite.ID))
+		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", favorite.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 135, Col: 71}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var37)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -779,11 +779,11 @@ func FavoriteEditForm(favorite *entity.Favorite, folders []*entity.Folder) templ
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var38 string
-		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(favorite.Title)
+		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.ResolveAttributeValue(favorite.Title)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 136, Col: 81}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var38)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -792,11 +792,11 @@ func FavoriteEditForm(favorite *entity.Favorite, folders []*entity.Folder) templ
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var39 string
-		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(favorite.FaviconURL)
+		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(favorite.FaviconURL)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 137, Col: 93}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -866,11 +866,11 @@ func FavoriteTagControls(favorite *entity.Favorite, tags []*entity.Tag) templ.Co
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var42 string
-					templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var41).String())
+					templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var41).String())
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 1, Col: 0}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var42)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -879,11 +879,11 @@ func FavoriteTagControls(favorite *entity.Favorite, tags []*entity.Tag) templ.Co
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var43 string
-					templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(favoriteTagButtonAction(favorite, tag))
+					templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.ResolveAttributeValue(favoriteTagButtonAction(favorite, tag))
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 150, Col: 130}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var43)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -892,11 +892,11 @@ func FavoriteTagControls(favorite *entity.Favorite, tags []*entity.Tag) templ.Co
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var44 string
-					templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", favorite.ID))
+					templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", favorite.ID))
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 150, Col: 182}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var44)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -905,11 +905,11 @@ func FavoriteTagControls(favorite *entity.Favorite, tags []*entity.Tag) templ.Co
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var45 string
-					templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", tag.ID))
+					templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", tag.ID))
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 150, Col: 224}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var45)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -1017,11 +1017,11 @@ func FolderItem(folder *entity.Folder) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var50 string
-		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", folder.ID))
+		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", folder.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 170, Col: 70}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var50)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1030,11 +1030,11 @@ func FolderItem(folder *entity.Folder) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var51 string
-		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(folder.Name)
+		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.ResolveAttributeValue(folder.Name)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 171, Col: 77}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var51)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1043,11 +1043,11 @@ func FolderItem(folder *entity.Folder) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var52 string
-		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(folder.Icon)
+		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.ResolveAttributeValue(folder.Icon)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 172, Col: 77}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var52)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1064,11 +1064,11 @@ func FolderItem(folder *entity.Folder) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var53 string
-		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", folder.ID))
+		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", folder.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 174, Col: 169}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var53)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1151,11 +1151,11 @@ func TagItem(tag *entity.Tag) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var56 string
-		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", tag.ID))
+		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", tag.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 190, Col: 67}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var56)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1177,11 +1177,11 @@ func TagItem(tag *entity.Tag) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var58 string
-		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(tag.Name)
+		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.ResolveAttributeValue(tag.Name)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 192, Col: 74}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var58)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1190,11 +1190,11 @@ func TagItem(tag *entity.Tag) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var59 string
-		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(tag.Color)
+		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.ResolveAttributeValue(tag.Color)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 193, Col: 77}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var59)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1211,11 +1211,11 @@ func TagItem(tag *entity.Tag) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var60 string
-		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", tag.ID))
+		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", tag.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 195, Col: 163}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var60)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1274,11 +1274,11 @@ func FolderSelect(name string, folders []*entity.Folder, selected *entity.Folder
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var63 string
-		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.ResolveAttributeValue(name)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 201, Col: 49}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var63)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1293,11 +1293,11 @@ func FolderSelect(name string, folders []*entity.Folder, selected *entity.Folder
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var64 string
-				templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", folder.ID))
+				templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", folder.ID))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 205, Col: 48}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var64)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1369,11 +1369,11 @@ func ShortcutSelect(selected *int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var67 string
-			templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", i))
+			templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", i))
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `favorites.templ`, Line: 215, Col: 39}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var67)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/internal/ui/systemviews/history_templ.go
+++ b/internal/ui/systemviews/history_templ.go
@@ -138,11 +138,11 @@ func HistoryControls(data historyRenderData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(data.Query)
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.Query)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 27, Col: 96}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -245,11 +245,11 @@ func HistoryControls(data historyRenderData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(item.RangeID)
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.RangeID)
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 49, Col: 111}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -258,11 +258,11 @@ func HistoryControls(data historyRenderData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(item.Confirm)
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Confirm)
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 49, Col: 144}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -337,11 +337,11 @@ func HistoryDomains(data historyRenderData) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var14 string
-					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(domainKey)
+					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(domainKey)
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 68, Col: 115}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -376,11 +376,11 @@ func HistoryDomains(data historyRenderData) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var17 string
-					templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(domainKey)
+					templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(domainKey)
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 71, Col: 114}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -389,11 +389,11 @@ func HistoryDomains(data historyRenderData) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var18 string
-					templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs("Delete all history for " + displayDomain + "?")
+					templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue("Delete all history for " + displayDomain + "?")
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 71, Col: 182}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -402,11 +402,11 @@ func HistoryDomains(data historyRenderData) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var19 string
-					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs("Delete history for " + displayDomain)
+					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue("Delete history for " + displayDomain)
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 71, Col: 235}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -588,11 +588,11 @@ func HistoryTimelineAppendGroups(entries []*entity.HistoryEntry, mergeFirstDate 
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var25 string
-				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(group.Date)
+				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(group.Date)
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 111, Col: 47}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -649,11 +649,11 @@ func HistoryTimelineGroup(group historyTimelineGroup, showHeading bool) templ.Co
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(group.Date)
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(group.Date)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 125, Col: 69}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -731,11 +731,11 @@ func HistoryLoadMore(data historyRenderData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(historyLoadMoreCursor(data))
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(historyLoadMoreCursor(data))
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 142, Col: 138}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -783,11 +783,11 @@ func HistoryItem(entry *entity.HistoryEntry) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var32 string
-		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.ID))
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", entry.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 151, Col: 100}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -806,11 +806,11 @@ func HistoryItem(entry *entity.HistoryEntry) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var34 string
-		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var33).String())
+		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var33).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var34)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -837,11 +837,11 @@ func HistoryItem(entry *entity.HistoryEntry) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var36 string
-			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(templ.SafeURL(faviconURL))
+			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.SafeURL(faviconURL))
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 157, Col: 42}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var36)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -881,11 +881,11 @@ func HistoryItem(entry *entity.HistoryEntry) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var39 string
-		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(entry.URL)
+		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(entry.URL)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 162, Col: 48}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -941,11 +941,11 @@ func HistoryItem(entry *entity.HistoryEntry) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var43 string
-		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.ID))
+		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", entry.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `history.templ`, Line: 168, Col: 175}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var43)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/ui/systemviews/icons_templ.go
+++ b/internal/ui/systemviews/icons_templ.go
@@ -38,11 +38,11 @@ func Icon(name systemIcon) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var2).String())
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var2).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `icons.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "dumber",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary
- Harden filter downloads by validating manifest filenames, bounding manifest/filter payload sizes, and confining nested cache writes/lookups with `os.Root`.
- Make favicon cache shutdown no-op safe, clamp WebUI history query limits, and restrict the WebKit native bridge to trusted `dumb://` pages.
- Pin lint/staticcheck tooling, add generated-asset CI verification, update source-build docs, and remove the orphan root `package-lock.json`.

Closes #286.
Closes #287.
Closes #288.
Closes #289.
Closes #291.
Closes #292.
Closes #293.
Closes #294.
Closes #298.
Closes #299.

## Test Plan
- [x] `go test ./...`
- [x] `make verify-generated`
- [x] `git diff --check`

## Review
- [x] go-reviewer initial pass
- [x] go-reviewer re-review after symlink containment fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cache writes during shutdown; tightened shutdown safety.
  * Consistent pagination/limit clamping for search/history APIs.
  * Hardened downloads and manifest/filter validation with filesystem/path safety and byte limits.
  * Safer HTML attribute handling in systemviews templates; improved message/WebView sender validation.

* **Refactor**
  * Safer window/input teardown: new teardown-safe detach APIs and consolidated destroy helpers.

* **Chores**
  * Pinned dev tools and CI Go setup, added verify-generated and staticcheck targets; updated docs and build prerequisites (Go 1.26+, Brotli; removed Node requirement).

* **Tests**
  * Expanded tests for clamping, downloads/path-safety, cache shutdown, teardown behavior, debounce timing, and trusted-message checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->