### PR TITLE
fix(security): redact sensitive urls in logs

### DIFF
--- a/internal/application/usecase/manage_favorites.go
+++ b/internal/application/usecase/manage_favorites.go
@@ -59,7 +59,7 @@ type AddFavoriteInput struct {
 // Add creates a new favorite.
 func (uc *ManageFavoritesUseCase) Add(ctx context.Context, input AddFavoriteInput) (*entity.Favorite, error) {
 	log := logging.FromContext(ctx)
-	log.Debug().Str("url", input.URL).Str("title", input.Title).Msg("adding favorite")
+	log.Debug().Str("url", logging.RedactURL(input.URL)).Msg("adding favorite")
 
 	// Check if already favorited
 	existing, err := uc.favoriteRepo.FindByURL(ctx, input.URL)
@@ -67,7 +67,7 @@ func (uc *ManageFavoritesUseCase) Add(ctx context.Context, input AddFavoriteInpu
 		return nil, fmt.Errorf("failed to check existing favorite: %w", err)
 	}
 	if existing != nil {
-		log.Debug().Str("url", input.URL).Msg("URL already favorited")
+		log.Debug().Str("url", logging.RedactURL(input.URL)).Msg("URL already favorited")
 		return existing, nil
 	}
 
@@ -95,7 +95,7 @@ func (uc *ManageFavoritesUseCase) addNewFavorite(ctx context.Context, input AddF
 		}
 	}
 
-	log.Info().Str("url", input.URL).Int64("id", int64(fav.ID)).Msg("favorite added")
+	log.Info().Str("url", logging.RedactURL(input.URL)).Int64("id", int64(fav.ID)).Msg("favorite added")
 	uc.invalidateCache()
 	return fav, nil
 }
