### PR TITLE
test: add strict Wayland Vulkan gate

### DIFF
--- a/.github/workflows/wayland-vulkan-gate.yml
+++ b/.github/workflows/wayland-vulkan-gate.yml
@@ -1,0 +1,101 @@
+name: Wayland Vulkan gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      gpu_profile:
+        description: Exact self-hosted hardware pool; this is a scheduling label, not a success claim.
+        required: true
+        type: choice
+        options: [intel-integrated, amd]
+      baseline_ref:
+        description: Git ref to measure as the baseline
+        required: true
+        default: chore/upstream-foundations
+        type: string
+      candidate_ref:
+        description: Git ref to measure as the candidate
+        required: true
+        default: test/wayland-vulkan-gate
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    # Explicit pool mapping prevents an arbitrary runner from being described as
+    # Intel or AMD hardware. A missing labelled runner leaves this workflow
+    # queued; it does not skip, fall back, or report a hardware result.
+    runs-on: ${{ inputs.gpu_profile == 'intel-integrated' && fromJSON('["self-hosted","linux","intel-integrated"]') || fromJSON('["self-hosted","linux","amd"]') }}
+    timeout-minutes: 30
+    env:
+      DUMBER_MACHINE_GPU_PROFILE: ${{ inputs.gpu_profile }}
+      DUMBER_WAYLAND_VULKAN_OUTPUT: ${{ runner.temp }}/wayland-vulkan-evidence
+      DUMBER_WAYLAND_VULKAN_TIMEOUT_SECONDS: "45"
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ inputs.candidate_ref }}
+          path: candidate
+          fetch-depth: 1
+      - name: Checkout baseline
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ inputs.baseline_ref }}
+          path: baseline
+          fetch-depth: 1
+      - name: Set up pinned Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: candidate/go.mod
+          cache: false
+      - name: Require self-hosted Wayland Vulkan prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v weston
+          command -v vulkaninfo
+          test -d "${DUMBER_CEF_DIR:-$HOME/.local/share/cef-147-runtime}"
+      - name: Build baseline and candidate with vendored modules
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd baseline && GOFLAGS=-mod=vendor make build-quick)
+          (cd candidate && GOFLAGS=-mod=vendor make build-quick)
+      - name: Start isolated Weston headless compositor
+        shell: bash
+        run: |
+          set -euo pipefail
+          export XDG_RUNTIME_DIR="$RUNNER_TEMP/wayland-runtime"
+          install -d -m 700 "$XDG_RUNTIME_DIR"
+          weston --backend=headless-backend.so --socket=wayland-vulkan-gate --idle-time=0 >"$RUNNER_TEMP/weston.log" 2>&1 &
+          echo "WESTON_PID=$!" >> "$GITHUB_ENV"
+          echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
+          echo "WAYLAND_DISPLAY=wayland-vulkan-gate" >> "$GITHUB_ENV"
+          for _ in $(seq 1 30); do test -S "$XDG_RUNTIME_DIR/wayland-vulkan-gate" && exit 0; sleep 1; done
+          cat "$RUNNER_TEMP/weston.log" >&2
+          exit 1
+      - name: Run strict five-by-five Wayland Vulkan gate
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          export DUMBER_WAYLAND_VULKAN_BASELINE_BIN="$GITHUB_WORKSPACE/baseline/dist/dumber"
+          export DUMBER_WAYLAND_VULKAN_CANDIDATE_BIN="$GITHUB_WORKSPACE/candidate/dist/dumber"
+          export DUMBER_WAYLAND_VULKAN_BASELINE_SOURCE="$GITHUB_WORKSPACE/baseline"
+          export DUMBER_WAYLAND_VULKAN_CANDIDATE_SOURCE="$GITHUB_WORKSPACE/candidate"
+          ./scripts/wayland_vulkan_gate.sh
+      - name: Stop Weston
+        if: always()
+        shell: bash
+        run: test -z "${WESTON_PID:-}" || kill "$WESTON_PID"
+      - name: Upload sanitized gate evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: wayland-vulkan-${{ inputs.gpu_profile }}
+          path: ${{ runner.temp }}/wayland-vulkan-evidence
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/first-presentation.md
+++ b/docs/first-presentation.md
@@ -48,3 +48,40 @@ do not use a device model or other identifier. Publish only the seven reviewed
 JSON files to an external Gist. Raw logs and temporary XDG homes are removed and
 must not be published. A missing or incomplete timeline, non-DMABUF backend, or
 invalid run fails collection.
