### PR TITLE
fix(panes): stabilize pane eject with stacked layouts

### DIFF
--- a/internal/application/usecase/extract_pane_to_tab_list_test.go
+++ b/internal/application/usecase/extract_pane_to_tab_list_test.go
@@ -45,6 +45,39 @@ func TestExtractPaneToTabList_FromThreePaneStack(t *testing.T) {
 	require.Nil(t, out.MovedPaneNode.Parent)
 }
 
+func TestExtractPaneToTabList_FromThreePaneStackUsesWorkspaceActivePaneWhenStackIndexIsStale(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	paneC := entity.NewPane(entity.PaneID("pC"))
+	sourceTab := newStackedTab("tA", "wA", paneA, paneB, paneC)
+	// ActivePaneID is the workspace source of truth, but stacked UI state can lag.
+	// Eject should remove pB deterministically and activate the pane that takes its slot.
+	sourceTab.Workspace.ActivePaneID = paneB.ID
+	sourceTab.Workspace.Root.ActiveStackIndex = 0
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneB.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.False(t, out.SourceTabClosed)
+
+	require.True(t, sourceTab.Workspace.Root.IsStacked)
+	require.Len(t, sourceTab.Workspace.Root.Children, 2)
+	require.Equal(t, paneA.ID, sourceTab.Workspace.Root.Children[0].Pane.ID)
+	require.Equal(t, paneC.ID, sourceTab.Workspace.Root.Children[1].Pane.ID)
+	require.Equal(t, 1, sourceTab.Workspace.Root.ActiveStackIndex)
+	require.Equal(t, paneC.ID, sourceTab.Workspace.ActivePaneID)
+	require.Same(t, paneB, out.NewTab.Workspace.Root.Pane)
+}
+
 func TestExtractPaneToTabList_FromTwoPaneStackDissolvesSource(t *testing.T) {
 	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
 	sourceTabs := entity.NewTabList()

--- a/internal/application/usecase/extract_pane_to_tab_list_test.go
+++ b/internal/application/usecase/extract_pane_to_tab_list_test.go
@@ -15,7 +15,7 @@ func TestExtractPaneToTabList_FromThreePaneStack(t *testing.T) {
 	paneA := entity.NewPane(entity.PaneID("pA"))
 	paneB := entity.NewPane(entity.PaneID("pB"))
 	paneC := entity.NewPane(entity.PaneID("pC"))
-	sourceTab := newStackedTab("tA", "wA", paneA, paneB, paneC)
+	sourceTab := newStackedTab(paneA, paneB, paneC)
 	sourceTab.Workspace.ActivePaneID = paneB.ID
 	sourceTabs.Add(sourceTab)
 
@@ -53,7 +53,7 @@ func TestExtractPaneToTabList_FromThreePaneStackUsesWorkspaceActivePaneWhenStack
 	paneA := entity.NewPane(entity.PaneID("pA"))
 	paneB := entity.NewPane(entity.PaneID("pB"))
 	paneC := entity.NewPane(entity.PaneID("pC"))
-	sourceTab := newStackedTab("tA", "wA", paneA, paneB, paneC)
+	sourceTab := newStackedTab(paneA, paneB, paneC)
 	// ActivePaneID is the workspace source of truth, but stacked UI state can lag.
 	// Eject should remove pB deterministically and activate the pane that takes its slot.
 	sourceTab.Workspace.ActivePaneID = paneB.ID
@@ -85,7 +85,7 @@ func TestExtractPaneToTabList_FromTwoPaneStackDissolvesSource(t *testing.T) {
 
 	paneA := entity.NewPane(entity.PaneID("pA"))
 	paneB := entity.NewPane(entity.PaneID("pB"))
-	sourceTab := newStackedTab("tA", "wA", paneA, paneB)
+	sourceTab := newStackedTab(paneA, paneB)
 	sourceTab.Workspace.ActivePaneID = paneB.ID
 	sourceTabs.Add(sourceTab)
 
@@ -333,7 +333,7 @@ func TestExtractPaneToTabList_ParentPointerTreeIntegrity(t *testing.T) {
 	paneA := entity.NewPane(entity.PaneID("pA"))
 	paneB := entity.NewPane(entity.PaneID("pB"))
 	paneC := entity.NewPane(entity.PaneID("pC"))
-	sourceTab := newStackedTab("tA", "wA", paneA, paneB, paneC)
+	sourceTab := newStackedTab(paneA, paneB, paneC)
 	sourceTabs.Add(sourceTab)
 
 	out, err := uc.Execute(ExtractPaneToTabListInput{
@@ -349,8 +349,8 @@ func TestExtractPaneToTabList_ParentPointerTreeIntegrity(t *testing.T) {
 	require.Nil(t, out.MovedPaneNode.Parent)
 }
 
-func newStackedTab(tabID entity.TabID, workspaceID entity.WorkspaceID, panes ...*entity.Pane) *entity.Tab {
-	tab := entity.NewTab(tabID, workspaceID, panes[0])
+func newStackedTab(panes ...*entity.Pane) *entity.Tab {
+	tab := entity.NewTab("tA", "wA", panes[0])
 	stack := &entity.PaneNode{ID: "stack", IsStacked: true, ActiveStackIndex: 0}
 	for _, pane := range panes {
 		child := &entity.PaneNode{ID: string(pane.ID), Pane: pane, Parent: stack}

--- a/internal/application/usecase/extract_pane_to_tab_list_test.go
+++ b/internal/application/usecase/extract_pane_to_tab_list_test.go
@@ -130,6 +130,121 @@ func TestExtractPaneToTabList_LastPaneClosesSourceTab(t *testing.T) {
 	require.Same(t, pane, out.NewTab.Workspace.Root.Pane)
 }
 
+func TestExtractPaneToTabList_FromStackPreservesActivePaneOutsideStack(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	paneC := entity.NewPane(entity.PaneID("pC"))
+	paneD := entity.NewPane(entity.PaneID("pD"))
+	stack := &entity.PaneNode{ID: "stack", IsStacked: true, ActiveStackIndex: 2}
+	stack.Children = []*entity.PaneNode{
+		{ID: string(paneA.ID), Pane: paneA, Parent: stack},
+		{ID: string(paneB.ID), Pane: paneB, Parent: stack},
+		{ID: string(paneC.ID), Pane: paneC, Parent: stack},
+	}
+	root := &entity.PaneNode{ID: "root", SplitDir: entity.SplitHorizontal, SplitRatio: 0.5}
+	paneDNode := &entity.PaneNode{ID: string(paneD.ID), Pane: paneD, Parent: root}
+	stack.Parent = root
+	root.Children = []*entity.PaneNode{stack, paneDNode}
+	sourceTab := &entity.Tab{ID: "tA", Workspace: &entity.Workspace{ID: "wA", Root: root, ActivePaneID: paneD.ID}}
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneB.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.False(t, out.SourceTabClosed)
+
+	require.Equal(t, paneD.ID, sourceTab.Workspace.ActivePaneID)
+	require.True(t, stack.IsStacked)
+	require.Len(t, stack.Children, 2)
+	require.Equal(t, 1, stack.ActiveStackIndex)
+	require.Same(t, paneB, out.NewTab.Workspace.Root.Pane)
+	assertParentPointers(t, sourceTab.Workspace.Root, nil)
+	assertParentPointers(t, out.NewTab.Workspace.Root, nil)
+}
+
+func TestExtractPaneToTabList_FromTwoPaneStackDissolvePreservesActivePaneOutsideStack(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	paneC := entity.NewPane(entity.PaneID("pC"))
+	stack := &entity.PaneNode{ID: "stack", IsStacked: true, ActiveStackIndex: 1}
+	stack.Children = []*entity.PaneNode{
+		{ID: string(paneA.ID), Pane: paneA, Parent: stack},
+		{ID: string(paneB.ID), Pane: paneB, Parent: stack},
+	}
+	root := &entity.PaneNode{ID: "root", SplitDir: entity.SplitHorizontal, SplitRatio: 0.5}
+	paneCNode := &entity.PaneNode{ID: string(paneC.ID), Pane: paneC, Parent: root}
+	stack.Parent = root
+	root.Children = []*entity.PaneNode{stack, paneCNode}
+	sourceTab := &entity.Tab{ID: "tA", Workspace: &entity.Workspace{ID: "wA", Root: root, ActivePaneID: paneC.ID}}
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneB.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.False(t, out.SourceTabClosed)
+
+	require.Equal(t, paneC.ID, sourceTab.Workspace.ActivePaneID)
+	require.True(t, stack.IsLeaf())
+	require.Same(t, paneA, stack.Pane)
+	require.Same(t, paneB, out.NewTab.Workspace.Root.Pane)
+	assertParentPointers(t, sourceTab.Workspace.Root, nil)
+	assertParentPointers(t, out.NewTab.Workspace.Root, nil)
+}
+
+func TestExtractPaneToTabList_FromNestedSplitPreservesActivePaneOutsidePromotedSibling(t *testing.T) {
+	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
+	sourceTabs := entity.NewTabList()
+	targetTabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	paneC := entity.NewPane(entity.PaneID("pC"))
+	root := &entity.PaneNode{ID: "root", SplitDir: entity.SplitHorizontal, SplitRatio: 0.5}
+	leftLeaf := &entity.PaneNode{ID: string(paneA.ID), Pane: paneA, Parent: root}
+	rightSplit := &entity.PaneNode{ID: "right-split", SplitDir: entity.SplitVertical, SplitRatio: 0.5, Parent: root}
+	paneBNode := &entity.PaneNode{ID: string(paneB.ID), Pane: paneB, Parent: rightSplit}
+	paneCNode := &entity.PaneNode{ID: string(paneC.ID), Pane: paneC, Parent: rightSplit}
+	rightSplit.Children = []*entity.PaneNode{paneBNode, paneCNode}
+	root.Children = []*entity.PaneNode{leftLeaf, rightSplit}
+	sourceTab := &entity.Tab{ID: "tA", Workspace: &entity.Workspace{ID: "wA", Root: root, ActivePaneID: paneA.ID}}
+	sourceTabs.Add(sourceTab)
+
+	out, err := uc.Execute(ExtractPaneToTabListInput{
+		SourceTabs:   sourceTabs,
+		SourceTabID:  sourceTab.ID,
+		SourcePaneID: paneC.ID,
+		TargetTabs:   targetTabs,
+	})
+	require.NoError(t, err)
+	require.False(t, out.SourceTabClosed)
+
+	require.Equal(t, paneA.ID, sourceTab.Workspace.ActivePaneID)
+	require.Same(t, root, sourceTab.Workspace.Root)
+	require.Same(t, leftLeaf, sourceTab.Workspace.Root.Left())
+	require.Same(t, paneBNode, sourceTab.Workspace.Root.Right())
+	require.Nil(t, paneCNode.Parent)
+	require.Empty(t, rightSplit.Children)
+	require.Same(t, paneC, out.NewTab.Workspace.Root.Pane)
+	assertParentPointers(t, sourceTab.Workspace.Root, nil)
+	assertParentPointers(t, out.NewTab.Workspace.Root, nil)
+}
+
 func TestExtractPaneToTabList_FromSplitSeversMovedNode(t *testing.T) {
 	uc := NewExtractPaneToTabListUseCase(newTestIDGen())
 	sourceTabs := entity.NewTabList()

--- a/internal/application/usecase/move_pane_to_tab.go
+++ b/internal/application/usecase/move_pane_to_tab.go
@@ -220,14 +220,37 @@ func detachFromStackIfNeeded(ws *entity.Workspace, leaf *entity.PaneNode) (bool,
 		return false, nil
 	}
 
-	stackNode := leaf.Parent
-	removedIndex := stackChildIndex(stackNode, leaf)
-	if removedIndex < 0 {
-		return false, fmt.Errorf("pane not found in stack")
+	if err := removeLeafFromStackPreservingActive(ws, leaf.Parent, leaf); err != nil {
+		return false, err
 	}
-	activeIndex, activeInStack := stackPaneIndex(stackNode, ws.ActivePaneID)
-	if !activeInStack {
-		activeIndex = stackNode.ActiveStackIndex
+	return true, nil
+}
+
+func removeLeafFromStackPreservingActive(ws *entity.Workspace, stackNode, leaf *entity.PaneNode) error {
+	if ws == nil {
+		return fmt.Errorf("workspace is required")
+	}
+	if stackNode == nil || !stackNode.IsStacked {
+		return fmt.Errorf("node is not a stack")
+	}
+	if leaf == nil || leaf.Pane == nil {
+		return fmt.Errorf("pane node is required")
+	}
+
+	previousActive := ws.ActivePaneID
+	removedPaneID := leaf.Pane.ID
+	removedIndex := -1
+	activeIndex := stackNode.ActiveStackIndex
+	for i, child := range stackNode.Children {
+		if child == leaf {
+			removedIndex = i
+		}
+		if child != nil && child.Pane != nil && child.Pane.ID == previousActive {
+			activeIndex = i
+		}
+	}
+	if removedIndex < 0 {
+		return fmt.Errorf("pane not found in stack")
 	}
 
 	stackNode.Children = append(stackNode.Children[:removedIndex], stackNode.Children[removedIndex+1:]...)
@@ -241,68 +264,57 @@ func detachFromStackIfNeeded(ws *entity.Workspace, leaf *entity.PaneNode) (bool,
 		stackNode.IsStacked = false
 		stackNode.ActiveStackIndex = 0
 		remaining.Parent = nil
-		if stackNode.Pane != nil {
-			ws.ActivePaneID = stackNode.Pane.ID
-		} else {
-			ws.ActivePaneID = ""
-		}
-		return true, nil
+		setActiveAfterPaneDetach(ws, previousActive, removedPaneID, paneIDFromNode(stackNode))
+		return nil
 	}
 
-	stackNode.ActiveStackIndex = nextStackActiveIndex(activeIndex, removedIndex, len(stackNode.Children))
-	if activeChild := stackNode.ActivePane(); activeChild != nil && activeChild.Pane != nil {
-		ws.ActivePaneID = activeChild.Pane.ID
-	}
-	return true, nil
-}
-
-func stackChildIndex(stackNode, child *entity.PaneNode) int {
-	if stackNode == nil {
-		return -1
-	}
-	for i, candidate := range stackNode.Children {
-		if candidate == child {
-			return i
-		}
-	}
-	return -1
-}
-
-func stackPaneIndex(stackNode *entity.PaneNode, paneID entity.PaneID) (int, bool) {
-	if stackNode == nil || paneID == "" {
-		return -1, false
-	}
-	for i, child := range stackNode.Children {
-		if child != nil && child.Pane != nil && child.Pane.ID == paneID {
-			return i, true
-		}
-	}
-	return -1, false
-}
-
-func nextStackActiveIndex(activeIndex, removedIndex, remainingCount int) int {
-	if remainingCount <= 0 {
-		return 0
-	}
 	if activeIndex == removedIndex {
-		if removedIndex >= remainingCount {
-			return remainingCount - 1
+		if removedIndex >= len(stackNode.Children) {
+			activeIndex = len(stackNode.Children) - 1
+		} else {
+			activeIndex = removedIndex
 		}
-		return removedIndex
-	}
-	if activeIndex > removedIndex {
+	} else if activeIndex > removedIndex {
 		activeIndex--
 	}
 	if activeIndex < 0 {
-		return 0
+		activeIndex = 0
 	}
-	if activeIndex >= remainingCount {
-		return remainingCount - 1
+	if activeIndex >= len(stackNode.Children) {
+		activeIndex = len(stackNode.Children) - 1
 	}
-	return activeIndex
+	stackNode.ActiveStackIndex = activeIndex
+
+	fallbackID := entity.PaneID("")
+	if activeChild := stackNode.ActivePane(); activeChild != nil {
+		fallbackID = paneIDFromNode(activeChild)
+	}
+	setActiveAfterPaneDetach(ws, previousActive, removedPaneID, fallbackID)
+	return nil
+}
+
+func setActiveAfterPaneDetach(ws *entity.Workspace, previousActive, removedPaneID, fallbackID entity.PaneID) {
+	if ws == nil {
+		return
+	}
+	if previousActive != "" && previousActive != removedPaneID && ws.FindPane(previousActive) != nil {
+		ws.ActivePaneID = previousActive
+		return
+	}
+	ws.ActivePaneID = fallbackID
+}
+
+func paneIDFromNode(node *entity.PaneNode) entity.PaneID {
+	if node == nil || node.Pane == nil {
+		return ""
+	}
+	return node.Pane.ID
 }
 
 func detachLeafFromWorkspace(ws *entity.Workspace, leaf *entity.PaneNode) error {
+	previousActive := ws.ActivePaneID
+	removedPaneID := leaf.Pane.ID
+
 	parent := leaf.Parent
 	if parent == nil {
 		ws.Root = nil
@@ -321,7 +333,7 @@ func detachLeafFromWorkspace(ws *entity.Workspace, leaf *entity.PaneNode) error 
 	promoteSibling(ws, parent, sibling)
 	leaf.Parent = nil
 	parent.Children = nil
-	ws.ActivePaneID = findFirstLeafPaneID(sibling)
+	setActiveAfterPaneDetach(ws, previousActive, removedPaneID, findFirstLeafPaneID(sibling))
 	return nil
 }
 

--- a/internal/application/usecase/move_pane_to_tab.go
+++ b/internal/application/usecase/move_pane_to_tab.go
@@ -221,26 +221,17 @@ func detachFromStackIfNeeded(ws *entity.Workspace, leaf *entity.PaneNode) (bool,
 	}
 
 	stackNode := leaf.Parent
-
-	idx := -1
-	for i, child := range stackNode.Children {
-		if child == leaf {
-			idx = i
-			break
-		}
-	}
-	if idx < 0 {
+	removedIndex := stackChildIndex(stackNode, leaf)
+	if removedIndex < 0 {
 		return false, fmt.Errorf("pane not found in stack")
 	}
+	activeIndex, activeInStack := stackPaneIndex(stackNode, ws.ActivePaneID)
+	if !activeInStack {
+		activeIndex = stackNode.ActiveStackIndex
+	}
 
-	stackNode.Children = append(stackNode.Children[:idx], stackNode.Children[idx+1:]...)
+	stackNode.Children = append(stackNode.Children[:removedIndex], stackNode.Children[removedIndex+1:]...)
 	leaf.Parent = nil
-	if stackNode.ActiveStackIndex >= len(stackNode.Children) {
-		stackNode.ActiveStackIndex = len(stackNode.Children) - 1
-	}
-	if stackNode.ActiveStackIndex < 0 {
-		stackNode.ActiveStackIndex = 0
-	}
 
 	// If only one pane remains in stack, dissolve it into a leaf node.
 	if len(stackNode.Children) == 1 {
@@ -258,11 +249,57 @@ func detachFromStackIfNeeded(ws *entity.Workspace, leaf *entity.PaneNode) (bool,
 		return true, nil
 	}
 
-	// Otherwise, set workspace active pane to the stack's current active.
-	if stackNode.ActivePane() != nil && stackNode.ActivePane().Pane != nil {
-		ws.ActivePaneID = stackNode.ActivePane().Pane.ID
+	stackNode.ActiveStackIndex = nextStackActiveIndex(activeIndex, removedIndex, len(stackNode.Children))
+	if activeChild := stackNode.ActivePane(); activeChild != nil && activeChild.Pane != nil {
+		ws.ActivePaneID = activeChild.Pane.ID
 	}
 	return true, nil
+}
+
+func stackChildIndex(stackNode, child *entity.PaneNode) int {
+	if stackNode == nil {
+		return -1
+	}
+	for i, candidate := range stackNode.Children {
+		if candidate == child {
+			return i
+		}
+	}
+	return -1
+}
+
+func stackPaneIndex(stackNode *entity.PaneNode, paneID entity.PaneID) (int, bool) {
+	if stackNode == nil || paneID == "" {
+		return -1, false
+	}
+	for i, child := range stackNode.Children {
+		if child != nil && child.Pane != nil && child.Pane.ID == paneID {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func nextStackActiveIndex(activeIndex, removedIndex, remainingCount int) int {
+	if remainingCount <= 0 {
+		return 0
+	}
+	if activeIndex == removedIndex {
+		if removedIndex >= remainingCount {
+			return remainingCount - 1
+		}
+		return removedIndex
+	}
+	if activeIndex > removedIndex {
+		activeIndex--
+	}
+	if activeIndex < 0 {
+		return 0
+	}
+	if activeIndex >= remainingCount {
+		return remainingCount - 1
+	}
+	return activeIndex
 }
 
 func detachLeafFromWorkspace(ws *entity.Workspace, leaf *entity.PaneNode) error {

--- a/internal/ui/app_eject_pane_to_window_test.go
+++ b/internal/ui/app_eject_pane_to_window_test.go
@@ -154,6 +154,22 @@ func TestApp_EjectActivePaneToWindowHandlesThreePaneSplitTree(t *testing.T) {
 	if got := sourceTab.Workspace.FindPane("pane-c"); got != nil {
 		t.Fatal("source workspace still contains moved split pane")
 	}
+	if got := sourceTab.Workspace.ActivePaneID; got != entity.PaneID("pane-b") {
+		t.Fatalf("source active pane = %q, want pane-b", got)
+	}
+	if sourceTab.Workspace.Root == nil || sourceTab.Workspace.Root.ID != "left-split" || !sourceTab.Workspace.Root.IsSplit() {
+		t.Fatalf("source root = %#v, want promoted left split", sourceTab.Workspace.Root)
+	}
+	if got := sourceTab.Workspace.Root.Parent; got != nil {
+		t.Fatalf("source root parent = %#v, want nil", got)
+	}
+	if got := sourceTab.Workspace.Root.Left(); got == nil || got.Pane == nil || got.Pane.ID != entity.PaneID("pane-a") {
+		t.Fatalf("source left leaf = %#v, want pane-a", got)
+	}
+	if got := sourceTab.Workspace.Root.Right(); got == nil || got.Pane == nil || got.Pane.ID != entity.PaneID("pane-b") {
+		t.Fatalf("source right leaf = %#v, want pane-b", got)
+	}
+	assertPaneTreeParents(t, sourceTab.Workspace.Root, nil)
 	targetWindow := app.browserWindows["target-window"]
 	if targetWindow == nil || targetWindow.tabs.Count() != 1 {
 		t.Fatalf("target window/tabs not created correctly: %#v", targetWindow)
@@ -161,6 +177,9 @@ func TestApp_EjectActivePaneToWindowHandlesThreePaneSplitTree(t *testing.T) {
 	newTab := targetWindow.tabs.Tabs[0]
 	if got := newTab.Workspace.ActivePaneID; got != entity.PaneID("pane-c") {
 		t.Fatalf("target active pane = %q, want pane-c", got)
+	}
+	if got := newTab.Workspace.Root.Parent; got != nil {
+		t.Fatalf("target root parent = %#v, want nil", got)
 	}
 	if got := app.windowForTab[newTab.ID]; got != targetWindow {
 		t.Fatalf("target owner = %p, want target window %p", got, targetWindow)
@@ -340,6 +359,19 @@ func splitTreeTab(tabID entity.TabID, workspaceID entity.WorkspaceID, paneAID, p
 
 	workspace := &entity.Workspace{ID: workspaceID, Root: root, ActivePaneID: paneAID}
 	return &entity.Tab{ID: tabID, Workspace: workspace}
+}
+
+func assertPaneTreeParents(t *testing.T, node, wantParent *entity.PaneNode) {
+	t.Helper()
+	if node == nil {
+		return
+	}
+	if node.Parent != wantParent {
+		t.Fatalf("node %q parent = %#v, want %#v", node.ID, node.Parent, wantParent)
+	}
+	for _, child := range node.Children {
+		assertPaneTreeParents(t, child, node)
+	}
 }
 
 func assertTargetSnapshotContainsPane(t *testing.T, window entity.WindowTabListState, paneID entity.PaneID) {

--- a/internal/ui/app_eject_pane_to_window_test.go
+++ b/internal/ui/app_eject_pane_to_window_test.go
@@ -139,51 +139,9 @@ func TestApp_EjectActivePaneToWindowHandlesThreePaneSplitTree(t *testing.T) {
 		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
 	}
 
-	if got := len(app.browserWindows); got != 2 {
-		t.Fatalf("browserWindows length = %d, want source and target", got)
-	}
-	if app.browserWindows[sourceWindow.id] == nil {
-		t.Fatal("source window should remain registered")
-	}
-	if got := sourceTab.Workspace.PaneCount(); got != 2 {
-		t.Fatalf("source pane count = %d, want 2", got)
-	}
-	if sourceTab.Workspace.FindPane("pane-a") == nil || sourceTab.Workspace.FindPane("pane-b") == nil {
-		t.Fatal("source workspace missing remaining split panes")
-	}
-	if got := sourceTab.Workspace.FindPane("pane-c"); got != nil {
-		t.Fatal("source workspace still contains moved split pane")
-	}
-	if got := sourceTab.Workspace.ActivePaneID; got != entity.PaneID("pane-b") {
-		t.Fatalf("source active pane = %q, want pane-b", got)
-	}
-	if sourceTab.Workspace.Root == nil || sourceTab.Workspace.Root.ID != "left-split" || !sourceTab.Workspace.Root.IsSplit() {
-		t.Fatalf("source root = %#v, want promoted left split", sourceTab.Workspace.Root)
-	}
-	if got := sourceTab.Workspace.Root.Parent; got != nil {
-		t.Fatalf("source root parent = %#v, want nil", got)
-	}
-	if got := sourceTab.Workspace.Root.Left(); got == nil || got.Pane == nil || got.Pane.ID != entity.PaneID("pane-a") {
-		t.Fatalf("source left leaf = %#v, want pane-a", got)
-	}
-	if got := sourceTab.Workspace.Root.Right(); got == nil || got.Pane == nil || got.Pane.ID != entity.PaneID("pane-b") {
-		t.Fatalf("source right leaf = %#v, want pane-b", got)
-	}
-	assertPaneTreeParents(t, sourceTab.Workspace.Root, nil)
-	targetWindow := app.browserWindows["target-window"]
-	if targetWindow == nil || targetWindow.tabs.Count() != 1 {
-		t.Fatalf("target window/tabs not created correctly: %#v", targetWindow)
-	}
-	newTab := targetWindow.tabs.Tabs[0]
-	if got := newTab.Workspace.ActivePaneID; got != entity.PaneID("pane-c") {
-		t.Fatalf("target active pane = %q, want pane-c", got)
-	}
-	if got := newTab.Workspace.Root.Parent; got != nil {
-		t.Fatalf("target root parent = %#v, want nil", got)
-	}
-	if got := app.windowForTab[newTab.ID]; got != targetWindow {
-		t.Fatalf("target owner = %p, want target window %p", got, targetWindow)
-	}
+	assertEjectWindowCount(t, app, sourceWindow)
+	assertEjectedThreePaneSplitSource(t, sourceTab)
+	assertEjectedThreePaneSplitTarget(t, app, "pane-c")
 }
 
 func TestApp_EjectActivePaneToWindowSnapshotReplacesEmptySourceWindow(t *testing.T) {
@@ -340,6 +298,71 @@ func stackedTab(tabID entity.TabID, workspaceID entity.WorkspaceID, paneIDs ...e
 	stack.Children = children
 	workspace := &entity.Workspace{ID: workspaceID, Root: stack, ActivePaneID: paneIDs[0]}
 	return &entity.Tab{ID: tabID, Workspace: workspace}
+}
+
+func assertEjectWindowCount(t *testing.T, app *App, sourceWindow *browserWindow) {
+	t.Helper()
+	if got := len(app.browserWindows); got != 2 {
+		t.Fatalf("browserWindows length = %d, want source and target", got)
+	}
+	if app.browserWindows[sourceWindow.id] == nil {
+		t.Fatal("source window should remain registered")
+	}
+}
+
+func assertEjectedThreePaneSplitSource(t *testing.T, sourceTab *entity.Tab) {
+	t.Helper()
+	if got := sourceTab.Workspace.PaneCount(); got != 2 {
+		t.Fatalf("source pane count = %d, want 2", got)
+	}
+	if sourceTab.Workspace.FindPane("pane-a") == nil || sourceTab.Workspace.FindPane("pane-b") == nil {
+		t.Fatal("source workspace missing remaining split panes")
+	}
+	if got := sourceTab.Workspace.FindPane("pane-c"); got != nil {
+		t.Fatal("source workspace still contains moved split pane")
+	}
+	if got := sourceTab.Workspace.ActivePaneID; got != entity.PaneID("pane-b") {
+		t.Fatalf("source active pane = %q, want pane-b", got)
+	}
+	assertPromotedLeftSplitRoot(t, sourceTab.Workspace.Root)
+}
+
+func assertPromotedLeftSplitRoot(t *testing.T, root *entity.PaneNode) {
+	t.Helper()
+	if root == nil || root.ID != "left-split" || !root.IsSplit() {
+		t.Fatalf("source root = %#v, want promoted left split", root)
+	}
+	if got := root.Parent; got != nil {
+		t.Fatalf("source root parent = %#v, want nil", got)
+	}
+	assertLeafPaneID(t, root.Left(), "pane-a")
+	assertLeafPaneID(t, root.Right(), "pane-b")
+	assertPaneTreeParents(t, root, nil)
+}
+
+func assertEjectedThreePaneSplitTarget(t *testing.T, app *App, paneID entity.PaneID) {
+	t.Helper()
+	targetWindow := app.browserWindows["target-window"]
+	if targetWindow == nil || targetWindow.tabs.Count() != 1 {
+		t.Fatalf("target window/tabs not created correctly: %#v", targetWindow)
+	}
+	newTab := targetWindow.tabs.Tabs[0]
+	if got := newTab.Workspace.ActivePaneID; got != paneID {
+		t.Fatalf("target active pane = %q, want %q", got, paneID)
+	}
+	if got := newTab.Workspace.Root.Parent; got != nil {
+		t.Fatalf("target root parent = %#v, want nil", got)
+	}
+	if got := app.windowForTab[newTab.ID]; got != targetWindow {
+		t.Fatalf("target owner = %p, want target window %p", got, targetWindow)
+	}
+}
+
+func assertLeafPaneID(t *testing.T, node *entity.PaneNode, paneID entity.PaneID) {
+	t.Helper()
+	if node == nil || node.Pane == nil || node.Pane.ID != paneID {
+		t.Fatalf("leaf = %#v, want %s", node, paneID)
+	}
 }
 
 func splitTreeTab(tabID entity.TabID, workspaceID entity.WorkspaceID, paneAID, paneBID, paneCID entity.PaneID) *entity.Tab {

--- a/internal/ui/app_eject_pane_to_window_test.go
+++ b/internal/ui/app_eject_pane_to_window_test.go
@@ -11,7 +11,10 @@ import (
 
 func TestApp_EjectActivePaneToWindowRegistersTargetOwnership(t *testing.T) {
 	app, sourceWindow, sourceTab := newEjectTestApp(t, stackedTab("source-tab-a", "source-ws-a", "pane-a", "pane-b", "pane-c"))
+	// ActivePaneID is the source of truth. Keep ActiveStackIndex stale to cover
+	// ejection after stack/UI state drift with more than two panes.
 	sourceTab.Workspace.ActivePaneID = "pane-b"
+	sourceTab.Workspace.Root.ActiveStackIndex = 0
 
 	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
 		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
@@ -39,6 +42,12 @@ func TestApp_EjectActivePaneToWindowRegistersTargetOwnership(t *testing.T) {
 	}
 	if got := sourceTab.Workspace.FindPane("pane-b"); got != nil {
 		t.Fatal("source workspace still contains moved pane")
+	}
+	if got := sourceTab.Workspace.ActivePaneID; got != entity.PaneID("pane-c") {
+		t.Fatalf("source active pane = %q, want pane-c", got)
+	}
+	if got := sourceTab.Workspace.Root.ActiveStackIndex; got != 1 {
+		t.Fatalf("source active stack index = %d, want 1", got)
 	}
 	if got := app.lastFocusedWindowID; got != targetWindow.id {
 		t.Fatalf("lastFocusedWindowID = %q, want %q", got, targetWindow.id)
@@ -120,6 +129,42 @@ func TestApp_EjectActivePaneToWindowSnapshotRetainsSourceWindowWhenTabsRemain(t 
 		t.Fatalf("source snapshot missing retained tab %q", sourceTab.ID)
 	}
 	assertTargetSnapshotContainsPane(t, windows[1], "pane-b")
+}
+
+func TestApp_EjectActivePaneToWindowHandlesThreePaneSplitTree(t *testing.T) {
+	app, sourceWindow, sourceTab := newEjectTestApp(t, splitTreeTab("source-tab", "source-ws", "pane-a", "pane-b", "pane-c"))
+	sourceTab.Workspace.ActivePaneID = "pane-c"
+
+	if err := app.EjectActivePaneToWindow(context.Background(), ""); err != nil {
+		t.Fatalf("EjectActivePaneToWindow returned error: %v", err)
+	}
+
+	if got := len(app.browserWindows); got != 2 {
+		t.Fatalf("browserWindows length = %d, want source and target", got)
+	}
+	if app.browserWindows[sourceWindow.id] == nil {
+		t.Fatal("source window should remain registered")
+	}
+	if got := sourceTab.Workspace.PaneCount(); got != 2 {
+		t.Fatalf("source pane count = %d, want 2", got)
+	}
+	if sourceTab.Workspace.FindPane("pane-a") == nil || sourceTab.Workspace.FindPane("pane-b") == nil {
+		t.Fatal("source workspace missing remaining split panes")
+	}
+	if got := sourceTab.Workspace.FindPane("pane-c"); got != nil {
+		t.Fatal("source workspace still contains moved split pane")
+	}
+	targetWindow := app.browserWindows["target-window"]
+	if targetWindow == nil || targetWindow.tabs.Count() != 1 {
+		t.Fatalf("target window/tabs not created correctly: %#v", targetWindow)
+	}
+	newTab := targetWindow.tabs.Tabs[0]
+	if got := newTab.Workspace.ActivePaneID; got != entity.PaneID("pane-c") {
+		t.Fatalf("target active pane = %q, want pane-c", got)
+	}
+	if got := app.windowForTab[newTab.ID]; got != targetWindow {
+		t.Fatalf("target owner = %p, want target window %p", got, targetWindow)
+	}
 }
 
 func TestApp_EjectActivePaneToWindowSnapshotReplacesEmptySourceWindow(t *testing.T) {
@@ -275,6 +320,25 @@ func stackedTab(tabID entity.TabID, workspaceID entity.WorkspaceID, paneIDs ...e
 	}
 	stack.Children = children
 	workspace := &entity.Workspace{ID: workspaceID, Root: stack, ActivePaneID: paneIDs[0]}
+	return &entity.Tab{ID: tabID, Workspace: workspace}
+}
+
+func splitTreeTab(tabID entity.TabID, workspaceID entity.WorkspaceID, paneAID, paneBID, paneCID entity.PaneID) *entity.Tab {
+	paneA := entity.NewPane(paneAID)
+	paneB := entity.NewPane(paneBID)
+	paneC := entity.NewPane(paneCID)
+
+	leftSplit := &entity.PaneNode{ID: "left-split", SplitDir: entity.SplitVertical, SplitRatio: 0.5}
+	leafA := &entity.PaneNode{ID: string(paneAID) + "-node", Pane: paneA, Parent: leftSplit}
+	leafB := &entity.PaneNode{ID: string(paneBID) + "-node", Pane: paneB, Parent: leftSplit}
+	leftSplit.Children = []*entity.PaneNode{leafA, leafB}
+
+	root := &entity.PaneNode{ID: "root-split", SplitDir: entity.SplitHorizontal, SplitRatio: 0.5}
+	leafC := &entity.PaneNode{ID: string(paneCID) + "-node", Pane: paneC, Parent: root}
+	leftSplit.Parent = root
+	root.Children = []*entity.PaneNode{leftSplit, leafC}
+
+	workspace := &entity.Workspace{ID: workspaceID, Root: root, ActivePaneID: paneAID}
 	return &entity.Tab{ID: tabID, Workspace: workspace}
 }
 


### PR DESCRIPTION
## Summary
- Stabilize pane extraction/ejection when stacked pane active state drifts from the workspace active pane
- Preserve an existing active pane when detaching from stacks or promoting split siblings
- Add regression coverage for >2-pane stacks, stack dissolve, nested split trees, and App-level eject ownership/layout updates

## Test Plan
- [x] go test ./internal/application/usecase
- [x] go test ./internal/ui -run 'TestApp_EjectActivePaneToWindow'
- [x] git diff --check
- [x] coderabbit review --agent --base main
- [x] wrap-up review workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for extracting panes from stacked/nested layouts and for ejecting the active pane to a window, including complex three-pane split scenarios and state drift cases.

* **Refactor**
  * Improved active-pane handling when removing or moving panes so the correct pane remains selected (and layout focus is updated deterministically) across stack reduction, dissolve, and window eject operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->