### PR TITLE
fix(cef): keep webview viewport synced during resize

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.13.3
-	github.com/bnema/purego-cef2gtk v0.8.2-0.20260620140111-e7e819925e8a
+	github.com/bnema/purego-cef2gtk v0.8.2-0.20260620142512-33162fc2478b
 	github.com/bnema/purego-pipewire v0.1.4
 	github.com/bnema/purego-sqlite v0.1.3
 	github.com/bnema/puregotk v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.13.3
-	github.com/bnema/purego-cef2gtk v0.8.1
+	github.com/bnema/purego-cef2gtk v0.8.2-0.20260620140111-e7e819925e8a
 	github.com/bnema/purego-pipewire v0.1.4
 	github.com/bnema/purego-sqlite v0.1.3
 	github.com/bnema/puregotk v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.13.3
-	github.com/bnema/purego-cef2gtk v0.8.2-0.20260620142512-33162fc2478b
+	github.com/bnema/purego-cef2gtk v0.8.2
 	github.com/bnema/purego-pipewire v0.1.4
 	github.com/bnema/purego-sqlite v0.1.3
 	github.com/bnema/puregotk v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.13.3 h1:41b+cEg0TvoYSiSMsZWh/YlWdNzTYM/gCxuBFeMv4qk=
 github.com/bnema/purego-cef v0.13.3/go.mod h1:yy/Ogjgk+VcppcUhI0A+NcXvfnqFEDOckwErdhlJQjo=
-github.com/bnema/purego-cef2gtk v0.8.1 h1:hhD8bIWJBq5dZISwSV0wt2+LXbtfFL/c/Y/OUyjxiP4=
-github.com/bnema/purego-cef2gtk v0.8.1/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
+github.com/bnema/purego-cef2gtk v0.8.2-0.20260620140111-e7e819925e8a h1:X/NfHxvMk9E8Tg7yqznDFUvqB83Qg/oPGZzzb669UNc=
+github.com/bnema/purego-cef2gtk v0.8.2-0.20260620140111-e7e819925e8a/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=
 github.com/bnema/purego-pipewire v0.1.4/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.3 h1:aXysq9+wuRkbFzlVe2oIiooYseFZFb6ArwbfDYYafvY=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.13.3 h1:41b+cEg0TvoYSiSMsZWh/YlWdNzTYM/gCxuBFeMv4qk=
 github.com/bnema/purego-cef v0.13.3/go.mod h1:yy/Ogjgk+VcppcUhI0A+NcXvfnqFEDOckwErdhlJQjo=
-github.com/bnema/purego-cef2gtk v0.8.2-0.20260620140111-e7e819925e8a h1:X/NfHxvMk9E8Tg7yqznDFUvqB83Qg/oPGZzzb669UNc=
-github.com/bnema/purego-cef2gtk v0.8.2-0.20260620140111-e7e819925e8a/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
+github.com/bnema/purego-cef2gtk v0.8.2-0.20260620142512-33162fc2478b h1:j0bLZFpqdH2GEtAONfNVECkihZzXfteuKogokgqxr6Y=
+github.com/bnema/purego-cef2gtk v0.8.2-0.20260620142512-33162fc2478b/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=
 github.com/bnema/purego-pipewire v0.1.4/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.3 h1:aXysq9+wuRkbFzlVe2oIiooYseFZFb6ArwbfDYYafvY=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.13.3 h1:41b+cEg0TvoYSiSMsZWh/YlWdNzTYM/gCxuBFeMv4qk=
 github.com/bnema/purego-cef v0.13.3/go.mod h1:yy/Ogjgk+VcppcUhI0A+NcXvfnqFEDOckwErdhlJQjo=
