### PR TITLE
fix(release): address final review blockers

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,9 @@ version: 2
 
 before:
   hooks:
-    # Build systemviews assets before building binaries
+    # Build and verify systemviews assets before building binaries
     - make build-systemviews
+    - make verify-systemviews-assets
 
 builds:
   # Pure Go build (no CGO required)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for dumber (Clean Architecture - puregotk)
 
-.PHONY: build build-systemviews generate-systemviews build-quick install-local test lint staticcheck clean install-tools install-golangci-lint install-staticcheck dev generate help init man flatpak-deps flatpak-build flatpak-install flatpak-run flatpak-clean stress-omnibox-callbacks verify-purego verify-generated check
+.PHONY: build build-systemviews generate-systemviews build-quick install-local test lint staticcheck clean install-tools install-golangci-lint install-staticcheck dev generate help init man flatpak-deps flatpak-build flatpak-install flatpak-run flatpak-clean stress-omnibox-callbacks verify-purego verify-generated verify-systemviews-assets check
 
 # Load local overrides from .env.local if present (Makefile syntax)
 ifneq (,$(wildcard .env.local))
@@ -135,6 +135,10 @@ verify-generated: ## Verify generated systemviews artifacts are committed
 		echo "Generated systemviews artifacts are out of date. Run 'make build-systemviews' and commit the result."; \
 		exit 1; \
 	}
+
+verify-systemviews-assets: ## Verify release embeds a compressed systemviews WASM asset
+	@echo "Verifying embedded systemviews WASM asset..."
+	DUMBER_REQUIRE_SYSTEMVIEWS_WASM=1 GOFLAGS=$(GOFLAGS) go test -count=1 -run TestWebUIAssetsIncludesCompressedSystemviewsWASM ./assets
 
 # Linting
 lint: ## Run golangci-lint

--- a/assets/webui_embed_test.go
+++ b/assets/webui_embed_test.go
@@ -1,0 +1,34 @@
+package assets
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+)
+
+func TestWebUIAssetsIncludesCompressedSystemviewsWASM(t *testing.T) {
+	compressed, err := WebUIAssets.ReadFile("systemviews/systemviews.wasm.br")
+	if err != nil {
+		if os.Getenv("DUMBER_REQUIRE_SYSTEMVIEWS_WASM") == "" {
+			t.Skipf("generated systemviews WASM asset not present; run make build-systemviews: %v", err)
+		}
+		t.Fatalf("read embedded systemviews WASM asset: %v", err)
+	}
+	if len(compressed) == 0 {
+		t.Fatal("embedded systemviews WASM asset is empty")
+	}
+
+	reader := brotli.NewReader(bytes.NewReader(compressed))
+	header := make([]byte, 8)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		t.Fatalf("decompress embedded systemviews WASM header: %v", err)
+	}
+
+	wantHeader := []byte{0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00}
+	if !bytes.Equal(header, wantHeader) {
+		t.Fatalf("embedded systemviews asset is not a WASM module: got header % x", header)
+	}
+}

--- a/assets/webui_embed_test.go
+++ b/assets/webui_embed_test.go
@@ -31,4 +31,7 @@ func TestWebUIAssetsIncludesCompressedSystemviewsWASM(t *testing.T) {
 	if !bytes.Equal(header, wantHeader) {
 		t.Fatalf("embedded systemviews asset is not a WASM module: got header % x", header)
 	}
+	if _, err := io.ReadAll(reader); err != nil {
+		t.Fatalf("decompress embedded systemviews WASM body: %v", err)
+	}
 }

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -149,27 +149,29 @@ auto_open_on_new_pane = false
 ### Color Palettes
 
 **Light palette:**
+
 ```toml
 [appearance.light_palette]
-background = "#f8f8f8"
-surface = "#f2f2f2"
-surface_variant = "#ececec"
-text = "#1a1a1a"
-muted = "#6e6e6e"
-accent = "#404040"
-border = "#d2d2d2"
+background = "#fafafa"
+surface = "#f4f4f5"
+surface_variant = "#e4e4e7"
+text = "#18181b"
+muted = "#71717a"
+accent = "#22c55e"
+border = "#d4d4d8"
 ```
 
 **Dark palette:**
