### PR TITLE
fix(config): make migration idempotent

### DIFF
--- a/internal/infrastructure/config/migrate.go
+++ b/internal/infrastructure/config/migrate.go
@@ -195,7 +195,7 @@ func (m *Migrator) DetectChanges() ([]port.KeyChange, error) {
 func (m *Migrator) findDeprecatedKeys(userKeys map[string]any, defaultKeys map[string]bool) []string {
 	var deprecated []string
 	for userKey := range userKeys {
-		if userKey == databasePathKey {
+		if m.isMigrationIgnoredDeprecatedKey(userKey) {
 			continue
 		}
 		if !m.keyOrRelatedExistsInDefaults(userKey, defaultKeys) {
@@ -813,9 +813,12 @@ func (m *Migrator) flattenMap(data map[string]any, prefix string, keys map[strin
 // isUserDataSection checks if a key path represents user-defined data
 // that should not be compared key-by-key (e.g., search shortcuts, action bindings).
 func (*Migrator) isUserDataSection(keyPath string) bool {
-	// User data sections - treat entire section as one key
+	// User data sections - treat entire section as one key.
+	// Some of these sections legitimately default to an empty map/table; keeping
+	// them as leaf keys makes detection agree with TOML writing.
 	switch keyPath {
-	case "search_shortcuts":
+	case "search_shortcuts",
+		"workspace.floating_pane.profiles":
 		return true
 	}
 
@@ -915,6 +918,20 @@ func appendUniqueKeys(base, extra []string) []string {
 
 	sort.Strings(base)
 	return base
+}
+
+func (*Migrator) isMigrationIgnoredDeprecatedKey(key string) bool {
+	switch key {
+	case databasePathKey:
+		return true
+	case "appearance.external_theme.path":
+		// Runtime may derive this path when it is omitted, so it is not a Viper
+		// default. It remains a valid explicit config key and should not be
+		// removed as deprecated.
+		return true
+	default:
+		return false
+	}
 }
 
 func excludeKeys(keys []string, excluded map[string]bool) []string {

--- a/internal/infrastructure/config/migrate.go
+++ b/internal/infrastructure/config/migrate.go
@@ -670,8 +670,7 @@ func (m *Migrator) getAllDefaultKeys() []string {
 	// Filter out keys that should not be migrated
 	filtered := make([]string, 0, len(keys))
 	for _, key := range keys {
-		// Skip database.path as it's set dynamically
-		if key == databasePathKey {
+		if m.isMigrationIgnoredDeprecatedKey(key) {
 			continue
 		}
 		filtered = append(filtered, key)

--- a/internal/infrastructure/config/migrate_test.go
+++ b/internal/infrastructure/config/migrate_test.go
@@ -974,6 +974,54 @@ func TestMigrator_DeleteNestedKey(t *testing.T) {
 	})
 }
 
+func TestMigrator_Migrate_IsIdempotentForExternalThemePathAndEmptyProfiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	configFile, err := GetConfigFile()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configFile), 0o755))
+
+	content, err := encodeConfigToTOML(DefaultConfig())
+	require.NoError(t, err)
+	require.Contains(t, content, "path = '")
+	require.Contains(t, content, "[workspace.floating_pane.profiles]")
+	content = strings.Replace(content, "\n    [workspace.floating_pane.profiles]\n", "", 1)
+	require.NoError(t, os.WriteFile(configFile, []byte(content), 0o644))
+
+	m := NewMigrator()
+	firstChanges, err := m.DetectChanges()
+	require.NoError(t, err)
+	assertContainsChange(t, firstChanges, port.KeyChangeAdded, "", "workspace.floating_pane.profiles")
+
+	appliedKeys, err := m.Migrate()
+	require.NoError(t, err)
+	require.NotEmpty(t, appliedKeys, "first migration should apply the missing profiles default")
+
+	secondChanges, err := m.DetectChanges()
+	require.NoError(t, err)
+	assert.Empty(t, secondChanges, "second migration detection should report no changes after a successful migration")
+
+	secondAppliedKeys, err := m.Migrate()
+	require.NoError(t, err)
+	assert.Empty(t, secondAppliedKeys, "second migration should be a no-op")
+}
+
+func assertContainsChange(t *testing.T, changes []port.KeyChange, changeType port.KeyChangeType, oldKey, newKey string) {
+	t.Helper()
+
+	for _, change := range changes {
+		if change.Type == changeType && change.OldKey == oldKey && change.NewKey == newKey {
+			return
+		}
+	}
+	assert.Failf(t, "missing expected change", "type=%v old=%q new=%q changes=%v", changeType, oldKey, newKey, changes)
+}
+
 // --- Migrate-path popup → browsing_contexts transform tests ---
 
 func TestMigrator_GetUserConfigKeysWithValues_TransformsLegacyPopups(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat empty `workspace.floating_pane.profiles` tables as present during migration detection.
- Keep valid explicit `appearance.external_theme.path` from being reported as deprecated.
- Add regression coverage proving first migration applies changes and second migration is a no-op.

## Test Plan
- [x] `go test ./internal/infrastructure/config -run TestMigrator_Migrate_IsIdempotentForExternalThemePathAndEmptyProfiles -count=1`
- [x] `go test ./internal/infrastructure/config`
- [x] `go test ./internal/infrastructure/config ./internal/application/usecase`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration migration behavior for deprecated keys, including better handling of external theme paths.
  * Prevented unnecessary key-by-key migration issues when `workspace.floating_pane.profiles` is empty or absent.

* **Tests**
  * Added an idempotency test to ensure configuration migration makes no further changes on repeated runs when using an external theme path and an empty profiles section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->