+
+## Strict Wayland/Vulkan gate
+
+The dispatch-only `wayland-vulkan-gate` workflow is the authoritative hardware
+gate. It requires a labelled self-hosted `intel-integrated` or `amd` runner;
+queueing for unavailable hardware is not a pass and the workflow makes no
+vendor-hardware success claim. It checks out the requested `baseline_ref` and
+`candidate_ref`, starts an isolated headless Weston instance, and runs exactly
+five fresh baseline launches followed by five fresh candidate launches with the
+same CEF runtime, Wayland compositor, and non-identifying GPU profile.
+
+Reproduce the same gate locally from the candidate checkout after building both
+refs. `baseline` and `candidate` below are separate checkouts and must use the
+same CEF runtime and live Wayland session:
+
+```bash
+(cd baseline && GOFLAGS=-mod=vendor make build-quick)
+(cd candidate && GOFLAGS=-mod=vendor make build-quick)
+cd candidate
+DUMBER_MACHINE_GPU_PROFILE=intel-integrated \
+DUMBER_CEF_DIR="$HOME/.local/share/cef-147-runtime" \
+DUMBER_WAYLAND_VULKAN_BASELINE_BIN="../baseline/dist/dumber" \
+DUMBER_WAYLAND_VULKAN_CANDIDATE_BIN="$PWD/dist/dumber" \
+DUMBER_WAYLAND_VULKAN_BASELINE_SOURCE="../baseline" \
+DUMBER_WAYLAND_VULKAN_CANDIDATE_SOURCE="$PWD" \
+  scripts/wayland_vulkan_gate.sh
+```
+
+The gate creates a fresh external XDG-state directory locally (or a fresh
+`RUNNER_TEMP` directory in Actions) containing only sanitized JSON. It requires
+ordered startup milestones, Vulkan and `gdk-dmabuf` import confirmation, resize,
+`OnBeforeClose`, and `Engine.Close` lifecycle confirmation. It rejects a timeout,
+unsafe/reused output directory, unpaired provenance, CEF GPU error **1002**, or
+candidate median or nearest-rank p95 regression over 10%. There is no software
+fallback, skip, or green result for those conditions. The current headless
+Weston result is blocked by CEF GPU error 1002; retain its failed evidence rather
+than interpreting it as hardware validation.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.13.4-0.20260714140305-f0b7414af67e
-	github.com/bnema/purego-cef2gtk v0.8.4
+	github.com/bnema/purego-cef2gtk v0.8.4-0.20260714143951-2a5b796c8bef
 	github.com/bnema/purego-pipewire v0.1.5-0.20260714124450-6504b9cdf02a
 	github.com/bnema/purego-sqlite v0.1.4-0.20260714131321-3614fe683b9c
 	github.com/bnema/puregotk v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/bnema/purego-cef2gtk v0.8.3 h1:7alzzanbJzpqWXdbo+GfnCSGF/GmwYz9KhcQeg
 github.com/bnema/purego-cef2gtk v0.8.3/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
 github.com/bnema/purego-cef2gtk v0.8.4-0.20260714083412-f217ece342de h1:fs1e2dUPrPcoIOBCc8hLvCsiWRmySjJUpRgVwKChBoQ=
 github.com/bnema/purego-cef2gtk v0.8.4-0.20260714083412-f217ece342de/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
+github.com/bnema/purego-cef2gtk v0.8.4-0.20260714143951-2a5b796c8bef h1:wAf/iB+LahfgeOaljTCSufaoZOgNSJdKe93UeLjNdHs=
+github.com/bnema/purego-cef2gtk v0.8.4-0.20260714143951-2a5b796c8bef/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
 github.com/bnema/purego-cef2gtk v0.8.4 h1:WIBU2F3rrT30WfhZV9b7xFBz8ktg8uHRzbKMuaffnMg=
 github.com/bnema/purego-cef2gtk v0.8.4/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
 github.com/bnema/purego-pipewire v0.1.4 h1:ThuPiZo9BeYn1w06hg/g0INgQUIBi8n9Gq1o5VRtjxk=

--- a/internal/logging/first_presentation_collector_test.go
+++ b/internal/logging/first_presentation_collector_test.go
@@ -143,8 +143,8 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 	}
 	for _, required := range []string{
 		`"measured_source_revision"`,
-		`"tag": "v0.8.4"`,
-		`"revision": "f217ece342dea3ef2a3f98671fcd16a39ad0037d"`,
+		`"tag": "v0.8.4-0.20260714143951-2a5b796c8bef"`,
+		`"revision": "2a5b796c8befa686b663ecfba4fb00dcd870d539"`,
 	} {
 		require.Contains(t, artifacts.String(), required)
 	}