+
 ```toml
 [appearance.dark_palette]
-background = "#0e0e0e"
-surface = "#1a1a1a"
-surface_variant = "#141414"
-text = "#e4e4e4"
-muted = "#848484"
-accent = "#a8a8a8"
-border = "#363636"
+background = "#0a0a0b"
+surface = "#18181b"
+surface_variant = "#27272a"
+text = "#fafafa"
+muted = "#a1a1aa"
+accent = "#4ade80"
+border = "#3f3f46"
 ```
 
 ### External Theme: Noctalia

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,20 +38,20 @@
 | `appearance.external_theme.provider` | string | `noctalia` | `noctalia` |
 | `appearance.external_theme.format` | string | `colors-json` | `colors-json`, `dumber-json` |
 | `appearance.external_theme.path` | string | `$XDG_CONFIG_HOME/noctalia/colors.json` | path to Noctalia `colors.json` or a `dumber-json` theme file; when empty and `format = "dumber-json"`, dumber uses the built-in dumber-json template path |
-| `appearance.light_palette.background` | string | `#f8f8f8` | |
-| `appearance.light_palette.surface` | string | `#f2f2f2` | |
-| `appearance.light_palette.surface_variant` | string | `#ececec` | |
-| `appearance.light_palette.text` | string | `#1a1a1a` | |
-| `appearance.light_palette.muted` | string | `#6e6e6e` | |
-| `appearance.light_palette.accent` | string | `#404040` | |
-| `appearance.light_palette.border` | string | `#d2d2d2` | |
-| `appearance.dark_palette.background` | string | `#0e0e0e` | |
-| `appearance.dark_palette.surface` | string | `#1a1a1a` | |
-| `appearance.dark_palette.surface_variant` | string | `#141414` | |
-| `appearance.dark_palette.text` | string | `#e4e4e4` | |
-| `appearance.dark_palette.muted` | string | `#848484` | |
-| `appearance.dark_palette.accent` | string | `#a8a8a8` | |
-| `appearance.dark_palette.border` | string | `#363636` | |
+| `appearance.light_palette.background` | string | `#fafafa` | |
+| `appearance.light_palette.surface` | string | `#f4f4f5` | |
+| `appearance.light_palette.surface_variant` | string | `#e4e4e7` | |
+| `appearance.light_palette.text` | string | `#18181b` | |
+| `appearance.light_palette.muted` | string | `#71717a` | |
+| `appearance.light_palette.accent` | string | `#22c55e` | |
+| `appearance.light_palette.border` | string | `#d4d4d8` | |
+| `appearance.dark_palette.background` | string | `#0a0a0b` | |
+| `appearance.dark_palette.surface` | string | `#18181b` | |
+| `appearance.dark_palette.surface_variant` | string | `#27272a` | |
+| `appearance.dark_palette.text` | string | `#fafafa` | |
+| `appearance.dark_palette.muted` | string | `#a1a1aa` | |
+| `appearance.dark_palette.accent` | string | `#4ade80` | |
+| `appearance.dark_palette.border` | string | `#3f3f46` | |
 | `debug.enable_devtools` | bool | `true` | |
 | `engine.cef.log_file` | string | `` | CEF runtime log path |
 | `engine.cef.log_severity` | int32 | `0` | `0`, `1`, `2`, `3`, `4`, `99` |

