### PR TITLE
fix(ui): synchronize favorites sidebar notices

### DIFF
--- a/internal/ui/component/favorites_sidebar.go
+++ b/internal/ui/component/favorites_sidebar.go
@@ -55,6 +55,7 @@ type FavoritesSidebar struct {
 	displayRows     []favoriteSidebarDisplayRow
 	currentQuery    string
 	notice          string
+	noticeLoadGen   uint64
 	loadGen         uint64
 	destroyed       bool
 	visible         bool
@@ -263,6 +264,7 @@ func (fs *FavoritesSidebar) startLoad() {
 	ctx := fs.ctx
 	visible := fs.visible
 	fs.notice = "Loading favorites..."
+	fs.noticeLoadGen = gen
 	fs.mu.Unlock()
 	if visible {
 		fs.scheduleIdle(glib.SourceFunc(func(uintptr) bool {
@@ -311,10 +313,13 @@ func (fs *FavoritesSidebar) applyLoadedData(favorites []*entity.Favorite, tags [
 	}
 	fs.allFavorites = favorites
 	fs.allTags = tags
-	if err != nil {
-		fs.notice = err.Error()
-	} else {
-		fs.notice = ""
+	if fs.noticeLoadGen == gen {
+		fs.noticeLoadGen = 0
+		if err != nil {
+			fs.notice = err.Error()
+		} else {
+			fs.notice = ""
+		}
 	}
 	fs.rebuildDisplayRowsLocked()
 	fs.mu.Unlock()
@@ -361,6 +366,12 @@ func (fs *FavoritesSidebar) rebuildDisplayRowsLocked() {
 	}
 	filtered := usecase.FilterFavoritesForSidebar(fs.allFavorites, query)
 	fs.displayRows = buildFavoriteSidebarDisplayRows(filtered)
+}
+
+// setNoticeLocked records a notice not owned by an in-flight load. fs.mu must be held.
+func (fs *FavoritesSidebar) setNoticeLocked(notice string) {
+	fs.notice = notice
+	fs.noticeLoadGen = 0
 }
 
 func (fs *FavoritesSidebar) scheduleIdle(cb glib.SourceFunc) {

--- a/internal/ui/component/favorites_sidebar_forms.go
+++ b/internal/ui/component/favorites_sidebar_forms.go
@@ -42,7 +42,7 @@ func (fs *FavoritesSidebar) beginAddForm() {
 	fs.editingID = 0
 	fs.confirmDelete = false
 	fs.confirmDeleteID = 0
-	fs.notice = "Add favorite: URL, title, comma-separated tag IDs, shortcut 1-9. Press Ctrl+Enter or Save."
+	fs.setNoticeLocked("Add favorite: URL, title, comma-separated tag IDs, shortcut 1-9. Press Ctrl+Enter or Save.")
 	fs.mu.Unlock()
 	fs.renderForm(nil)
 	fs.rebuildList()
@@ -63,7 +63,7 @@ func (fs *FavoritesSidebar) beginEditForm() {
 	fs.editingID = fav.ID
 	fs.confirmDelete = false
 	fs.confirmDeleteID = 0
-	fs.notice = "Edit favorite: URL is read-only; use tag mode for tags. Press Ctrl+Enter or Save."
+	fs.setNoticeLocked("Edit favorite: URL is read-only; use tag mode for tags. Press Ctrl+Enter or Save.")
 	fs.mu.Unlock()
 	fs.renderForm(fav)
 	fs.rebuildList()
@@ -170,7 +170,7 @@ func (fs *FavoritesSidebar) cancelManagement() bool {
 	fs.confirmDelete = false
 	fs.confirmDeleteID = 0
 	if active {
-		fs.notice = ""
+		fs.setNoticeLocked("")
 	}
 	fs.mu.Unlock()
 	if fs.formBox != nil {
@@ -250,7 +250,7 @@ func (fs *FavoritesSidebar) setModeNotice(mode favoritesSidebarMode, notice stri
 		fs.mode = mode
 		fs.confirmDelete = false
 		fs.confirmDeleteID = 0
-		fs.notice = notice
+		fs.setNoticeLocked(notice)
 	}
 	fs.mu.Unlock()
 	fs.rebuildList()
@@ -324,7 +324,7 @@ func (fs *FavoritesSidebar) requestDeleteConfirmation() bool {
 	if !fs.destroyed {
 		fs.confirmDelete = true
 		fs.confirmDeleteID = fav.ID
-		fs.notice = "Delete selected favorite? Press Delete again to confirm, Esc to cancel."
+		fs.setNoticeLocked("Delete selected favorite? Press Delete again to confirm, Esc to cancel.")
 	}
 	fs.mu.Unlock()
 	fs.rebuildList()
@@ -396,7 +396,7 @@ func (fs *FavoritesSidebar) selectedFavorite() *entity.Favorite {
 func (fs *FavoritesSidebar) setNotice(notice string) {
 	fs.mu.Lock()
 	if !fs.destroyed {
-		fs.notice = notice
+		fs.setNoticeLocked(notice)
 	}
 	fs.mu.Unlock()
 	fs.rebuildList()

--- a/internal/ui/component/favorites_sidebar_keyboard.go
+++ b/internal/ui/component/favorites_sidebar_keyboard.go
@@ -463,7 +463,7 @@ func (fs *FavoritesSidebar) handleNavigationError(err error) {
 		fs.mu.Unlock()
 		return
 	}
-	fs.notice = err.Error()
+	fs.setNoticeLocked(err.Error())
 	fs.mu.Unlock()
 	fs.rebuildList()
 }

--- a/internal/ui/component/favorites_sidebar_test.go
+++ b/internal/ui/component/favorites_sidebar_test.go
@@ -486,6 +486,8 @@ func TestFavoritesSidebarAddShortcutFailureClosesFormAfterCreate(t *testing.T) {
 	uc := &fakeFavoritesSidebarUC{errOnSetShortcut: errors.New("shortcut failed")}
 	fs := newFavoritesSidebarHarness(nil, nil)
 	fs.favoritesUC = uc
+	loaded := make(chan glib.SourceFunc, 1)
+	fs.idleScheduler = func(cb glib.SourceFunc) { loaded <- cb }
 	fs.formURL = "https://add.test"
 	fs.formTitle = "Added"
 	fs.formShortcut = "3"
@@ -493,6 +495,12 @@ func TestFavoritesSidebarAddShortcutFailureClosesFormAfterCreate(t *testing.T) {
 
 	assert.True(t, fs.submitForm())
 	require.Len(t, uc.addInputs, 1)
+	select {
+	case cb := <-loaded:
+		cb(0)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for favorites reload")
+	}
 	assert.Equal(t, favoritesSidebarModeNone, fs.mode)
 	assert.Contains(t, fs.notice, "failed to set shortcut")
 }


### PR DESCRIPTION
## Summary
- preserve explicit favorites sidebar notices when an older reload completes
- make the shortcut-create failure regression deterministic

## Validation
- `go test -race ./internal/ui/component -run '^TestFavoritesSidebarAddShortcutFailureClosesFormAfterCreate$' -count=20`\n- `go test -race ./internal/ui/component`\n- `make lint`, `make test`, `make check`\n\nUnblocks the FavoritesSidebar race acceptance required by crash-stability PR #341.