### PR TITLE
fix(usecase): reject invalid pane split directions

### DIFF
--- a/internal/application/usecase/manage_panes.go
+++ b/internal/application/usecase/manage_panes.go
@@ -112,6 +112,14 @@ func (uc *ManagePanesUseCase) Split(ctx context.Context, input SplitPaneInput) (
 		return nil, fmt.Errorf("target pane is required")
 	}
 
+	// Validate split direction before any mutations
+	switch input.Direction {
+	case SplitLeft, SplitRight, SplitUp, SplitDown:
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid split direction: %s", input.Direction)
+	}
+
 	// If target is inside a stack, split around the entire stack
 	// (i.e., create the new pane as a sibling to the stack, not inside it)
 	// This applies to all directions - we don't want to nest split containers inside stacks.

--- a/internal/application/usecase/manage_panes_split_test.go
+++ b/internal/application/usecase/manage_panes_split_test.go
@@ -1,0 +1,91 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bnema/dumber/internal/domain/entity"
+)
+
+func TestManagePanesUseCase_Split_ValidDirections(t *testing.T) {
+	uc := NewManagePanesUseCase(func() string { return "id" })
+	ctx := context.Background()
+
+	dirs := []SplitDirection{SplitLeft, SplitRight, SplitUp, SplitDown}
+	for _, dir := range dirs {
+		t.Run(string(dir), func(t *testing.T) {
+			target := leaf("target")
+			ws := &entity.Workspace{Root: target, ActivePaneID: "target"}
+			target.Parent = nil // root
+
+			out, err := uc.Split(ctx, SplitPaneInput{
+				Workspace:  ws,
+				TargetPane: target,
+				Direction:  dir,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error for direction %s: %v", dir, err)
+			}
+			if out == nil {
+				t.Fatalf("output is nil for direction %s", dir)
+			}
+			if out.NewPaneNode == nil {
+				t.Fatalf("new pane node is nil for direction %s", dir)
+			}
+			if out.ParentNode == nil {
+				t.Fatalf("parent node is nil for direction %s", dir)
+			}
+			if !out.ParentNode.IsSplit() {
+				t.Fatalf("parent node should be a split for direction %s, got SplitDir=%v", dir, out.ParentNode.SplitDir)
+			}
+			if ws.Root != out.ParentNode {
+				t.Fatalf("workspace root should be the parent node for direction %s", dir)
+			}
+			// Verify the tree has 2 leaf panes
+			if ws.PaneCount() != 2 {
+				t.Fatalf("workspace should have 2 panes for direction %s, got %d", dir, ws.PaneCount())
+			}
+		})
+	}
+}
+
+func TestManagePanesUseCase_Split_InvalidDirection_ReturnsError(t *testing.T) {
+	uc := NewManagePanesUseCase(func() string { return "id" })
+	ctx := context.Background()
+
+	target := leaf("target")
+	ws := &entity.Workspace{Root: target, ActivePaneID: "target"}
+
+	// Save initial state
+	initialRoot := ws.Root
+	initialActive := ws.ActivePaneID
+
+	_, err := uc.Split(ctx, SplitPaneInput{
+		Workspace:  ws,
+		TargetPane: target,
+		Direction:  SplitDirection("diagonal"),
+	})
+	if err == nil {
+		t.Fatalf("expected error for invalid direction, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid split direction: diagonal") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+
+	// Verify workspace state is unchanged
+	if ws.Root != initialRoot {
+		t.Fatalf("workspace root was modified")
+	}
+	if ws.ActivePaneID != initialActive {
+		t.Fatalf("workspace active pane was modified")
+	}
+	// Verify target pane parent is still nil (was root)
+	if target.Parent != nil {
+		t.Fatalf("target pane parent was modified")
+	}
+	// Verify pane count is still 1
+	if ws.PaneCount() != 1 {
+		t.Fatalf("workspace pane count changed: got %d, want 1", ws.PaneCount())
+	}
+}


### PR DESCRIPTION
## Summary\n- reject invalid pane split directions before mutating pane trees\n- add valid-direction coverage and invalid-direction no-mutation coverage\n- assert invalid-direction error content\n\n## Verification\n- rtk go test ./internal/application/usecase/...\n- CodeRabbit review against origin/main: 0 findings after rerun\n- Go reviewer: approved\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for pane split operations to prevent invalid directions from causing state mutations.

* **Tests**
  * Added test coverage for valid and invalid pane split direction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->