--- a/internal/application/port/mocks/local_path_resolver.go
+++ b/internal/application/port/mocks/local_path_resolver.go
@@ -99,8 +99,8 @@ func (_c *MockLocalPathResolver_ResolveExistingPath_Call) Run(run func(ctx conte
 	return _c
 }
 
-func (_c *MockLocalPathResolver_ResolveExistingPath_Call) Return(s string, b bool, err error) *MockLocalPathResolver_ResolveExistingPath_Call {
-	_c.Call.Return(s, b, err)
+func (_c *MockLocalPathResolver_ResolveExistingPath_Call) Return(absPath string, ok bool, err error) *MockLocalPathResolver_ResolveExistingPath_Call {
+	_c.Call.Return(absPath, ok, err)
 	return _c
 }
 

--- a/internal/infrastructure/cef/scheme_handler.go
+++ b/internal/infrastructure/cef/scheme_handler.go
@@ -616,7 +616,7 @@ func safeSystemviewsAssetPath(assetDir, relPath string) (fullPath, cleanRelPath 
 	return fullPath, cleanRelPath, true
 }
 
-func readAssetWithEncoding(assets embed.FS, fullPath, relPath string) ([]byte, error) {
+func readAssetWithEncoding(assets fs.FS, fullPath, relPath string) ([]byte, error) {
 	if strings.HasSuffix(relPath, ".wasm") {
 		if compressed, err := fs.ReadFile(assets, fullPath+".br"); err == nil {
 			data, err := io.ReadAll(io.LimitReader(brotli.NewReader(bytes.NewReader(compressed)), maxSystemviewsWASMBytes+1))

--- a/internal/infrastructure/cef/scheme_handler_systemviews_test.go
+++ b/internal/infrastructure/cef/scheme_handler_systemviews_test.go
@@ -1,10 +1,12 @@
 package cef
 
 import (
+	"bytes"
 	"net/url"
 	"testing"
+	"testing/fstest"
 
-	"github.com/bnema/dumber/assets"
+	"github.com/andybalholm/brotli"
 )
 
 func TestResolveAssetPath_SystemviewsRootsUseSystemviewsShell(t *testing.T) {
@@ -42,19 +44,34 @@ func TestResolveAssetPath_SystemviewsRootsUseSystemviewsShell(t *testing.T) {
 	}
 }
 
-func TestReadAssetWithEncoding_DecompressesEmbeddedBrotliWASM(t *testing.T) {
+func TestReadAssetWithEncoding_DecompressesBrotliWASM(t *testing.T) {
 	t.Parallel()
 
-	data, err := readAssetWithEncoding(assets.WebUIAssets, "systemviews/systemviews.wasm", "systemviews.wasm")
+	wasm := []byte("\x00asmfixture")
+	fsys := fstest.MapFS{
+		"systemviews/systemviews.wasm.br": {Data: brotliCompressForTest(t, wasm)},
+	}
+
+	data, err := readAssetWithEncoding(fsys, "systemviews/systemviews.wasm", "systemviews.wasm")
 	if err != nil {
 		t.Fatalf("readAssetWithEncoding() error = %v", err)
 	}
-	if len(data) < 4 {
-		t.Fatalf("decompressed wasm too short: got %d bytes", len(data))
+	if !bytes.Equal(data, wasm) {
+		t.Fatalf("decompressed wasm = %q, want %q", data, wasm)
 	}
-	if string(data[:4]) != "\x00asm" {
-		t.Fatalf("decompressed wasm magic = %q, want \\x00asm", data[:4])
+}
+
+func brotliCompressForTest(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := brotli.NewWriter(&buf)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("brotli write: %v", err)
 	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("brotli close: %v", err)
+	}
+	return buf.Bytes()
 }
 
 func mustParseURL(t *testing.T, raw string) *url.URL {

--- a/internal/infrastructure/cef/webview_handlers_test.go
+++ b/internal/infrastructure/cef/webview_handlers_test.go
@@ -263,14 +263,14 @@ func TestHandleNativePopupAborted_PreservesPrimedNavigationForFallback(t *testin
 }
 
 func TestOnBeforePopup_TimesOutGTKDispatchAndBlocksPopup(t *testing.T) {
-	var delayed func()
+	delayed := make(chan func(), 1)
 	parentWV := &WebView{
 		ctx:            context.Background(),
 		id:             16,
 		gtkSyncTimeout: 5 * time.Millisecond,
 		gtkSyncIsOwner: func() bool { return false },
 		gtkSyncDispatch: func(fn func()) {
-			delayed = fn
+			delayed <- fn
 		},
 	}
 	var createCalls atomic.Int32
@@ -286,9 +286,13 @@ func TestOnBeforePopup_TimesOutGTKDispatchAndBlocksPopup(t *testing.T) {
 
 	require.True(t, blocked)
 	require.Zero(t, createCalls.Load())
-	require.NotNil(t, delayed)
 
-	delayed()
+	select {
+	case fn := <-delayed:
+		fn()
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delayed popup dispatch")
+	}
 	require.Zero(t, createCalls.Load())
 }
 

--- a/internal/infrastructure/updater/github.go
+++ b/internal/infrastructure/updater/github.go
@@ -279,6 +279,11 @@ func isRetryableRequestError(err error) bool {
 		return true
 	}
 
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.IsTemporary {
+		return true
+	}
+
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
 		if isTransientSyscallError(opErr.Err) {

--- a/internal/infrastructure/updater/github_test.go
+++ b/internal/infrastructure/updater/github_test.go
@@ -405,6 +405,7 @@ func TestIsRetryableRequestError(t *testing.T) {
 		{name: "context canceled", err: context.Canceled, want: false},
 		{name: "context deadline exceeded", err: context.DeadlineExceeded, want: true},
 		{name: "timeout net error", err: &net.DNSError{IsTimeout: true}, want: true},
+		{name: "temporary dns error", err: &net.DNSError{IsTemporary: true}, want: true},
 		{name: "non-timeout net error", err: &net.DNSError{Err: "lookup failed"}, want: false},
 		{name: "transient errno through net op error", err: &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}, want: true},
 		{name: "non-transient errno", err: syscall.EINVAL, want: false},

--- a/internal/infrastructure/webkit/messaging.go
+++ b/internal/infrastructure/webkit/messaging.go
@@ -68,7 +68,22 @@ func (r *MessageRouter) SetBaseContext(ctx context.Context) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	r.mu.Lock()
 	r.baseCtx = ctx
+	r.mu.Unlock()
+}
+
+func (r *MessageRouter) baseContext() context.Context {
+	if r == nil {
+		return context.Background()
+	}
+	r.mu.RLock()
+	ctx := r.baseCtx
+	r.mu.RUnlock()
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
 }
 
 // RegisterHandler registers a handler for a message type.
@@ -116,7 +131,8 @@ func (r *MessageRouter) RegisterHandlerWithCallbacks(msgType, callback, errorCal
 // WebKit's messageHandlers is only available in main world.
 // The isolated world GUI scripts dispatch CustomEvents to main world, which forwards to this handler.
 func (r *MessageRouter) SetupMessageHandler(ucm *webkit.UserContentManager, _ string) (uint, error) {
-	log := logging.FromContext(r.baseCtx).With().Str("component", "message-router").Logger()
+	baseCtx := r.baseContext()
+	log := logging.FromContext(baseCtx).With().Str("component", "message-router").Logger()
 
 	log.Debug().Msg("SetupMessageHandler called")
 
@@ -166,7 +182,8 @@ func (r *MessageRouter) SetupMessageHandler(ucm *webkit.UserContentManager, _ st
 
 // handleScriptMessage decodes the JSC value and routes it to the correct handler.
 func (r *MessageRouter) handleScriptMessage(senderUCM webkit.UserContentManager, valuePtr uintptr) {
-	log := logging.FromContext(r.baseCtx).With().Str("component", "message-router").Logger()
+	baseCtx := r.baseContext()
+	log := logging.FromContext(baseCtx).With().Str("component", "message-router").Logger()
 
 	log.Debug().Uint64("value_ptr", uint64(valuePtr)).Msg("handleScriptMessage entry")
 
@@ -225,13 +242,11 @@ func (r *MessageRouter) handleScriptMessage(senderUCM webkit.UserContentManager,
 
 	entry, ok := r.getHandler(msg.Type)
 	if !ok || entry.handler == nil {
-		log.Warn().Str("type", msg.Type).Int("registered_handlers", len(r.handlers)).Msg("no handler registered for message type")
-		// Debug: list all registered handlers
-		r.mu.RLock()
-		for handlerType := range r.handlers {
+		handlerTypes := r.registeredHandlerTypes()
+		log.Warn().Str("type", msg.Type).Int("registered_handlers", len(handlerTypes)).Msg("no handler registered for message type")
+		for _, handlerType := range handlerTypes {
 			log.Debug().Str("registered_type", handlerType).Msg("available handler")
 		}
-		r.mu.RUnlock()
 		return
 	}
 
@@ -242,12 +257,12 @@ func (r *MessageRouter) handleScriptMessage(senderUCM webkit.UserContentManager,
 		Str("callback", entry.callback).
 		Msg("received script message, dispatching to handler")
 
-	resp, err := entry.handler.Handle(r.baseCtx, WebViewID(msg.WebViewID), msg.Payload)
+	resp, err := entry.handler.Handle(baseCtx, WebViewID(msg.WebViewID), msg.Payload)
 	log.Debug().Str("type", msg.Type).Err(err).Msg("handler execution completed")
 	if err != nil {
 		log.Error().Err(err).Str("type", msg.Type).Msg("message handler returned error")
 		if entry.errorCallback != "" {
-			if respErr := r.dispatchResponse(r.baseCtx, WebViewID(msg.WebViewID), entry.errorCallback, entry.world, err.Error()); respErr != nil {
+			if respErr := r.dispatchResponse(baseCtx, WebViewID(msg.WebViewID), entry.errorCallback, entry.world, err.Error()); respErr != nil {
 				log.Warn().Err(respErr).Msg("failed to dispatch error callback")
 			}
 		}
@@ -255,7 +270,7 @@ func (r *MessageRouter) handleScriptMessage(senderUCM webkit.UserContentManager,
 	}
 
 	if entry.callback != "" {
-		if err := r.dispatchResponse(r.baseCtx, WebViewID(msg.WebViewID), entry.callback, entry.world, resp); err != nil {
+		if err := r.dispatchResponse(baseCtx, WebViewID(msg.WebViewID), entry.callback, entry.world, resp); err != nil {
 			log.Warn().Err(err).
 				Str("callback", entry.callback).
 				Uint64("webview_id", msg.WebViewID).
@@ -291,7 +306,7 @@ func (r *MessageRouter) syncWebViewID(wv *WebView) {
 		return
 	}
 	script := fmt.Sprintf("window.__dumber_webview_id=%d;", uint64(wv.ID()))
-	wv.RunJavaScriptInWorld(r.baseCtx, script, "")
+	wv.RunJavaScriptInWorld(r.baseContext(), script, "")
 }
 
 func (r *MessageRouter) markWebViewIDSynced(id WebViewID) bool {
@@ -312,10 +327,20 @@ func (r *MessageRouter) getHandler(msgType string) (handlerEntry, bool) {
 	return entry, ok
 }
 
+func (r *MessageRouter) registeredHandlerTypes() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	types := make([]string, 0, len(r.handlers))
+	for handlerType := range r.handlers {
+		types = append(types, handlerType)
+	}
+	return types
+}
+
 // dispatchResponse serializes the payload and invokes a window callback in JS.
 func (r *MessageRouter) dispatchResponse(ctx context.Context, webviewID WebViewID, callback, world string, payload any) error {
 	if ctx == nil {
-		ctx = r.baseCtx
+		ctx = r.baseContext()
 	}
 
 	if callback == "" {

--- a/internal/infrastructure/webkit/messaging_test.go
+++ b/internal/infrastructure/webkit/messaging_test.go
@@ -1,10 +1,39 @@
 package webkit
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+type messageRouterContextKey struct{}
+
+func TestMessageRouterBaseContextConcurrentUpdate(t *testing.T) {
+	t.Parallel()
+
+	router := NewMessageRouter(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := range 1000 {
+			router.SetBaseContext(context.WithValue(context.Background(), messageRouterContextKey{}, i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			if router.baseContext() == nil {
+				t.Error("base context must never be nil")
+			}
+		}
+	}()
+
+	wg.Wait()
+}
 
 func TestIsTrustedBridgeURI(t *testing.T) {
 	t.Parallel()

--- a/internal/infrastructure/webkit/scheme_handler.go
+++ b/internal/infrastructure/webkit/scheme_handler.go
@@ -499,7 +499,7 @@ func safeSystemviewsAssetPath(assetDir, relPath string) (fullPath, cleanRelPath 
 	return fullPath, cleanRelPath, true
 }
 
-func readAssetWithEncoding(assets embed.FS, fullPath, relPath string) ([]byte, error) {
+func readAssetWithEncoding(assets fs.FS, fullPath, relPath string) ([]byte, error) {
 	var compressedErr error
 	if strings.HasSuffix(relPath, ".wasm") {
 		if compressed, err := fs.ReadFile(assets, fullPath+".br"); err == nil {

--- a/internal/infrastructure/webkit/scheme_handler_test.go
+++ b/internal/infrastructure/webkit/scheme_handler_test.go
@@ -1,12 +1,15 @@
 package webkit
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+	"testing/fstest"
 
+	"github.com/andybalholm/brotli"
 	"github.com/bnema/dumber/assets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -327,13 +330,27 @@ func TestResponseHeadersForPath_WASMIncludesContentTypeAndCORS(t *testing.T) {
 	assert.Equal(t, "GET, POST, OPTIONS", headers["Access-Control-Allow-Methods"])
 }
 
-func TestReadAssetWithEncodingDecompressesEmbeddedBrotliWASM(t *testing.T) {
+func TestReadAssetWithEncodingDecompressesBrotliWASM(t *testing.T) {
 	t.Parallel()
 
-	data, err := readAssetWithEncoding(assets.WebUIAssets, "systemviews/systemviews.wasm", "systemviews.wasm")
+	wasm := []byte("\x00asmfixture")
+	fsys := fstest.MapFS{
+		"systemviews/systemviews.wasm.br": {Data: brotliCompressForTest(t, wasm)},
+	}
+
+	data, err := readAssetWithEncoding(fsys, "systemviews/systemviews.wasm", "systemviews.wasm")
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(data), 4)
-	assert.Equal(t, "\x00asm", string(data[:4]))
+	assert.Equal(t, wasm, data)
+}
+
+func brotliCompressForTest(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := brotli.NewWriter(&buf)
+	_, err := w.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return buf.Bytes()
 }
 
 func TestHandleAssetRejectsTraversalOutsideSystemviews(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix final release-review blockers around WebKit message routing, updater retry behavior, and CEF/WebKit scheme-handler test reproducibility.
- Make clean-checkout tests independent of ignored generated WASM assets while adding a release-time check that the compressed systemviews WASM asset is embedded and valid.
- Sync documented palette defaults, refresh mockery output, and stabilize the CEF popup timeout race test.

## Verification
- `git diff --check origin/main...HEAD`
- `make lint`
- `go vet ./...`
- `staticcheck ./...`
- `goreleaser check`
- `go test -race ./internal/infrastructure/cef ./internal/infrastructure/webkit`
- `make check`
- `make verify-systemviews-assets`
- `make release-snapshot`
- clean-checkout `GOFLAGS=-mod=mod go test ./...` without ignored generated WASM assets

## Reviews
- Final release-review subagent plan completed with all findings resolved.
- Wrap-up review rerun after commit: no findings.
- CodeRabbit initial review found one minor markdown fence-spacing issue; fixed. Rerun hit CodeRabbit rate limit before producing findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release checks for web assets so missing or invalid packaged files are caught earlier.
  * Enhanced retry behavior for network-related update requests, including temporary DNS failures.
  * Tightened context handling in web messaging to improve stability under concurrency.

* **Documentation**
  * Updated theme color palette examples and default values in the configuration docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->