--- a/internal/logging/wayland_vulkan_gate_test.go
+++ b/internal/logging/wayland_vulkan_gate_test.go
@@ -89,6 +89,13 @@ func TestCompareFirstPresentationRejectsUnpairedProvenanceAndRegression(t *testi
 	require.Contains(t, string(result), "candidate p95 regression exceeds 10%")
 
 	require.NoError(t, os.RemoveAll(candidate))
+	writeComparisonEvidence(t, candidate, []int{12, 12, 12, 12, 12}, "intel-integrated")
+	cmd = exec.Command("python3", filepath.Join(repoRoot, "scripts", "compare_first_presentation.py"), baseline, candidate)
+	result, err = cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(result), "candidate median regression exceeds 10%")
+
+	require.NoError(t, os.RemoveAll(candidate))
 	writeComparisonEvidence(t, candidate, []int{10, 10, 10, 10, 10}, "amd")
 	cmd = exec.Command("python3", filepath.Join(repoRoot, "scripts", "compare_first_presentation.py"), baseline, candidate)
 	result, err = cmd.CombinedOutput()

--- a/internal/logging/wayland_vulkan_gate_test.go
+++ b/internal/logging/wayland_vulkan_gate_test.go
@@ -1,0 +1,199 @@
+package logging
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaylandVulkanGateRejectsIncompleteLifecycleAndGPU1002(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		log  string
+		want string
+	}{
+		{name: "missing startup milestone", log: strings.Replace(gateLog(), `echo '{"message":"startup_trace: milestone","milestone":"process_entry","t_ms":0,"delta_ms":0}'`, "", 1), want: "incomplete Wayland Vulkan lifecycle"},
+		{name: "out of order startup milestone", log: strings.Replace(gateLog(), `"milestone":"config_complete"`, `"milestone":"cef_initialized"`, 1), want: "incomplete Wayland Vulkan lifecycle"},
+		{name: "missing dmabuf import", log: gateLog("dmabuf"), want: "incomplete Wayland Vulkan lifecycle"},
+		{name: "missing vulkan renderer", log: gateLog("vulkan"), want: "incomplete Wayland Vulkan lifecycle"},
+		{name: "missing resize", log: gateLog("resize"), want: "incomplete Wayland Vulkan lifecycle"},
+		{name: "missing OnBeforeClose", log: gateLog("before-close"), want: "incomplete Wayland Vulkan lifecycle"},
+		{name: "missing Engine.Close", log: gateLog("engine-close"), want: "incomplete Wayland Vulkan lifecycle"},
+		{name: "GPU error 1002", log: gateLog() + `{"message":"GPU process error 1002"}` + "\n", want: "CEF GPU error 1002 (blocked)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output, result := runGate(t, repoRoot, tc.log, 5)
+			require.Error(t, result)
+			require.Contains(t, string(output), tc.want)
+		})
+	}
+}
+
+func TestWaylandVulkanGateProducesOnlySanitizedPairedJSON(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	output, result := runGate(t, repoRoot, gateLog(), 5)
+	require.NoErrorf(t, result, "gate failed: %s", output)
+
+	root := gateOutput(t, string(output))
+	for _, side := range []string{"baseline", "candidate"} {
+		entries, err := os.ReadDir(filepath.Join(root, side))
+		require.NoError(t, err)
+		require.Len(t, entries, 7)
+		for _, entry := range entries {
+			contents, readErr := os.ReadFile(filepath.Join(root, side, entry.Name()))
+			require.NoError(t, readErr)
+			var value any
+			require.NoError(t, json.Unmarshal(contents, &value), "artifact %s is not JSON", entry.Name())
+			for _, forbidden := range []string{"/home/", "private-host", "raw-log"} {
+				require.NotContains(t, string(contents), forbidden)
+			}
+		}
+	}
+	require.FileExists(t, filepath.Join(root, "result.json"))
+}
+
+func TestWaylandVulkanGateRejectsUnsafeOrReusedOutput(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	temp := t.TempDir()
+	unsafe := filepath.Join(repoRoot, "unsafe-gate-artifacts")
+	binary := gateBinary(t, temp, gateLog())
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "wayland_vulkan_gate.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = gateEnv(repoRoot, binary, unsafe)
+	result, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(result), "output must be external")
+}
+
+func TestCompareFirstPresentationRejectsUnpairedProvenanceAndRegression(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	root := t.TempDir()
+	baseline, candidate := filepath.Join(root, "baseline"), filepath.Join(root, "candidate")
+	writeComparisonEvidence(t, baseline, []int{10, 10, 10, 10, 10}, "intel-integrated")
+	writeComparisonEvidence(t, candidate, []int{10, 10, 10, 10, 12}, "intel-integrated")
+	cmd := exec.Command("python3", filepath.Join(repoRoot, "scripts", "compare_first_presentation.py"), baseline, candidate)
+	result, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(result), "candidate p95 regression exceeds 10%")
+
+	require.NoError(t, os.RemoveAll(candidate))
+	writeComparisonEvidence(t, candidate, []int{10, 10, 10, 10, 10}, "amd")
+	cmd = exec.Command("python3", filepath.Join(repoRoot, "scripts", "compare_first_presentation.py"), baseline, candidate)
+	result, err = cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(result), "unpaired provenance")
+}
+
+func TestWaylandVulkanGateFailsTimeout(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	output, result := runGate(t, repoRoot, "sleep 2", 1)
+	require.Error(t, result)
+	require.Contains(t, string(output), "timed out")
+}
+
+func runGate(t *testing.T, repoRoot, log string, timeout int) ([]byte, error) {
+	t.Helper()
+	temp := t.TempDir()
+	binary := gateBinary(t, temp, log)
+	output := filepath.Join(temp, "evidence")
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "wayland_vulkan_gate.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(gateEnv(repoRoot, binary, output), "DUMBER_WAYLAND_VULKAN_TIMEOUT_SECONDS="+strconv.Itoa(timeout))
+	return cmd.CombinedOutput()
+}
+
+func gateEnv(repoRoot, binary, output string) []string {
+	runtime := filepath.Join(filepath.Dir(binary), "cef")
+	_ = os.Mkdir(runtime, 0o755)
+	return append(os.Environ(),
+		"WAYLAND_DISPLAY=wayland-test", "XDG_RUNTIME_DIR=/tmp", "DUMBER_CEF_DIR="+runtime,
+		"DUMBER_WAYLAND_VULKAN_BASELINE_BIN="+binary, "DUMBER_WAYLAND_VULKAN_CANDIDATE_BIN="+binary,
+		"DUMBER_WAYLAND_VULKAN_BASELINE_SOURCE="+repoRoot, "DUMBER_WAYLAND_VULKAN_CANDIDATE_SOURCE="+repoRoot,
+		"DUMBER_WAYLAND_VULKAN_OUTPUT="+output, "DUMBER_MACHINE_GPU_PROFILE=intel-integrated",
+	)
+}
+
+func gateBinary(t *testing.T, directory, log string) string {
+	t.Helper()
+	path := filepath.Join(directory, "dumber")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+log+"\n"), 0o755))
+	return path
+}
+
+func gateLog(without ...string) string {
+	skip := map[string]bool{}
+	for _, value := range without {
+		skip[value] = true
+	}
+	var lines []string
+	milestones := []string{"process_entry", "config_complete", "cef_library_load_begin", "cef_initialized", "browser_create_requested", "first_accelerated_paint_received", "first_dmabuf_texture_swap", "first_gtk_presentation"}
+	for index, milestone := range milestones {
+		delta := 1
+		if index == 0 {
+			delta = 0
+		}
+		lines = append(lines, `echo '{"message":"startup_trace: milestone","milestone":"`+milestone+`","t_ms":`+strconv.Itoa(index)+`,"delta_ms":`+strconv.Itoa(delta)+`}'`)
+	}
+	lines = append(lines, `echo '{"message":"startup_trace: first presentation","backend":"gdk-dmabuf","incomplete_reason":"","total_ms":7}'`)
+	if !skip["dmabuf"] {
+		lines = append(lines, `echo '{"message":"wayland_vulkan_gate: dmabuf import","backend":"gdk-dmabuf"}'`)
+	}
+	if !skip["vulkan"] {
+		lines = append(lines, `echo '{"message":"wayland_vulkan_gate: vulkan renderer","renderer":"vulkan"}'`)
+	}
+	if !skip["resize"] {
+		lines = append(lines, `echo '{"message":"wayland_vulkan_gate: resize"}'`)
+	}
+	if !skip["before-close"] {
+		lines = append(lines, `echo '{"message":"wayland_vulkan_gate: OnBeforeClose"}'`)
+	}
+	if !skip["engine-close"] {
+		lines = append(lines, `echo '{"message":"wayland_vulkan_gate: Engine.Close"}'`)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func gateOutput(t *testing.T, output string) string {
+	t.Helper()
+	prefix := "wayland-vulkan gate artifacts: "
+	index := strings.LastIndex(output, prefix)
+	require.NotEqual(t, -1, index)
+	return strings.TrimSpace(output[index+len(prefix):])
+}
+
+func writeComparisonEvidence(t *testing.T, root string, values []int, profile string) {
+	t.Helper()
+	require.NoError(t, os.Mkdir(root, 0o755))
+	metadata := map[string]any{"upstream": map[string]any{"revision": "2a5b796c8befa686b663ecfba4fb00dcd870d539"}, "runtime": map[string]any{"version": "147"}, "comparison": map[string]any{"machine_gpu_profile": profile}, "render_configuration": map[string]any{"renderer": "vulkan"}}
+	writeJSON(t, filepath.Join(root, "metadata.json"), metadata)
+	for i, value := range values {
+		name := "run-" + strconv.FormatInt(int64(i+1), 10)
+		if i < 9 {
+			name = "run-0" + strconv.Itoa(i+1)
+		}
+		writeJSON(t, filepath.Join(root, name+".json"), map[string]any{"run": name, "valid": true, "summary": map[string]any{"total_ms": value}})
+	}
+	ordered := append([]int(nil), values...)
+	// Inputs are already ordered in this test; five makes median index 2 and p95 index 4.
+	writeJSON(t, filepath.Join(root, "baseline.json"), map[string]any{"runs": 5, "total_ms": map[string]any{"min": ordered[0], "median": ordered[2], "max": ordered[4], "p95": ordered[4]}})
+}
+
+func writeJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	contents, err := json.Marshal(value)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, contents, 0o600))
+}

