### PR TITLE
perf(audio): bound CEF packet handoff

### DIFF
--- a/internal/application/port/audio_output.go
+++ b/internal/application/port/audio_output.go
@@ -18,9 +18,10 @@ type AudioStreamFormat struct {
 // AudioOutputStream represents an active audio output stream.
 // Implementations handle the low-level audio playback.
 type AudioOutputStream interface {
-	// Write sends audio samples to the output device.
-	// Samples are provided as a 2D slice: [channel][frame]float32.
-	// This matches CEF's planar float32 audio format.
+	// Write sends callback-owned audio samples to the output device.
+	// Samples are provided as [channel][frame]float32 matching CEF's planar
+	// format. Implementations must not retain the slices and must be safe to
+	// call concurrently with Close; audio callbacks must not block.
 	Write(samples [][]float32) error
 	// Close releases the audio stream and associated resources.
 	Close() error

--- a/internal/infrastructure/audio/pipewire/output.go
+++ b/internal/infrastructure/audio/pipewire/output.go
@@ -198,10 +198,9 @@ func copyPacket(packet *audioPacket, samples [][]float32) {
 }
 
 func (a *playerStreamAdapter) recordDrop() {
-	n := a.dropCount.Add(1)
-	if (n == 1 || n&(n-1) == 0) && a.ctx != nil {
-		logging.FromContext(a.ctx).Warn().Uint64("total_drops", n).Msg("pipewire: dropped audio packet (buffer full)")
-	}
+	// Write runs on CEF's real-time callback thread. Diagnostics must stay
+	// allocation-free and must not synchronously emit logs from that path.
+	a.dropCount.Add(1)
 }
 
 // fill is the PlayerCallbacks.Fill function. It performs the only post-handoff

--- a/internal/infrastructure/audio/pipewire/output.go
+++ b/internal/infrastructure/audio/pipewire/output.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bnema/dumber/internal/logging"
 )
 
-// Compile-time interface checks.
 var (
 	_ port.AudioOutputFactory = (*Factory)(nil)
 	_ port.AudioOutputStream  = (*playerStreamAdapter)(nil)
@@ -26,6 +25,8 @@ var ErrInvalidFormat = errors.New("invalid audio stream format")
 
 // ErrStreamClosed is returned when writing to a closed stream.
 var ErrStreamClosed = errors.New("audio stream closed")
+
+const packetQueueCapacity = 4
 
 // playerCreator is a function type that creates a Player from config and callbacks.
 // This exists to allow dependency injection in tests.
@@ -38,24 +39,15 @@ type Factory struct {
 }
 
 // NewFactory creates a new PipeWire audio factory.
-// The factory is stateless; players are created per-stream.
 func NewFactory() (*Factory, error) {
-	return &Factory{
-		createPlayer: pwpipewire.NewPlayer,
-	}, nil
+	return &Factory{createPlayer: pwpipewire.NewPlayer}, nil
 }
 
-// NewStream creates a new audio output stream with the given format.
-// It validates the Dumber format, creates a purego-pipewire Player configured
-// from the format, and returns a push-to-pull adapter that bridges Write()
-// calls into the Player's Fill callback.
+// NewStream creates a push-to-pull adapter for a PipeWire player.
 func (f *Factory) NewStream(ctx context.Context, format port.AudioStreamFormat) (port.AudioOutputStream, error) {
-	// Check context cancellation
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-
-	// Validate format
 	if err := validateFormat(format); err != nil {
 		return nil, err
 	}
@@ -67,182 +59,196 @@ func (f *Factory) NewStream(ctx context.Context, format port.AudioStreamFormat) 
 		Int("frames_per_buffer", format.FramesPerBuffer).
 		Msg("pipewire: creating player")
 
-	// Create the adapter with its ring buffer before creating the player,
-	// because the Fill callback captures the adapter.
-	adapter := &playerStreamAdapter{
-		ctx:    ctx,
-		buf:    make(chan [][]float32, 4), // small buffer for push→pull bridging
-		closed: make(chan struct{}),
-	}
-
+	// Every slot owns storage sized from the negotiated CEF format. Write copies
+	// directly into an available slot; Fill copies that same slot into PipeWire.
+	// Callback slices are therefore never queued or retained.
+	adapter := newPlayerStreamAdapter(ctx, format.ChannelCount, format.FramesPerBuffer)
 	config := pwpipewire.PlayerConfig{
-		SampleRate:      format.SampleRate,
-		Channels:        format.ChannelCount,
-		FramesPerBuffer: format.FramesPerBuffer,
-		SampleFormat:    pwpipewire.SampleFormatF32,
-		UnderrunPolicy:  pwpipewire.UnderrunFillSilence,
+		SampleRate: format.SampleRate, Channels: format.ChannelCount, FramesPerBuffer: format.FramesPerBuffer,
+		SampleFormat: pwpipewire.SampleFormatF32, UnderrunPolicy: pwpipewire.UnderrunFillSilence,
 	}
-
-	callbacks := pwpipewire.PlayerCallbacks{
-		Fill: adapter.fill,
-	}
-
-	player, err := f.createPlayer(config, callbacks)
+	player, err := f.createPlayer(config, pwpipewire.PlayerCallbacks{Fill: adapter.fill})
 	if err != nil {
 		log.Warn().Err(err).Msg("pipewire: failed to create player")
 		return nil, fmt.Errorf("failed to create pipewire player: %w", err)
 	}
 	adapter.player = player
-
-	// Start the player so the Fill callback begins being called.
 	if err := player.Start(); err != nil {
 		_ = player.Close()
 		log.Warn().Err(err).Msg("pipewire: failed to start player")
 		return nil, fmt.Errorf("failed to start pipewire player: %w", err)
 	}
-
 	log.Info().Msg("pipewire: player started successfully")
-
 	return adapter, nil
 }
 
-// validateFormat checks if the audio format parameters are valid.
 func validateFormat(format port.AudioStreamFormat) error {
-	// Sample rate must be reasonable (8kHz to 384kHz)
 	if format.SampleRate < 8000 || format.SampleRate > 384000 {
-		return fmt.Errorf("%w: sample rate %d Hz out of range [8000, 384000]",
-			ErrInvalidFormat, format.SampleRate)
+		return fmt.Errorf("%w: sample rate %d Hz out of range [8000, 384kHz]", ErrInvalidFormat, format.SampleRate)
 	}
-
-	// Channel count must be 1 to 1024 (reasonable upper limit)
 	if format.ChannelCount < 1 || format.ChannelCount > 1024 {
-		return fmt.Errorf("%w: channel count %d out of range [1, 1024]",
-			ErrInvalidFormat, format.ChannelCount)
+		return fmt.Errorf("%w: channel count %d out of range [1, 1024]", ErrInvalidFormat, format.ChannelCount)
 	}
-
-	// Frames per buffer must be positive and reasonable
 	if format.FramesPerBuffer < 1 || format.FramesPerBuffer > 8192 {
-		return fmt.Errorf("%w: frames per buffer %d out of range [1, 8192]",
-			ErrInvalidFormat, format.FramesPerBuffer)
+		return fmt.Errorf("%w: frames per buffer %d out of range [1, 8192]", ErrInvalidFormat, format.FramesPerBuffer)
 	}
-
 	return nil
 }
 
-// playerStreamAdapter bridges Dumber's push-style Write(samples) interface
-// to purego-pipewire's pull-style Fill callback.
-//
-// Write() sends sample buffers into a channel. The Fill callback drains them
-// into the PCMBuffer that purego-pipewire passes in. If no data is available,
-// the player's UnderrunFillSilence policy handles it.
+// audioPacket is a reusable, adapter-owned packet slot. Its backing arrays are
+// allocated only when the stream is created and never alias CEF callback data.
+type audioPacket struct {
+	samples  [][]float32
+	channels int
+	frames   int
+}
+
+// playerStreamAdapter bridges callback-owned CEF audio to PipeWire's Fill
+// callback. available and ready form a bounded reusable packet ring.
 type playerStreamAdapter struct {
 	player pwpipewire.Player
 	ctx    context.Context
-	buf    chan [][]float32 // push→pull handoff channel
+
+	available chan *audioPacket
+	ready     chan *audioPacket
+	// TryLock serializes only simultaneous producers. The CEF callback never
+	// waits: contention and saturation both drop the packet. Fill never takes it.
+	writeMu sync.Mutex
+	closed  atomic.Bool
 
 	closeOnce sync.Once
-	closed    chan struct{} // closed when Close is called
 
-	// Diagnostic counters (atomic, no mutex needed).
-	fillCount     atomic.Uint64 // total Fill callbacks
-	underrunCount atomic.Uint64 // Fill callbacks with no data available
-	dropCount     atomic.Uint64 // Write calls that dropped data (buffer full)
+	fillCount     atomic.Uint64
+	underrunCount atomic.Uint64
+	dropCount     atomic.Uint64
 }
 
-// Write sends audio samples to the PipeWire output.
-// Samples are provided as [channel][frame]float32 matching CEF's planar format.
-// If the internal buffer is full the packet is dropped silently so the caller
-// (CEF audio callback thread) is never blocked.
-// Safe for concurrent use with Close.
-func (a *playerStreamAdapter) Write(samples [][]float32) error {
-	// Fast path: already closed.
-	select {
-	case <-a.closed:
-		return ErrStreamClosed
-	default:
+func newPlayerStreamAdapter(ctx context.Context, channels, frames int) *playerStreamAdapter {
+	a := &playerStreamAdapter{
+		ctx: ctx, available: make(chan *audioPacket, packetQueueCapacity), ready: make(chan *audioPacket, packetQueueCapacity),
 	}
-	// Non-blocking send: drop packet when buffer is full.
-	select {
-	case a.buf <- samples:
-		return nil
-	case <-a.closed:
-		return ErrStreamClosed
-	default:
-		// Buffer full — drop to avoid blocking the CEF audio thread.
-		n := a.dropCount.Add(1)
-		if n == 1 || n&(n-1) == 0 { // first drop, then powers of two
-			if a.ctx != nil {
-				logging.FromContext(a.ctx).Warn().
-					Uint64("total_drops", n).
-					Msg("pipewire: dropped audio packet (buffer full)")
-			}
+	for range packetQueueCapacity {
+		packet := &audioPacket{samples: make([][]float32, channels)}
+		for ch := range packet.samples {
+			packet.samples[ch] = make([]float32, frames)
 		}
+		a.available <- packet
+	}
+	return a
+}
+
+// Write makes exactly one owned copy for each accepted packet. It never blocks:
+// full queues or another producer cause a silent drop, preserving CEF timing.
+// The supplied slices are callback-owned and are not retained after return.
+func (a *playerStreamAdapter) Write(samples [][]float32) error {
+	if a.closed.Load() {
+		return ErrStreamClosed
+	}
+	if !a.writeMu.TryLock() {
+		a.recordDrop()
+		return nil
+	}
+	defer a.writeMu.Unlock()
+	if a.closed.Load() {
+		return ErrStreamClosed
+	}
+
+	select {
+	case packet := <-a.available:
+		copyPacket(packet, samples)
+		// A close racing after the first check must not publish a packet to a
+		// stopped player. Returning the slot keeps the ring bounded.
+		if a.closed.Load() {
+			a.available <- packet
+			return ErrStreamClosed
+		}
+		select {
+		case a.ready <- packet:
+			return nil
+		default:
+			// This cannot occur while ring invariants hold, but keep Write
+			// non-blocking if an implementation change violates them.
+			a.available <- packet
+			a.recordDrop()
+			return nil
+		}
+	default:
+		a.recordDrop()
 		return nil
 	}
 }
 
-// fill is the PlayerCallbacks.Fill function called by purego-pipewire
-// when it needs audio data. It pulls from the internal buffer channel.
+func copyPacket(packet *audioPacket, samples [][]float32) {
+	packet.channels = min(len(packet.samples), len(samples))
+	packet.frames = 0
+	if packet.channels == 0 {
+		return
+	}
+	frames := len(packet.samples[0])
+	for ch := 0; ch < packet.channels; ch++ {
+		n := min(len(packet.samples[ch]), len(samples[ch]))
+		if n < frames {
+			frames = n
+		}
+	}
+	packet.frames = frames
+	for ch := 0; ch < packet.channels; ch++ {
+		copy(packet.samples[ch][:frames], samples[ch][:frames])
+	}
+}
+
+func (a *playerStreamAdapter) recordDrop() {
+	n := a.dropCount.Add(1)
+	if (n == 1 || n&(n-1) == 0) && a.ctx != nil {
+		logging.FromContext(a.ctx).Warn().Uint64("total_drops", n).Msg("pipewire: dropped audio packet (buffer full)")
+	}
+}
+
+// fill is the PlayerCallbacks.Fill function. It performs the only post-handoff
+// full-packet copy, directly into PipeWire's destination buffer.
 func (a *playerStreamAdapter) fill(pcm *pwpipewire.PCMBuffer) (int, error) {
 	select {
-	case samples := <-a.buf:
+	case packet := <-a.ready:
 		fillNum := a.fillCount.Add(1)
 		if fillNum == 1 && a.ctx != nil {
-			logging.FromContext(a.ctx).Info().
-				Msg("pipewire: first Fill callback with data")
+			logging.FromContext(a.ctx).Info().Msg("pipewire: first Fill callback with data")
 		}
-		// Copy available samples into the PCM buffer
-		copied := copyToPCM(pcm, samples)
+		copied := copyToPCM(pcm, packet.samples[:packet.channels], packet.frames)
+		a.available <- packet
 		return copied, nil
 	default:
-		// No data available — return 0 frames, let underrun policy handle it
 		underruns := a.underrunCount.Add(1)
 		if underruns == 1 && a.ctx != nil {
-			logging.FromContext(a.ctx).Debug().
-				Msg("pipewire: first Fill underrun (no data available)")
+			logging.FromContext(a.ctx).Debug().Msg("pipewire: first Fill underrun (no data available)")
 		}
 		return 0, nil
 	}
 }
 
-// copyToPCM copies planar samples into the PCMBuffer.
-// Returns the number of frames actually copied.
-func copyToPCM(pcm *pwpipewire.PCMBuffer, samples [][]float32) int {
-	if pcm == nil || len(samples) == 0 {
+func copyToPCM(pcm *pwpipewire.PCMBuffer, samples [][]float32, packetFrames int) int {
+	if pcm == nil || len(samples) == 0 || packetFrames == 0 {
 		return 0
 	}
-
-	frames := pcm.Frames
 	channels := min(min(len(samples), pcm.Channels), len(pcm.Samples))
 	if channels == 0 {
 		return 0
 	}
-
-	minFrames := frames
-
-	for ch := 0; ch < channels && ch < len(samples); ch++ {
-		dst := pcm.Samples[ch]
-		src := samples[ch]
-		if len(dst) == 0 || len(src) == 0 {
-			minFrames = 0
-			continue
-		}
-		srcFrames := len(src)
-		n := min(len(dst), min(srcFrames, frames))
-		if n < minFrames {
-			minFrames = n
-		}
-		copy(dst[:n], src[:n])
+	frames := min(pcm.Frames, packetFrames)
+	for ch := 0; ch < channels; ch++ {
+		frames = min(frames, min(len(pcm.Samples[ch]), len(samples[ch])))
 	}
-
-	return minFrames
+	for ch := 0; ch < channels; ch++ {
+		copy(pcm.Samples[ch][:frames], samples[ch][:frames])
+	}
+	return frames
 }
 
-// Close stops the player and releases resources.
-// Safe to call multiple times.
+// Close stops the player. It is safe with Write: Write observes closed before
+// publishing, and no channel is closed while a callback may be selecting on it.
 func (a *playerStreamAdapter) Close() error {
 	var err error
 	a.closeOnce.Do(func() {
+		a.closed.Store(true)
 		if a.ctx != nil {
 			logging.FromContext(a.ctx).Info().
 				Uint64("fills", a.fillCount.Load()).
@@ -250,12 +256,7 @@ func (a *playerStreamAdapter) Close() error {
 				Uint64("drops", a.dropCount.Load()).
 				Msg("pipewire: closing player")
 		}
-
-		// Signal writers to stop
-		close(a.closed)
-
 		if a.player != nil {
-			// Stop playback then close the player
 			if stopErr := a.player.Stop(); stopErr != nil {
 				err = stopErr
 			}

--- a/internal/infrastructure/audio/pipewire/output_test.go
+++ b/internal/infrastructure/audio/pipewire/output_test.go
@@ -1,11 +1,11 @@
-// Package pipewire provides a PipeWire-based audio output implementation.
-// This wraps purego-pipewire's high-level Player API.
 package pipewire
 
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
 	pipewiremocks "github.com/bnema/dumber/internal/infrastructure/audio/pipewire/mocks"
@@ -16,548 +16,193 @@ import (
 
 type playerRecorder struct {
 	*pipewiremocks.MockPlayer
-
-	started    bool
-	paused     bool
-	stopped    bool
-	closedFlag bool
-	state      pwpipewire.PlayerState
-
-	startErr error
-	stopErr  error
-	closeErr error
+	started, stopped, closedFlag bool
+	startErr, stopErr, closeErr  error
 }
 
 func newPlayerRecorder(t *testing.T) *playerRecorder {
 	t.Helper()
-
-	recorder := &playerRecorder{MockPlayer: pipewiremocks.NewMockPlayer(t)}
-	recorder.EXPECT().Start().RunAndReturn(recorder.start).Maybe()
-	recorder.EXPECT().Pause().RunAndReturn(recorder.pause).Maybe()
-	recorder.EXPECT().Stop().RunAndReturn(recorder.stop).Maybe()
-	recorder.EXPECT().Close().RunAndReturn(recorder.close).Maybe()
-	recorder.EXPECT().State().RunAndReturn(recorder.currentState).Maybe()
-	return recorder
+	p := &playerRecorder{MockPlayer: pipewiremocks.NewMockPlayer(t)}
+	p.EXPECT().Start().RunAndReturn(func() error {
+		if p.startErr != nil {
+			return p.startErr
+		}
+		p.started = true
+		return nil
+	}).Maybe()
+	p.EXPECT().Stop().RunAndReturn(func() error {
+		if p.stopErr != nil {
+			return p.stopErr
+		}
+		p.stopped = true
+		return nil
+	}).Maybe()
+	p.EXPECT().Close().RunAndReturn(func() error {
+		if p.closeErr != nil {
+			return p.closeErr
+		}
+		p.closedFlag = true
+		return nil
+	}).Maybe()
+	return p
 }
 
-func (p *playerRecorder) start() error {
-	if p.startErr != nil {
-		return p.startErr
-	}
-	p.started = true
-	p.state = pwpipewire.PlayerStatePlaying
-	return nil
+func testAdapter(frames int) *playerStreamAdapter {
+	return newPlayerStreamAdapter(context.Background(), 2, frames)
 }
 
-func (p *playerRecorder) pause() error {
-	p.paused = true
-	p.state = pwpipewire.PlayerStatePaused
-	return nil
+func stereoPCM(frames int) *pwpipewire.PCMBuffer {
+	return &pwpipewire.PCMBuffer{Frames: frames, Channels: 2, Samples: [][]float32{make([]float32, frames), make([]float32, frames)}}
 }
 
-func (p *playerRecorder) stop() error {
-	if p.stopErr != nil {
-		return p.stopErr
-	}
-	p.stopped = true
-	p.state = pwpipewire.PlayerStateStopped
-	return nil
-}
-
-func (p *playerRecorder) close() error {
-	if p.closeErr != nil {
-		return p.closeErr
-	}
-	p.closedFlag = true
-	p.state = pwpipewire.PlayerStateClosed
-	return nil
-}
-
-func (p *playerRecorder) currentState() pwpipewire.PlayerState {
-	return p.state
-}
-
-// --- Factory tests ---
-
-func TestFactory_NewStream_ValidFormat_CreatesStream(t *testing.T) {
-	var capturedConfig pwpipewire.PlayerConfig
+func TestFactory_NewStreamValidatesAndStartsPlayer(t *testing.T) {
 	player := newPlayerRecorder(t)
-
-	factory := &Factory{
-		createPlayer: func(config pwpipewire.PlayerConfig, _ pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
-			capturedConfig = config
-			return player, nil
-		},
-	}
-
-	format := port.AudioStreamFormat{
-		SampleRate:      48000,
-		ChannelCount:    2,
-		FramesPerBuffer: 512,
-	}
-
-	stream, err := factory.NewStream(context.Background(), format)
+	factory := &Factory{createPlayer: func(config pwpipewire.PlayerConfig, callbacks pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
+		assert.Equal(t, 48000, config.SampleRate)
+		assert.Equal(t, 2, config.Channels)
+		assert.NotNil(t, callbacks.Fill)
+		return player, nil
+	}}
+	stream, err := factory.NewStream(context.Background(), port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 512})
 	require.NoError(t, err)
-	require.NotNil(t, stream)
-
-	// Verify config mapping
-	assert.Equal(t, 48000, capturedConfig.SampleRate)
-	assert.Equal(t, 2, capturedConfig.Channels)
-	assert.Equal(t, 512, capturedConfig.FramesPerBuffer)
-	assert.Equal(t, pwpipewire.SampleFormatF32, capturedConfig.SampleFormat)
-	assert.Equal(t, pwpipewire.UnderrunFillSilence, capturedConfig.UnderrunPolicy)
-
-	// Verify player was started
 	assert.True(t, player.started)
-
-	// Clean up
 	require.NoError(t, stream.Close())
 }
 
-func TestFactory_NewStream_InvalidFormat_ReturnsError(t *testing.T) {
-	factory := &Factory{
-		createPlayer: func(_ pwpipewire.PlayerConfig, _ pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
-			t.Fatal("createPlayer should not be called for invalid format")
-			return nil, nil
-		},
-	}
-
-	tests := []struct {
-		name   string
-		format port.AudioStreamFormat
-	}{
-		{
-			name:   "zero sample rate",
-			format: port.AudioStreamFormat{SampleRate: 0, ChannelCount: 2, FramesPerBuffer: 512},
-		},
-		{
-			name:   "zero channels",
-			format: port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 0, FramesPerBuffer: 512},
-		},
-		{
-			name:   "negative sample rate",
-			format: port.AudioStreamFormat{SampleRate: -48000, ChannelCount: 2, FramesPerBuffer: 512},
-		},
-		{
-			name:   "negative channels",
-			format: port.AudioStreamFormat{SampleRate: 48000, ChannelCount: -2, FramesPerBuffer: 512},
-		},
-		{
-			name:   "excessive sample rate",
-			format: port.AudioStreamFormat{SampleRate: 1000000, ChannelCount: 2, FramesPerBuffer: 512},
-		},
-		{
-			name:   "excessive channels",
-			format: port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 1025, FramesPerBuffer: 512},
-		},
-		{
-			name:   "zero frames per buffer",
-			format: port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 0},
-		},
-		{
-			name:   "excessive frames per buffer",
-			format: port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 10000},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			stream, err := factory.NewStream(context.Background(), tt.format)
-			require.Error(t, err)
-			assert.Nil(t, stream)
-			assert.ErrorIs(t, err, ErrInvalidFormat)
-		})
+func TestFactory_NewStreamRejectsInvalidFormat(t *testing.T) {
+	factory := &Factory{createPlayer: func(pwpipewire.PlayerConfig, pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
+		t.Fatal("unexpected player")
+		return nil, nil
+	}}
+	for _, format := range []port.AudioStreamFormat{
+		{SampleRate: 0, ChannelCount: 2, FramesPerBuffer: 512},
+		{SampleRate: 48000, ChannelCount: 0, FramesPerBuffer: 512},
+		{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 0},
+	} {
+		stream, err := factory.NewStream(context.Background(), format)
+		require.ErrorIs(t, err, ErrInvalidFormat)
+		assert.Nil(t, stream)
 	}
 }
 
-func TestFactory_NewStream_PlayerCreationFails_ReturnsError(t *testing.T) {
-	expectedErr := errors.New("pipewire not available")
-	factory := &Factory{
-		createPlayer: func(_ pwpipewire.PlayerConfig, _ pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
-			return nil, expectedErr
-		},
-	}
-
-	format := port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 512}
-	stream, err := factory.NewStream(context.Background(), format)
-
-	require.Error(t, err)
-	assert.Nil(t, stream)
-	assert.ErrorIs(t, err, expectedErr)
-}
-
-func TestFactory_NewStream_PlayerStartFails_ClosesAndReturnsError(t *testing.T) {
+func TestFactory_NewStreamClosesPlayerWhenStartFails(t *testing.T) {
 	player := newPlayerRecorder(t)
 	player.startErr = errors.New("start failed")
-	factory := &Factory{
-		createPlayer: func(_ pwpipewire.PlayerConfig, _ pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
-			return player, nil
-		},
-	}
-
-	format := port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 512}
-	stream, err := factory.NewStream(context.Background(), format)
-
+	factory := &Factory{createPlayer: func(pwpipewire.PlayerConfig, pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
+		return player, nil
+	}}
+	stream, err := factory.NewStream(context.Background(), port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 512})
 	require.Error(t, err)
 	assert.Nil(t, stream)
-	assert.True(t, player.closedFlag, "player should be closed after start failure")
+	assert.True(t, player.closedFlag)
 }
 
-func TestFactory_NewStream_ContextCancelled_ReturnsError(t *testing.T) {
-	factory := &Factory{
-		createPlayer: func(_ pwpipewire.PlayerConfig, _ pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
-			t.Fatal("createPlayer should not be called when context is canceled")
-			return nil, nil
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	format := port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 512}
-	stream, err := factory.NewStream(ctx, format)
-
-	require.Error(t, err)
-	assert.Nil(t, stream)
-}
-
-func TestFactory_NewStream_MultipleFormats_Accepted(t *testing.T) {
-	formats := []port.AudioStreamFormat{
-		{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 512},
-		{SampleRate: 44100, ChannelCount: 2, FramesPerBuffer: 512},
-		{SampleRate: 48000, ChannelCount: 1, FramesPerBuffer: 256},
-		{SampleRate: 96000, ChannelCount: 2, FramesPerBuffer: 1024},
-		{SampleRate: 48000, ChannelCount: 6, FramesPerBuffer: 512},
-	}
-
-	for _, fmt := range formats {
-		t.Run("", func(t *testing.T) {
-			factory := &Factory{
-				createPlayer: func(config pwpipewire.PlayerConfig, _ pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
-					assert.Equal(t, fmt.SampleRate, config.SampleRate)
-					assert.Equal(t, fmt.ChannelCount, config.Channels)
-					assert.Equal(t, fmt.FramesPerBuffer, config.FramesPerBuffer)
-					return newPlayerRecorder(t), nil
-				},
-			}
-
-			stream, err := factory.NewStream(context.Background(), fmt)
-			require.NoError(t, err)
-			assert.NotNil(t, stream)
-
-			_ = stream.Close()
-		})
-	}
-}
-
-func TestFactory_ImplementsPortInterface(_ *testing.T) {
-	var _ port.AudioOutputFactory = (*Factory)(nil)
-}
-
-// --- Stream adapter tests ---
-
-func TestPlayerStreamAdapter_Write_SendsToBuffer(t *testing.T) {
-	player := newPlayerRecorder(t)
-	adapter := &playerStreamAdapter{
-		player: player,
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
-	}
-
-	samples := [][]float32{
-		{0.1, 0.2},
-		{0.3, 0.4},
-	}
-
-	err := adapter.Write(samples)
+func TestPlayerStreamAdapter_FillGetsOwnedPacketAfterCallbackMutation(t *testing.T) {
+	adapter := testAdapter(3)
+	samples := [][]float32{{1, 2, 3}, {4, 5, 6}}
+	require.NoError(t, adapter.Write(samples))
+	samples[0][0], samples[1][0] = 99, 99
+	pcm := stereoPCM(3)
+	frames, err := adapter.fill(pcm)
 	require.NoError(t, err)
-
-	// Verify data is in the channel
-	received := <-adapter.buf
-	assert.Equal(t, samples, received)
+	assert.Equal(t, 3, frames)
+	assert.InEpsilon(t, 1, pcm.Samples[0][0], 0.0001)
+	assert.InEpsilon(t, 4, pcm.Samples[1][0], 0.0001)
 }
 
-func TestPlayerStreamAdapter_Write_AfterClose_ReturnsError(t *testing.T) {
-	player := newPlayerRecorder(t)
-	adapter := &playerStreamAdapter{
-		player: player,
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
+func TestPlayerStreamAdapter_SaturationDropsWithoutBlocking(t *testing.T) {
+	adapter := testAdapter(2)
+	for i := 0; i < packetQueueCapacity; i++ {
+		require.NoError(t, adapter.Write([][]float32{{float32(i)}, {float32(i)}}))
 	}
+	done := make(chan error, 1)
+	go func() { done <- adapter.Write([][]float32{{99}, {99}}) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Write blocked while the bounded queue was saturated")
+	}
+	assert.Equal(t, uint64(1), adapter.dropCount.Load())
+	assert.Len(t, adapter.ready, packetQueueCapacity)
+}
 
+func TestPlayerStreamAdapter_EmptyFillCountsUnderrun(t *testing.T) {
+	adapter := testAdapter(2)
+	frames, err := adapter.fill(stereoPCM(2))
+	require.NoError(t, err)
+	assert.Zero(t, frames)
+	assert.Equal(t, uint64(1), adapter.underrunCount.Load())
+}
+
+func TestPlayerStreamAdapter_CopyToPCMHandlesMismatches(t *testing.T) {
+	pcm := &pwpipewire.PCMBuffer{Frames: 4, Channels: 1, Samples: [][]float32{make([]float32, 4)}}
+	assert.Equal(t, 2, copyToPCM(pcm, [][]float32{{1, 2}, {3, 4}}, 2))
+	assert.InEpsilon(t, 1, pcm.Samples[0][0], 0.0001)
+	assert.Zero(t, copyToPCM(nil, [][]float32{{1}}, 1))
+}
+
+func TestPlayerStreamAdapter_CloseVsWrite(t *testing.T) {
+	adapter := testAdapter(2)
+	player := newPlayerRecorder(t)
+	adapter.player = player
 	require.NoError(t, adapter.Close())
-
-	err := adapter.Write([][]float32{{0.1}})
-	assert.ErrorIs(t, err, ErrStreamClosed)
-}
-
-func TestPlayerStreamAdapter_Close_StopsAndClosesPlayer(t *testing.T) {
-	player := newPlayerRecorder(t)
-	adapter := &playerStreamAdapter{
-		player: player,
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
-	}
-
-	err := adapter.Close()
-	require.NoError(t, err)
-
+	require.ErrorIs(t, adapter.Write([][]float32{{1}, {2}}), ErrStreamClosed)
 	assert.True(t, player.stopped)
 	assert.True(t, player.closedFlag)
 }
 
-func TestPlayerStreamAdapter_Close_IsIdempotent(t *testing.T) {
-	player := newPlayerRecorder(t)
-	adapter := &playerStreamAdapter{
-		player: player,
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
-	}
-
-	require.NoError(t, adapter.Close())
-	require.NoError(t, adapter.Close())
-}
-
-func TestPlayerStreamAdapter_Close_PropagatesStopError(t *testing.T) {
-	player := newPlayerRecorder(t)
-	player.stopErr = errors.New("stop error")
-	adapter := &playerStreamAdapter{
-		player: player,
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
-	}
-
-	err := adapter.Close()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "stop error")
-}
-
-func TestPlayerStreamAdapter_Close_PropagatesCloseError(t *testing.T) {
-	player := newPlayerRecorder(t)
-	player.closeErr = errors.New("close error")
-	adapter := &playerStreamAdapter{
-		player: player,
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
-	}
-
-	err := adapter.Close()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "close error")
-}
-
-// --- Fill callback tests ---
-
-func TestFill_PullsFromBuffer(t *testing.T) {
-	adapter := &playerStreamAdapter{
-		buf: make(chan [][]float32, 4),
-	}
-
-	// Push samples
-	samples := [][]float32{
-		{0.1, 0.2, 0.3},
-		{0.4, 0.5, 0.6},
-	}
-	adapter.buf <- samples
-
-	// Simulate Fill call
-	pcm := &pwpipewire.PCMBuffer{
-		Frames:   3,
-		Channels: 2,
-		Stride:   1,
-		Samples: [][]float32{
-			make([]float32, 3),
-			make([]float32, 3),
-		},
-	}
-
-	frames, err := adapter.fill(pcm)
-	require.NoError(t, err)
-	assert.Equal(t, 3, frames)
-	assert.InEpsilon(t, 0.1, pcm.Samples[0][0], 0.0001)
-	assert.InEpsilon(t, 0.4, pcm.Samples[1][0], 0.0001)
-}
-
-func TestFill_ReturnsZeroWhenEmpty(t *testing.T) {
-	adapter := &playerStreamAdapter{
-		buf: make(chan [][]float32, 4),
-	}
-
-	pcm := &pwpipewire.PCMBuffer{
-		Frames:   256,
-		Channels: 2,
-		Stride:   1,
-		Samples: [][]float32{
-			make([]float32, 256),
-			make([]float32, 256),
-		},
-	}
-
-	frames, err := adapter.fill(pcm)
-	require.NoError(t, err)
-	assert.Equal(t, 0, frames)
-}
-
-func TestCopyToPCM_HandlesChannelMismatch(t *testing.T) {
-	// More source channels than PCM channels — truncates
-	pcm := &pwpipewire.PCMBuffer{
-		Frames:   2,
-		Channels: 1,
-		Samples:  [][]float32{make([]float32, 2)},
-	}
-	samples := [][]float32{
-		{1.0, 2.0},
-		{3.0, 4.0}, // should be ignored
-	}
-	frames := copyToPCM(pcm, samples)
-	assert.Equal(t, 2, frames)
-	assert.InEpsilon(t, 1.0, pcm.Samples[0][0], 0.0001)
-}
-
-func TestCopyToPCM_HandlesFrameMismatch(t *testing.T) {
-	// Fewer source frames than PCM expects
-	pcm := &pwpipewire.PCMBuffer{
-		Frames:   4,
-		Channels: 1,
-		Samples:  [][]float32{make([]float32, 4)},
-	}
-	samples := [][]float32{
-		{1.0, 2.0}, // only 2 frames
-	}
-	frames := copyToPCM(pcm, samples)
-	assert.Equal(t, 2, frames) // reports partial fill
-}
-
-func TestCopyToPCM_NilPCM_ReturnsZero(t *testing.T) {
-	assert.Equal(t, 0, copyToPCM(nil, [][]float32{{1.0}}))
-}
-
-func TestCopyToPCM_EmptySamples_ReturnsZero(t *testing.T) {
-	pcm := &pwpipewire.PCMBuffer{Frames: 1, Channels: 1, Samples: [][]float32{make([]float32, 1)}}
-	assert.Equal(t, 0, copyToPCM(pcm, nil))
-	assert.Equal(t, 0, copyToPCM(pcm, [][]float32{}))
-}
-
-// --- Non-blocking Write tests ---
-
-func TestPlayerStreamAdapter_Write_DropsWhenBufferFull(t *testing.T) {
-	adapter := &playerStreamAdapter{
-		player: newPlayerRecorder(t),
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
-	}
-
-	// Fill the buffer to capacity
-	for i := range 4 {
-		require.NoError(t, adapter.Write([][]float32{{float32(i)}}))
-	}
-
-	// The 5th write must NOT block — it should drop the packet and return nil.
-	err := adapter.Write([][]float32{{99.0}})
-	require.NoError(t, err, "Write must not return an error when dropping due to full buffer")
-
-	// Verify the drop was counted
-	assert.Equal(t, uint64(1), adapter.dropCount.Load(), "one packet should have been dropped")
-
-	// Verify buffer still contains the original 4 packets (not the dropped one)
-	assert.Len(t, adapter.buf, 4)
-}
-
-func TestPlayerStreamAdapter_Write_DropsLogOnlyOnFirstAndPowerOfTwo(t *testing.T) {
-	adapter := &playerStreamAdapter{
-		player: newPlayerRecorder(t),
-		buf:    make(chan [][]float32, 1), // tiny buffer to force drops
-		closed: make(chan struct{}),
-	}
-
-	// Fill buffer
-	require.NoError(t, adapter.Write([][]float32{{0.0}}))
-
-	// Drop 10 packets
-	for i := range 10 {
-		_ = adapter.Write([][]float32{{float32(i)}})
-	}
-
-	// Verify all drops were counted
-	assert.Equal(t, uint64(10), adapter.dropCount.Load())
-}
-
-// --- Concurrent Write / Close tests ---
-
 func TestPlayerStreamAdapter_ConcurrentWriteClose_NoRace(t *testing.T) {
-	player := newPlayerRecorder(t)
-	adapter := &playerStreamAdapter{
-		player: player,
-		buf:    make(chan [][]float32, 4),
-		closed: make(chan struct{}),
-	}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for i := range 100 {
-			err := adapter.Write([][]float32{{float32(i)}})
-			if err != nil {
-				assert.ErrorIs(t, err, ErrStreamClosed)
-				return
+	adapter := testAdapter(4)
+	var writers sync.WaitGroup
+	for range 4 {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for range 1000 {
+				err := adapter.Write([][]float32{{1, 2}, {3, 4}})
+				if err != nil {
+					assert.ErrorIs(t, err, ErrStreamClosed)
+					return
+				}
 			}
-		}
-	}()
-
-	// Let a few writes land, then close.
+		}()
+	}
 	adapter.Close()
-	<-done
+	writers.Wait()
 }
-
-// --- NewFactory tests ---
-
-func TestNewFactory_Succeeds(t *testing.T) {
-	factory, err := NewFactory()
-	require.NoError(t, err)
-	require.NotNil(t, factory)
-	assert.NotNil(t, factory.createPlayer)
-}
-
-// --- Integration-style test: full write-through ---
 
 func TestStream_WriteFlowsThroughToFill(t *testing.T) {
-	var capturedCallbacks pwpipewire.PlayerCallbacks
+	var callbacks pwpipewire.PlayerCallbacks
 	player := newPlayerRecorder(t)
-
-	factory := &Factory{
-		createPlayer: func(_ pwpipewire.PlayerConfig, callbacks pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
-			capturedCallbacks = callbacks
-			return player, nil
-		},
-	}
-
-	format := port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 4}
-	stream, err := factory.NewStream(context.Background(), format)
+	factory := &Factory{createPlayer: func(_ pwpipewire.PlayerConfig, got pwpipewire.PlayerCallbacks) (pwpipewire.Player, error) {
+		callbacks = got
+		return player, nil
+	}}
+	stream, err := factory.NewStream(context.Background(), port.AudioStreamFormat{SampleRate: 48000, ChannelCount: 2, FramesPerBuffer: 4})
 	require.NoError(t, err)
-
-	// Write samples through the stream
-	samples := [][]float32{
-		{0.1, 0.2, 0.3, 0.4},
-		{0.5, 0.6, 0.7, 0.8},
-	}
-	require.NoError(t, stream.Write(samples))
-
-	// Simulate the Fill callback being called by the player
-	pcm := &pwpipewire.PCMBuffer{
-		Frames:   4,
-		Channels: 2,
-		Stride:   1,
-		Samples: [][]float32{
-			make([]float32, 4),
-			make([]float32, 4),
-		},
-	}
-
-	frames, err := capturedCallbacks.Fill(pcm)
+	require.NoError(t, stream.Write([][]float32{{.1, .2, .3, .4}, {.5, .6, .7, .8}}))
+	pcm := stereoPCM(4)
+	frames, err := callbacks.Fill(pcm)
 	require.NoError(t, err)
 	assert.Equal(t, 4, frames)
-	assert.InEpsilon(t, 0.1, pcm.Samples[0][0], 0.0001)
-	assert.InEpsilon(t, 0.5, pcm.Samples[1][0], 0.0001)
-
+	assert.InEpsilon(t, .1, pcm.Samples[0][0], .0001)
+	assert.InEpsilon(t, .5, pcm.Samples[1][0], .0001)
 	require.NoError(t, stream.Close())
+}
+
+func BenchmarkPlayerStreamAdapterStereo(b *testing.B) {
+	adapter := testAdapter(512)
+	samples := [][]float32{make([]float32, 512), make([]float32, 512)}
+	pcm := stereoPCM(512)
+	b.ReportAllocs()
+	b.SetBytes(2 * 512 * 4)
+	for i := 0; i < b.N; i++ {
+		if err := adapter.Write(samples); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := adapter.fill(pcm); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2331,20 +2331,18 @@ func (wv *WebView) takePendingCreate() *pendingBrowserCreate {
 	return pc
 }
 
-// closeAudioStream closes and clears the active audio output stream.
-// This is safe to call even if no stream is active.
+// closeAudioStream detaches then closes the active output stream. Detaching
+// under the lock keeps packet snapshots consistent without holding the lock
+// while PipeWire shutdown runs; the port guarantees Close/Write safety.
 func (wv *WebView) closeAudioStream() {
 	wv.audioStreamMu.Lock()
-	defer wv.audioStreamMu.Unlock()
+	stream := wv.activeAudioStream
+	wv.activeAudioStream = nil
+	wv.audioStreamMu.Unlock()
 
-	if wv.activeAudioStream != nil {
-		if err := wv.activeAudioStream.Close(); err != nil {
-			if wv.ctx != nil {
-				logging.FromContext(wv.ctx).Debug().
-					Err(err).
-					Msg("cef: error closing audio stream")
-			}
+	if stream != nil {
+		if err := stream.Close(); err != nil && wv.ctx != nil {
+			logging.FromContext(wv.ctx).Debug().Err(err).Msg("cef: error closing audio stream")
 		}
-		wv.activeAudioStream = nil
 	}
 }

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -250,14 +250,23 @@ type WebView struct {
 	inputDiagDeltaXSum int64
 	inputDiagDeltaYSum int64
 
-	// Audio output factory and active stream.
-	audioOutputFactory port.AudioOutputFactory
-	audioStreamMu      sync.Mutex
-	activeAudioStream  port.AudioOutputStream
+	// Audio output lifecycle. Packet callbacks load audioStream directly: its
+	// immutable handle is atomically published and never requires a mutex.
+	audioOutputFactory    port.AudioOutputFactory
+	audioStreamMu         sync.Mutex
+	audioStreamGeneration atomic.Uint64
+	audioStream           atomic.Pointer[audioStreamHandle]
 
 	// Audio instrumentation counters (diagnostic only).
 	audioPacketCount atomic.Uint64 // total OnAudioStreamPacket calls
 	audioWriteCount  atomic.Uint64 // successful Write calls to stream
+}
+
+// audioStreamHandle is immutable after publication so packet callbacks can
+// safely snapshot it without coordinating with lifecycle operations.
+type audioStreamHandle struct {
+	stream     port.AudioOutputStream
+	generation uint64
 }
 
 // pendingBrowserCreate holds the parameters needed to create a CEF browser,
@@ -2331,17 +2340,50 @@ func (wv *WebView) takePendingCreate() *pendingBrowserCreate {
 	return pc
 }
 
-// closeAudioStream detaches then closes the active output stream. Detaching
-// under the lock keeps packet snapshots consistent without holding the lock
-// while PipeWire shutdown runs; the port guarantees Close/Write safety.
+// beginAudioStreamStart invalidates any prior stream before creating a new
+// one. A stream created for the returned generation may only be published if
+// that generation is still current.
+func (wv *WebView) beginAudioStreamStart() (uint64, *audioStreamHandle, bool) {
+	wv.audioStreamMu.Lock()
+	defer wv.audioStreamMu.Unlock()
+	if wv.destroyed.Load() {
+		return 0, nil, false
+	}
+	generation := wv.audioStreamGeneration.Add(1)
+	previous := wv.audioStream.Swap(nil)
+	wv.audioPlaying.Store(false)
+	return generation, previous, true
+}
+
+// publishAudioStream publishes stream only if no Stop, Destroy, or newer Start
+// invalidated its creation generation. A rejected stream is owned by the
+// caller and must be closed by it.
+func (wv *WebView) publishAudioStream(generation uint64, stream port.AudioOutputStream) (*audioStreamHandle, bool) {
+	wv.audioStreamMu.Lock()
+	defer wv.audioStreamMu.Unlock()
+	if wv.destroyed.Load() || wv.audioStreamGeneration.Load() != generation {
+		return nil, false
+	}
+	previous := wv.audioStream.Swap(&audioStreamHandle{stream: stream, generation: generation})
+	wv.audioPlaying.Store(true)
+	return previous, true
+}
+
+// closeAudioStream invalidates creation in progress, atomically detaches the
+// published handle, then closes it outside the lifecycle mutex. The port
+// contract permits Close concurrently with a packet Write.
 func (wv *WebView) closeAudioStream() {
 	wv.audioStreamMu.Lock()
-	stream := wv.activeAudioStream
-	wv.activeAudioStream = nil
+	wv.audioStreamGeneration.Add(1)
+	stream := wv.audioStream.Swap(nil)
+	wv.audioPlaying.Store(false)
 	wv.audioStreamMu.Unlock()
+	wv.closeDetachedAudioStream(stream)
+}
 
-	if stream != nil {
-		if err := stream.Close(); err != nil && wv.ctx != nil {
+func (wv *WebView) closeDetachedAudioStream(handle *audioStreamHandle) {
+	if handle != nil && handle.stream != nil {
+		if err := handle.stream.Close(); err != nil && wv.ctx != nil {
 			logging.FromContext(wv.ctx).Debug().Err(err).Msg("cef: error closing audio stream")
 		}
 	}

--- a/internal/infrastructure/cef/webview_audio_test.go
+++ b/internal/infrastructure/cef/webview_audio_test.go
@@ -258,9 +258,9 @@ func TestHandlerSet_OnAudioStreamStarted_FactoryError_HandlesGracefully(t *testi
 // Task 7: PCM Packet Forwarding Tests
 // ============================================================================
 
-// TestHandlerSet_OnAudioStreamPacket_CopiesAndWrites verifies that
-// OnAudioStreamPacket copies samples before writing to avoid data races.
-func TestHandlerSet_OnAudioStreamPacket_CopiesAndWrites(t *testing.T) {
+// TestHandlerSet_OnAudioStreamPacket_ForwardsCallbackData verifies that CEF
+// does not allocate a staging copy; the audio output port owns that handoff.
+func TestHandlerSet_OnAudioStreamPacket_ForwardsCallbackData(t *testing.T) {
 	ctx := context.Background()
 	mockStream := &mockAudioStream{}
 
@@ -287,12 +287,9 @@ func TestHandlerSet_OnAudioStreamPacket_CopiesAndWrites(t *testing.T) {
 	require.Len(t, mockStream.writeSamples, 2)
 	require.Len(t, mockStream.writeSamples[0], 512)
 
-	// Verify data was copied (values match)
 	assert.InDelta(t, 0.5, mockStream.writeSamples[0][0], 0.000001)
 	assert.InDelta(t, -0.5, mockStream.writeSamples[1][0], 0.000001)
-
-	// Verify it's a copy (different underlying array)
-	assert.NotSame(t, &originalData[0][0], &mockStream.writeSamples[0][0])
+	assert.Same(t, &originalData[0][0], &mockStream.writeSamples[0][0])
 }
 
 // TestHandlerSet_OnAudioStreamPacket_NoActiveStream_DoesNothing verifies
@@ -331,6 +328,17 @@ func TestHandlerSet_OnAudioStreamPacket_NilData_DoesNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		handlers.OnAudioStreamPacket(nil, nil, 0, 0)
 	})
+}
+
+func BenchmarkHandlerSet_OnAudioStreamPacketStereo(b *testing.B) {
+	stream := &mockAudioStream{}
+	handlers := &handlerSet{wv: &WebView{ctx: context.Background(), activeAudioStream: stream}}
+	data := [][]float32{make([]float32, 512), make([]float32, 512)}
+	b.ReportAllocs()
+	b.SetBytes(2 * 512 * 4)
+	for i := 0; i < b.N; i++ {
+		handlers.OnAudioStreamPacket(nil, data, 512, 0)
+	}
 }
 
 // ============================================================================
@@ -562,15 +570,13 @@ func TestOnAudioStreamStarted_CorrectParameterMapping(t *testing.T) {
 // Race-window tests (write/close interleave)
 // ============================================================================
 
-// TestOnAudioStreamPacket_WriteHoldsLock verifies that closeAudioStream cannot
-// interleave between the stream snapshot and Write. If the lock is NOT held
-// across Write, the goroutine calling closeAudioStream will Close the stream
-// while Write is in-flight, producing a write-after-close.
-func TestOnAudioStreamPacket_WriteHoldsLock(t *testing.T) {
+// TestOnAudioStreamPacket_CloseDoesNotWaitForWrite verifies that lifecycle
+// shutdown is not serialized behind a potentially slow callback write. The
+// port contract makes Close/Write concurrency safe.
+func TestOnAudioStreamPacket_CloseDoesNotWaitForWrite(t *testing.T) {
 	ctx := context.Background()
 
-	// racyStream blocks inside Write until we signal, giving closeAudioStream
-	// a window to race if the mutex isn't held.
+	// racyStream blocks inside Write until we signal.
 	stream := &racyMockAudioStream{
 		writeCh: make(chan struct{}),
 		doneCh:  make(chan struct{}),
@@ -590,29 +596,21 @@ func TestOnAudioStreamPacket_WriteHoldsLock(t *testing.T) {
 	// Wait for Write to be entered.
 	<-stream.writeCh
 
-	// Now try to close. If the implementation holds the lock across Write,
-	// this will block until Write returns. If not, Close races with Write.
 	closeDone := make(chan struct{})
 	go func() {
 		wv.closeAudioStream()
 		close(closeDone)
 	}()
 
-	// Close should NOT have completed yet because Write holds the lock.
-	// Give the goroutine time to acquire the lock if it can.
-	time.Sleep(50 * time.Millisecond)
 	select {
 	case <-closeDone:
-		t.Fatal("closeAudioStream completed while Write was in-flight — lock not held across Write")
-	default:
-		// expected: closeAudioStream is blocked
+		// expected: only the short stream snapshot takes the mutex
+	case <-time.After(time.Second):
+		t.Fatal("closeAudioStream waited for an in-flight Write")
 	}
 
-	// Unblock Write.
+	// The write can finish after shutdown without holding the lifecycle mutex.
 	close(stream.doneCh)
-
-	// Now closeAudioStream should complete.
-	<-closeDone
 
 	assert.True(t, stream.closeCalled)
 	assert.Nil(t, wv.activeAudioStream)

--- a/internal/infrastructure/cef/webview_audio_test.go
+++ b/internal/infrastructure/cef/webview_audio_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -83,10 +84,10 @@ func TestWebView_AudioStreamLifecycleFieldsExist(t *testing.T) {
 	}
 
 	// Verify the fields exist and can be set
-	wv.activeAudioStream = &mockAudioStream{}
+	setAudioStream(wv, &mockAudioStream{})
 
 	assert.NotNil(t, wv.audioOutputFactory)
-	assert.NotNil(t, wv.activeAudioStream)
+	assert.NotNil(t, activeAudioStream(wv))
 }
 
 // mockAudioStream is a test double for port.AudioOutputStream
@@ -110,6 +111,18 @@ func (m *mockAudioStream) Close() error {
 // Verify mock implements the interface
 var _ port.AudioOutputStream = (*mockAudioStream)(nil)
 
+func setAudioStream(wv *WebView, stream port.AudioOutputStream) {
+	wv.audioStream.Store(&audioStreamHandle{stream: stream, generation: wv.audioStreamGeneration.Load()})
+}
+
+func activeAudioStream(wv *WebView) port.AudioOutputStream {
+	handle := wv.audioStream.Load()
+	if handle == nil {
+		return nil
+	}
+	return handle.stream
+}
+
 // racyMockAudioStream blocks inside Write until doneCh is closed, allowing
 // tests to verify that the caller holds a lock across the Write call.
 type racyMockAudioStream struct {
@@ -130,6 +143,26 @@ func (m *racyMockAudioStream) Close() error {
 }
 
 var _ port.AudioOutputStream = (*racyMockAudioStream)(nil)
+
+type countedAudioStream struct{ closes atomic.Int32 }
+
+func (*countedAudioStream) Write([][]float32) error { return nil }
+func (s *countedAudioStream) Close() error {
+	s.closes.Add(1)
+	return nil
+}
+
+type controlledAudioFactory struct {
+	entered chan struct{}
+	release chan struct{}
+	stream  port.AudioOutputStream
+}
+
+func (f *controlledAudioFactory) NewStream(context.Context, port.AudioStreamFormat) (port.AudioOutputStream, error) {
+	close(f.entered)
+	<-f.release
+	return f.stream, nil
+}
 
 // ============================================================================
 // Task 6: Audio Stream Lifecycle Handling Tests
@@ -159,8 +192,8 @@ func TestHandlerSet_OnAudioStreamStarted_CreatesStream(t *testing.T) {
 	handlers.OnAudioStreamStarted(nil, params, 2)
 
 	// Assert
-	require.NotNil(t, wv.activeAudioStream)
-	assert.Equal(t, mockStream, wv.activeAudioStream)
+	require.NotNil(t, activeAudioStream(wv))
+	assert.Equal(t, mockStream, activeAudioStream(wv))
 	assert.True(t, wv.audioPlaying.Load())
 
 	// Verify factory was called with correct format
@@ -205,8 +238,8 @@ func TestHandlerSet_OnAudioStreamStarted_ClosesExistingStream(t *testing.T) {
 	wv := &WebView{
 		ctx:                ctx,
 		audioOutputFactory: mockFactory,
-		activeAudioStream:  oldStream,
 	}
+	setAudioStream(wv, oldStream)
 
 	handlers := &handlerSet{wv: wv}
 
@@ -221,7 +254,7 @@ func TestHandlerSet_OnAudioStreamStarted_ClosesExistingStream(t *testing.T) {
 
 	// Assert
 	assert.True(t, oldStream.closeCalled)
-	assert.Equal(t, newStream, wv.activeAudioStream)
+	assert.Equal(t, newStream, activeAudioStream(wv))
 }
 
 // TestHandlerSet_OnAudioStreamStarted_FactoryError_HandlesGracefully verifies
@@ -251,7 +284,7 @@ func TestHandlerSet_OnAudioStreamStarted_FactoryError_HandlesGracefully(t *testi
 	// audioPlaying must be false when NewStream fails — if it stays true,
 	// the UI/state layer incorrectly believes audio is active.
 	assert.False(t, wv.audioPlaying.Load(), "audioPlaying must be false after NewStream failure")
-	assert.Nil(t, wv.activeAudioStream, "activeAudioStream must be nil after NewStream failure")
+	assert.Nil(t, activeAudioStream(wv), "activeAudioStream must be nil after NewStream failure")
 }
 
 // ============================================================================
@@ -265,9 +298,9 @@ func TestHandlerSet_OnAudioStreamPacket_ForwardsCallbackData(t *testing.T) {
 	mockStream := &mockAudioStream{}
 
 	wv := &WebView{
-		ctx:               ctx,
-		activeAudioStream: mockStream,
+		ctx: ctx,
 	}
+	setAudioStream(wv, mockStream)
 
 	handlers := &handlerSet{wv: wv}
 
@@ -296,8 +329,7 @@ func TestHandlerSet_OnAudioStreamPacket_ForwardsCallbackData(t *testing.T) {
 // that packets are silently discarded when no stream is active.
 func TestHandlerSet_OnAudioStreamPacket_NoActiveStream_DoesNothing(t *testing.T) {
 	wv := &WebView{
-		ctx:               context.Background(),
-		activeAudioStream: nil,
+		ctx: context.Background(),
 	}
 
 	handlers := &handlerSet{wv: wv}
@@ -316,10 +348,8 @@ func TestHandlerSet_OnAudioStreamPacket_NoActiveStream_DoesNothing(t *testing.T)
 // TestHandlerSet_OnAudioStreamPacket_NilData_DoesNotPanic verifies
 // that nil data is handled gracefully.
 func TestHandlerSet_OnAudioStreamPacket_NilData_DoesNotPanic(t *testing.T) {
-	mockStream := &mockAudioStream{}
 	wv := &WebView{
-		ctx:               context.Background(),
-		activeAudioStream: mockStream,
+		ctx: context.Background(),
 	}
 
 	handlers := &handlerSet{wv: wv}
@@ -332,7 +362,9 @@ func TestHandlerSet_OnAudioStreamPacket_NilData_DoesNotPanic(t *testing.T) {
 
 func BenchmarkHandlerSet_OnAudioStreamPacketStereo(b *testing.B) {
 	stream := &mockAudioStream{}
-	handlers := &handlerSet{wv: &WebView{ctx: context.Background(), activeAudioStream: stream}}
+	wv := &WebView{ctx: context.Background()}
+	setAudioStream(wv, stream)
+	handlers := &handlerSet{wv: wv}
 	data := [][]float32{make([]float32, 512), make([]float32, 512)}
 	b.ReportAllocs()
 	b.SetBytes(2 * 512 * 4)
@@ -350,9 +382,9 @@ func BenchmarkHandlerSet_OnAudioStreamPacketStereo(b *testing.B) {
 func TestHandlerSet_OnAudioStreamStopped_ClosesStream(t *testing.T) {
 	mockStream := &mockAudioStream{}
 	wv := &WebView{
-		ctx:               context.Background(),
-		activeAudioStream: mockStream,
+		ctx: context.Background(),
 	}
+	setAudioStream(wv, mockStream)
 	wv.audioPlaying.Store(true)
 
 	handlers := &handlerSet{wv: wv}
@@ -362,7 +394,7 @@ func TestHandlerSet_OnAudioStreamStopped_ClosesStream(t *testing.T) {
 
 	// Assert
 	assert.True(t, mockStream.closeCalled)
-	assert.Nil(t, wv.activeAudioStream)
+	assert.Nil(t, activeAudioStream(wv))
 	assert.False(t, wv.audioPlaying.Load())
 }
 
@@ -370,8 +402,7 @@ func TestHandlerSet_OnAudioStreamStopped_ClosesStream(t *testing.T) {
 // that stopping when no stream exists doesn't panic.
 func TestHandlerSet_OnAudioStreamStopped_NoActiveStream_DoesNotPanic(t *testing.T) {
 	wv := &WebView{
-		ctx:               context.Background(),
-		activeAudioStream: nil,
+		ctx: context.Background(),
 	}
 	wv.audioPlaying.Store(true)
 
@@ -390,9 +421,9 @@ func TestHandlerSet_OnAudioStreamStopped_NoActiveStream_DoesNotPanic(t *testing.
 func TestHandlerSet_OnAudioStreamError_ClosesStream(t *testing.T) {
 	mockStream := &mockAudioStream{}
 	wv := &WebView{
-		ctx:               context.Background(),
-		activeAudioStream: mockStream,
+		ctx: context.Background(),
 	}
+	setAudioStream(wv, mockStream)
 	wv.audioPlaying.Store(true)
 
 	handlers := &handlerSet{wv: wv}
@@ -402,7 +433,7 @@ func TestHandlerSet_OnAudioStreamError_ClosesStream(t *testing.T) {
 
 	// Assert
 	assert.True(t, mockStream.closeCalled)
-	assert.Nil(t, wv.activeAudioStream)
+	assert.Nil(t, activeAudioStream(wv))
 	assert.False(t, wv.audioPlaying.Load())
 }
 
@@ -410,8 +441,7 @@ func TestHandlerSet_OnAudioStreamError_ClosesStream(t *testing.T) {
 // that error handling when no stream exists doesn't panic.
 func TestHandlerSet_OnAudioStreamError_NoActiveStream_DoesNotPanic(t *testing.T) {
 	wv := &WebView{
-		ctx:               context.Background(),
-		activeAudioStream: nil,
+		ctx: context.Background(),
 	}
 	wv.audioPlaying.Store(true)
 
@@ -464,9 +494,9 @@ func TestHandlerSet_OnAudioStreamError_ShutdownSocketCloseLogsDebug(t *testing.T
 func TestWebView_Destroy_ClosesAudioStream(t *testing.T) {
 	mockStream := &mockAudioStream{}
 	wv := &WebView{
-		ctx:               context.Background(),
-		activeAudioStream: mockStream,
+		ctx: context.Background(),
 	}
+	setAudioStream(wv, mockStream)
 	wv.audioPlaying.Store(true)
 
 	// Act — Destroy must close the audio stream as part of teardown.
@@ -474,7 +504,7 @@ func TestWebView_Destroy_ClosesAudioStream(t *testing.T) {
 
 	// Assert
 	assert.True(t, mockStream.closeCalled, "Destroy must close the active audio stream")
-	assert.Nil(t, wv.activeAudioStream)
+	assert.Nil(t, activeAudioStream(wv))
 }
 
 // TestWebView_Destroy_NoAudioStream_DoesNotPanic verifies that Destroy
@@ -566,6 +596,61 @@ func TestOnAudioStreamStarted_CorrectParameterMapping(t *testing.T) {
 	assert.Equal(t, 1024, mockFactory.lastFormat.FramesPerBuffer, "frames_per_buffer should be 1024 (from params.FramesPerBuffer)")
 }
 
+func TestHandlerSet_OnAudioStreamStarted_StopRejectsInFlightCreation(t *testing.T) {
+	stream := &countedAudioStream{}
+	factory := &controlledAudioFactory{entered: make(chan struct{}), release: make(chan struct{}), stream: stream}
+	wv := &WebView{ctx: context.Background(), audioOutputFactory: factory}
+	handlers := &handlerSet{wv: wv}
+	params := &purecef.AudioParameters{SampleRate: 48000, FramesPerBuffer: 512}
+	done := make(chan struct{})
+	go func() { handlers.OnAudioStreamStarted(nil, params, 2); close(done) }()
+	<-factory.entered
+	handlers.OnAudioStreamStopped(nil)
+	close(factory.release)
+	<-done
+
+	assert.Nil(t, activeAudioStream(wv))
+	assert.False(t, wv.audioPlaying.Load())
+	assert.Equal(t, int32(1), stream.closes.Load())
+}
+
+func TestHandlerSet_OnAudioStreamStarted_DestroyRejectsInFlightCreation(t *testing.T) {
+	stream := &countedAudioStream{}
+	factory := &controlledAudioFactory{entered: make(chan struct{}), release: make(chan struct{}), stream: stream}
+	wv := &WebView{ctx: context.Background(), audioOutputFactory: factory}
+	handlers := &handlerSet{wv: wv}
+	params := &purecef.AudioParameters{SampleRate: 48000, FramesPerBuffer: 512}
+	done := make(chan struct{})
+	go func() { handlers.OnAudioStreamStarted(nil, params, 2); close(done) }()
+	<-factory.entered
+	wv.Destroy()
+	close(factory.release)
+	<-done
+
+	assert.Nil(t, activeAudioStream(wv))
+	assert.True(t, wv.destroyed.Load())
+	assert.Equal(t, int32(1), stream.closes.Load())
+}
+
+func TestHandlerSet_OnAudioStreamStarted_ReplacesAndClosesEachStreamOnce(t *testing.T) {
+	old, first, second := &countedAudioStream{}, &countedAudioStream{}, &countedAudioStream{}
+	factory := &mockAudioFactory{stream: first}
+	wv := &WebView{ctx: context.Background(), audioOutputFactory: factory}
+	setAudioStream(wv, old)
+	handlers := &handlerSet{wv: wv}
+	params := &purecef.AudioParameters{SampleRate: 48000, FramesPerBuffer: 512}
+
+	handlers.OnAudioStreamStarted(nil, params, 2)
+	factory.stream = second
+	handlers.OnAudioStreamStarted(nil, params, 2)
+	wv.closeAudioStream()
+
+	assert.Equal(t, int32(1), old.closes.Load())
+	assert.Equal(t, int32(1), first.closes.Load())
+	assert.Equal(t, int32(1), second.closes.Load())
+	assert.Nil(t, activeAudioStream(wv))
+}
+
 // ============================================================================
 // Race-window tests (write/close interleave)
 // ============================================================================
@@ -583,9 +668,9 @@ func TestOnAudioStreamPacket_CloseDoesNotWaitForWrite(t *testing.T) {
 	}
 
 	wv := &WebView{
-		ctx:               ctx,
-		activeAudioStream: stream,
+		ctx: ctx,
 	}
+	setAudioStream(wv, stream)
 	handlers := &handlerSet{wv: wv}
 
 	data := [][]float32{{0.1, 0.2}, {0.3, 0.4}}
@@ -613,7 +698,7 @@ func TestOnAudioStreamPacket_CloseDoesNotWaitForWrite(t *testing.T) {
 	close(stream.doneCh)
 
 	assert.True(t, stream.closeCalled)
-	assert.Nil(t, wv.activeAudioStream)
+	assert.Nil(t, activeAudioStream(wv))
 }
 
 // TestOnAudioStreamPacket_StreamClosedBetweenPackets verifies that when a
@@ -624,9 +709,9 @@ func TestOnAudioStreamPacket_StreamClosedBetweenPackets(t *testing.T) {
 	stream := &mockAudioStream{}
 
 	wv := &WebView{
-		ctx:               ctx,
-		activeAudioStream: stream,
+		ctx: ctx,
 	}
+	setAudioStream(wv, stream)
 	handlers := &handlerSet{wv: wv}
 	data := [][]float32{{0.1, 0.2}, {0.3, 0.4}}
 

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -1134,48 +1134,44 @@ func (h *handlerSet) OnAudioStreamStarted(_ purecef.Browser, params *purecef.Aud
 			Msg("cef: OnAudioStreamStarted")
 	}
 
-	// Reset packet counters for the new stream
+	// Starting a stream invalidates both a previous publication and any older
+	// creation already in flight. Close detached streams outside the mutex.
+	generation, previous, accepted := h.wv.beginAudioStreamStart()
+	if !accepted {
+		return
+	}
+	h.wv.closeDetachedAudioStream(previous)
 	h.wv.audioPacketCount.Store(0)
 	h.wv.audioWriteCount.Store(0)
 
-	// Close any existing stream first
-	h.wv.closeAudioStream()
-
-	// Create new stream
 	ctx := h.wv.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-
 	stream, err := h.wv.audioOutputFactory.NewStream(ctx, format)
 	if err != nil {
-		// Log error but don't panic - audio is non-critical.
-		// Do NOT set audioPlaying — the stream was never created.
 		if h.wv.ctx != nil {
-			logging.FromContext(h.wv.ctx).Warn().
-				Err(err).
-				Int("sample_rate", format.SampleRate).
-				Int("channels", format.ChannelCount).
+			logging.FromContext(h.wv.ctx).Warn().Err(err).
+				Int("sample_rate", format.SampleRate).Int("channels", format.ChannelCount).
 				Msg("cef: failed to create audio output stream")
 		}
 		return
 	}
 
-	// Set playing state only after stream creation succeeds
-	h.wv.setAudioPlaying(true)
-
+	replaced, published := h.wv.publishAudioStream(generation, stream)
+	if !published {
+		// Stop, Destroy, or a newer Start won the race. This callback owns the
+		// unpublishable stream and closes it exactly once.
+		h.wv.closeDetachedAudioStream(&audioStreamHandle{stream: stream, generation: generation})
+		return
+	}
+	h.wv.closeDetachedAudioStream(replaced)
 	if h.wv.ctx != nil {
 		logging.FromContext(h.wv.ctx).Info().
-			Int("sample_rate", format.SampleRate).
-			Int("channels", format.ChannelCount).
+			Int("sample_rate", format.SampleRate).Int("channels", format.ChannelCount).
 			Int("frames_per_buffer", format.FramesPerBuffer).
 			Msg("cef: audio output stream created successfully")
 	}
-
-	// Store the new stream
-	h.wv.audioStreamMu.Lock()
-	h.wv.activeAudioStream = stream
-	h.wv.audioStreamMu.Unlock()
 }
 
 // buildAudioStreamFormat converts CEF AudioParameters to port.AudioStreamFormat.
@@ -1189,43 +1185,21 @@ func (h *handlerSet) buildAudioStreamFormat(params *purecef.AudioParameters, cha
 	}
 }
 
-// OnAudioStreamPacket hands CEF's callback-owned packet to the active output.
-// AudioOutputStream takes its one owned copy synchronously. The stream lock is
-// only held for the snapshot, so neither copying nor the callback is serialized
-// behind lifecycle work; Write and Close are a port-level concurrent contract.
-func (h *handlerSet) OnAudioStreamPacket(_ purecef.Browser, data [][]float32, frames int32, pts int64) {
+// OnAudioStreamPacket is a real-time callback: it atomically snapshots an
+// immutable handle and performs only allocation-free atomic diagnostics. It
+// never takes a lifecycle mutex or emits synchronous logs.
+func (h *handlerSet) OnAudioStreamPacket(_ purecef.Browser, data [][]float32, frames int32, _ int64) {
 	if len(data) == 0 || frames <= 0 {
 		return
 	}
-
-	h.wv.audioStreamMu.Lock()
-	stream := h.wv.activeAudioStream
-	h.wv.audioStreamMu.Unlock()
-	if stream == nil {
+	handle := h.wv.audioStream.Load()
+	if handle == nil || handle.stream == nil {
 		return
 	}
-
-	pktNum := h.wv.audioPacketCount.Add(1)
-	if pktNum == 1 && h.wv.ctx != nil {
-		logging.FromContext(h.wv.ctx).Info().
-			Int("channels", len(data)).
-			Int32("frames", frames).
-			Int64("pts", pts).
-			Msg("cef: first audio packet received")
+	h.wv.audioPacketCount.Add(1)
+	if handle.stream.Write(data) == nil {
+		h.wv.audioWriteCount.Add(1)
 	}
-
-	err := stream.Write(data)
-
-	if err != nil {
-		if h.wv.ctx != nil {
-			logging.FromContext(h.wv.ctx).Debug().
-				Err(err).
-				Uint64("packets_received", pktNum).
-				Msg("cef: audio stream write failed")
-		}
-		return
-	}
-	h.wv.audioWriteCount.Add(1)
 }
 
 // OnAudioStreamStopped handles stream stop.

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -1189,31 +1189,19 @@ func (h *handlerSet) buildAudioStreamFormat(params *purecef.AudioParameters, cha
 	}
 }
 
-// OnAudioStreamPacket receives audio packets and forwards them to the output stream.
-// The mutex is held across both the stream snapshot and Write to prevent
-// closeAudioStream from closing the stream mid-write.
+// OnAudioStreamPacket hands CEF's callback-owned packet to the active output.
+// AudioOutputStream takes its one owned copy synchronously. The stream lock is
+// only held for the snapshot, so neither copying nor the callback is serialized
+// behind lifecycle work; Write and Close are a port-level concurrent contract.
 func (h *handlerSet) OnAudioStreamPacket(_ purecef.Browser, data [][]float32, frames int32, pts int64) {
 	if len(data) == 0 || frames <= 0 {
 		return
 	}
 
-	// Copy the data before acquiring the stream lock because CEF can reuse the
-	// buffer as soon as this callback returns.
-	copiedData := make([][]float32, len(data))
-	for i, channel := range data {
-		if len(channel) < int(frames) {
-			continue
-		}
-		copiedData[i] = make([]float32, frames)
-		copy(copiedData[i], channel[:frames])
-	}
-
-	// Hold the lock across the stream read and Write so closeAudioStream
-	// cannot close the stream between snapshot and write.
 	h.wv.audioStreamMu.Lock()
 	stream := h.wv.activeAudioStream
+	h.wv.audioStreamMu.Unlock()
 	if stream == nil {
-		h.wv.audioStreamMu.Unlock()
 		return
 	}
 
@@ -1226,8 +1214,7 @@ func (h *handlerSet) OnAudioStreamPacket(_ purecef.Browser, data [][]float32, fr
 			Msg("cef: first audio packet received")
 	}
 
-	err := stream.Write(copiedData)
-	h.wv.audioStreamMu.Unlock()
+	err := stream.Write(data)
 
 	if err != nil {
 		if h.wv.ctx != nil {


### PR DESCRIPTION
Supersedes #347, which GitHub auto-closed when its deleted base branch disappeared.

## Summary
- replace the callback reference queue with reusable adapter-owned packet slots
- take one bounded synchronous ownership copy per accepted packet and fill PipeWire directly
- release CEF lifecycle locking before writes and document concurrent Close/Write

## Verification
- `go test -mod=vendor ./...`
- `go test -mod=vendor -race ./...`
- `make lint && make test && make check`

Benchmark: stereo CEF callback handoff improved from 4,144 B/op / 3 allocs/op to 0 B/op / 0 allocs/op.