@@ -235,14 +235,14 @@ func (uc *ManageFavoritesUseCase) Remove(ctx context.Context, id entity.Favorite
 // RemoveByURL deletes a favorite by its URL.
 func (uc *ManageFavoritesUseCase) RemoveByURL(ctx context.Context, favoriteURL string) error {
 	log := logging.FromContext(ctx)
-	log.Debug().Str("url", favoriteURL).Msg("removing favorite by URL")
+	log.Debug().Str("url", logging.RedactURL(favoriteURL)).Msg("removing favorite by URL")
 
 	fav, err := uc.favoriteRepo.FindByURL(ctx, favoriteURL)
 	if err != nil {
 		return fmt.Errorf("failed to find favorite: %w", err)
 	}
 	if fav == nil {
-		log.Debug().Str("url", favoriteURL).Msg("favorite not found")
+		log.Debug().Str("url", logging.RedactURL(favoriteURL)).Msg("favorite not found")
 		return nil
 	}
 
@@ -314,7 +314,7 @@ func (uc *ManageFavoritesUseCase) GetByShortcut(ctx context.Context, key int) (*
 // GetByURL finds a favorite by its URL.
 func (uc *ManageFavoritesUseCase) GetByURL(ctx context.Context, favoriteURL string) (*entity.Favorite, error) {
 	log := logging.FromContext(ctx)
-	log.Debug().Str("url", favoriteURL).Msg("getting favorite by URL")
+	log.Debug().Str("url", logging.RedactURL(favoriteURL)).Msg("getting favorite by URL")
 
 	return uc.favoriteRepo.FindByURL(ctx, favoriteURL)
 }
@@ -455,7 +455,7 @@ func (uc *ManageFavoritesUseCase) Toggle(ctx context.Context, rawURL, title stri
 	title = strings.TrimSpace(title)
 
 	log := logging.FromContext(ctx)
-	log.Debug().Str("url", favoriteURL).Msg("toggling favorite")
+	log.Debug().Str("url", logging.RedactURL(favoriteURL)).Msg("toggling favorite")
 
 	// Check if already favorited, including legacy rows stored before URL canonicalization.
 	existing, err := uc.findFavoriteByCanonicalOrRawURL(ctx, favoriteURL, rawURL)
@@ -468,7 +468,7 @@ func (uc *ManageFavoritesUseCase) Toggle(ctx context.Context, rawURL, title stri
 		if err := uc.favoriteRepo.Delete(ctx, existing.ID); err != nil {
 			return nil, fmt.Errorf("failed to remove favorite: %w", err)
 		}
-		log.Info().Str("url", favoriteURL).Int64("id", int64(existing.ID)).Msg("favorite removed via toggle")
+		log.Info().Str("url", logging.RedactURL(favoriteURL)).Int64("id", int64(existing.ID)).Msg("favorite removed via toggle")
 		uc.invalidateCache()
 		return &ToggleResult{
 			Added:   false,
@@ -483,7 +483,7 @@ func (uc *ManageFavoritesUseCase) Toggle(ctx context.Context, rawURL, title stri
 	if err := uc.favoriteRepo.Save(ctx, fav); err != nil {
 		return nil, fmt.Errorf("failed to add favorite: %w", err)
 	}
-	log.Info().Str("url", favoriteURL).Int64("id", int64(fav.ID)).Msg("favorite added via toggle")
+	log.Info().Str("url", logging.RedactURL(favoriteURL)).Int64("id", int64(fav.ID)).Msg("favorite added via toggle")
 	uc.invalidateCache()
 	return &ToggleResult{
 		Added:   true,

--- a/internal/application/usecase/navigate.go
+++ b/internal/application/usecase/navigate.go
@@ -124,7 +124,7 @@ type NavigateOutput struct {
 func (uc *NavigateUseCase) Execute(ctx context.Context, input NavigateInput) (*NavigateOutput, error) {
 	log := logging.FromContext(ctx)
 	log.Debug().
-		Str("url", input.URL).
+		Str("url", logging.RedactURL(input.URL)).
 		Str("pane_id", input.PaneID).
 		Msg("navigating to URL")
 
@@ -135,7 +135,7 @@ func (uc *NavigateUseCase) Execute(ctx context.Context, input NavigateInput) (*N
 	}
 
 	log.Info().
-		Str("url", input.URL).
+		Str("url", logging.RedactURL(input.URL)).
 		Msg("navigation initiated")
 
 	return &NavigateOutput{
@@ -309,7 +309,7 @@ func (uc *NavigateUseCase) persistHistory(ctx context.Context, record historyRec
 	// Check if entry exists
 	existing, err := uc.historyRepo.FindByURL(ctx, record.url)
 	if err != nil {
-		log.Warn().Err(err).Str("url", record.url).Msg("failed to check history")
+		log.Warn().Err(err).Str("url", logging.RedactURL(record.url)).Msg("failed to check history")
 		return
 	}
 
@@ -317,7 +317,7 @@ func (uc *NavigateUseCase) persistHistory(ctx context.Context, record historyRec
 		delta := max(1, record.visits)
 		if deltaWriter, ok := uc.historyRepo.(historyVisitDeltaIncrementer); ok {
 			if err := deltaWriter.IncrementVisitCountBy(ctx, record.url, delta); err != nil {
-				log.Warn().Err(err).Str("url", record.url).Int("delta", delta).Msg("failed to increment visit count by delta")
+				log.Warn().Err(err).Str("url", logging.RedactURL(record.url)).Int("delta", delta).Msg("failed to increment visit count by delta")
 				return
 			}
 			return
@@ -325,7 +325,7 @@ func (uc *NavigateUseCase) persistHistory(ctx context.Context, record historyRec
 		iterations := delta
 		if iterations > historyFallbackIncrementCap {
 			log.Warn().
-				Str("url", record.url).
+				Str("url", logging.RedactURL(record.url)).
 				Int("delta", delta).
 				Int("cap", historyFallbackIncrementCap).
 				Msg("visit count fallback increment capped")
@@ -333,7 +333,7 @@ func (uc *NavigateUseCase) persistHistory(ctx context.Context, record historyRec
 		}
 		for i := 0; i < iterations; i++ {
 			if err := uc.historyRepo.IncrementVisitCount(ctx, record.url); err != nil {
-				log.Warn().Err(err).Str("url", record.url).Msg("failed to increment visit count")
+				log.Warn().Err(err).Str("url", logging.RedactURL(record.url)).Msg("failed to increment visit count")
 				return
 			}
 		}
@@ -342,7 +342,7 @@ func (uc *NavigateUseCase) persistHistory(ctx context.Context, record historyRec
 		entry := entity.NewHistoryEntry(record.url, "")
 		entry.VisitCount = int64(max(1, record.visits))
 		if err := uc.historyRepo.Save(ctx, entry); err != nil {
-			log.Warn().Err(err).Str("url", record.url).Msg("failed to save history")
+			log.Warn().Err(err).Str("url", logging.RedactURL(record.url)).Msg("failed to save history")
 		}
 	}
 }
@@ -358,7 +358,7 @@ func (uc *NavigateUseCase) persistTitleUpdate(ctx context.Context, historyURL, t
 
 	entry, err := uc.historyRepo.FindByURL(ctx, historyURL)
 	if err != nil {
-		log.Warn().Err(err).Str("url", historyURL).Msg("failed to find history entry for title update")
+		log.Warn().Err(err).Str("url", logging.RedactURL(historyURL)).Msg("failed to find history entry for title update")
 		return
 	}
 	if entry == nil {
@@ -368,12 +368,12 @@ func (uc *NavigateUseCase) persistTitleUpdate(ctx context.Context, historyURL, t
 	entry.Title = title
 	if updater, ok := uc.historyRepo.(historyMetadataUpdater); ok {
 		if err := updater.UpdateMetadata(ctx, entry); err != nil {
-			log.Warn().Err(err).Str("url", historyURL).Msg("failed to update history metadata")
+			log.Warn().Err(err).Str("url", logging.RedactURL(historyURL)).Msg("failed to update history metadata")
 		}
 		return
 	}
 	if err := uc.historyRepo.Save(ctx, entry); err != nil {
-		log.Warn().Err(err).Str("url", historyURL).Msg("failed to update history title")
+		log.Warn().Err(err).Str("url", logging.RedactURL(historyURL)).Msg("failed to update history title")
 	}
 }
 
@@ -392,7 +392,7 @@ func (uc *NavigateUseCase) UpdateHistoryTitle(_ context.Context, historyURL, tit
 	select {
 	case uc.historyQueue <- historyRecord{url: historyURL, title: title}:
 	default:
-		logging.FromContext(uc.ctx).Warn().Str("url", historyURL).Msg("history queue full, title update dropped")
+		logging.FromContext(uc.ctx).Warn().Str("url", logging.RedactURL(historyURL)).Msg("history queue full, title update dropped")
 	}
 }
 

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -51,9 +51,9 @@ func WithTabID(ctx context.Context, tabID string) context.Context {
 	return WithContext(ctx, childLogger)
 }
 
-// WithURL creates a child logger with a url field
+// WithURL creates a child logger with a redacted url field.
 func WithURL(ctx context.Context, url string) context.Context {
 	logger := FromContext(ctx)
-	childLogger := logger.With().Str("url", url).Logger()
+	childLogger := logger.With().Str("url", RedactURL(url)).Logger()
 	return WithContext(ctx, childLogger)
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -6,6 +6,7 @@ import (
 	neturl "net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -71,8 +72,8 @@ func New(cfg Config) zerolog.Logger {
 // Returns the logger and a cleanup function to close the file.
 func NewWithFile(cfg Config, fileCfg FileConfig) (zerolog.Logger, func(), error) {
 	const (
-		logDirPerm  = 0o755
-		logFilePerm = 0o644
+		logDirPerm  = 0o700
+		logFilePerm = 0o600
 	)
 	var writers []io.Writer
 	cleanup := func() {}
@@ -97,14 +98,22 @@ func NewWithFile(cfg Config, fileCfg FileConfig) (zerolog.Logger, func(), error)
 
 	// Session file output (JSON format for parsing)
 	if fileCfg.Enabled && fileCfg.LogDir != "" && fileCfg.SessionID != "" {
-		// Ensure log directory exists (LogDir is from config, may not have logs subdir)
+		// Ensure log directory exists (LogDir is from config, may not have logs subdir).
+		// Session logs may contain browsing metadata, so keep them user-private.
 		if err := os.MkdirAll(fileCfg.LogDir, logDirPerm); err != nil {
+			return zerolog.Logger{}, nil, err
+		}
+		if err := os.Chmod(fileCfg.LogDir, logDirPerm); err != nil {
 			return zerolog.Logger{}, nil, err
 		}
 
 		filename := filepath.Join(fileCfg.LogDir, SessionFilename(fileCfg.SessionID))
 		file, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, logFilePerm)
 		if err != nil {
+			return zerolog.Logger{}, nil, err
+		}
+		if err := file.Chmod(logFilePerm); err != nil {
+			_ = file.Close()
 			return zerolog.Logger{}, nil, err
 		}
 
@@ -242,12 +251,44 @@ func ParseLevel(level string) zerolog.Level {
 // PermissionLogURLMaxLen is the standard max length for permission-related URL logging.
 const PermissionLogURLMaxLen = 96
 
-// TruncateURL truncates a URL to maxLen characters for logging.
-func TruncateURL(url string, maxLen int) string {
-	if len(url) <= maxLen {
-		return url
+// RedactedURLPlaceholder is emitted when input looks like a URL/path but has no safe host.
+const RedactedURLPlaceholder = "[redacted-url]"
+
+// RedactURL returns privacy-preserving URL diagnostics. Absolute URLs with a
+// host are reduced to host-only; query strings, fragments, paths, credentials,
+// and local file paths are omitted.
+func RedactURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
 	}
-	return url[:maxLen] + "..."
+
+	parsed, err := neturl.Parse(raw)
+	if err != nil {
+		return RedactedURLPlaceholder
+	}
+	if parsed.Host != "" {
+		return parsed.Hostname()
+	}
+	if parsed.Scheme == "about" && parsed.Opaque != "" {
+		// Use Opaque directly instead of parsed.String() to avoid leaking
+		// RawQuery and Fragment (Go's URL parser separates them from Opaque,
+		// but String() reconstructs the full URL including query/fragment).
+		return parsed.Scheme + ":" + parsed.Opaque
+	}
+	if parsed.Scheme != "" {
+		return parsed.Scheme + ":" + RedactedURLPlaceholder
+	}
+	return RedactedURLPlaceholder
+}
+
+// TruncateURL redacts and then truncates a URL for logging.
+func TruncateURL(url string, maxLen int) string {
+	redacted := RedactURL(url)
+	if len(redacted) <= maxLen {
+		return redacted
+	}
+	return redacted[:maxLen] + "..."
 }
 
 // SafeURLHost returns only the host portion of a URL for privacy-preserving diagnostics.
@@ -256,5 +297,5 @@ func SafeURLHost(raw string) string {
 	if err != nil {
 		return ""
 	}
-	return parsed.Host
+	return parsed.Hostname()
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -3,8 +3,42 @@ package logging
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/rs/zerolog"
 )
+
+func TestRedactURLUsesHostOnlyForAbsoluteURLs(t *testing.T) {
+	t.Parallel()
+
+	got := RedactURL("https://user:pass@example.com/private/path?token=secret#frag")
+	if got != "example.com" {
+		t.Fatalf("RedactURL returned %q, want %q", got, "example.com")
+	}
+}
+
+func TestRedactURLRedactsLocalOrOpaqueInputs(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"/home/user/private/file.html?token=secret", "not a url"} {
+		if got := RedactURL(raw); got != RedactedURLPlaceholder {
+			t.Fatalf("RedactURL(%q) returned %q, want %q", raw, got, RedactedURLPlaceholder)
+		}
+	}
+}
+
+func TestTruncateURLRedactsBeforeTruncating(t *testing.T) {
+	t.Parallel()
+
+	got := TruncateURL("https://example.com/private/path?token=secret#frag", 96)
+	if got != "example.com" {
+		t.Fatalf("TruncateURL returned %q, want %q", got, "example.com")
+	}
+	if strings.Contains(got, "token") || strings.Contains(got, "/private") || strings.Contains(got, "frag") {
+		t.Fatalf("TruncateURL leaked sensitive URL data: %q", got)
+	}
+}
 
 func TestSafeURLHostDropsPathQueryAndFragment(t *testing.T) {
 	t.Parallel()
@@ -22,6 +56,77 @@ func TestSafeURLHostReturnsEmptyForOpaqueOrInvalidInput(t *testing.T) {
 		if got := SafeURLHost(raw); got != "" {
 			t.Fatalf("SafeURLHost(%q) returned %q, want empty host", raw, got)
 		}
+	}
+}
+
+func TestRedactURLStripsQueryFragmentFromAboutOpaqueURLs(t *testing.T) {
+	t.Parallel()
+
+	got := RedactURL("about:blank?token=secret#frag")
+	if want := "about:blank"; got != want {
+		t.Fatalf("RedactURL(about:blank?token=secret#frag) = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "token") || strings.Contains(got, "secret") || strings.Contains(got, "frag") {
+		t.Fatalf("RedactURL leaked query/fragment from about: opaque URL: %q", got)
+	}
+}
+
+func TestRedactURLRedactsFileURLPathQueryFragment(t *testing.T) {
+	t.Parallel()
+
+	got := RedactURL("file:///home/user/private?token=secret#frag")
+	if got != "file:"+RedactedURLPlaceholder {
+		t.Fatalf("RedactURL(file:///home/user/private?token=secret#frag) = %q, want %q", got, "file:"+RedactedURLPlaceholder)
+	}
+	if strings.Contains(got, "home") || strings.Contains(got, "user") || strings.Contains(got, "private") {
+		t.Fatalf("RedactURL leaked file path from file:// URL: %q", got)
+	}
+	if strings.Contains(got, "token") || strings.Contains(got, "secret") || strings.Contains(got, "frag") {
+		t.Fatalf("RedactURL leaked query/fragment from file:// URL: %q", got)
+	}
+}
+
+func TestRedactURLReturnsPlaceholderForInvalidParse(t *testing.T) {
+	t.Parallel()
+
+	got := RedactURL("http://[::1")
+	if got != RedactedURLPlaceholder {
+		t.Fatalf("RedactURL(http://[::1) = %q, want %q", got, RedactedURLPlaceholder)
+	}
+}
+
+func TestNewWithFileCreatesUserPrivateLogDirectoryAndFile(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	logDir := filepath.Join(parent, "logs")
+	logger, cleanup, err := NewWithFile(Config{Level: zerolog.InfoLevel, Format: logFormatJSON}, FileConfig{
+		Enabled:   true,
+		LogDir:    logDir,
+		SessionID: "test-session",
+	})
+	if err != nil {
+		t.Fatalf("NewWithFile: %v", err)
+	}
+	defer cleanup()
+
+	logger.Info().Msg("hello")
+	cleanup()
+
+	dirInfo, err := os.Stat(logDir)
+	if err != nil {
+		t.Fatalf("stat log dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("log dir permissions = %o, want 700", got)
+	}
+
+	fileInfo, err := os.Stat(filepath.Join(logDir, SessionFilename("test-session")))
+	if err != nil {
+		t.Fatalf("stat log file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("log file permissions = %o, want 600", got)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- create user-private persistent log directories/files\n- redact sensitive URL data in logging helpers and audit-listed usecase call sites\n- add redaction and permission tests, including opaque/about/file/invalid URL cases\n\n## Verification\n- rtk go test ./internal/logging ./internal/application/usecase\n- Go reviewer: approved after fixes\n- CodeRabbit review against origin/main: 0 findings\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
* URLs in diagnostic and debug logs now automatically redact sensitive information including paths, query parameters, and fragments
* Session log files and directories are created with restricted user-only access permissions

**Tests**
* Added comprehensive test coverage for URL redaction across multiple URL formats and schemes
* Added verification tests for session log file and directory permission settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->