--- a/scripts/collect_first_presentation.sh
+++ b/scripts/collect_first_presentation.sh
@@ -31,8 +31,8 @@ else
 fi
 readonly output
 readonly upstream_module="github.com/bnema/purego-cef2gtk"
-readonly upstream_tag="v0.8.4"
-readonly upstream_revision="f217ece342dea3ef2a3f98671fcd16a39ad0037d"
+readonly upstream_tag="v0.8.4-0.20260714143951-2a5b796c8bef"
+readonly upstream_revision="2a5b796c8befa686b663ecfba4fb00dcd870d539"
 
 # The artifact destination is caller-controlled. Never empty or recursively
 # clear it: collection only writes to a newly-created directory whose parent is

--- a/scripts/compare_first_presentation.py
+++ b/scripts/compare_first_presentation.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Strictly compare paired five-run Wayland/Vulkan presentation evidence."""
+import json
+import math
+import sys
+from pathlib import Path
+
+RUNS = 5
+UPSTREAM_SHA = "2a5b796c8befa686b663ecfba4fb00dcd870d539"
+ALLOWED_TOP_LEVEL = {"metadata.json", "baseline.json", *(f"run-{i:02d}.json" for i in range(1, RUNS + 1))}
+
+
+def fail(message):
+    raise SystemExit(f"wayland-vulkan comparison: {message}")
+
+
+def load(path):
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as err:
+        fail(f"invalid JSON {path.name}: {err}")
+    if not isinstance(value, dict):
+        fail(f"{path.name} must contain an object")
+    return value
+
+
+def totals(root):
+    names = {entry.name for entry in root.iterdir()}
+    if names != ALLOWED_TOP_LEVEL:
+        fail(f"{root} contains non-allowlisted artifacts")
+    metadata = load(root / "metadata.json")
+    upstream = metadata.get("upstream")
+    if not isinstance(upstream, dict) or upstream.get("revision") != UPSTREAM_SHA:
+        fail(f"{root}: unpinned or missing purego-cef2gtk provenance")
+    values = []
+    for index in range(1, RUNS + 1):
+        run = load(root / f"run-{index:02d}.json")
+        summary = run.get("summary")
+        if run.get("run") != f"run-{index:02d}" or run.get("valid") is not True or not isinstance(summary, dict):
+            fail(f"{root}: invalid run-{index:02d}")
+        total = summary.get("total_ms")
+        if type(total) is not int or total < 0:
+            fail(f"{root}: invalid run-{index:02d} total")
+        values.append(total)
+    aggregate = load(root / "baseline.json")
+    reported = aggregate.get("total_ms")
+    ordered = sorted(values)
+    expected = {
+        "min": ordered[0],
+        "median": ordered[len(ordered) // 2],
+        "max": ordered[-1],
+        "p95": ordered[math.ceil(0.95 * RUNS) - 1],
+    }
+    if aggregate.get("runs") != RUNS or reported != expected:
+        fail(f"{root}: aggregate is not five-run median/nearest-rank-p95 evidence")
+    return metadata, expected
+
+
+def main():
+    if len(sys.argv) != 3:
+        fail("usage: compare_first_presentation.py BASELINE_DIR CANDIDATE_DIR")
+    baseline_root, candidate_root = (Path(arg).resolve() for arg in sys.argv[1:])
+    if baseline_root == candidate_root:
+        fail("baseline and candidate evidence must be distinct")
+    baseline_metadata, baseline = totals(baseline_root)
+    candidate_metadata, candidate = totals(candidate_root)
+    for key in ("runtime", "comparison", "render_configuration"):
+        if baseline_metadata.get(key) != candidate_metadata.get(key):
+            fail(f"unpaired provenance: {key} differs")
+    for metric in ("median", "p95"):
+        limit = baseline[metric] * 1.10
+        if candidate[metric] > limit:
+            fail(f"candidate {metric} regression exceeds 10% ({candidate[metric]} > {limit:g})")
+    print(json.dumps({
+        "runs": RUNS,
+        "status": "passed",
+        "baseline": {"median_ms": baseline["median"], "p95_ms": baseline["p95"]},
+        "candidate": {"median_ms": candidate["median"], "p95_ms": candidate["p95"]},
+    }, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wayland_vulkan_gate.sh
+++ b/scripts/wayland_vulkan_gate.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Strict, five-by-five Wayland/Vulkan evidence gate. A missing prerequisite,
+# incomplete lifecycle, timeout, or CEF GPU error is a failure, never a skip.
+set -euo pipefail
+
+readonly runs=5
+readonly timeout_seconds="${DUMBER_WAYLAND_VULKAN_TIMEOUT_SECONDS:-45}"
+readonly runtime="${DUMBER_CEF_DIR:-$HOME/.local/share/cef-147-runtime}"
+readonly baseline_bin="${DUMBER_WAYLAND_VULKAN_BASELINE_BIN:-}"
+readonly candidate_bin="${DUMBER_WAYLAND_VULKAN_CANDIDATE_BIN:-}"
+readonly baseline_source="${DUMBER_WAYLAND_VULKAN_BASELINE_SOURCE:-$PWD}"
+readonly candidate_source="${DUMBER_WAYLAND_VULKAN_CANDIDATE_SOURCE:-$PWD}"
+readonly upstream_module="github.com/bnema/purego-cef2gtk"
+readonly upstream_version="v0.8.4-0.20260714143951-2a5b796c8bef"
+readonly upstream_revision="2a5b796c8befa686b663ecfba4fb00dcd870d539"
+
+fail() { echo "wayland-vulkan gate: $*" >&2; exit 2; }
+
+repo_root="$(git -c safe.directory="$PWD" rev-parse --show-toplevel)" || fail "must run in a checkout"
+repo_root="$(realpath -e -- "$repo_root")"
+[[ -n "${WAYLAND_DISPLAY:-}" && -n "${XDG_RUNTIME_DIR:-}" ]] || fail "a live Wayland display is required"
+[[ -d "$runtime" ]] || fail "CEF runtime not found: $runtime"
+[[ -x "$baseline_bin" && -x "$candidate_bin" ]] || fail "both executable baseline and candidate binaries are required"
+[[ "$(go list -mod=vendor -m -f '{{.Version}}' "$upstream_module")" == "$upstream_version" ]] || fail "purego-cef2gtk is not pinned to PR #28"
+
+# Evidence must be freshly made outside the checkout. GitHub Actions uses its
+# runner temp; local invocations use XDG state. The raw process logs stay under
+# work_root and are removed before the script returns.
+if [[ -v DUMBER_WAYLAND_VULKAN_OUTPUT ]]; then
+  output="$DUMBER_WAYLAND_VULKAN_OUTPUT"
+else
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    root="${RUNNER_TEMP:-}"
+  else
+    root="${XDG_STATE_HOME:-$HOME/.local/state}"
+  fi
+  [[ "$root" == /* ]] || fail "external XDG/Actions temporary root must be absolute"
+  mkdir -p -- "$root" || fail "cannot create external evidence root"
+  root="$(realpath -e -- "$root")"
+  output="$root/dumber-wayland-vulkan-gate-$(date -u +%Y%m%dT%H%M%S)-$$"
+fi
+[[ "$output" == /* && "$output" != / && "$output" != "$repo_root" && "$output" != "$repo_root"/* ]] || fail "output must be external to the checkout"
+[[ ! -e "$output" && ! -L "$output" ]] || fail "output must be a fresh directory"
+parent="$(dirname -- "$output")"
+[[ -d "$parent" && ! -L "$parent" && "$(realpath -e -- "$parent")" == "$parent" ]] || fail "output parent must be an existing canonical directory"
+mkdir -- "$output" || fail "could not create output"
+readonly output
+
+work_root="$(mktemp -d "${TMPDIR:-/tmp}/dumber-wayland-vulkan.XXXXXX")"
+cleanup() { [[ -d "${work_root:-}" && ! -L "$work_root" ]] && rm -rf -- "$work_root"; }
+trap cleanup EXIT
+
+write_metadata() {
+  local destination="$1" source_dir="$2" binary="$3"
+  python3 - "$destination" "$source_dir" "$binary" "$timeout_seconds" "$upstream_module" "$upstream_version" "$upstream_revision" <<'PY'
+import hashlib, json, os, platform, subprocess, sys
+path, source, binary, timeout, module, version, revision = sys.argv[1:]
+profile = os.environ.get("DUMBER_MACHINE_GPU_PROFILE", "unknown-gpu")
+if profile not in {"intel-integrated", "amd", "unknown-gpu"}:
+    raise SystemExit("invalid non-identifying machine GPU profile")
+architecture = {"x86_64":"amd64", "amd64":"amd64", "aarch64":"arm64", "arm64":"arm64"}.get(platform.machine().lower(), "other")
+with open(binary, "rb") as f: digest = hashlib.file_digest(f, "sha256").hexdigest()
+revision_source = subprocess.check_output(["git", "-c", f"safe.directory={source}", "-C", source, "rev-parse", "HEAD"], text=True).strip()
+json.dump({
+ "runs": 5,
+ "runtime": {"label":"cef", "version":"147"},
+ "binary": {"label":"dumber", "sha256":digest},
+ "timeout_seconds": int(timeout),
+ "measured_source_revision": revision_source,
+ "upstream": {"module":module, "version":version, "revision":revision},
+ "comparison": {"os":"linux", "architecture":architecture, "display_protocol":"wayland", "machine_gpu_profile":profile},
+ "render_configuration": {"backend":"gdk-dmabuf", "buffer_sharing":"dmabuf", "renderer":"vulkan"}
+}, open(path, "w"), sort_keys=True, indent=2)
+PY
+}
+
+parse_run() {
+  local log="$1" destination="$2" name="$3"
+  python3 - "$log" "$destination" "$name" <<'PY'
+import json, re, sys
+log, destination, name = sys.argv[1:]
+order = ["process_entry", "config_complete", "cef_library_load_begin", "cef_initialized", "browser_create_requested", "first_accelerated_paint_received", "first_dmabuf_texture_swap", "first_gtk_presentation"]
+records, summary = [], None
+flags = {"dmabuf_import":False, "vulkan":False, "resize":False, "before_close":False, "engine_close":False, "gpu_1002":False}
+for raw in open(log, encoding="utf-8", errors="replace"):
+    # GPU process error 1002 is an authoritative blocked outcome even if a
+    # renderer subsequently emits presentation-looking output.
+    if re.search(r"(?:gpu|GPU).{0,120}(?:error[^0-9]{0,40})?1002|1002.{0,120}(?:gpu|GPU)", raw): flags["gpu_1002"] = True
+    try: event = json.loads(raw)
+    except json.JSONDecodeError: continue
+    message = event.get("message", "")
+    if message == "startup_trace: milestone": records.append({k:event.get(k) for k in ("milestone", "t_ms", "delta_ms")})
+    elif message == "startup_trace: first presentation": summary = {k:event.get(k) for k in ("backend", "incomplete_reason", "total_ms")}
+    # These fields are emitted by the PR #28 diagnostic path; fields instead
+    # of raw log copying keeps artifacts allowlisted and machine-safe.
+    elif message == "wayland_vulkan_gate: dmabuf import": flags["dmabuf_import"] = event.get("backend") == "gdk-dmabuf"
+    elif message == "wayland_vulkan_gate: vulkan renderer": flags["vulkan"] = event.get("renderer") == "vulkan"
+    elif message == "wayland_vulkan_gate: resize": flags["resize"] = True
+    elif message == "wayland_vulkan_gate: OnBeforeClose": flags["before_close"] = True
+    elif message == "wayland_vulkan_gate: Engine.Close": flags["engine_close"] = True
+names, times, deltas = [r["milestone"] for r in records], [r["t_ms"] for r in records], [r["delta_ms"] for r in records]
+valid = names == order and all(type(v) is int and v >= 0 for v in times + deltas) and times == sorted(times)
+valid = valid and all(delta == current - previous for previous, current, delta in zip([0] + times, times, deltas))
+valid = valid and summary is not None and summary.get("backend") == "gdk-dmabuf" and not summary.get("incomplete_reason") and type(summary.get("total_ms")) is int and summary["total_ms"] == times[-1]
+valid = valid and not flags["gpu_1002"] and all(value for key, value in flags.items() if key != "gpu_1002")
+json.dump({"run":name, "valid":valid, "milestones":records, "summary":summary, "checks":flags}, open(destination, "w"), sort_keys=True, indent=2)
+if flags["gpu_1002"]: raise SystemExit(f"{name}: CEF GPU error 1002 (blocked)")
+if not valid: raise SystemExit(f"{name}: incomplete Wayland Vulkan lifecycle or presentation")
+PY
+}
+
+collect() {
+  local label="$1" binary="$2" source_dir="$3" evidence="$output/$1"
+  mkdir -- "$evidence"
+  write_metadata "$evidence/metadata.json" "$source_dir" "$binary"
+  for number in $(seq 1 "$runs"); do
+    local name root status
+    name="$(printf 'run-%02d' "$number")"; root="$work_root/$label-$name"
+    mkdir -p "$root"/{config,data,state,cache,cef-root-cache}
+    set +e
+    env -i HOME="$HOME" PATH="$PATH" LANG="${LANG:-C.UTF-8}" WAYLAND_DISPLAY="$WAYLAND_DISPLAY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+      XDG_CONFIG_HOME="$root/config" XDG_DATA_HOME="$root/data" XDG_STATE_HOME="$root/state" XDG_CACHE_HOME="$root/cache" DUMBER_CEF_ROOT_CACHE_PATH="$root/cef-root-cache" \
+      DUMBER_RENDER_STACK=vulkan-dmabuf PUREGO_CEF2GTK_BACKEND=gdk-dmabuf PUREGO_CEF2GTK_ANGLE_BACKEND=vulkan GSK_RENDERER=vulkan \
+      timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" "$binary" browse about:blank >"$root/process.log" 2>&1
+    status=$?
+    set -e
+    if [[ $status -eq 124 || $status -eq 137 ]]; then fail "$label/$name: timed out"; fi
+    parse_run "$root/process.log" "$evidence/$name.json" "$name"
+  done
+  python3 - "$evidence" <<'PY'
+import json, math, statistics, sys
+root=sys.argv[1]; totals=[]
+for n in range(1,6):
+ r=json.load(open(f"{root}/run-{n:02d}.json"));
+ if r.get("valid") is not True: raise SystemExit("invalid run")
+ totals.append(r["summary"]["total_ms"])
+totals.sort(); json.dump({"runs":5,"total_ms":{"min":totals[0],"median":statistics.median(totals),"max":totals[-1],"p95":totals[math.ceil(.95*5)-1]}},open(f"{root}/baseline.json","w"),sort_keys=True,indent=2)
+PY
+}
+
+collect baseline "$baseline_bin" "$baseline_source"
+collect candidate "$candidate_bin" "$candidate_source"
+python3 "$(dirname -- "$0")/compare_first_presentation.py" "$output/baseline" "$output/candidate" >"$output/result.json"
+printf 'wayland-vulkan gate artifacts: %s\n' "$output"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -65,7 +65,7 @@ github.com/bnema/purego-cef/internal/core
 github.com/bnema/purego-cef/internal/loader
 github.com/bnema/purego-cef/internal/ports/in
 github.com/bnema/purego-cef/internal/ports/out
-# github.com/bnema/purego-cef2gtk v0.8.4
+# github.com/bnema/purego-cef2gtk v0.8.4-0.20260714143951-2a5b796c8bef
 ## explicit; go 1.26
 github.com/bnema/purego-cef2gtk
 github.com/bnema/purego-cef2gtk/internal/cefadapter


### PR DESCRIPTION
## Summary
- pins purego-cef2gtk PR #28 at `2a5b796c8befa686b663ecfba4fb00dcd870d539`
- adds strict five-by-five Weston Wayland/Vulkan evidence gate and dispatch-only labelled workflow
- rejects GPU error 1002, missing lifecycle/provenance, unsafe artifacts, and >10% median/p95 regressions

## Validation
- `go test -mod=vendor ./...`
- `make lint`
- `make test`
- `make check`

## Live result
Local headless Weston attempt was blocked nonzero by the bounded startup timeout; it is not a hardware success claim. The harness treats CEF GPU error 1002 as a nonzero blocked result with no fallback or skip.