-github.com/bnema/purego-cef2gtk v0.8.2-0.20260620142512-33162fc2478b h1:j0bLZFpqdH2GEtAONfNVECkihZzXfteuKogokgqxr6Y=
-github.com/bnema/purego-cef2gtk v0.8.2-0.20260620142512-33162fc2478b/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
+github.com/bnema/purego-cef2gtk v0.8.2 h1:C1ijk9oWkqMKI1C4GrQ9j7Z3SmZPBhoM+f5zOYiSvRU=
+github.com/bnema/purego-cef2gtk v0.8.2/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=
 github.com/bnema/purego-pipewire v0.1.4/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.3 h1:aXysq9+wuRkbFzlVe2oIiooYseFZFb6ArwbfDYYafvY=

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -94,7 +94,11 @@ func (wv *WebView) syncViewportOnGTK(ctx context.Context) {
 	if wv == nil {
 		return
 	}
-	wv.syncViewportNowOnGTK(ctx, wv.takeViewportSyncReason())
+	reason := wv.takeViewportSyncReason()
+	ctx = wv.viewportSyncContext(ctx)
+	if wv.syncViewportNowOnGTK(ctx, reason) {
+		wv.scheduleResizeRepaintPulse(ctx, reason)
+	}
 }
 
 func (wv *WebView) syncViewportNowOnGTK(ctx context.Context, reason string) bool {
@@ -148,6 +152,12 @@ func (wv *WebView) scheduleResizeRepaintPulse(ctx context.Context, reason string
 	if wv == nil || wv.destroyed.Load() {
 		return
 	}
+	visible := true
+	if wv.viewBridge != nil {
+		if widget := wv.viewBridge.Widget(); widget != nil {
+			visible = widget.IsVisible()
+		}
+	}
 	seq := wv.viewportResizePulseSeq.Add(1)
 	for _, delayMs := range [...]int64{16, 48} {
 		task := cefNewTask(cefTaskFunc(func() {
@@ -160,12 +170,13 @@ func (wv *WebView) scheduleResizeRepaintPulse(ctx context.Context, reason string
 			if host == nil {
 				return
 			}
-			host.Invalidate(purecef.PaintElementTypePetView)
+			notifyBrowserViewportSync(host, visible)
 			logging.FromContext(ctx).Debug().
 				Uint64("webview_id", uint64(wv.id)).
 				Int64("delay_ms", delayMs).
+				Bool("visible", visible).
 				Str("reason", reason).
-				Msg("cef: delayed resize repaint pulse")
+				Msg("cef: delayed resize viewport sync")
 		}))
 		if task == nil {
 			continue

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -152,11 +152,11 @@ func (wv *WebView) scheduleResizeRepaintPulse(ctx context.Context, reason string
 	if wv == nil || wv.destroyed.Load() {
 		return
 	}
-	visible := true
-	if wv.viewBridge != nil {
-		if widget := wv.viewBridge.Widget(); widget != nil {
-			visible = widget.IsVisible()
-		}
+	wv.mu.RLock()
+	host := wv.host
+	wv.mu.RUnlock()
+	if host == nil {
+		return
 	}
 	seq := wv.viewportResizePulseSeq.Add(1)
 	for _, delayMs := range [...]int64{16, 48} {
@@ -165,16 +165,15 @@ func (wv *WebView) scheduleResizeRepaintPulse(ctx context.Context, reason string
 				return
 			}
 			wv.mu.RLock()
-			host := wv.host
+			currentHost := wv.host
 			wv.mu.RUnlock()
-			if host == nil {
+			if currentHost != host {
 				return
 			}
-			notifyBrowserViewportSync(host, visible)
+			notifyBrowserViewportResize(host)
 			logging.FromContext(ctx).Debug().
 				Uint64("webview_id", uint64(wv.id)).
 				Int64("delay_ms", delayMs).
-				Bool("visible", visible).
 				Str("reason", reason).
 				Msg("cef: delayed resize viewport sync")
 		}))
@@ -532,6 +531,13 @@ func notifyBrowserViewportSync(host viewportSyncBrowserHost, visible bool) {
 	}
 	if visible {
 		host.WasHidden(0)
+	}
+	notifyBrowserViewportResize(host)
+}
+
+func notifyBrowserViewportResize(host viewportSyncBrowserHost) {
+	if host == nil {
+		return
 	}
 	host.NotifyScreenInfoChanged()
 	notifyBrowserResize(host)

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -492,3 +492,57 @@ func TestScheduleResizeRepaintPulse_SkipsStaleHost(t *testing.T) {
 	require.Empty(t, capturedHost.calls)
 	require.Empty(t, currentHost.calls)
 }
+
+func TestScheduleResizeRepaintPulse_SkipsWhenHostNilAtScheduleTime(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled []purecef.Task
+	cefPostDelayedTask = func(_ purecef.ThreadID, task purecef.Task, _ int64) int32 {
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	wv := &WebView{ctx: context.Background()}
+
+	wv.scheduleResizeRepaintPulse(context.Background(), "nil-host")
+
+	require.Empty(t, scheduled)
+}
+
+func TestScheduleResizeRepaintPulse_SkipsWhenHostClearedBeforeExecution(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled []purecef.Task
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
+		require.Equal(t, purecef.ThreadIDTidUi, threadID)
+		require.NotNil(t, task)
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	host := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: host}
+
+	wv.scheduleResizeRepaintPulse(context.Background(), "nil-host-before-execute")
+	wv.host = nil
+
+	require.Len(t, scheduled, 2)
+	scheduled[0].Execute()
+	scheduled[1].Execute()
+
+	require.Empty(t, host.calls)
+}

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -450,5 +450,14 @@ func TestScheduleResizeRepaintPulse_CoalescesToLatestSequence(t *testing.T) {
 
 	scheduled[2].Execute()
 	scheduled[3].Execute()
-	require.Equal(t, []string{"Invalidate", "Invalidate"}, host.calls)
+	require.Equal(t, []string{
+		"WasHidden",
+		"NotifyScreenInfoChanged",
+		"WasResized",
+		"Invalidate",
+		"WasHidden",
+		"NotifyScreenInfoChanged",
+		"WasResized",
+		"Invalidate",
+	}, host.calls)
 }

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -451,13 +451,44 @@ func TestScheduleResizeRepaintPulse_CoalescesToLatestSequence(t *testing.T) {
 	scheduled[2].Execute()
 	scheduled[3].Execute()
 	require.Equal(t, []string{
-		"WasHidden",
 		"NotifyScreenInfoChanged",
 		"WasResized",
 		"Invalidate",
-		"WasHidden",
 		"NotifyScreenInfoChanged",
 		"WasResized",
 		"Invalidate",
 	}, host.calls)
+}
+
+func TestScheduleResizeRepaintPulse_SkipsStaleHost(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled []purecef.Task
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
+		require.Equal(t, purecef.ThreadIDTidUi, threadID)
+		require.NotNil(t, task)
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	capturedHost := &viewportSyncOrderHost{}
+	currentHost := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: capturedHost}
+
+	wv.scheduleResizeRepaintPulse(context.Background(), "stale-host")
+	wv.host = currentHost
+
+	require.Len(t, scheduled, 2)
+	scheduled[0].Execute()
+	scheduled[1].Execute()
+
+	require.Empty(t, capturedHost.calls)
+	require.Empty(t, currentHost.calls)
 }

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -471,7 +471,7 @@ func TestScheduleResizeRepaintPulse_SkipsStaleHost(t *testing.T) {
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
 
 	var scheduled []purecef.Task
-	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, _ int64) int32 {
 		require.Equal(t, purecef.ThreadIDTidUi, threadID)
 		require.NotNil(t, task)
 		scheduled = append(scheduled, task)
@@ -527,7 +527,7 @@ func TestScheduleResizeRepaintPulse_SkipsWhenHostClearedBeforeExecution(t *testi
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
 
 	var scheduled []purecef.Task
-	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, _ int64) int32 {
 		require.Equal(t, purecef.ThreadIDTidUi, threadID)
 		require.NotNil(t, task)
 		scheduled = append(scheduled, task)


### PR DESCRIPTION
## Summary
- resync CEF viewport after GTK size/lifecycle changes with bounded delayed resize pulses
- guard delayed pulses against stale or nil browser hosts
- update to `github.com/bnema/purego-cef2gtk v0.8.2`, which fills the GTK picture presenter during resize to hide transient fill artifacts
- add focused viewport pulse tests for coalescing, stale-host, and nil-host cases

## Verification
- `go test -mod=vendor ./internal/infrastructure/cef`
- wrap-up review rerun: no further review jobs recommended
- CodeRabbit rerun: 0 findings
- manual verification: browser/window resizing and split close/promote paths refit promptly without getting stuck

## Related
- purego-cef2gtk release: https://github.com/bnema/purego-cef2gtk/releases/tag/v0.8.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced viewport synchronization and resize notification handling to improve browser view responsiveness during viewport updates.

* **Tests**
  * Added comprehensive test coverage for viewport resize scheduling edge cases.

* **Chores**
  * Updated dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->