### PR TITLE
fix(ui): release WebViews when closing tabs

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3222,6 +3222,9 @@ func (a *App) initTabCoordinator(ctx context.Context) {
 		}
 		a.switchWorkspaceView(ctx, tab.ID)
 	})
+	a.tabCoord.SetOnTabClosed(func(ctx context.Context, _ coordinator.TabTarget, tab *entity.Tab) {
+		a.releaseTabWorkspace(ctx, tab)
+	})
 	a.tabCoord.SetOnStateChanged(a.MarkDirty)
 	// Per-window tab ownership is now enforced through explicit TabTarget.
 	// The per-window TabList (bw.tabs) is the source of truth; no scope filtering needed.

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -296,6 +296,30 @@ func (a *App) registerBrowserWindow(bw *browserWindow) {
 	a.browserWindowOrder = append(a.browserWindowOrder, bw.id)
 }
 
+func (a *App) releaseTabWorkspace(ctx context.Context, tab *entity.Tab) {
+	if tab == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	a.releaseFloatingSessionsForTab(ctx, tab.ID)
+	if a.contentCoord != nil && tab.Workspace != nil {
+		for _, pane := range tab.Workspace.AllPanes() {
+			if pane == nil {
+				continue
+			}
+			a.contentCoord.ReleaseWebView(ctx, pane.ID)
+		}
+	}
+	delete(a.workspaceViews, tab.ID)
+	delete(a.windowForTab, tab.ID)
+	if a.tabs != nil && a.tabs.Find(tab.ID) != nil {
+		a.tabs.Remove(tab.ID)
+	}
+}
+
 func (a *App) removeBrowserWindow(id string) {
 	if id == "" || a.browserWindows == nil {
 		return
@@ -310,18 +334,42 @@ func (a *App) removeBrowserWindow(id string) {
 		}
 	}
 	wasMainWindow := removed != nil && removed.mainWindow == a.mainWindow
-	ownedTabIDs := make([]entity.TabID, 0)
-	for tabID, bw := range a.windowForTab {
-		if bw != nil && bw.id == id {
-			ownedTabIDs = append(ownedTabIDs, tabID)
+	ownedTabs := make(map[entity.TabID]*entity.Tab)
+	if removed != nil && removed.tabs != nil {
+		for _, tab := range removed.tabs.Tabs {
+			if tab != nil {
+				ownedTabs[tab.ID] = tab
+			}
 		}
 	}
+	for tabID, bw := range a.windowForTab {
+		if bw != nil && bw.id == id {
+			if bw.tabs != nil {
+				if tab := bw.tabs.Find(tabID); tab != nil {
+					ownedTabs[tabID] = tab
+					continue
+				}
+			}
+			if a.tabs != nil {
+				ownedTabs[tabID] = a.tabs.Find(tabID)
+			}
+		}
+	}
+	ownedTabIDs := make([]entity.TabID, 0, len(ownedTabs))
+	for tabID := range ownedTabs {
+		ownedTabIDs = append(ownedTabIDs, tabID)
+	}
+	sort.Slice(ownedTabIDs, func(i, j int) bool { return ownedTabIDs[i] < ownedTabIDs[j] })
 	for _, tabID := range ownedTabIDs {
-		a.releaseFloatingSessionsForTab(context.Background(), tabID)
-		delete(a.workspaceViews, tabID)
-		delete(a.windowForTab, tabID)
-		if a.tabs != nil && a.tabs.Find(tabID) != nil {
-			a.tabs.Remove(tabID)
+		a.releaseTabWorkspace(context.Background(), ownedTabs[tabID])
+	}
+	for tabID, bw := range a.windowForTab {
+		if bw != nil && bw.id == id {
+			delete(a.workspaceViews, tabID)
+			delete(a.windowForTab, tabID)
+			if a.tabs != nil && a.tabs.Find(tabID) != nil {
+				a.tabs.Remove(tabID)
+			}
 		}
 	}
 	if removed != nil {

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -325,53 +325,10 @@ func (a *App) removeBrowserWindow(id string) {
 		return
 	}
 	removed := a.browserWindows[id]
-
-	// Remove from registration order
-	for i, wid := range a.browserWindowOrder {
-		if wid == id {
-			a.browserWindowOrder = append(a.browserWindowOrder[:i], a.browserWindowOrder[i+1:]...)
-			break
-		}
-	}
 	wasMainWindow := removed != nil && removed.mainWindow == a.mainWindow
-	ownedTabs := make(map[entity.TabID]*entity.Tab)
-	if removed != nil && removed.tabs != nil {
-		for _, tab := range removed.tabs.Tabs {
-			if tab != nil {
-				ownedTabs[tab.ID] = tab
-			}
-		}
-	}
-	for tabID, bw := range a.windowForTab {
-		if bw != nil && bw.id == id {
-			if bw.tabs != nil {
-				if tab := bw.tabs.Find(tabID); tab != nil {
-					ownedTabs[tabID] = tab
-					continue
-				}
-			}
-			if a.tabs != nil {
-				ownedTabs[tabID] = a.tabs.Find(tabID)
-			}
-		}
-	}
-	ownedTabIDs := make([]entity.TabID, 0, len(ownedTabs))
-	for tabID := range ownedTabs {
-		ownedTabIDs = append(ownedTabIDs, tabID)
-	}
-	sort.Slice(ownedTabIDs, func(i, j int) bool { return ownedTabIDs[i] < ownedTabIDs[j] })
-	for _, tabID := range ownedTabIDs {
-		a.releaseTabWorkspace(context.Background(), ownedTabs[tabID])
-	}
-	for tabID, bw := range a.windowForTab {
-		if bw != nil && bw.id == id {
-			delete(a.workspaceViews, tabID)
-			delete(a.windowForTab, tabID)
-			if a.tabs != nil && a.tabs.Find(tabID) != nil {
-				a.tabs.Remove(tabID)
-			}
-		}
-	}
+
+	a.removeBrowserWindowOrder(id)
+	a.releaseBrowserWindowTabs(context.Background(), id, removed)
 	if removed != nil {
 		removed.teardownForDestroy()
 	}
@@ -379,27 +336,107 @@ func (a *App) removeBrowserWindow(id string) {
 		a.contentCoord.ClearPopupNamedContextsForWindow(id)
 	}
 	delete(a.browserWindows, id)
+
 	fallback := a.deterministicBrowserWindowFallback()
-	if a.lastFocusedWindowID == id {
-		if fallback != nil {
-			a.lastFocusedWindowID = fallback.id
-		} else {
-			a.lastFocusedWindowID = ""
-		}
-	}
+	a.updateLastFocusedWindowAfterRemoval(id, fallback)
 	if wasMainWindow {
-		a.clearResizeModeBorder()
-		if fallback != nil {
-			a.activateBrowserWindow(fallback)
+		a.clearMainBrowserWindowAfterRemoval(fallback)
+	}
+}
+
+func (a *App) removeBrowserWindowOrder(id string) {
+	for i, wid := range a.browserWindowOrder {
+		if wid == id {
+			a.browserWindowOrder = append(a.browserWindowOrder[:i], a.browserWindowOrder[i+1:]...)
 			return
 		}
-		a.lastFocusedWindowID = ""
-		a.mainWindow = nil
-		a.keyboardHandler = nil
-		a.globalShortcutHandler = nil
-		if a.tabCoord != nil {
-			a.tabCoord.SetCurrentTarget(coordinator.TabTarget{})
+	}
+}
+
+func (a *App) releaseBrowserWindowTabs(ctx context.Context, windowID string, bw *browserWindow) {
+	ownedTabs := a.collectBrowserWindowTabs(windowID, bw)
+	for _, tabID := range sortedTabIDs(ownedTabs) {
+		a.releaseTabWorkspace(ctx, ownedTabs[tabID])
+	}
+	a.cleanupStaleTabMappingsForWindow(windowID)
+}
+
+func (a *App) collectBrowserWindowTabs(windowID string, bw *browserWindow) map[entity.TabID]*entity.Tab {
+	ownedTabs := make(map[entity.TabID]*entity.Tab)
+	if bw != nil && bw.tabs != nil {
+		for _, tab := range bw.tabs.Tabs {
+			if tab != nil {
+				ownedTabs[tab.ID] = tab
+			}
 		}
+	}
+	for tabID, owner := range a.windowForTab {
+		if owner == nil || owner.id != windowID {
+			continue
+		}
+		if tab := tabFromBrowserWindow(owner, tabID); tab != nil {
+			ownedTabs[tabID] = tab
+			continue
+		}
+		if a.tabs != nil {
+			ownedTabs[tabID] = a.tabs.Find(tabID)
+		}
+	}
+	return ownedTabs
+}
+
+func tabFromBrowserWindow(bw *browserWindow, tabID entity.TabID) *entity.Tab {
+	if bw == nil || bw.tabs == nil {
+		return nil
+	}
+	return bw.tabs.Find(tabID)
+}
+
+func sortedTabIDs(tabs map[entity.TabID]*entity.Tab) []entity.TabID {
+	ids := make([]entity.TabID, 0, len(tabs))
+	for tabID := range tabs {
+		ids = append(ids, tabID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func (a *App) cleanupStaleTabMappingsForWindow(windowID string) {
+	for tabID, bw := range a.windowForTab {
+		if bw == nil || bw.id != windowID {
+			continue
+		}
+		delete(a.workspaceViews, tabID)
+		delete(a.windowForTab, tabID)
+		if a.tabs != nil && a.tabs.Find(tabID) != nil {
+			a.tabs.Remove(tabID)
+		}
+	}
+}
+
+func (a *App) updateLastFocusedWindowAfterRemoval(removedID string, fallback *browserWindow) {
+	if a.lastFocusedWindowID != removedID {
+		return
+	}
+	if fallback != nil {
+		a.lastFocusedWindowID = fallback.id
+		return
+	}
+	a.lastFocusedWindowID = ""
+}
+
+func (a *App) clearMainBrowserWindowAfterRemoval(fallback *browserWindow) {
+	a.clearResizeModeBorder()
+	if fallback != nil {
+		a.activateBrowserWindow(fallback)
+		return
+	}
+	a.lastFocusedWindowID = ""
+	a.mainWindow = nil
+	a.keyboardHandler = nil
+	a.globalShortcutHandler = nil
+	if a.tabCoord != nil {
+		a.tabCoord.SetCurrentTarget(coordinator.TabTarget{})
 	}
 }
 

--- a/internal/ui/browser_window_test.go
+++ b/internal/ui/browser_window_test.go
@@ -8,9 +8,12 @@ import (
 	"unsafe"
 
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/config"
 	"github.com/bnema/dumber/internal/shared/syncdispatch"
 	"github.com/bnema/dumber/internal/ui/component"
+	contentcoord "github.com/bnema/dumber/internal/ui/coordinator/content"
 	"github.com/bnema/dumber/internal/ui/focus"
 	"github.com/bnema/dumber/internal/ui/input"
 	"github.com/bnema/dumber/internal/ui/layout"
@@ -101,6 +104,171 @@ func TestApp_CleanupCreatedBrowserWindowsDetachesUnregisteredWindowBeforeDestroy
 	if got := app.browserWindows[fallback.id]; got != fallback {
 		t.Fatalf("fallback browser window changed during transient cleanup: got %p want %p", got, fallback)
 	}
+}
+
+type recordingWebViewPool struct {
+	released []port.WebView
+}
+
+func (p *recordingWebViewPool) Acquire(context.Context) (port.WebView, error) {
+	return nil, errors.New("not implemented")
+}
+func (p *recordingWebViewPool) Release(wv port.WebView)           { p.released = append(p.released, wv) }
+func (p *recordingWebViewPool) Prewarm(int)                       {}
+func (p *recordingWebViewPool) PrewarmAsync(context.Context, int) {}
+func (p *recordingWebViewPool) Size() int                         { return 0 }
+func (p *recordingWebViewPool) Close()                            {}
+
+func TestTabCoordinator_CloseReleasesClosedTabWorkspaceWebViews(t *testing.T) {
+	ctx := context.Background()
+	closedTab := entity.NewTab(entity.TabID("tab-x"), entity.WorkspaceID("workspace-x"), entity.NewPane(entity.PaneID("pane-x")))
+	survivingTab := entity.NewTab(entity.TabID("tab-survivor"), entity.WorkspaceID("workspace-survivor"), entity.NewPane(entity.PaneID("pane-survivor")))
+	tabs := entity.NewTabList()
+	tabs.Add(closedTab)
+	tabs.Add(survivingTab)
+	tabs.SetActive(closedTab.ID)
+
+	pool := &recordingWebViewPool{}
+	contentCoord := contentcoord.NewCoordinator(ctx, pool, nil, nil, nil, nil, nil, nil)
+	closedWV := &fakeRecordingWebView{id: 101}
+	survivingWV := &fakeRecordingWebView{id: 102}
+	contentCoord.RegisterPopupWebView(closedTab.Workspace.ActivePaneID, closedWV)
+	contentCoord.RegisterPopupWebView(survivingTab.Workspace.ActivePaneID, survivingWV)
+
+	bw := &browserWindow{id: "window-1", tabs: tabs}
+	app := &App{
+		deps:             &Dependencies{Config: config.DefaultConfig()},
+		tabsUC:           usecase.NewManageTabsUseCase(counterIDGen()),
+		contentCoord:     contentCoord,
+		browserWindows:   map[string]*browserWindow{bw.id: bw},
+		tabs:             entity.NewTabList(),
+		workspaceViews:   map[entity.TabID]*component.WorkspaceView{closedTab.ID: {}, survivingTab.ID: {}},
+		windowForTab:     map[entity.TabID]*browserWindow{closedTab.ID: bw, survivingTab.ID: bw},
+		floatingSessions: map[floatingSessionKey]*floatingWorkspaceSession{},
+	}
+	app.tabs.Add(closedTab)
+	app.tabs.Add(survivingTab)
+	app.initTabCoordinator(ctx)
+
+	require.NoError(t, app.tabCoord.Close(ctx, app.ensureTabTargetForBrowserWindow(bw)))
+
+	require.Len(t, pool.released, 1)
+	assert.Same(t, closedWV, pool.released[0])
+	assert.Nil(t, contentCoord.GetWebView(closedTab.Workspace.ActivePaneID))
+	assert.Same(t, survivingWV, contentCoord.GetWebView(survivingTab.Workspace.ActivePaneID))
+	assert.Nil(t, app.workspaceViews[closedTab.ID])
+	assert.Nil(t, app.windowForTab[closedTab.ID])
+	assert.Nil(t, app.tabs.Find(closedTab.ID))
+	assert.Equal(t, survivingTab.ID, tabs.ActiveTabID)
+}
+
+func TestTabCoordinator_SwitchDoesNotReleaseWorkspaceWebViews(t *testing.T) {
+	ctx := context.Background()
+	firstTab := entity.NewTab(entity.TabID("tab-first"), entity.WorkspaceID("workspace-first"), entity.NewPane(entity.PaneID("pane-first")))
+	secondTab := entity.NewTab(entity.TabID("tab-second"), entity.WorkspaceID("workspace-second"), entity.NewPane(entity.PaneID("pane-second")))
+	tabs := entity.NewTabList()
+	tabs.Add(firstTab)
+	tabs.Add(secondTab)
+	tabs.SetActive(firstTab.ID)
+
+	pool := &recordingWebViewPool{}
+	contentCoord := contentcoord.NewCoordinator(ctx, pool, nil, nil, nil, nil, nil, nil)
+	firstWV := &fakeRecordingWebView{id: 111}
+	secondWV := &fakeRecordingWebView{id: 112}
+	contentCoord.RegisterPopupWebView(firstTab.Workspace.ActivePaneID, firstWV)
+	contentCoord.RegisterPopupWebView(secondTab.Workspace.ActivePaneID, secondWV)
+
+	bw := &browserWindow{id: "window-1", tabs: tabs}
+	app := &App{
+		deps:             &Dependencies{Config: config.DefaultConfig()},
+		tabsUC:           usecase.NewManageTabsUseCase(counterIDGen()),
+		contentCoord:     contentCoord,
+		browserWindows:   map[string]*browserWindow{bw.id: bw},
+		tabs:             entity.NewTabList(),
+		workspaceViews:   map[entity.TabID]*component.WorkspaceView{firstTab.ID: {}, secondTab.ID: {}},
+		windowForTab:     map[entity.TabID]*browserWindow{firstTab.ID: bw, secondTab.ID: bw},
+		floatingSessions: map[floatingSessionKey]*floatingWorkspaceSession{},
+	}
+	app.tabs.Add(firstTab)
+	app.tabs.Add(secondTab)
+	app.initTabCoordinator(ctx)
+
+	require.NoError(t, app.tabCoord.Switch(ctx, app.ensureTabTargetForBrowserWindow(bw), secondTab.ID))
+
+	assert.Empty(t, pool.released)
+	assert.Same(t, firstWV, contentCoord.GetWebView(firstTab.Workspace.ActivePaneID))
+	assert.Same(t, secondWV, contentCoord.GetWebView(secondTab.Workspace.ActivePaneID))
+}
+
+func TestTabCoordinator_CloseLastTabReleasesWorkspaceBeforeWindowRemoval(t *testing.T) {
+	ctx := context.Background()
+	closedTab := entity.NewTab(entity.TabID("tab-only"), entity.WorkspaceID("workspace-only"), entity.NewPane(entity.PaneID("pane-only")))
+	tabs := entity.NewTabList()
+	tabs.Add(closedTab)
+	tabs.SetActive(closedTab.ID)
+
+	pool := &recordingWebViewPool{}
+	contentCoord := contentcoord.NewCoordinator(ctx, pool, nil, nil, nil, nil, nil, nil)
+	closedWV := &fakeRecordingWebView{id: 121}
+	contentCoord.RegisterPopupWebView(closedTab.Workspace.ActivePaneID, closedWV)
+
+	bw := &browserWindow{id: "window-1", tabs: tabs}
+	app := &App{
+		deps:             &Dependencies{Config: config.DefaultConfig()},
+		tabsUC:           usecase.NewManageTabsUseCase(counterIDGen()),
+		contentCoord:     contentCoord,
+		browserWindows:   map[string]*browserWindow{bw.id: bw},
+		tabs:             entity.NewTabList(),
+		workspaceViews:   map[entity.TabID]*component.WorkspaceView{closedTab.ID: {}},
+		windowForTab:     map[entity.TabID]*browserWindow{closedTab.ID: bw},
+		floatingSessions: map[floatingSessionKey]*floatingWorkspaceSession{},
+	}
+	app.tabs.Add(closedTab)
+	app.initTabCoordinator(ctx)
+
+	require.NoError(t, app.tabCoord.Close(ctx, app.ensureTabTargetForBrowserWindow(bw)))
+
+	require.Len(t, pool.released, 1)
+	assert.Same(t, closedWV, pool.released[0])
+	assert.Nil(t, contentCoord.GetWebView(closedTab.Workspace.ActivePaneID))
+	assert.Empty(t, app.browserWindows)
+	assert.Nil(t, app.workspaceViews[closedTab.ID])
+	assert.Nil(t, app.windowForTab[closedTab.ID])
+}
+
+func TestBrowserWindow_RemoveBrowserWindowReleasesOwnedTabWorkspaceWebViews(t *testing.T) {
+	ctx := context.Background()
+	ownedTab := entity.NewTab(entity.TabID("tab-owned"), entity.WorkspaceID("workspace-owned"), entity.NewPane(entity.PaneID("pane-owned")))
+	otherTab := entity.NewTab(entity.TabID("tab-other"), entity.WorkspaceID("workspace-other"), entity.NewPane(entity.PaneID("pane-other")))
+	removed := &browserWindow{id: "window-1", tabs: entity.NewTabList()}
+	remaining := &browserWindow{id: "window-2", tabs: entity.NewTabList()}
+	removed.tabs.Add(ownedTab)
+	remaining.tabs.Add(otherTab)
+
+	pool := &recordingWebViewPool{}
+	contentCoord := contentcoord.NewCoordinator(ctx, pool, nil, nil, nil, nil, nil, nil)
+	ownedWV := &fakeRecordingWebView{id: 201}
+	otherWV := &fakeRecordingWebView{id: 202}
+	contentCoord.RegisterPopupWebView(ownedTab.Workspace.ActivePaneID, ownedWV)
+	contentCoord.RegisterPopupWebView(otherTab.Workspace.ActivePaneID, otherWV)
+
+	app := &App{
+		contentCoord:     contentCoord,
+		browserWindows:   map[string]*browserWindow{removed.id: removed, remaining.id: remaining},
+		tabs:             entity.NewTabList(),
+		workspaceViews:   map[entity.TabID]*component.WorkspaceView{ownedTab.ID: {}, otherTab.ID: {}},
+		windowForTab:     map[entity.TabID]*browserWindow{ownedTab.ID: removed, otherTab.ID: remaining},
+		floatingSessions: map[floatingSessionKey]*floatingWorkspaceSession{},
+	}
+	app.tabs.Add(ownedTab)
+	app.tabs.Add(otherTab)
+
+	app.removeBrowserWindow(removed.id)
+
+	require.Len(t, pool.released, 1)
+	assert.Same(t, ownedWV, pool.released[0])
+	assert.Nil(t, contentCoord.GetWebView(ownedTab.Workspace.ActivePaneID))
+	assert.Same(t, otherWV, contentCoord.GetWebView(otherTab.Workspace.ActivePaneID))
 }
 
 func TestBrowserWindow_RemoveBrowserWindowCleansOwnedTabState(t *testing.T) {

--- a/internal/ui/coordinator/tab.go
+++ b/internal/ui/coordinator/tab.go
@@ -32,6 +32,7 @@ type TabCoordinator struct {
 	// Callbacks to avoid circular dependencies
 	onTabCreated         func(ctx context.Context, target TabTarget, tab *entity.Tab)
 	onTabSwitched        func(ctx context.Context, target TabTarget, tab *entity.Tab)
+	onTabClosed          func(ctx context.Context, target TabTarget, tab *entity.Tab)
 	onQuit               func()
 	onCurrentWindowEmpty func(ctx context.Context, target TabTarget)
 	onAttachPopupToTab   func(ctx context.Context, tabID entity.TabID, pane *entity.Pane, wv port.WebView) // For popup tabs
@@ -85,6 +86,11 @@ func (c *TabCoordinator) SetOnTabCreated(fn func(ctx context.Context, target Tab
 // This is used to swap workspace views in the content area.
 func (c *TabCoordinator) SetOnTabSwitched(fn func(ctx context.Context, target TabTarget, tab *entity.Tab)) {
 	c.onTabSwitched = fn
+}
+
+// SetOnTabClosed sets the callback for when a tab is removed from its target.
+func (c *TabCoordinator) SetOnTabClosed(fn func(ctx context.Context, target TabTarget, tab *entity.Tab)) {
+	c.onTabClosed = fn
 }
 
 // SetOnQuit sets the callback for when the last tab is closed.
@@ -236,10 +242,15 @@ func (c *TabCoordinator) Close(ctx context.Context, target TabTarget) error {
 		}
 	}
 
+	closedTab := target.Tabs.Find(activeID)
 	wasLast, err := c.tabsUC.Close(ctx, target.Tabs, activeID)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to close tab")
 		return err
+	}
+
+	if c.onTabClosed != nil && closedTab != nil {
+		c.onTabClosed(ctx, target, closedTab)
 	}
 
 	if target.MainWindow != nil && target.MainWindow.TabBar() != nil {


### PR DESCRIPTION
## Summary
- Release every pane WebView when its owning tab is closed or its browser window is removed.
- Route tab close cleanup through the content lifecycle so the WebView pool decides reuse vs destroy.
- Add regressions for normal tab close, tab switch, last-tab close, and whole-window removal.

## Test Plan
- [x] `go test -mod=mod ./...`

## Notes
- Generated local `assets/systemviews/*.wasm*` artifacts were needed for asset tests but are ignored and not included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab and browser window closure to properly release workspace resources, preventing potential resource leaks when tabs are closed or windows are removed.

* **Tests**
  * Added comprehensive test coverage for tab closure and workspace cleanup behavior during tab switching and window removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->