### PR TITLE
fix(omnibox): reconcil entry buffer

### DIFF
--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -748,7 +748,6 @@ func (o *Omnibox) initList() error {
 	o.listBox.SetSelectionMode(gtk.SelectionSingleValue)
 
 	rowSelectedCb := func(_ gtk.ListBox, rowPtr uintptr) {
-		o.restoreEntryToRealInput()
 		row := gtk.ListBoxRowNewFromInternalPtr(rowPtr)
 		if row == nil {
 			o.mu.Lock()
@@ -1295,41 +1294,51 @@ func (o *Omnibox) updateGhostFromURL(userInput, targetURL string) bool {
 
 // updateGhostFromSelection updates ghost text based on the currently selected row.
 func (o *Omnibox) updateGhostFromSelection() {
+	o.restoreEntryToRealInput()
+
 	o.mu.RLock()
-	realInput := o.realInput
-	hasGhost := o.ghostSuffix != ""
+	query := o.realInput
 	o.mu.RUnlock()
 
-	entryText := ""
-	if o.entry != nil {
-		entryText = o.entry.GetText()
-	}
-
-	query := effectiveSearchQuery(entryText, realInput, hasGhost)
-	o.restoreEntryToRealInput()
 	o.updateGhostFromSelectionWithInput(query)
 }
 
+// reconcileEntryState decides how to resync the entry buffer with the
+// realInput/ghostSuffix shadow state. The buffer is the source of truth:
+// search-changed is debounced, so realInput lags behind fresh keystrokes.
+// The buffer is only ever rewritten to strip a still-intact ghost suffix —
+// never to restore older text, which would delete characters the user just
+// typed.
+func reconcileEntryState(buffer, realInput, ghostSuffix string) (newRealInput string, rewrite bool) {
+	if ghostSuffix != "" && buffer == realInput+ghostSuffix {
+		return realInput, true
+	}
+	return buffer, false
+}
+
+// restoreEntryToRealInput strips any intact ghost suffix from the entry buffer
+// and resyncs realInput from the buffer. It never writes stale realInput over
+// the buffer (see reconcileEntryState).
 func (o *Omnibox) restoreEntryToRealInput() {
 	if o.entry == nil {
 		return
 	}
 
-	// Clear ghost text first (removes suffix from buffer with guard).
-	o.clearGhostText()
+	buffer := o.entry.GetText()
 
-	// If the buffer still doesn't match realInput, force-set it.
-	o.mu.RLock()
-	realInput := o.realInput
-	o.mu.RUnlock()
+	o.mu.Lock()
+	newRealInput, rewrite := reconcileEntryState(buffer, o.realInput, o.ghostSuffix)
+	o.realInput = newRealInput
+	o.ghostSuffix = ""
+	o.mu.Unlock()
 
-	if o.entry.GetText() != realInput {
+	if rewrite {
 		o.withGhostGuard(func() {
-			o.entry.SetText(realInput)
+			o.entry.SetText(newRealInput)
+			o.entry.SelectRegion(-1, -1)
+			o.entry.SetPosition(-1)
 		})
 	}
-	o.entry.SelectRegion(-1, -1)
-	o.entry.SetPosition(-1)
 }
 
 // updateGhostFromSelectionWithInput updates ghost text based on selected row and input.

--- a/internal/ui/component/omnibox_entry_reconcile_test.go
+++ b/internal/ui/component/omnibox_entry_reconcile_test.go
@@ -1,0 +1,89 @@
+package component
+
+import "testing"
+
+// reconcileEntryState decides how row-selected handlers resync the entry
+// buffer with the realInput/ghostSuffix shadow. The entry buffer is the source
+// of truth: search-changed is debounced (~150ms), so realInput lags behind
+// what the user actually typed. The old force-restore behavior rewrote the
+// buffer to the stale realInput, deleting characters typed during the
+// debounce window (fast typing dropped letters).
+func TestReconcileEntryState(t *testing.T) {
+	tests := []struct {
+		name          string
+		buffer        string
+		realInput     string
+		ghostSuffix   string
+		wantRealInput string
+		wantRewrite   bool
+	}{
+		{
+			name:          "ghost visible and untouched: strip it from the buffer",
+			buffer:        "google.com",
+			realInput:     "goo",
+			ghostSuffix:   "gle.com",
+			wantRealInput: "goo",
+			wantRewrite:   true,
+		},
+		{
+			name:          "buffer in sync, no ghost: nothing to do",
+			buffer:        "goo",
+			realInput:     "goo",
+			ghostSuffix:   "",
+			wantRealInput: "goo",
+			wantRewrite:   false,
+		},
+		{
+			name:          "user typed ahead of debounced realInput: buffer wins, never rewrite",
+			buffer:        "bne",
+			realInput:     "bn",
+			ghostSuffix:   "",
+			wantRealInput: "bne",
+			wantRewrite:   false,
+		},
+		{
+			name:          "user typed over the selected ghost suffix: buffer wins",
+			buffer:        "goog",
+			realInput:     "goo",
+			ghostSuffix:   "gle.com",
+			wantRealInput: "goog",
+			wantRewrite:   false,
+		},
+		{
+			name:          "stale ghost flag but buffer already shows real input only",
+			buffer:        "goo",
+			realInput:     "goo",
+			ghostSuffix:   "gle.com",
+			wantRealInput: "goo",
+			wantRewrite:   false,
+		},
+		{
+			name:          "user cleared the entry: buffer wins",
+			buffer:        "",
+			realInput:     "goo",
+			ghostSuffix:   "",
+			wantRealInput: "",
+			wantRewrite:   false,
+		},
+		{
+			name:          "empty ghost with empty input stays empty",
+			buffer:        "",
+			realInput:     "",
+			ghostSuffix:   "",
+			wantRealInput: "",
+			wantRewrite:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRealInput, gotRewrite := reconcileEntryState(tt.buffer, tt.realInput, tt.ghostSuffix)
+			if gotRealInput != tt.wantRealInput {
+				t.Errorf("realInput = %q, want %q", gotRealInput, tt.wantRealInput)
+			}
+			if gotRewrite != tt.wantRewrite {
+				t.Errorf("rewrite = %v, want %v", gotRewrite, tt.wantRewrite)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request improves the reliability and user experience of the omnibox input handling by refactoring how the input buffer and ghost text are reconciled, ensuring that user-typed input is never lost due to stale state overwrites. The changes introduce a new reconciliation function, update the logic for restoring input state, and add comprehensive unit tests to verify correct behavior.

### Input Reconciliation Improvements

* Introduced the `reconcileEntryState` function in `omnibox.go` to determine when the omnibox input buffer should update the internal `realInput` and whether to rewrite the buffer, preventing loss of user input during debounce windows. (`internal/ui/component/omnibox.go`, [internal/ui/component/omnibox.goR1297-R1341](diffhunk://#diff-37c6ff822b9760e3932de2521fa30ec46fd5dc3df8ec1b66b80c4eb651cbad0fR1297-R1341))
* Refactored the `restoreEntryToRealInput` method to use `reconcileEntryState`, ensuring that the buffer is only rewritten to remove an intact ghost suffix and never to overwrite newer user input. (`internal/ui/component/omnibox.go`, [internal/ui/component/omnibox.goR1297-R1341](diffhunk://#diff-37c6ff822b9760e3932de2521fa30ec46fd5dc3df8ec1b66b80c4eb651cbad0fR1297-R1341))

### Event Handling Adjustments

* Updated the `updateGhostFromSelection` method to call `restoreEntryToRealInput` at the start, ensuring consistent state before updating ghost text based on selection. (`internal/ui/component/omnibox.go`, [internal/ui/component/omnibox.goR1297-R1341](diffhunk://#diff-37c6ff822b9760e3932de2521fa30ec46fd5dc3df8ec1b66b80c4eb651cbad0fR1297-R1341))
* Removed a redundant call to `restoreEntryToRealInput` from the row selection callback, as this logic is now handled more robustly elsewhere. (`internal/ui/component/omnibox.go`, [internal/ui/component/omnibox.goL751](diffhunk://#diff-37c6ff822b9760e3932de2521fa30ec46fd5dc3df8ec1b66b80c4eb651cbad0fL751))

### Testing

* Added a new test file `omnibox_entry_reconcile_test.go` with thorough unit tests for `reconcileEntryState`, covering various edge cases to ensure correct synchronization between the input buffer, `realInput`, and `ghostSuffix`. (`internal/ui/component/omnibox_entry_reconcile_test.go`, [internal/ui/component/omnibox_entry_reconcile_test.goR1-R89](diffhunk://#diff-baf64cb113f774ef12ed685f0db69ce929096e37c63c9267eb947682e50e093bR1-R89))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved omnibox selection behavior so typed input is less likely to be overwritten when suggestions or ghost text are updated.
  * Made search field updates more reliable when switching between selected results and user-entered text.
* **Tests**
  * Added coverage for multiple input-reconciliation scenarios to help prevent regressions in omnibox behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->