### PR TITLE
fix(security): require trust for external scheme launches

### DIFF
--- a/internal/ui/coordinator/content/navigation.go
+++ b/internal/ui/coordinator/content/navigation.go
@@ -330,25 +330,19 @@ func (c *Coordinator) handleURIChanged(ctx context.Context, paneID entity.PaneID
 	isExternal := urlutil.IsExternalScheme(uri)
 
 	if isExternal {
-		log.Info().Str("pane_id", string(paneID)).Str("uri", uri).Msg("external scheme detected, launching externally")
+		log.Info().Str("pane_id", string(paneID)).Str("uri", uri).Msg("external scheme URI change blocked")
 
-		// Launch externally via injected callback
-		if c.onLaunchExternalURL != nil {
-			c.onLaunchExternalURL(uri)
-		} else {
-			log.Warn().Str("pane_id", string(paneID)).Str("uri", uri).Msg("external URL not launched: no handler registered")
-		}
-
-		// Stop loading to prevent WebKit from showing an error page
-		// The page stays on the previous URL before the JS redirect
+		// External schemes must only be launched from WebKit's navigation-policy path,
+		// where NavigationAction.IsUserGesture is available and verified. URI changes can
+		// be driven by page script or redirects, so this path only cleans up WebKit state.
 		if err := wv.Stop(ctx); err != nil {
-			log.Warn().Str("pane_id", string(paneID)).Str("uri", uri).Err(err).Msg("stop webview for external URL")
+			log.Warn().Str("pane_id", string(paneID)).Str("uri", uri).Err(err).Msg("stop webview for blocked external URL")
 		}
 
-		// Navigate back to avoid stale URI in omnibox/history
+		// Navigate back to avoid stale URI in omnibox/history.
 		if wv.CanGoBack() {
 			if err := wv.GoBack(ctx); err != nil {
-				log.Warn().Str("pane_id", string(paneID)).Err(err).Msg("GoBack after external URL")
+				log.Warn().Str("pane_id", string(paneID)).Err(err).Msg("GoBack after blocked external URL")
 			}
 		}
 		return

--- a/internal/ui/coordinator/content/navigation_security_test.go
+++ b/internal/ui/coordinator/content/navigation_security_test.go
@@ -1,0 +1,121 @@
+package content
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bnema/dumber/internal/application/port/mocks"
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+func TestHandleURIChanged_BlocksExternalSchemeWithoutLaunching(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	paneID := entity.PaneID("pane-1")
+	wv := mocks.NewMockWebView(t)
+	wv.EXPECT().Stop(ctx).Return(nil).Once()
+	wv.EXPECT().CanGoBack().Return(false).Once()
+
+	launchCount := 0
+	c := &Coordinator{
+		onLaunchExternalURL: func(uri string) {
+			launchCount++
+		},
+	}
+
+	c.handleURIChanged(ctx, paneID, wv, "vscode://file/etc/passwd")
+
+	assert.Equal(t, 0, launchCount)
+}
+
+func TestHandleURIChanged_BlocksExternalSchemeRedirectAndRestoresPreviousPage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	paneID := entity.PaneID("pane-1")
+	wv := mocks.NewMockWebView(t)
+	wv.EXPECT().Stop(ctx).Return(nil).Once()
+	wv.EXPECT().CanGoBack().Return(true).Once()
+	wv.EXPECT().GoBack(ctx).Return(nil).Once()
+
+	launchCount := 0
+	c := &Coordinator{
+		onLaunchExternalURL: func(uri string) {
+			launchCount++
+		},
+	}
+
+	c.handleURIChanged(ctx, paneID, wv, "spotify://track/123")
+
+	assert.Equal(t, 0, launchCount)
+}
+
+func TestHandleURIChanged_HTTPURIStillRecordsSPANavigation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	paneID := entity.PaneID("pane-1")
+	wv := mocks.NewMockWebView(t)
+	wv.EXPECT().IsLoading().Return(false).Once()
+
+	var recordedPane entity.PaneID
+	var recordedURI string
+	c := &Coordinator{
+		onPaneURIUpdated: func(paneID entity.PaneID, uri string) {
+			recordedPane = paneID
+			recordedURI = uri
+		},
+	}
+
+	c.handleURIChanged(ctx, paneID, wv, "https://example.com/app#state")
+
+	assert.Equal(t, paneID, recordedPane)
+	assert.Equal(t, "https://example.com/app#state", recordedURI)
+}
+
+func TestHandleURIChanged_StopErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	paneID := entity.PaneID("pane-1")
+	wv := mocks.NewMockWebView(t)
+	wv.EXPECT().Stop(ctx).Return(errors.New("stop failed")).Once()
+	wv.EXPECT().CanGoBack().Return(false).Once()
+
+	launchCount := 0
+	c := &Coordinator{
+		onLaunchExternalURL: func(uri string) {
+			launchCount++
+		},
+	}
+
+	c.handleURIChanged(ctx, paneID, wv, "vscode://file/etc/passwd")
+
+	assert.Equal(t, 0, launchCount)
+}
+
+func TestHandleURIChanged_GoBackErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	paneID := entity.PaneID("pane-1")
+	wv := mocks.NewMockWebView(t)
+	wv.EXPECT().Stop(ctx).Return(nil).Once()
+	wv.EXPECT().CanGoBack().Return(true).Once()
+	wv.EXPECT().GoBack(ctx).Return(errors.New("goback failed")).Once()
+
+	launchCount := 0
+	c := &Coordinator{
+		onLaunchExternalURL: func(uri string) {
+			launchCount++
+		},
+	}
+
+	c.handleURIChanged(ctx, paneID, wv, "spotify://track/123")
+
+	assert.Equal(t, 0, launchCount)
+}


### PR DESCRIPTION
## Summary\n- block external-scheme URI-change handling from launching desktop handlers\n- preserve normal HTTP URI-change handling\n- add regression coverage for block/restore behavior and Stop/GoBack error paths\n\n## Verification\n- rtk go test ./internal/ui/coordinator/content\n- rtk go test ./internal/ui/coordinator/...\n- CodeRabbit review against origin/main: 0 findings after rerun\n- Go reviewer: approved\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External scheme links (e.g., `vscode://`) no longer corrupt browser history or UI state.
  * Browser automatically navigates back when encountering external protocol redirects instead of leaving stale navigation state.

* **Tests**
  * Added comprehensive test coverage for external URI handling scenarios, including error resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->