### PR TITLE
fix(usecase): preserve pane state on failed moves

### DIFF
--- a/internal/application/usecase/move_pane_to_tab.go
+++ b/internal/application/usecase/move_pane_to_tab.go
@@ -46,12 +46,9 @@ func (uc *MovePaneToTabUseCase) Execute(input MovePaneToTabInput) (*MovePaneToTa
 		return nil, err
 	}
 
-	if detachErr := detachPaneFromWorkspace(sourceTab.Workspace, sourceNode); detachErr != nil {
-		return nil, detachErr
-	}
-
-	sourceTabClosed := closeSourceTabIfEmpty(input.TabList, sourceTab)
-
+	// CORRECTNESS-02: Resolve/prepare the target BEFORE mutating source.
+	// This ensures that target resolution (idGenerator check for new tabs)
+	// and insertion validation happen while source state is still intact.
 	targetTab, newTabCreated, err := uc.resolveTargetTab(input.TabList, input.TargetTabID, movedPane)
 	if err != nil {
 		return nil, err
@@ -60,7 +57,29 @@ func (uc *MovePaneToTabUseCase) Execute(input MovePaneToTabInput) (*MovePaneToTa
 		return nil, fmt.Errorf("target tab/workspace is nil")
 	}
 
+	// Pre-validate insertion prerequisites before mutating source.
+	// Insertion into an existing non-empty workspace requires idGenerator
+	// for creating split parent nodes (for non-empty targets with Root != nil),
+	// and requires a valid active pane. Fail early if either is unavailable.
+	if !newTabCreated && targetTab.Workspace.Root != nil {
+		if uc.idGenerator == nil {
+			return nil, fmt.Errorf("id generator is required to insert pane into existing workspace")
+		}
+		activePane := targetTab.Workspace.ActivePane()
+		if activePane == nil || activePane.Pane == nil {
+			return nil, fmt.Errorf("target tab has no active pane")
+		}
+	}
+
+	// Now mutate source — pane is detached from original location.
+	if detachErr := detachPaneFromWorkspace(sourceTab.Workspace, sourceNode); detachErr != nil {
+		return nil, detachErr
+	}
+
+	sourceTabClosed := closeSourceTabIfEmpty(input.TabList, sourceTab)
+
 	if newTabCreated {
+		input.TabList.Add(targetTab)
 		return &MovePaneToTabOutput{
 			TargetTab:       targetTab,
 			MovedPaneNode:   targetTab.Workspace.Root,
@@ -158,7 +177,10 @@ func (uc *MovePaneToTabUseCase) resolveTargetTab(
 	tabID := entity.TabID(uc.idGenerator())
 	wsID := entity.WorkspaceID(uc.idGenerator())
 	targetTab := entity.NewTab(tabID, wsID, movedPane)
-	tl.Add(targetTab)
+	// NOTE: tab is NOT added to TabList here. Addition is deferred until
+	// after successful detach in Execute() (see newTabCreated path).
+	// This prevents leaving a stale/duplicate tab in the list if detach fails
+	// (CORRECTNESS-02).
 	return targetTab, true, nil
 }
 

--- a/internal/application/usecase/move_pane_to_tab_test.go
+++ b/internal/application/usecase/move_pane_to_tab_test.go
@@ -191,6 +191,124 @@ func TestMovePaneToTab_InsertsRightOfActiveEvenWhenActiveInStack(t *testing.T) {
 	require.Equal(t, paneA.ID, out.TargetTab.Workspace.Root.Right().Pane.ID)
 }
 
+// CORRECTNESS-02: Resolve move targets before detaching panes.
+//
+// When a pane move fails after source detach (e.g., nil idGenerator prevents
+// insertion into an existing workspace), the source tab must retain its pane.
+// Previously, detachPaneFromWorkspace was called before resolveTargetTab and
+// insertIntoTargetWorkspace, so a failure in either would leave the pane
+// detached from its original location while returning an error.
+func TestMovePaneToTab_FailedMovePreservesSourcePane(t *testing.T) {
+	// Source tab with a single pane.
+	tabs := entity.NewTabList()
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	tabA := entity.NewTab(entity.TabID("tA"), entity.WorkspaceID("wA"), paneA)
+	tabs.Add(tabA)
+
+	// Target tab with an existing pane (non-nil Root), so insertion needs idGenerator.
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	tabB := entity.NewTab(entity.TabID("tB"), entity.WorkspaceID("wB"), paneB)
+	tabs.Add(tabB)
+	tabB.Workspace.ActivePaneID = paneB.ID
+
+	// Use nil idGenerator — insertion into existing workspace will fail.
+	uc := NewMovePaneToTabUseCase(nil)
+
+	_, err := uc.Execute(MovePaneToTabInput{
+		TabList:      tabs,
+		SourceTabID:  tabA.ID,
+		SourcePaneID: paneA.ID,
+		TargetTabID:  tabB.ID,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "id generator is required")
+
+	// Source must be preserved: tab still exists and pane is still inside it.
+	require.NotNil(t, tabs.Find(tabA.ID), "source tab must not be removed on failed move")
+	require.NotNil(t, tabA.Workspace.FindPane(paneA.ID), "source pane must not be detached on failed move")
+}
+
+// CORRECTNESS-02: Pre-validate that target workspace has a valid active pane
+// before detaching source. When a target workspace has Root != nil but
+// ActivePane() returns nil (e.g., ActivePaneID points to a non-existent pane),
+// insertIntoTargetWorkspace would fail after detach. Pre-validation catches
+// this early.
+func TestMovePaneToTab_FailsOnTargetWithNoActivePane(t *testing.T) {
+	id := newTestIDGen()
+	uc := NewMovePaneToTabUseCase(id)
+
+	tabs := entity.NewTabList()
+
+	// Source tab.
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	tabA := entity.NewTab(entity.TabID("tA"), entity.WorkspaceID("wA"), paneA)
+	tabs.Add(tabA)
+
+	// Target tab with Root != nil but ActivePaneID pointing to a non-existent pane.
+	paneB := entity.NewPane(entity.PaneID("pB"))
+	tabB := entity.NewTab(entity.TabID("tB"), entity.WorkspaceID("wB"), paneB)
+	tabB.Workspace.ActivePaneID = "nonexistent"
+	tabs.Add(tabB)
+
+	_, err := uc.Execute(MovePaneToTabInput{
+		TabList:      tabs,
+		SourceTabID:  tabA.ID,
+		SourcePaneID: paneA.ID,
+		TargetTabID:  tabB.ID,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no active pane")
+
+	// Source must be preserved.
+	require.NotNil(t, tabs.Find(tabA.ID), "source tab must not be removed on failed move")
+	require.NotNil(t, tabA.Workspace.FindPane(paneA.ID), "source pane must not be detached on failed move")
+}
+
+// CORRECTNESS-02: New tab must not be added to TabList when detach fails.
+// When create-new-tab is requested (empty TargetTabID), resolveTargetTab
+// generates IDs and creates the tab but must NOT add it to TabList until
+// after successful detach from source. This test verifies that a detach
+// failure (e.g., pane's parent is not a valid split) does not leave a
+// stale/duplicate tab in the list.
+func TestMovePaneToTab_NewTabNotAddedOnDetachFailure(t *testing.T) {
+	id := newTestIDGen()
+	uc := NewMovePaneToTabUseCase(id)
+
+	tabs := entity.NewTabList()
+
+	paneA := entity.NewPane(entity.PaneID("pA"))
+	tabA := entity.NewTab(entity.TabID("tA"), entity.WorkspaceID("wA"), paneA)
+	tabs.Add(tabA)
+
+	// Construct an invalid parent structure so detach fails:
+	// Make paneA's PaneNode a child of a non-split container node.
+	// detachLeafFromWorkspace will reject because parent.IsSplit() is false.
+	invalidParent := &entity.PaneNode{
+		ID:       "invalid-parent",
+		Children: []*entity.PaneNode{tabA.Workspace.Root},
+		// SplitDir is deliberately SplitNone (zero value), so IsSplit() returns false.
+	}
+	tabA.Workspace.Root.Parent = invalidParent
+	tabA.Workspace.Root = invalidParent
+
+	initialCount := tabs.Count()
+
+	_, err := uc.Execute(MovePaneToTabInput{
+		TabList:      tabs,
+		SourceTabID:  tabA.ID,
+		SourcePaneID: paneA.ID,
+		TargetTabID:  "", // creates new tab
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pane parent is not a split")
+
+	// No new tab should have been added to the list.
+	require.Equal(t, initialCount, tabs.Count(), "no new tab should be added on failed move")
+	// Source tab and pane should still be in their original positions.
+	require.NotNil(t, tabs.Find(tabA.ID), "source tab must not be removed on failed move")
+	require.NotNil(t, tabA.Workspace.FindPane(paneA.ID), "source pane must not be detached on failed move")
+}
+
 func newTestIDGen() func() string {
 	counter := 0
 	return func() string {


### PR DESCRIPTION
## Summary\n- resolve and prevalidate move targets before detaching the source pane\n- defer new-tab insertion until after successful source detach\n- add regression coverage for failed insertion, missing active pane, and detach failure paths\n\n## Verification\n- rtk go test ./internal/application/usecase/ -run TestMovePaneToTab\n- rtk go test ./internal/application/usecase/\n- Go reviewer: approved after fixes\n- CodeRabbit review against origin/main: 0 findings after rerun\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the move-pane-to-tab operation by validating prerequisites before modifying state, preventing potential data corruption in edge cases.

* **Tests**
  * Added comprehensive test coverage for failure scenarios to ensure state preservation during failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->