### PR TITLE
fix(ui): preserve revealed webviews across rebuilds

### DIFF
--- a/internal/ui/component/pane_view.go
+++ b/internal/ui/component/pane_view.go
@@ -135,58 +135,70 @@ func (pv *PaneView) WebViewWidget() layout.Widget {
 	return pv.webViewWidget
 }
 
-// SetWebViewWidget replaces the WebView widget.
+// SetWebViewWidget replaces the WebView widget as not-yet-revealed content.
+// Call AttachWebViewWidget when the content coordinator knows the WebView has
+// already painted.
 func (pv *PaneView) SetWebViewWidget(widget layout.Widget) {
+	pv.AttachWebViewWidget(widget, false)
+}
+
+// AttachWebViewWidget replaces the WebView widget and applies its explicit
+// content reveal state. GTK parentage is used only to satisfy GTK's one-parent
+// ownership rule; it must not be used to infer whether CEF has painted.
+func (pv *PaneView) AttachWebViewWidget(widget layout.Widget, revealed bool) {
 	pv.mu.Lock()
 	defer pv.mu.Unlock()
 
-	// Remove old widget from this overlay
+	// Remove old widget from this overlay.
 	if pv.webViewWidget != nil {
 		pv.overlay.SetChild(nil)
 	}
 
 	pv.webViewWidget = widget
-
-	if widget != nil {
-		overlayAllocWidthBefore := pv.overlay.GetAllocatedWidth()
-		overlayAllocHeightBefore := pv.overlay.GetAllocatedHeight()
-		widgetAllocWidthBefore := widget.GetAllocatedWidth()
-		widgetAllocHeightBefore := widget.GetAllocatedHeight()
-		hadParent := widget.GetParent() != nil
-		wasVisible := widget.IsVisible()
-
-		// If this widget already had a parent, we're reparenting an existing WebView
-		// (e.g. after rebuilding/moving panes). In that case the WebView has likely
-		// already painted, so the loading skeleton should be hidden immediately.
-
-		// Unparent widget from any previous parent (critical for rebuild scenarios)
-		// In GTK4, a widget can only have one parent at a time
-		if hadParent {
-			widget.Unparent()
-		}
-		pv.overlay.SetChild(widget)
-
-		if hadParent && wasVisible {
-			widget.SetVisible(true)
-		}
-		if hadParent && pv.loading != nil {
-			pv.loading.SetVisible(false)
-		}
-
-		logging.FromContext(pv.ctx).Debug().
-			Str("pane_id", string(pv.paneID)).
-			Bool("had_parent", hadParent).
-			Bool("was_visible", wasVisible).
-			Int("overlay_alloc_width_before", overlayAllocWidthBefore).
-			Int("overlay_alloc_height_before", overlayAllocHeightBefore).
-			Int("widget_alloc_width_before", widgetAllocWidthBefore).
-			Int("widget_alloc_height_before", widgetAllocHeightBefore).
-			Int("overlay_alloc_width_after", pv.overlay.GetAllocatedWidth()).
-			Int("overlay_alloc_height_after", pv.overlay.GetAllocatedHeight()).
-			Int("widget_alloc_width_after", widget.GetAllocatedWidth()).
-			Int("widget_alloc_height_after", widget.GetAllocatedHeight()).
-			Msg("pane view webview widget attached")
+	if widget == nil {
+		return
 	}
+
+	overlayAllocWidthBefore := pv.overlay.GetAllocatedWidth()
+	overlayAllocHeightBefore := pv.overlay.GetAllocatedHeight()
+	widgetAllocWidthBefore := widget.GetAllocatedWidth()
+	widgetAllocHeightBefore := widget.GetAllocatedHeight()
+	hadParent := widget.GetParent() != nil
+	wasVisible := widget.IsVisible()
+
+	// GTK4 widgets may have only one parent. Cleanup during a WorkspaceView
+	// rebuild leaves a reusable native widget unparented, which says nothing
+	// about whether its content was previously revealed.
+	if hadParent {
+		widget.Unparent()
+	}
+	pv.overlay.SetChild(widget)
+
+	if hadParent && wasVisible {
+		widget.SetVisible(true)
+	}
+	if revealed && pv.loading != nil {
+		pv.loading.SetVisible(false)
+	}
+
+	ctx := pv.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	logging.FromContext(ctx).Debug().
+		Str("pane_id", string(pv.paneID)).
+		Bool("had_parent", hadParent).
+		Bool("was_visible", wasVisible).
+		Bool("revealed", revealed).
+		Int("overlay_alloc_width_before", overlayAllocWidthBefore).
+		Int("overlay_alloc_height_before", overlayAllocHeightBefore).
+		Int("widget_alloc_width_before", widgetAllocWidthBefore).
+		Int("widget_alloc_height_before", widgetAllocHeightBefore).
+		Int("overlay_alloc_width_after", pv.overlay.GetAllocatedWidth()).
+		Int("overlay_alloc_height_after", pv.overlay.GetAllocatedHeight()).
+		Int("widget_alloc_width_after", widget.GetAllocatedWidth()).
+		Int("widget_alloc_height_after", widget.GetAllocatedHeight()).
+		Msg("pane view webview widget attached")
 }
 
 // GrabFocus attempts to focus the WebView.

--- a/internal/ui/component/pane_view.go
+++ b/internal/ui/component/pane_view.go
@@ -177,8 +177,11 @@ func (pv *PaneView) AttachWebViewWidget(widget layout.Widget, revealed bool) {
 	if hadParent && wasVisible {
 		widget.SetVisible(true)
 	}
-	if revealed && pv.loading != nil {
-		pv.loading.SetVisible(false)
+	// A replacement can follow an already-revealed WebView in the same pane.
+	// Apply both states explicitly: an unrevealed current WebView must restart
+	// the skeleton rather than inheriting the previous view's hidden overlay.
+	if pv.loading != nil {
+		pv.loading.SetVisible(!revealed)
 	}
 
 	ctx := pv.ctx

--- a/internal/ui/component/pane_view_internal_test.go
+++ b/internal/ui/component/pane_view_internal_test.go
@@ -118,6 +118,7 @@ func TestPaneView_AttachWebViewWidget_UsesExplicitRevealStateAfterCleanup(t *tes
 		widget.EXPECT().GetParent().Return(nil).Once()
 		widget.EXPECT().IsVisible().Return(true).Once()
 		overlay.EXPECT().SetChild(widget).Once()
+		loadingContainer.EXPECT().SetVisible(true).Once()
 
 		pv := &PaneView{
 			overlay: overlay,
@@ -125,4 +126,27 @@ func TestPaneView_AttachWebViewWidget_UsesExplicitRevealStateAfterCleanup(t *tes
 		}
 		pv.AttachWebViewWidget(widget, false)
 	})
+}
+
+func TestPaneView_AttachWebViewWidget_UnrevealedReplacementRestartsLoadingSkeleton(t *testing.T) {
+	overlay := mocks.NewMockOverlayWidget(t)
+	widget := mocks.NewMockWidget(t)
+	loadingContainer := mocks.NewMockBoxWidget(t)
+	spinner := mocks.NewMockSpinnerWidget(t)
+
+	overlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
+	overlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
+	widget.EXPECT().GetAllocatedWidth().Return(0).Twice()
+	widget.EXPECT().GetAllocatedHeight().Return(0).Twice()
+	widget.EXPECT().GetParent().Return(nil).Once()
+	widget.EXPECT().IsVisible().Return(true).Once()
+	overlay.EXPECT().SetChild(widget).Once()
+	loadingContainer.EXPECT().SetVisible(true).Once()
+	spinner.EXPECT().Start().Once()
+
+	pv := &PaneView{
+		overlay: overlay,
+		loading: &LoadingSkeleton{container: loadingContainer, spinner: spinner},
+	}
+	pv.AttachWebViewWidget(widget, false)
 }

--- a/internal/ui/component/pane_view_internal_test.go
+++ b/internal/ui/component/pane_view_internal_test.go
@@ -3,6 +3,7 @@ package component
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/bnema/dumber/internal/ui/layout"
@@ -81,66 +82,26 @@ func TestPaneView_HideLoadingSkeleton_NoOpWhenNil(t *testing.T) {
 	pv.HideLoadingSkeleton()
 }
 
-func TestPaneView_AttachWebViewWidget_UsesExplicitRevealStateAfterCleanup(t *testing.T) {
-	widget := mocks.NewMockWidget(t)
-	oldOverlay := mocks.NewMockOverlayWidget(t)
-	oldOverlay.EXPECT().SetChild(nil).Once()
-	(&PaneView{overlay: oldOverlay, webViewWidget: widget}).Cleanup()
-
-	t.Run("revealed widget detached by cleanup hides fresh skeleton", func(t *testing.T) {
-		overlay := mocks.NewMockOverlayWidget(t)
-		loadingContainer := mocks.NewMockBoxWidget(t)
-		spinner := mocks.NewMockSpinnerWidget(t)
-		overlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
-		overlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
-		widget.EXPECT().GetAllocatedWidth().Return(0).Twice()
-		widget.EXPECT().GetAllocatedHeight().Return(0).Twice()
-		widget.EXPECT().GetParent().Return(nil).Once()
-		widget.EXPECT().IsVisible().Return(true).Once()
-		overlay.EXPECT().SetChild(widget).Once()
-		loadingContainer.EXPECT().SetVisible(false).Once()
-		spinner.EXPECT().Stop().Once()
-
-		pv := &PaneView{
-			overlay: overlay,
-			loading: &LoadingSkeleton{container: loadingContainer, spinner: spinner},
-		}
-		pv.AttachWebViewWidget(widget, true)
-	})
-
-	t.Run("new unrevealed widget keeps fresh skeleton visible", func(t *testing.T) {
-		overlay := mocks.NewMockOverlayWidget(t)
-		loadingContainer := mocks.NewMockBoxWidget(t)
-		overlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
-		overlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
-		widget.EXPECT().GetAllocatedWidth().Return(0).Twice()
-		widget.EXPECT().GetAllocatedHeight().Return(0).Twice()
-		widget.EXPECT().GetParent().Return(nil).Once()
-		widget.EXPECT().IsVisible().Return(true).Once()
-		overlay.EXPECT().SetChild(widget).Once()
-		loadingContainer.EXPECT().SetVisible(true).Once()
-
-		pv := &PaneView{
-			overlay: overlay,
-			loading: &LoadingSkeleton{container: loadingContainer},
-		}
-		pv.AttachWebViewWidget(widget, false)
-	})
-}
-
-func TestPaneView_AttachWebViewWidget_UnrevealedReplacementRestartsLoadingSkeleton(t *testing.T) {
+func TestPaneView_AttachWebViewWidget_RevealedThenUnrevealedReplacementRestartsSkeleton(t *testing.T) {
 	overlay := mocks.NewMockOverlayWidget(t)
-	widget := mocks.NewMockWidget(t)
+	revealedWidget := mocks.NewMockWidget(t)
+	unrevealedWidget := mocks.NewMockWidget(t)
 	loadingContainer := mocks.NewMockBoxWidget(t)
 	spinner := mocks.NewMockSpinnerWidget(t)
 
-	overlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
-	overlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
-	widget.EXPECT().GetAllocatedWidth().Return(0).Twice()
-	widget.EXPECT().GetAllocatedHeight().Return(0).Twice()
-	widget.EXPECT().GetParent().Return(nil).Once()
-	widget.EXPECT().IsVisible().Return(true).Once()
-	overlay.EXPECT().SetChild(widget).Once()
+	overlay.EXPECT().GetAllocatedWidth().Return(0).Times(4)
+	overlay.EXPECT().GetAllocatedHeight().Return(0).Times(4)
+	for _, widget := range []*mocks.MockWidget{revealedWidget, unrevealedWidget} {
+		widget.EXPECT().GetAllocatedWidth().Return(0).Twice()
+		widget.EXPECT().GetAllocatedHeight().Return(0).Twice()
+		widget.EXPECT().GetParent().Return(nil).Once()
+		widget.EXPECT().IsVisible().Return(true).Once()
+	}
+	overlay.EXPECT().SetChild(revealedWidget).Once()
+	loadingContainer.EXPECT().SetVisible(false).Once()
+	spinner.EXPECT().Stop().Once()
+	overlay.EXPECT().SetChild(nil).Once()
+	overlay.EXPECT().SetChild(unrevealedWidget).Once()
 	loadingContainer.EXPECT().SetVisible(true).Once()
 	spinner.EXPECT().Start().Once()
 
@@ -148,5 +109,9 @@ func TestPaneView_AttachWebViewWidget_UnrevealedReplacementRestartsLoadingSkelet
 		overlay: overlay,
 		loading: &LoadingSkeleton{container: loadingContainer, spinner: spinner},
 	}
-	pv.AttachWebViewWidget(widget, false)
+
+	pv.AttachWebViewWidget(revealedWidget, true)
+	pv.AttachWebViewWidget(unrevealedWidget, false)
+
+	assert.Same(t, unrevealedWidget, pv.WebViewWidget())
 }

--- a/internal/ui/component/pane_view_internal_test.go
+++ b/internal/ui/component/pane_view_internal_test.go
@@ -80,3 +80,49 @@ func TestPaneView_HideLoadingSkeleton_NoOpWhenNil(t *testing.T) {
 	pv := &PaneView{}
 	pv.HideLoadingSkeleton()
 }
+
+func TestPaneView_AttachWebViewWidget_UsesExplicitRevealStateAfterCleanup(t *testing.T) {
+	widget := mocks.NewMockWidget(t)
+	oldOverlay := mocks.NewMockOverlayWidget(t)
+	oldOverlay.EXPECT().SetChild(nil).Once()
+	(&PaneView{overlay: oldOverlay, webViewWidget: widget}).Cleanup()
+
+	t.Run("revealed widget detached by cleanup hides fresh skeleton", func(t *testing.T) {
+		overlay := mocks.NewMockOverlayWidget(t)
+		loadingContainer := mocks.NewMockBoxWidget(t)
+		spinner := mocks.NewMockSpinnerWidget(t)
+		overlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
+		overlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
+		widget.EXPECT().GetAllocatedWidth().Return(0).Twice()
+		widget.EXPECT().GetAllocatedHeight().Return(0).Twice()
+		widget.EXPECT().GetParent().Return(nil).Once()
+		widget.EXPECT().IsVisible().Return(true).Once()
+		overlay.EXPECT().SetChild(widget).Once()
+		loadingContainer.EXPECT().SetVisible(false).Once()
+		spinner.EXPECT().Stop().Once()
+
+		pv := &PaneView{
+			overlay: overlay,
+			loading: &LoadingSkeleton{container: loadingContainer, spinner: spinner},
+		}
+		pv.AttachWebViewWidget(widget, true)
+	})
+
+	t.Run("new unrevealed widget keeps fresh skeleton visible", func(t *testing.T) {
+		overlay := mocks.NewMockOverlayWidget(t)
+		loadingContainer := mocks.NewMockBoxWidget(t)
+		overlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
+		overlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
+		widget.EXPECT().GetAllocatedWidth().Return(0).Twice()
+		widget.EXPECT().GetAllocatedHeight().Return(0).Twice()
+		widget.EXPECT().GetParent().Return(nil).Once()
+		widget.EXPECT().IsVisible().Return(true).Once()
+		overlay.EXPECT().SetChild(widget).Once()
+
+		pv := &PaneView{
+			overlay: overlay,
+			loading: &LoadingSkeleton{container: loadingContainer},
+		}
+		pv.AttachWebViewWidget(widget, false)
+	})
+}

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -482,8 +482,16 @@ func (wv *WorkspaceView) DeactivatePane(paneID entity.PaneID) {
 	}
 }
 
-// SetWebViewWidget attaches a WebView widget to a specific pane.
+// SetWebViewWidget attaches a not-yet-revealed WebView widget to a specific pane.
+// Call AttachWebViewWidget when the content coordinator has explicit reveal state.
 func (wv *WorkspaceView) SetWebViewWidget(paneID entity.PaneID, widget layout.Widget) error {
+	return wv.AttachWebViewWidget(paneID, widget, false)
+}
+
+// AttachWebViewWidget attaches a WebView widget with the content coordinator's
+// explicit reveal state. A WorkspaceView rebuild can unparent a live widget, so
+// widget parentage cannot determine whether its loading skeleton is still needed.
+func (wv *WorkspaceView) AttachWebViewWidget(paneID entity.PaneID, widget layout.Widget, revealed bool) error {
 	wv.mu.RLock()
 	pv, ok := wv.paneViews[paneID]
 	callback := wv.onWebViewAttached
@@ -493,7 +501,7 @@ func (wv *WorkspaceView) SetWebViewWidget(paneID entity.PaneID, widget layout.Wi
 		return ErrPaneNotFound
 	}
 
-	pv.SetWebViewWidget(widget)
+	pv.AttachWebViewWidget(widget, revealed)
 	if widget != nil && callback != nil {
 		callback(paneID)
 	}

--- a/internal/ui/coordinator/content/callbacks.go
+++ b/internal/ui/coordinator/content/callbacks.go
@@ -79,7 +79,7 @@ func (c *Coordinator) setupWebViewCallbacks(ctx context.Context, paneID entity.P
 			}
 		},
 		OnProgressChanged: func(progress float64) {
-			c.onProgressChanged(paneID, progress)
+			c.onProgressChanged(paneID, wv, progress)
 		},
 		OnURIChanged: func(uri string) {
 			c.handleURIChanged(ctx, paneID, wv, uri)

--- a/internal/ui/coordinator/content/callbacks.go
+++ b/internal/ui/coordinator/content/callbacks.go
@@ -62,8 +62,13 @@ func buildCrashPageURI(originalURI string) string {
 // setupWebViewCallbacks configures standard callbacks and popup handling.
 func (c *Coordinator) setupWebViewCallbacks(ctx context.Context, paneID entity.PaneID, wv port.WebView) {
 	log := logging.FromContext(ctx)
+	identity, ok := identityForWebView(wv)
+	if !ok {
+		return
+	}
 
-	// Build port callbacks for standard events
+	// Capture the association at installation, rather than reading mutable
+	// WebView identity from a callback that can outlive a pool reuse.
 	callbacks := &port.WebViewCallbacks{
 		OnTitleChanged: func(title string) {
 			c.onTitleChanged(ctx, paneID, title)
@@ -73,13 +78,13 @@ func (c *Coordinator) setupWebViewCallbacks(ctx context.Context, paneID entity.P
 			case port.LoadStarted:
 				c.onLoadStarted(paneID)
 			case port.LoadCommitted:
-				c.onLoadCommitted(ctx, paneID, wv)
+				c.onLoadCommitted(ctx, paneID, wv, identity)
 			case port.LoadFinished:
-				c.onLoadFinished(ctx, paneID, wv)
+				c.onLoadFinished(ctx, paneID, wv, identity)
 			}
 		},
 		OnProgressChanged: func(progress float64) {
-			c.onProgressChanged(paneID, wv, progress)
+			c.onProgressChanged(paneID, wv, identity, progress)
 		},
 		OnURIChanged: func(uri string) {
 			c.handleURIChanged(ctx, paneID, wv, uri)

--- a/internal/ui/coordinator/content/content_reveal_test.go
+++ b/internal/ui/coordinator/content/content_reveal_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/port/mocks"
 	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/ui/component"
 )
 
 func newRevealTestCoordinator() *Coordinator {
@@ -38,14 +40,16 @@ func TestRevealState_IsBoundToCurrentWebViewAcrossReplacementPaths(t *testing.T)
 	c := newRevealTestCoordinator()
 
 	c.setWebViewLocked(paneID, first)
-	c.markWebViewRevealed(paneID, first)
+	firstIdentity, _ := identityForWebView(first)
+	c.markWebViewRevealed(paneID, firstIdentity)
 	assert.True(t, c.WebViewRevealed(paneID))
 
 	// A direct replacement for the same pane must show the fresh loading state.
 	c.setWebViewLocked(paneID, directReplacement)
 	assert.False(t, c.WebViewRevealed(paneID))
 
-	c.markWebViewRevealed(paneID, directReplacement)
+	directReplacementIdentity, _ := identityForWebView(directReplacement)
+	c.markWebViewRevealed(paneID, directReplacementIdentity)
 	c.RegisterPopupWebView(paneID, popupReplacement)
 	assert.False(t, c.WebViewRevealed(paneID), "popup registration must not inherit a prior WebView reveal")
 }
@@ -55,7 +59,8 @@ func TestRevealState_ReleaseClearsStateWithoutWebViewMapping(t *testing.T) {
 	wv := revealTestWebView(t, 101, 1)
 	c := newRevealTestCoordinator()
 	c.setWebViewLocked(paneID, wv)
-	c.markWebViewRevealed(paneID, wv)
+	identity, _ := identityForWebView(wv)
+	c.markWebViewRevealed(paneID, identity)
 
 	// Model an earlier partial cleanup that lost the WebView mapping. Release
 	// remains responsible for clearing presentation state on its early return.
@@ -70,6 +75,23 @@ func TestRevealState_ReleaseClearsStateWithoutWebViewMapping(t *testing.T) {
 	assert.False(t, retained)
 }
 
+func TestRevealState_ReleaseMappedWebViewClearsRevealStateAndReturnsToPool(t *testing.T) {
+	paneID := entity.PaneID("pane-1")
+	wv := revealTestWebView(t, 101, 1)
+	pool := mocks.NewMockWebViewPool(t)
+	pool.EXPECT().Release(wv).Once()
+	c := newRevealTestCoordinator()
+	c.pool = pool
+	c.setWebViewLocked(paneID, wv)
+	identity, _ := identityForWebView(wv)
+	c.markWebViewRevealed(paneID, identity)
+
+	c.ReleaseWebView(context.Background(), paneID)
+
+	assert.Nil(t, c.GetWebView(paneID))
+	assert.False(t, c.WebViewRevealed(paneID))
+}
+
 func TestRevealState_StaleCallbackCannotRevealReplacement(t *testing.T) {
 	paneID := entity.PaneID("pane-1")
 	oldWV := revealTestWebView(t, 101, 1)
@@ -77,10 +99,11 @@ func TestRevealState_StaleCallbackCannotRevealReplacement(t *testing.T) {
 	oldWV.EXPECT().IsDestroyed().Return(false).Maybe()
 	c := newRevealTestCoordinator()
 	c.setWebViewLocked(paneID, oldWV)
-	c.markPendingReveal(paneID, oldWV)
+	oldIdentity, _ := identityForWebView(oldWV)
+	c.markPendingReveal(paneID, oldIdentity)
 	c.setWebViewLocked(paneID, newWV)
 
-	c.revealIfPending(context.Background(), paneID, oldWV, "", "stale")
+	c.revealIfPending(context.Background(), paneID, oldWV, oldIdentity, "", "stale")
 	assert.False(t, c.WebViewRevealed(paneID))
 }
 
@@ -89,9 +112,85 @@ func TestRevealState_RevealedCurrentWebViewPersistsForWorkspaceRebuild(t *testin
 	wv := revealTestWebView(t, 101, 1)
 	c := newRevealTestCoordinator()
 	c.setWebViewLocked(paneID, wv)
-	c.markWebViewRevealed(paneID, wv)
+	identity, _ := identityForWebView(wv)
+	c.markWebViewRevealed(paneID, identity)
 
 	// AttachToWorkspace asks this identity-aware query when rebuilding a pane,
 	// so the replacement PaneView hides its skeleton for this same WebView.
-	assert.True(t, c.WebViewRevealed(paneID))
+	assert.True(t, c.webViewRevealed(paneID, wv))
+
+	replacement := revealTestWebView(t, 102, 1)
+	assert.False(t, c.webViewRevealed(paneID, replacement))
+}
+
+func TestRevealCallback_CapturesGenerationBeforeSameObjectPoolReuse(t *testing.T) {
+	paneID := entity.PaneID("pane-1")
+	wv := mocks.NewMockWebView(t)
+	generation := uint64(1)
+	wv.EXPECT().ID().Return(port.WebViewID(101)).Maybe()
+	wv.EXPECT().Generation().RunAndReturn(func() uint64 { return generation }).Maybe()
+	wv.EXPECT().IsDestroyed().Return(false).Maybe()
+	var callbacks *port.WebViewCallbacks
+	wv.EXPECT().SetCallbacks(mock.Anything).RunAndReturn(func(value *port.WebViewCallbacks) {
+		callbacks = value
+	}).Once()
+
+	c := newRevealTestCoordinator()
+	c.getActiveWS = func() (*entity.Workspace, *component.WorkspaceView) { return nil, nil }
+	c.setWebViewLocked(paneID, wv)
+	installedIdentity, _ := identityForWebView(wv)
+	c.markPendingReveal(paneID, installedIdentity)
+	c.setupWebViewCallbacks(context.Background(), paneID, wv)
+	revealed := false
+	c.setWebViewVisible = func(port.WebView) { revealed = true }
+
+	// The callback was installed at generation 1. A pool reuse can advance the
+	// same Go WebView object before its old callback is delivered.
+	generation = 2
+	callbacks.OnProgressChanged(1)
+
+	assert.False(t, revealed, "the generation-1 callback must not reveal generation 2")
+	assert.False(t, c.WebViewRevealed(paneID))
+}
+
+func TestRevealIfPending_SerializesReplacementUntilNativeVisibility(t *testing.T) {
+	paneID := entity.PaneID("pane-1")
+	oldWV := revealTestWebView(t, 101, 1)
+	oldWV.EXPECT().IsDestroyed().Return(false).Once()
+	newWV := revealTestWebView(t, 102, 1)
+	c := newRevealTestCoordinator()
+	c.setWebViewLocked(paneID, oldWV)
+	identity, _ := identityForWebView(oldWV)
+	c.markPendingReveal(paneID, identity)
+
+	nativeStarted := make(chan struct{})
+	allowNativeReturn := make(chan struct{})
+	c.setWebViewVisible = func(wv port.WebView) {
+		assert.Same(t, oldWV, wv)
+		close(nativeStarted)
+		<-allowNativeReturn
+	}
+	revealed := make(chan struct{})
+	go func() {
+		c.revealIfPending(context.Background(), paneID, oldWV, identity, "", "test")
+		close(revealed)
+	}()
+	<-nativeStarted
+
+	replaced := make(chan struct{})
+	go func() {
+		c.setWebViewLocked(paneID, newWV)
+		close(replaced)
+	}()
+	select {
+	case <-replaced:
+		t.Fatal("replacement interleaved before native visibility completed")
+	default:
+	}
+
+	close(allowNativeReturn)
+	<-revealed
+	<-replaced
+	assert.Same(t, newWV, c.GetWebView(paneID))
+	assert.False(t, c.WebViewRevealed(paneID), "replacement must not inherit old reveal state")
 }

--- a/internal/ui/coordinator/content/content_reveal_test.go
+++ b/internal/ui/coordinator/content/content_reveal_test.go
@@ -17,6 +17,19 @@ import (
 // These are internal package tests that verify the state transitions
 // without needing to mock WebKit dependencies.
 
+func TestWebViewRevealed_PersistsUntilWebViewRelease(t *testing.T) {
+	paneID := entity.PaneID("pane-1")
+	c := &Coordinator{}
+
+	assert.False(t, c.WebViewRevealed(paneID))
+
+	c.markWebViewRevealed(paneID)
+	assert.True(t, c.WebViewRevealed(paneID))
+
+	c.clearWebViewRevealed(paneID)
+	assert.False(t, c.WebViewRevealed(paneID))
+}
+
 func TestMarkPendingReveal_SetsState(t *testing.T) {
 	c := &Coordinator{
 		pendingReveal: make(map[entity.PaneID]bool),

--- a/internal/ui/coordinator/content/content_reveal_test.go
+++ b/internal/ui/coordinator/content/content_reveal_test.go
@@ -2,7 +2,6 @@ package content
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,217 +9,89 @@ import (
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/port/mocks"
 	"github.com/bnema/dumber/internal/domain/entity"
-	"github.com/bnema/dumber/internal/ui/component"
 )
 
-// TestPendingReveal tests the pending reveal state management.
-// These are internal package tests that verify the state transitions
-// without needing to mock WebKit dependencies.
+func newRevealTestCoordinator() *Coordinator {
+	return &Coordinator{
+		webViews:       make(map[entity.PaneID]port.WebView),
+		webViewPaneIDs: make(map[port.WebViewID]entity.PaneID),
+		paneTitles:     make(map[entity.PaneID]string),
+		navOrigins:     make(map[entity.PaneID]string),
+	}
+}
 
-func TestWebViewRevealed_PersistsUntilWebViewRelease(t *testing.T) {
+func revealTestWebView(t *testing.T, id port.WebViewID, generation uint64) *mocks.MockWebView {
+	t.Helper()
+	wv := mocks.NewMockWebView(t)
+	wv.EXPECT().ID().Return(id).Maybe()
+	wv.EXPECT().Generation().Return(generation).Maybe()
+	return wv
+}
+
+func TestRevealState_IsBoundToCurrentWebViewAcrossReplacementPaths(t *testing.T) {
 	paneID := entity.PaneID("pane-1")
-	c := &Coordinator{}
+	first := revealTestWebView(t, 101, 1)
+	// The pool may reuse the same native WebView ID; its reuse generation is
+	// part of the presentation identity.
+	directReplacement := revealTestWebView(t, 101, 2)
+	popupReplacement := revealTestWebView(t, 103, 1)
+	c := newRevealTestCoordinator()
 
-	assert.False(t, c.WebViewRevealed(paneID))
-
-	c.markWebViewRevealed(paneID)
+	c.setWebViewLocked(paneID, first)
+	c.markWebViewRevealed(paneID, first)
 	assert.True(t, c.WebViewRevealed(paneID))
 
-	c.clearWebViewRevealed(paneID)
+	// A direct replacement for the same pane must show the fresh loading state.
+	c.setWebViewLocked(paneID, directReplacement)
+	assert.False(t, c.WebViewRevealed(paneID))
+
+	c.markWebViewRevealed(paneID, directReplacement)
+	c.RegisterPopupWebView(paneID, popupReplacement)
+	assert.False(t, c.WebViewRevealed(paneID), "popup registration must not inherit a prior WebView reveal")
+}
+
+func TestRevealState_ReleaseClearsStateWithoutWebViewMapping(t *testing.T) {
+	paneID := entity.PaneID("pane-1")
+	wv := revealTestWebView(t, 101, 1)
+	c := newRevealTestCoordinator()
+	c.setWebViewLocked(paneID, wv)
+	c.markWebViewRevealed(paneID, wv)
+
+	// Model an earlier partial cleanup that lost the WebView mapping. Release
+	// remains responsible for clearing presentation state on its early return.
+	c.webViewsMu.Lock()
+	delete(c.webViews, paneID)
+	c.webViewsMu.Unlock()
+	c.ReleaseWebView(context.Background(), paneID)
+
+	c.revealMu.Lock()
+	_, retained := c.revealedWebViews[paneID]
+	c.revealMu.Unlock()
+	assert.False(t, retained)
+}
+
+func TestRevealState_StaleCallbackCannotRevealReplacement(t *testing.T) {
+	paneID := entity.PaneID("pane-1")
+	oldWV := revealTestWebView(t, 101, 1)
+	newWV := revealTestWebView(t, 102, 1)
+	oldWV.EXPECT().IsDestroyed().Return(false).Maybe()
+	c := newRevealTestCoordinator()
+	c.setWebViewLocked(paneID, oldWV)
+	c.markPendingReveal(paneID, oldWV)
+	c.setWebViewLocked(paneID, newWV)
+
+	c.revealIfPending(context.Background(), paneID, oldWV, "", "stale")
 	assert.False(t, c.WebViewRevealed(paneID))
 }
 
-func TestMarkPendingReveal_SetsState(t *testing.T) {
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-	}
+func TestRevealState_RevealedCurrentWebViewPersistsForWorkspaceRebuild(t *testing.T) {
 	paneID := entity.PaneID("pane-1")
+	wv := revealTestWebView(t, 101, 1)
+	c := newRevealTestCoordinator()
+	c.setWebViewLocked(paneID, wv)
+	c.markWebViewRevealed(paneID, wv)
 
-	c.markPendingReveal(paneID)
-
-	c.revealMu.Lock()
-	defer c.revealMu.Unlock()
-	assert.True(t, c.pendingReveal[paneID])
-}
-
-func TestClearPendingReveal_RemovesState(t *testing.T) {
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-	}
-	paneID := entity.PaneID("pane-1")
-
-	// First mark as pending
-	c.markPendingReveal(paneID)
-
-	// Then clear
-	c.clearPendingReveal(paneID)
-
-	c.revealMu.Lock()
-	defer c.revealMu.Unlock()
-	assert.False(t, c.pendingReveal[paneID])
-}
-
-func TestRevealIfPending_NotPending_DoesNothing(t *testing.T) {
-	callbackCalled := false
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-		webViews:      make(map[entity.PaneID]port.WebView),
-		onWebViewShown: func(paneID entity.PaneID) {
-			callbackCalled = true
-		},
-	}
-	paneID := entity.PaneID("pane-1")
-
-	// Call reveal without marking pending first
-	c.revealIfPending(context.Background(), paneID, "http://example.com", "test")
-
-	assert.False(t, callbackCalled, "callback should not be called when not pending")
-}
-
-func TestRevealIfPending_ClearsStateOnReveal(t *testing.T) {
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-		webViews:      make(map[entity.PaneID]port.WebView),
-	}
-	paneID := entity.PaneID("pane-1")
-
-	// Mark as pending
-	c.markPendingReveal(paneID)
-
-	// Reveal (will return early since webview is nil, but should still clear state)
-	c.revealIfPending(context.Background(), paneID, "http://example.com", "test")
-
-	c.revealMu.Lock()
-	defer c.revealMu.Unlock()
-	assert.False(t, c.pendingReveal[paneID], "pending state should be cleared after reveal attempt")
-}
-
-func TestRevealIfPending_OnlyRevealsOnce(t *testing.T) {
-	revealCount := 0
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-		webViews:      make(map[entity.PaneID]port.WebView),
-		onWebViewShown: func(paneID entity.PaneID) {
-			revealCount++
-		},
-	}
-	paneID := entity.PaneID("pane-1")
-
-	// Mark as pending
-	c.markPendingReveal(paneID)
-
-	// Call reveal multiple times
-	c.revealIfPending(context.Background(), paneID, "", "first")
-	c.revealIfPending(context.Background(), paneID, "", "second")
-	c.revealIfPending(context.Background(), paneID, "", "third")
-
-	// Callback should not be called since webview is nil, but state should be cleared
-	assert.Equal(t, 0, revealCount, "callback not called when webview is nil")
-
-	// Verify state is cleared
-	c.revealMu.Lock()
-	defer c.revealMu.Unlock()
-	assert.False(t, c.pendingReveal[paneID])
-}
-
-func TestOnLoadCommitted_RevealsPendingWebViewForCommittedPage(t *testing.T) {
-	paneID := entity.PaneID("pane-1")
-	shownCount := 0
-	var shownPane entity.PaneID
-
-	wv := mocks.NewMockWebView(t)
-	wv.EXPECT().URI().Return("https://example.com")
-	wv.EXPECT().ResetBackgroundToDefault()
-	wv.EXPECT().Title().Return("")
-	wv.EXPECT().IsDestroyed().Return(false).Maybe()
-
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-		webViews: map[entity.PaneID]port.WebView{
-			paneID: wv,
-		},
-		paneTitles:  make(map[entity.PaneID]string),
-		navOrigins:  make(map[entity.PaneID]string),
-		getActiveWS: func() (*entity.Workspace, *component.WorkspaceView) { return nil, nil },
-		onWebViewShown: func(id entity.PaneID) {
-			shownCount++
-			shownPane = id
-		},
-	}
-	c.pendingReveal[paneID] = true
-
-	c.onLoadCommitted(context.Background(), paneID, wv)
-
-	assert.Equal(t, 1, shownCount)
-	assert.Equal(t, paneID, shownPane)
-}
-
-func TestPendingReveal_ConcurrentAccess(t *testing.T) {
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-		webViews:      make(map[entity.PaneID]port.WebView),
-	}
-
-	var wg sync.WaitGroup
-	paneIDs := []entity.PaneID{"pane-1", "pane-2", "pane-3", "pane-4", "pane-5"}
-
-	// Concurrently mark and clear panes
-	for range 100 {
-		for _, paneID := range paneIDs {
-			wg.Add(3)
-
-			go func(id entity.PaneID) {
-				defer wg.Done()
-				c.markPendingReveal(id)
-			}(paneID)
-
-			go func(id entity.PaneID) {
-				defer wg.Done()
-				c.clearPendingReveal(id)
-			}(paneID)
-
-			go func(id entity.PaneID) {
-				defer wg.Done()
-				c.revealIfPending(context.Background(), id, "", "concurrent")
-			}(paneID)
-		}
-	}
-
-	wg.Wait()
-	// Test passes if no race conditions occur
-}
-
-func TestMarkPendingReveal_MultiplePanes(t *testing.T) {
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-	}
-
-	pane1 := entity.PaneID("pane-1")
-	pane2 := entity.PaneID("pane-2")
-
-	c.markPendingReveal(pane1)
-	c.markPendingReveal(pane2)
-
-	c.revealMu.Lock()
-	defer c.revealMu.Unlock()
-	assert.True(t, c.pendingReveal[pane1])
-	assert.True(t, c.pendingReveal[pane2])
-}
-
-func TestClearPendingReveal_OnlyAffectsTargetPane(t *testing.T) {
-	c := &Coordinator{
-		pendingReveal: make(map[entity.PaneID]bool),
-	}
-
-	pane1 := entity.PaneID("pane-1")
-	pane2 := entity.PaneID("pane-2")
-
-	c.markPendingReveal(pane1)
-	c.markPendingReveal(pane2)
-	c.clearPendingReveal(pane1)
-
-	c.revealMu.Lock()
-	defer c.revealMu.Unlock()
-	assert.False(t, c.pendingReveal[pane1], "pane1 should be cleared")
-	assert.True(t, c.pendingReveal[pane2], "pane2 should still be pending")
+	// AttachToWorkspace asks this identity-aware query when rebuilding a pane,
+	// so the replacement PaneView hides its skeleton for this same WebView.
+	assert.True(t, c.WebViewRevealed(paneID))
 }

--- a/internal/ui/coordinator/content/coordinator.go
+++ b/internal/ui/coordinator/content/coordinator.go
@@ -70,6 +70,14 @@ type Coordinator struct {
 	// Callback when the WebView becomes visible (first real commit)
 	onWebViewShown func(paneID entity.PaneID)
 
+	// setWebViewVisible is test-only injection for deterministic lifecycle
+	// serialization tests. Production uses the native widget provider directly.
+	setWebViewVisible func(port.WebView)
+
+	// revealMutationMu serializes mapping replacement/release with the native
+	// visibility transition. It is acquired before webViewsMu and revealMu.
+	revealMutationMu sync.Mutex
+
 	// revealMu is always acquired after webViewsMu. Reveal state is keyed by the
 	// WebView identity (ID plus pool-reuse generation), never by pane alone.
 	revealMu                sync.Mutex
@@ -348,6 +356,8 @@ func (c *Coordinator) ensureRevealMapsLocked() {
 // setWebViewLocked replaces the pane mapping and resets all reveal state in
 // one critical section. It is used by normal acquisition and popup paths.
 func (c *Coordinator) setWebViewLocked(paneID entity.PaneID, wv port.WebView) {
+	c.revealMutationMu.Lock()
+	defer c.revealMutationMu.Unlock()
 	c.webViewsMu.Lock()
 	c.revealMu.Lock()
 	defer c.revealMu.Unlock()
@@ -372,6 +382,8 @@ func (c *Coordinator) setWebViewLocked(paneID entity.PaneID, wv port.WebView) {
 // deleteWebViewLocked removes both the mapping and any presentation state,
 // including callers which release after another path already removed the map.
 func (c *Coordinator) deleteWebViewLocked(paneID entity.PaneID) port.WebView {
+	c.revealMutationMu.Lock()
+	defer c.revealMutationMu.Unlock()
 	c.webViewsMu.Lock()
 	c.revealMu.Lock()
 	defer c.revealMu.Unlock()

--- a/internal/ui/coordinator/content/coordinator.go
+++ b/internal/ui/coordinator/content/coordinator.go
@@ -70,8 +70,9 @@ type Coordinator struct {
 	// Callback when the WebView becomes visible (first real commit)
 	onWebViewShown func(paneID entity.PaneID)
 
-	revealMu      sync.Mutex
-	pendingReveal map[entity.PaneID]bool
+	revealMu         sync.Mutex
+	pendingReveal    map[entity.PaneID]bool
+	revealedWebViews map[entity.PaneID]bool
 
 	appearanceMu          sync.Mutex
 	pendingScriptRefresh  map[entity.PaneID]bool
@@ -148,6 +149,7 @@ func NewCoordinator(
 		paneTitles:           make(map[entity.PaneID]string),
 		navOrigins:           make(map[entity.PaneID]string),
 		pendingReveal:        make(map[entity.PaneID]bool),
+		revealedWebViews:     make(map[entity.PaneID]bool),
 		pendingScriptRefresh: make(map[entity.PaneID]bool),
 		pendingThemePanes:    make(map[entity.PaneID]bool),
 		getActiveWS:          getActiveWS,

--- a/internal/ui/coordinator/content/coordinator.go
+++ b/internal/ui/coordinator/content/coordinator.go
@@ -70,9 +70,13 @@ type Coordinator struct {
 	// Callback when the WebView becomes visible (first real commit)
 	onWebViewShown func(paneID entity.PaneID)
 
-	revealMu         sync.Mutex
-	pendingReveal    map[entity.PaneID]bool
-	revealedWebViews map[entity.PaneID]bool
+	// revealMu is always acquired after webViewsMu. Reveal state is keyed by the
+	// WebView identity (ID plus pool-reuse generation), never by pane alone.
+	revealMu                sync.Mutex
+	pendingReveal           map[entity.PaneID]bool
+	revealedWebViews        map[entity.PaneID]bool
+	revealedWebViewIdentity map[entity.PaneID]webViewIdentity
+	pendingRevealIdentity   map[entity.PaneID]webViewIdentity
 
 	appearanceMu          sync.Mutex
 	pendingScriptRefresh  map[entity.PaneID]bool
@@ -137,23 +141,25 @@ func NewCoordinator(
 	log.Debug().Msg("creating content coordinator")
 
 	return &Coordinator{
-		logger:               log.With().Str("component", "content-coordinator").Logger(),
-		pool:                 pool,
-		injector:             injector,
-		widgetFactory:        widgetFactory,
-		faviconAdapter:       faviconAdapter,
-		zoomUC:               zoomUC,
-		permissionUC:         permissionUC,
-		webViews:             make(map[entity.PaneID]port.WebView),
-		webViewPaneIDs:       make(map[port.WebViewID]entity.PaneID),
-		paneTitles:           make(map[entity.PaneID]string),
-		navOrigins:           make(map[entity.PaneID]string),
-		pendingReveal:        make(map[entity.PaneID]bool),
-		revealedWebViews:     make(map[entity.PaneID]bool),
-		pendingScriptRefresh: make(map[entity.PaneID]bool),
-		pendingThemePanes:    make(map[entity.PaneID]bool),
-		getActiveWS:          getActiveWS,
-		popups:               newPopupManager(),
+		logger:                  log.With().Str("component", "content-coordinator").Logger(),
+		pool:                    pool,
+		injector:                injector,
+		widgetFactory:           widgetFactory,
+		faviconAdapter:          faviconAdapter,
+		zoomUC:                  zoomUC,
+		permissionUC:            permissionUC,
+		webViews:                make(map[entity.PaneID]port.WebView),
+		webViewPaneIDs:          make(map[port.WebViewID]entity.PaneID),
+		paneTitles:              make(map[entity.PaneID]string),
+		navOrigins:              make(map[entity.PaneID]string),
+		pendingReveal:           make(map[entity.PaneID]bool),
+		revealedWebViews:        make(map[entity.PaneID]bool),
+		revealedWebViewIdentity: make(map[entity.PaneID]webViewIdentity),
+		pendingRevealIdentity:   make(map[entity.PaneID]webViewIdentity),
+		pendingScriptRefresh:    make(map[entity.PaneID]bool),
+		pendingThemePanes:       make(map[entity.PaneID]bool),
+		getActiveWS:             getActiveWS,
+		popups:                  newPopupManager(),
 	}
 }
 
@@ -312,8 +318,40 @@ func (c *Coordinator) getWebViewLocked(paneID entity.PaneID) port.WebView {
 	return c.webViews[paneID]
 }
 
+type webViewIdentity struct {
+	id         port.WebViewID
+	generation uint64
+}
+
+func identityForWebView(wv port.WebView) (webViewIdentity, bool) {
+	if wv == nil {
+		return webViewIdentity{}, false
+	}
+	return webViewIdentity{id: wv.ID(), generation: wv.Generation()}, true
+}
+
+func (c *Coordinator) ensureRevealMapsLocked() {
+	if c.pendingReveal == nil {
+		c.pendingReveal = make(map[entity.PaneID]bool)
+	}
+	if c.revealedWebViews == nil {
+		c.revealedWebViews = make(map[entity.PaneID]bool)
+	}
+	if c.revealedWebViewIdentity == nil {
+		c.revealedWebViewIdentity = make(map[entity.PaneID]webViewIdentity)
+	}
+	if c.pendingRevealIdentity == nil {
+		c.pendingRevealIdentity = make(map[entity.PaneID]webViewIdentity)
+	}
+}
+
+// setWebViewLocked replaces the pane mapping and resets all reveal state in
+// one critical section. It is used by normal acquisition and popup paths.
 func (c *Coordinator) setWebViewLocked(paneID entity.PaneID, wv port.WebView) {
 	c.webViewsMu.Lock()
+	c.revealMu.Lock()
+	defer c.revealMu.Unlock()
+	defer c.webViewsMu.Unlock()
 	if c.webViews == nil {
 		c.webViews = make(map[entity.PaneID]port.WebView)
 	}
@@ -324,17 +362,30 @@ func (c *Coordinator) setWebViewLocked(paneID entity.PaneID, wv port.WebView) {
 	if wv != nil && c.webViewPaneIDs != nil {
 		c.webViewPaneIDs[wv.ID()] = paneID
 	}
-	c.webViewsMu.Unlock()
+	c.ensureRevealMapsLocked()
+	delete(c.pendingReveal, paneID)
+	delete(c.pendingRevealIdentity, paneID)
+	delete(c.revealedWebViews, paneID)
+	delete(c.revealedWebViewIdentity, paneID)
 }
 
+// deleteWebViewLocked removes both the mapping and any presentation state,
+// including callers which release after another path already removed the map.
 func (c *Coordinator) deleteWebViewLocked(paneID entity.PaneID) port.WebView {
 	c.webViewsMu.Lock()
+	c.revealMu.Lock()
+	defer c.revealMu.Unlock()
 	defer c.webViewsMu.Unlock()
 	wv := c.webViews[paneID]
 	delete(c.webViews, paneID)
 	if wv != nil && c.webViewPaneIDs != nil {
 		delete(c.webViewPaneIDs, wv.ID())
 	}
+	c.ensureRevealMapsLocked()
+	delete(c.pendingReveal, paneID)
+	delete(c.pendingRevealIdentity, paneID)
+	delete(c.revealedWebViews, paneID)
+	delete(c.revealedWebViewIdentity, paneID)
 	return wv
 }
 

--- a/internal/ui/coordinator/content/lifecycle.go
+++ b/internal/ui/coordinator/content/lifecycle.go
@@ -39,9 +39,8 @@ func (c *Coordinator) EnsureWebView(ctx context.Context, paneID entity.PaneID) (
 	}
 	logging.Trace().Mark("webview_acquired")
 
-	// A pooled widget may have been previously revealed for another pane. Its
-	// presentation lifecycle starts unrevealed for this pane until a new reveal.
-	c.clearWebViewRevealed(paneID)
+	// setWebViewLocked atomically resets presentation state for the acquired
+	// WebView, including a pooled instance previously revealed in another pane.
 	c.setWebViewLocked(paneID, wv)
 	c.setupWebViewCallbacks(ctx, paneID, wv)
 
@@ -56,6 +55,8 @@ func (c *Coordinator) EnsureWebView(ctx context.Context, paneID entity.PaneID) (
 func (c *Coordinator) ReleaseWebView(ctx context.Context, paneID entity.PaneID) {
 	log := logging.FromContext(ctx)
 
+	// deleteWebViewLocked clears reveal state before returning, even when a
+	// previous cleanup already removed this pane's mapping.
 	wv := c.deleteWebViewLocked(paneID)
 	if wv == nil {
 		return
@@ -63,7 +64,6 @@ func (c *Coordinator) ReleaseWebView(ctx context.Context, paneID entity.PaneID) 
 	c.ensurePopupManager().clearReusableNamedPopupByPaneID(paneID)
 	c.ensurePopupManager().clearReusableNamedPopupByWebViewID(wv.ID())
 	c.clearPendingAppearance(paneID)
-	c.clearWebViewRevealed(paneID)
 
 	// CRITICAL: If this webview was inhibiting idle (fullscreen or audio playing),
 	// we must release the inhibition before destroying the webview.

--- a/internal/ui/coordinator/content/lifecycle.go
+++ b/internal/ui/coordinator/content/lifecycle.go
@@ -39,6 +39,9 @@ func (c *Coordinator) EnsureWebView(ctx context.Context, paneID entity.PaneID) (
 	}
 	logging.Trace().Mark("webview_acquired")
 
+	// A pooled widget may have been previously revealed for another pane. Its
+	// presentation lifecycle starts unrevealed for this pane until a new reveal.
+	c.clearWebViewRevealed(paneID)
 	c.setWebViewLocked(paneID, wv)
 	c.setupWebViewCallbacks(ctx, paneID, wv)
 
@@ -60,6 +63,7 @@ func (c *Coordinator) ReleaseWebView(ctx context.Context, paneID entity.PaneID) 
 	c.ensurePopupManager().clearReusableNamedPopupByPaneID(paneID)
 	c.ensurePopupManager().clearReusableNamedPopupByWebViewID(wv.ID())
 	c.clearPendingAppearance(paneID)
+	c.clearWebViewRevealed(paneID)
 
 	// CRITICAL: If this webview was inhibiting idle (fullscreen or audio playing),
 	// we must release the inhibition before destroying the webview.
@@ -136,7 +140,7 @@ func (c *Coordinator) AttachToWorkspace(ctx context.Context, ws *entity.Workspac
 			Int("wrapped_widget_alloc_height", widget.GetAllocatedHeight()).
 			Msg("wrapped webview widget prepared for pane")
 
-		if err := wsView.SetWebViewWidget(pane.ID, widget); err != nil {
+		if err := wsView.AttachWebViewWidget(pane.ID, widget, c.WebViewRevealed(pane.ID)); err != nil {
 			log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("failed to attach webview widget")
 			continue
 		}

--- a/internal/ui/coordinator/content/lifecycle.go
+++ b/internal/ui/coordinator/content/lifecycle.go
@@ -140,7 +140,7 @@ func (c *Coordinator) AttachToWorkspace(ctx context.Context, ws *entity.Workspac
 			Int("wrapped_widget_alloc_height", widget.GetAllocatedHeight()).
 			Msg("wrapped webview widget prepared for pane")
 
-		if err := wsView.AttachWebViewWidget(pane.ID, widget, c.WebViewRevealed(pane.ID)); err != nil {
+		if err := wsView.AttachWebViewWidget(pane.ID, widget, c.webViewRevealed(pane.ID, wv)); err != nil {
 			log.Warn().Err(err).Str("pane_id", string(pane.ID)).Msg("failed to attach webview widget")
 			continue
 		}

--- a/internal/ui/coordinator/content/lifecycle_test.go
+++ b/internal/ui/coordinator/content/lifecycle_test.go
@@ -58,7 +58,7 @@ func TestLifecycle_EnsureWebView_AcquiresFromPoolWhenNoneExists(t *testing.T) {
 	newWV := mocks.NewMockWebView(t)
 	newWV.EXPECT().SetCallbacks(mock.Anything).Maybe()
 	newWV.EXPECT().Generation().Return(uint64(0)).Maybe()
-	newWV.EXPECT().ID().Return(port.WebViewID(102)).Once()
+	newWV.EXPECT().ID().Return(port.WebViewID(102)).Maybe()
 
 	pool := mocks.NewMockWebViewPool(t)
 	pool.EXPECT().Acquire(mock.Anything).Return(newWV, nil)
@@ -82,7 +82,7 @@ func TestLifecycle_EnsureWebView_AcquiresFromPoolWhenExistingIsDestroyed(t *test
 	newWV := mocks.NewMockWebView(t)
 	newWV.EXPECT().SetCallbacks(mock.Anything).Maybe()
 	newWV.EXPECT().Generation().Return(uint64(0)).Maybe()
-	newWV.EXPECT().ID().Return(port.WebViewID(103)).Once()
+	newWV.EXPECT().ID().Return(port.WebViewID(103)).Maybe()
 
 	pool := mocks.NewMockWebViewPool(t)
 	pool.EXPECT().Acquire(mock.Anything).Return(newWV, nil)

--- a/internal/ui/coordinator/content/lifecycle_test.go
+++ b/internal/ui/coordinator/content/lifecycle_test.go
@@ -458,3 +458,205 @@ func TestLifecycle_SyncWebViewViewport_NoopWithoutCapability(t *testing.T) {
 
 	c.SyncWebViewViewport(context.Background(), "pane-1", "unit-test")
 }
+
+type nativeLifecycleWebView struct {
+	port.WebView
+	widget uintptr
+}
+
+func (w *nativeLifecycleWebView) NativeWidget() uintptr { return w.widget }
+
+func TestLifecycle_AttachToWorkspace_RebuildPropagatesRevealStateToFreshPaneView(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		revealed bool
+	}{
+		{name: "revealed current identity hides and stops skeleton", revealed: true},
+		{name: "unrevealed current identity shows and starts skeleton", revealed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paneID := entity.PaneID("pane-1")
+			ctx := context.Background()
+			factory := layoutmocks.NewMockWidgetFactory(t)
+			wsView, workspace, paneOverlay, loadingContainer, spinner := newLifecycleRebuildWorkspaceView(t, ctx, factory, paneID)
+			wrappedWidget := layoutmocks.NewMockWidget(t)
+			webViewMock := mocks.NewMockWebView(t)
+			webViewMock.EXPECT().ID().Return(port.WebViewID(201)).Maybe()
+			webViewMock.EXPECT().Generation().Return(uint64(3)).Maybe()
+			webViewMock.EXPECT().IsDestroyed().Return(false).Once()
+			webView := &nativeLifecycleWebView{WebView: webViewMock, widget: 0x351}
+
+			factory.EXPECT().WrapNativeWidget(uintptr(0x351)).Return(wrappedWidget).Once()
+			wrappedWidget.EXPECT().GtkWidget().Return(nil).Once()
+			wrappedWidget.EXPECT().GetAllocatedWidth().Return(0).Times(3)
+			wrappedWidget.EXPECT().GetAllocatedHeight().Return(0).Times(3)
+			wrappedWidget.EXPECT().GetParent().Return(nil).Once()
+			wrappedWidget.EXPECT().IsVisible().Return(true).Once()
+			paneOverlay.EXPECT().GetAllocatedWidth().Return(0).Twice()
+			paneOverlay.EXPECT().GetAllocatedHeight().Return(0).Twice()
+			paneOverlay.EXPECT().SetChild(wrappedWidget).Once()
+			loadingContainer.EXPECT().SetVisible(!tc.revealed).Once()
+			if tc.revealed {
+				spinner.EXPECT().Stop().Once()
+			} else {
+				spinner.EXPECT().Start().Once()
+			}
+
+			coordinator := newRevealTestCoordinator()
+			coordinator.widgetFactory = factory
+			coordinator.setWebViewLocked(paneID, webView)
+			if tc.revealed {
+				identity, ok := identityForWebView(webView)
+				require.True(t, ok)
+				coordinator.markWebViewRevealed(paneID, identity)
+			}
+
+			coordinator.AttachToWorkspace(ctx, workspace, wsView)
+
+			assert.Same(t, wrappedWidget, wsView.GetPaneView(paneID).WebViewWidget())
+		})
+	}
+}
+
+func newLifecycleRebuildWorkspaceView(
+	t *testing.T,
+	ctx context.Context,
+	factory *layoutmocks.MockWidgetFactory,
+	paneID entity.PaneID,
+) (*component.WorkspaceView, *entity.Workspace, *layoutmocks.MockOverlayWidget, *layoutmocks.MockBoxWidget, *layoutmocks.MockSpinnerWidget) {
+	t.Helper()
+	workspaceContainer := layoutmocks.NewMockBoxWidget(t)
+	workspaceOverlay := layoutmocks.NewMockOverlayWidget(t)
+	factory.EXPECT().NewBox(layout.OrientationVertical, 0).Return(workspaceContainer).Once()
+	workspaceContainer.EXPECT().SetHexpand(true).Once()
+	workspaceContainer.EXPECT().SetVexpand(true).Once()
+	workspaceContainer.EXPECT().SetVisible(true).Once()
+	factory.EXPECT().NewOverlay().Return(workspaceOverlay).Once()
+	workspaceOverlay.EXPECT().SetHexpand(true).Once()
+	workspaceOverlay.EXPECT().SetVexpand(true).Once()
+	workspaceOverlay.EXPECT().SetChild(workspaceContainer).Once()
+	workspaceOverlay.EXPECT().SetVisible(true).Once()
+	wsView := component.NewWorkspaceView(ctx, factory)
+
+	paneOverlay := layoutmocks.NewMockOverlayWidget(t)
+	loadingContainer := layoutmocks.NewMockBoxWidget(t)
+	loadingContent := layoutmocks.NewMockBoxWidget(t)
+	spinner := layoutmocks.NewMockSpinnerWidget(t)
+	logo := layoutmocks.NewMockImageWidget(t)
+	version := layoutmocks.NewMockLabelWidget(t)
+	border := layoutmocks.NewMockBoxWidget(t)
+
+	factory.EXPECT().NewOverlay().Return(paneOverlay).Once()
+	paneOverlay.EXPECT().SetHexpand(true).Once()
+	paneOverlay.EXPECT().SetVexpand(true).Once()
+	paneOverlay.EXPECT().SetVisible(true).Once()
+	paneOverlay.EXPECT().AddCssClass("pane-overlay").Once()
+	factory.EXPECT().NewBox(layout.OrientationVertical, 0).Return(loadingContainer).Once()
+	loadingContainer.EXPECT().SetHexpand(true).Once()
+	loadingContainer.EXPECT().SetVexpand(true).Once()
+	loadingContainer.EXPECT().SetHalign(mock.Anything).Once()
+	loadingContainer.EXPECT().SetValign(mock.Anything).Once()
+	loadingContainer.EXPECT().SetCanFocus(false).Times(2)
+	loadingContainer.EXPECT().SetCanTarget(false).Times(2)
+	loadingContainer.EXPECT().AddCssClass("loading-skeleton").Once()
+	factory.EXPECT().NewBox(layout.OrientationVertical, 6).Return(loadingContent).Once()
+	loadingContent.EXPECT().SetHalign(mock.Anything).Once()
+	loadingContent.EXPECT().SetValign(mock.Anything).Once()
+	loadingContent.EXPECT().SetCanFocus(false).Once()
+	loadingContent.EXPECT().SetCanTarget(false).Once()
+	loadingContent.EXPECT().AddCssClass("loading-skeleton-content").Once()
+	factory.EXPECT().NewImage().Return(logo).Once()
+	logo.EXPECT().SetHalign(mock.Anything).Once()
+	logo.EXPECT().SetValign(mock.Anything).Once()
+	logo.EXPECT().SetCanFocus(false).Once()
+	logo.EXPECT().SetCanTarget(false).Once()
+	logo.EXPECT().SetSizeRequest(256, 256).Once()
+	logo.EXPECT().SetPixelSize(256).Once()
+	logo.EXPECT().AddCssClass("loading-skeleton-logo").Once()
+	logo.EXPECT().SetFromPaintable(mock.Anything).Maybe()
+	factory.EXPECT().NewSpinner().Return(spinner).Once()
+	spinner.EXPECT().SetHalign(mock.Anything).Once()
+	spinner.EXPECT().SetValign(mock.Anything).Once()
+	spinner.EXPECT().SetCanFocus(false).Once()
+	spinner.EXPECT().SetCanTarget(false).Once()
+	spinner.EXPECT().SetSizeRequest(32, 32).Once()
+	spinner.EXPECT().AddCssClass("loading-skeleton-spinner").Once()
+	factory.EXPECT().NewLabel(mock.Anything).Return(version).Once()
+	version.EXPECT().SetHalign(mock.Anything).Once()
+	version.EXPECT().SetValign(mock.Anything).Once()
+	version.EXPECT().SetCanFocus(false).Once()
+	version.EXPECT().SetCanTarget(false).Once()
+	version.EXPECT().SetMaxWidthChars(mock.Anything).Once()
+	version.EXPECT().SetEllipsize(mock.Anything).Once()
+	version.EXPECT().AddCssClass("loading-skeleton-version").Once()
+	loadingContent.EXPECT().Append(logo).Once()
+	loadingContent.EXPECT().Append(spinner).Once()
+	loadingContent.EXPECT().Append(version).Once()
+	loadingContainer.EXPECT().Append(loadingContent).Once()
+	loadingContainer.EXPECT().SetVisible(true).Once()
+	spinner.EXPECT().Start().Once()
+	paneOverlay.EXPECT().AddOverlay(loadingContainer).Once()
+	paneOverlay.EXPECT().SetClipOverlay(loadingContainer, false).Once()
+	paneOverlay.EXPECT().SetMeasureOverlay(loadingContainer, false).Once()
+	factory.EXPECT().NewBox(layout.OrientationVertical, 0).Return(border).Once()
+	border.EXPECT().SetCanFocus(false).Once()
+	border.EXPECT().SetCanTarget(false).Once()
+	border.EXPECT().AddCssClass("pane-border").Once()
+	border.EXPECT().SetHexpand(true).Once()
+	border.EXPECT().SetVexpand(true).Once()
+	paneOverlay.EXPECT().AddOverlay(border).Once()
+	paneOverlay.EXPECT().SetClipOverlay(border, false).Once()
+	paneOverlay.EXPECT().SetMeasureOverlay(border, false).Once()
+
+	stackBox := layoutmocks.NewMockBoxWidget(t)
+	titleBar := layoutmocks.NewMockBoxWidget(t)
+	favicon := layoutmocks.NewMockImageWidget(t)
+	title := layoutmocks.NewMockLabelWidget(t)
+	closeButton := layoutmocks.NewMockButtonWidget(t)
+	factory.EXPECT().NewBox(layout.OrientationVertical, 0).Return(stackBox).Once()
+	stackBox.EXPECT().SetHexpand(true).Once()
+	stackBox.EXPECT().SetVexpand(true).Once()
+	factory.EXPECT().NewBox(layout.OrientationHorizontal, 4).Return(titleBar).Once()
+	titleBar.EXPECT().AddCssClass("stacked-pane-titlebar").Once()
+	titleBar.EXPECT().AddCssClass("stacked-pane-title-clickable").Once()
+	titleBar.EXPECT().SetVexpand(false).Once()
+	titleBar.EXPECT().SetHexpand(true).Once()
+	factory.EXPECT().NewImage().Return(favicon).Once()
+	favicon.EXPECT().SetFromIconName(mock.Anything).Once()
+	favicon.EXPECT().SetPixelSize(16).Once()
+	titleBar.EXPECT().Append(favicon).Once()
+	factory.EXPECT().NewLabel(mock.Anything).Return(title).Once()
+	title.EXPECT().SetEllipsize(layout.EllipsizeEnd).Once()
+	title.EXPECT().SetMaxWidthChars(30).Once()
+	title.EXPECT().SetHexpand(true).Once()
+	title.EXPECT().SetXalign(float32(0)).Once()
+	titleBar.EXPECT().Append(title).Once()
+	factory.EXPECT().NewButton().Return(closeButton).Once()
+	closeButton.EXPECT().SetIconName("window-close-symbolic").Once()
+	closeButton.EXPECT().AddCssClass("stacked-pane-close-button").Once()
+	closeButton.EXPECT().SetFocusOnClick(false).Once()
+	closeButton.EXPECT().SetVexpand(false).Once()
+	closeButton.EXPECT().SetHexpand(false).Once()
+	titleBar.EXPECT().Append(closeButton).Once()
+	titleBar.EXPECT().AddController(mock.Anything).Once()
+	closeButton.EXPECT().ConnectClicked(mock.Anything).Return(uint(2)).Once()
+	closeButton.EXPECT().GtkWidget().Return(nil).Maybe()
+	stackBox.EXPECT().Append(titleBar).Once()
+	stackBox.EXPECT().Append(paneOverlay).Once()
+	titleBar.EXPECT().SetVisible(false).Once()
+	paneOverlay.EXPECT().SetVisible(true).Once()
+	titleBar.EXPECT().AddCssClass("active").Once()
+	paneOverlay.EXPECT().GtkWidget().Return(nil).Maybe()
+	stackBox.EXPECT().SetVisible(true).Once()
+	workspaceContainer.EXPECT().Append(stackBox).Once()
+	workspaceContainer.EXPECT().AddCssClass("single-pane").Once()
+	border.EXPECT().AddCssClass("pane-active").Once()
+
+	workspace := &entity.Workspace{
+		ID:           "workspace-1",
+		Root:         &entity.PaneNode{ID: "node-1", Pane: entity.NewPane(paneID)},
+		ActivePaneID: paneID,
+	}
+	require.NoError(t, wsView.SetWorkspace(ctx, workspace))
+	return wsView, workspace, paneOverlay, loadingContainer, spinner
+}

--- a/internal/ui/coordinator/content/navigation.go
+++ b/internal/ui/coordinator/content/navigation.go
@@ -256,6 +256,30 @@ func (c *Coordinator) clearPendingReveal(paneID entity.PaneID) {
 	c.revealMu.Unlock()
 }
 
+// WebViewRevealed reports whether this pane's current WebView has completed a
+// reveal. This state belongs to content lifecycle rather than GTK widget
+// ownership, because WorkspaceView rebuilds unparent live native widgets.
+func (c *Coordinator) WebViewRevealed(paneID entity.PaneID) bool {
+	c.revealMu.Lock()
+	defer c.revealMu.Unlock()
+	return c.revealedWebViews[paneID]
+}
+
+func (c *Coordinator) markWebViewRevealed(paneID entity.PaneID) {
+	c.revealMu.Lock()
+	if c.revealedWebViews == nil {
+		c.revealedWebViews = make(map[entity.PaneID]bool)
+	}
+	c.revealedWebViews[paneID] = true
+	c.revealMu.Unlock()
+}
+
+func (c *Coordinator) clearWebViewRevealed(paneID entity.PaneID) {
+	c.revealMu.Lock()
+	delete(c.revealedWebViews, paneID)
+	c.revealMu.Unlock()
+}
+
 func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID, uri, reason string) {
 	c.revealMu.Lock()
 	pending := c.pendingReveal[paneID]
@@ -288,6 +312,10 @@ func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID,
 		}
 	}
 
+	// Record presentation state before notifying the UI. The callback may run
+	// while a WorkspaceView is being rebuilt, and the next PaneView must inherit
+	// this state even though the native widget was unparented during cleanup.
+	c.markWebViewRevealed(paneID)
 	if c.onWebViewShown != nil {
 		c.onWebViewShown(paneID)
 	}

--- a/internal/ui/coordinator/content/navigation.go
+++ b/internal/ui/coordinator/content/navigation.go
@@ -17,7 +17,7 @@ import (
 // WebKit may reset zoom during document transitions, so we reapply after LoadCommitted.
 // History is recorded here because the URI is guaranteed to be correct after commit.
 // Also shows the WebView widget (it's hidden during creation to avoid white flash).
-func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID, wv port.WebView) {
+func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID, wv port.WebView, identity webViewIdentity) {
 	log := logging.FromContext(ctx)
 	logging.Trace().Mark("load_committed")
 
@@ -69,7 +69,7 @@ func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID,
 		// Avoid updating UI/domain state to about:blank when we know the pane is
 		// navigating to a different URL. This prevents the omnibox/window title from
 		// briefly showing about:blank on cold start.
-		c.clearPendingReveal(paneID, wv)
+		c.clearPendingReveal(paneID, identity)
 		return
 	}
 
@@ -77,8 +77,8 @@ func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID,
 		c.applyCurrentTheme(ctx, paneID, wv)
 	}
 
-	c.markPendingReveal(paneID, wv)
-	c.revealIfPending(ctx, paneID, wv, uri, "progress-after-commit")
+	c.markPendingReveal(paneID, identity)
+	c.revealIfPending(ctx, paneID, wv, identity, uri, "progress-after-commit")
 
 	// Update domain model with current URI for session snapshots
 	c.updatePaneURI(paneID, uri)
@@ -202,7 +202,7 @@ func (c *Coordinator) onLoadStarted(paneID entity.PaneID) {
 }
 
 // onLoadFinished hides the progress bar when page loading completes.
-func (c *Coordinator) onLoadFinished(ctx context.Context, paneID entity.PaneID, wv port.WebView) {
+func (c *Coordinator) onLoadFinished(ctx context.Context, paneID entity.PaneID, wv port.WebView, identity webViewIdentity) {
 	_, wsView := c.getActiveWS()
 	var paneView *component.PaneView
 	if wsView != nil {
@@ -216,7 +216,7 @@ func (c *Coordinator) onLoadFinished(ctx context.Context, paneID entity.PaneID, 
 		paneView.SetLoading(false)
 	}
 
-	c.revealIfPending(ctx, paneID, wv, "", "load-finished")
+	c.revealIfPending(ctx, paneID, wv, identity, "", "load-finished")
 	if c.shouldSkipAboutBlankAppearance(paneID, wv) {
 		return
 	}
@@ -225,9 +225,9 @@ func (c *Coordinator) onLoadFinished(ctx context.Context, paneID entity.PaneID, 
 }
 
 // onProgressChanged updates the progress bar with current load progress.
-func (c *Coordinator) onProgressChanged(paneID entity.PaneID, wv port.WebView, progress float64) {
+func (c *Coordinator) onProgressChanged(paneID entity.PaneID, wv port.WebView, identity webViewIdentity, progress float64) {
 	if progress > 0 {
-		c.revealIfPending(context.Background(), paneID, wv, "", "progress")
+		c.revealIfPending(context.Background(), paneID, wv, identity, "", "progress")
 	}
 
 	_, wsView := c.getActiveWS()
@@ -244,11 +244,7 @@ func (c *Coordinator) onProgressChanged(paneID entity.PaneID, wv port.WebView, p
 	}
 }
 
-func (c *Coordinator) markPendingReveal(paneID entity.PaneID, wv port.WebView) {
-	identity, ok := identityForWebView(wv)
-	if !ok {
-		return
-	}
+func (c *Coordinator) markPendingReveal(paneID entity.PaneID, identity webViewIdentity) {
 	c.webViewsMu.RLock()
 	c.revealMu.Lock()
 	defer c.revealMu.Unlock()
@@ -266,11 +262,7 @@ func (c *Coordinator) markPendingReveal(paneID entity.PaneID, wv port.WebView) {
 	c.pendingRevealIdentity[paneID] = identity
 }
 
-func (c *Coordinator) clearPendingReveal(paneID entity.PaneID, wv port.WebView) {
-	identity, ok := identityForWebView(wv)
-	if !ok {
-		return
-	}
+func (c *Coordinator) clearPendingReveal(paneID entity.PaneID, identity webViewIdentity) {
 	c.webViewsMu.RLock()
 	c.revealMu.Lock()
 	defer c.revealMu.Unlock()
@@ -285,19 +277,29 @@ func (c *Coordinator) clearPendingReveal(paneID entity.PaneID, wv port.WebView) 
 // WebViewRevealed reports whether this pane's current WebView has completed a
 // reveal. State is identity-bound so a replacement cannot inherit it.
 func (c *Coordinator) WebViewRevealed(paneID entity.PaneID) bool {
+	return c.webViewRevealed(paneID, nil)
+}
+
+// webViewRevealed verifies the identity being attached when one is supplied.
+// This prevents a rebuild from applying a replacement's reveal state to a
+// previously read pooled WebView.
+func (c *Coordinator) webViewRevealed(paneID entity.PaneID, expected port.WebView) bool {
 	c.webViewsMu.RLock()
 	c.revealMu.Lock()
 	defer c.revealMu.Unlock()
 	defer c.webViewsMu.RUnlock()
-	identity, ok := identityForWebView(c.webViews[paneID])
-	return ok && c.revealedWebViews[paneID] && c.revealedWebViewIdentity[paneID] == identity
+	current := c.webViews[paneID]
+	identity, ok := identityForWebView(current)
+	if !ok || expected != nil {
+		expectedIdentity, expectedOK := identityForWebView(expected)
+		if !expectedOK || expectedIdentity != identity {
+			return false
+		}
+	}
+	return c.revealedWebViews[paneID] && c.revealedWebViewIdentity[paneID] == identity
 }
 
-func (c *Coordinator) markWebViewRevealed(paneID entity.PaneID, wv port.WebView) bool {
-	identity, ok := identityForWebView(wv)
-	if !ok {
-		return false
-	}
+func (c *Coordinator) markWebViewRevealed(paneID entity.PaneID, identity webViewIdentity) bool {
 	c.webViewsMu.RLock()
 	c.revealMu.Lock()
 	defer c.revealMu.Unlock()
@@ -312,22 +314,27 @@ func (c *Coordinator) markWebViewRevealed(paneID entity.PaneID, wv port.WebView)
 	return true
 }
 
-func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID, wv port.WebView, uri, reason string) {
-	identity, ok := identityForWebView(wv)
-	if !ok {
-		return
-	}
+func (c *Coordinator) revealIfPending(
+	ctx context.Context, paneID entity.PaneID, wv port.WebView, identity webViewIdentity, uri, reason string,
+) {
+	// Mapping replacement and release acquire this gate too. No ordinary map
+	// lock is held across the native call, but the gate keeps the validated
+	// identity current until its widget visibility has been changed.
+	c.revealMutationMu.Lock()
+
 	c.webViewsMu.RLock()
 	c.revealMu.Lock()
 	if c.pendingRevealIdentity[paneID] != identity || !c.pendingReveal[paneID] {
 		c.revealMu.Unlock()
 		c.webViewsMu.RUnlock()
+		c.revealMutationMu.Unlock()
 		return
 	}
 	currentIdentity, current := identityForWebView(c.webViews[paneID])
 	if !current || currentIdentity != identity {
 		c.revealMu.Unlock()
 		c.webViewsMu.RUnlock()
+		c.revealMutationMu.Unlock()
 		return
 	}
 	delete(c.pendingReveal, paneID)
@@ -336,11 +343,13 @@ func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID,
 	c.webViewsMu.RUnlock()
 
 	if wv.IsDestroyed() {
+		c.revealMutationMu.Unlock()
 		return
 	}
 
-	// Use NativeWidgetProvider to make the widget visible (engine-agnostic)
-	if nwp, ok := wv.(port.NativeWidgetProvider); ok {
+	if c.setWebViewVisible != nil {
+		c.setWebViewVisible(wv)
+	} else if nwp, ok := wv.(port.NativeWidgetProvider); ok {
 		if ptr := nwp.NativeWidget(); ptr != 0 {
 			gtkWidget := &gtk.Widget{}
 			gtkWidget.Ptr = ptr
@@ -354,10 +363,11 @@ func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID,
 		}
 	}
 
-	// Record presentation state before notifying the UI. The callback may run
-	// while a WorkspaceView is being rebuilt, and the next PaneView must inherit
-	// this state even though the native widget was unparented during cleanup.
-	if c.markWebViewRevealed(paneID, wv) && c.onWebViewShown != nil {
+	// Keep the presentation record in the same serialized operation as the
+	// native mutation. User callbacks run only after the gate is released.
+	revealed := c.markWebViewRevealed(paneID, identity)
+	c.revealMutationMu.Unlock()
+	if revealed && c.onWebViewShown != nil {
 		c.onWebViewShown(paneID)
 	}
 }

--- a/internal/ui/coordinator/content/navigation.go
+++ b/internal/ui/coordinator/content/navigation.go
@@ -69,7 +69,7 @@ func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID,
 		// Avoid updating UI/domain state to about:blank when we know the pane is
 		// navigating to a different URL. This prevents the omnibox/window title from
 		// briefly showing about:blank on cold start.
-		c.clearPendingReveal(paneID)
+		c.clearPendingReveal(paneID, wv)
 		return
 	}
 
@@ -77,8 +77,8 @@ func (c *Coordinator) onLoadCommitted(ctx context.Context, paneID entity.PaneID,
 		c.applyCurrentTheme(ctx, paneID, wv)
 	}
 
-	c.markPendingReveal(paneID)
-	c.revealIfPending(ctx, paneID, uri, "progress-after-commit")
+	c.markPendingReveal(paneID, wv)
+	c.revealIfPending(ctx, paneID, wv, uri, "progress-after-commit")
 
 	// Update domain model with current URI for session snapshots
 	c.updatePaneURI(paneID, uri)
@@ -216,7 +216,7 @@ func (c *Coordinator) onLoadFinished(ctx context.Context, paneID entity.PaneID, 
 		paneView.SetLoading(false)
 	}
 
-	c.revealIfPending(ctx, paneID, "", "load-finished")
+	c.revealIfPending(ctx, paneID, wv, "", "load-finished")
 	if c.shouldSkipAboutBlankAppearance(paneID, wv) {
 		return
 	}
@@ -225,9 +225,9 @@ func (c *Coordinator) onLoadFinished(ctx context.Context, paneID entity.PaneID, 
 }
 
 // onProgressChanged updates the progress bar with current load progress.
-func (c *Coordinator) onProgressChanged(paneID entity.PaneID, progress float64) {
+func (c *Coordinator) onProgressChanged(paneID entity.PaneID, wv port.WebView, progress float64) {
 	if progress > 0 {
-		c.revealIfPending(context.Background(), paneID, "", "progress")
+		c.revealIfPending(context.Background(), paneID, wv, "", "progress")
 	}
 
 	_, wsView := c.getActiveWS()
@@ -244,56 +244,98 @@ func (c *Coordinator) onProgressChanged(paneID entity.PaneID, progress float64) 
 	}
 }
 
-func (c *Coordinator) markPendingReveal(paneID entity.PaneID) {
+func (c *Coordinator) markPendingReveal(paneID entity.PaneID, wv port.WebView) {
+	identity, ok := identityForWebView(wv)
+	if !ok {
+		return
+	}
+	c.webViewsMu.RLock()
 	c.revealMu.Lock()
+	defer c.revealMu.Unlock()
+	defer c.webViewsMu.RUnlock()
+	currentWebView := c.webViews[paneID]
+	if currentWebView == nil {
+		return
+	}
+	currentIdentity, ok := identityForWebView(currentWebView)
+	if !ok || currentIdentity != identity {
+		return
+	}
+	c.ensureRevealMapsLocked()
 	c.pendingReveal[paneID] = true
-	c.revealMu.Unlock()
+	c.pendingRevealIdentity[paneID] = identity
 }
 
-func (c *Coordinator) clearPendingReveal(paneID entity.PaneID) {
+func (c *Coordinator) clearPendingReveal(paneID entity.PaneID, wv port.WebView) {
+	identity, ok := identityForWebView(wv)
+	if !ok {
+		return
+	}
+	c.webViewsMu.RLock()
 	c.revealMu.Lock()
+	defer c.revealMu.Unlock()
+	defer c.webViewsMu.RUnlock()
+	if c.pendingRevealIdentity[paneID] != identity {
+		return
+	}
 	delete(c.pendingReveal, paneID)
-	c.revealMu.Unlock()
+	delete(c.pendingRevealIdentity, paneID)
 }
 
 // WebViewRevealed reports whether this pane's current WebView has completed a
-// reveal. This state belongs to content lifecycle rather than GTK widget
-// ownership, because WorkspaceView rebuilds unparent live native widgets.
+// reveal. State is identity-bound so a replacement cannot inherit it.
 func (c *Coordinator) WebViewRevealed(paneID entity.PaneID) bool {
+	c.webViewsMu.RLock()
 	c.revealMu.Lock()
 	defer c.revealMu.Unlock()
-	return c.revealedWebViews[paneID]
+	defer c.webViewsMu.RUnlock()
+	identity, ok := identityForWebView(c.webViews[paneID])
+	return ok && c.revealedWebViews[paneID] && c.revealedWebViewIdentity[paneID] == identity
 }
 
-func (c *Coordinator) markWebViewRevealed(paneID entity.PaneID) {
-	c.revealMu.Lock()
-	if c.revealedWebViews == nil {
-		c.revealedWebViews = make(map[entity.PaneID]bool)
+func (c *Coordinator) markWebViewRevealed(paneID entity.PaneID, wv port.WebView) bool {
+	identity, ok := identityForWebView(wv)
+	if !ok {
+		return false
 	}
+	c.webViewsMu.RLock()
+	c.revealMu.Lock()
+	defer c.revealMu.Unlock()
+	defer c.webViewsMu.RUnlock()
+	currentIdentity, current := identityForWebView(c.webViews[paneID])
+	if !current || currentIdentity != identity {
+		return false
+	}
+	c.ensureRevealMapsLocked()
 	c.revealedWebViews[paneID] = true
-	c.revealMu.Unlock()
+	c.revealedWebViewIdentity[paneID] = identity
+	return true
 }
 
-func (c *Coordinator) clearWebViewRevealed(paneID entity.PaneID) {
-	c.revealMu.Lock()
-	delete(c.revealedWebViews, paneID)
-	c.revealMu.Unlock()
-}
-
-func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID, uri, reason string) {
-	c.revealMu.Lock()
-	pending := c.pendingReveal[paneID]
-	if pending {
-		delete(c.pendingReveal, paneID)
-	}
-	c.revealMu.Unlock()
-
-	if !pending {
+func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID, wv port.WebView, uri, reason string) {
+	identity, ok := identityForWebView(wv)
+	if !ok {
 		return
 	}
+	c.webViewsMu.RLock()
+	c.revealMu.Lock()
+	if c.pendingRevealIdentity[paneID] != identity || !c.pendingReveal[paneID] {
+		c.revealMu.Unlock()
+		c.webViewsMu.RUnlock()
+		return
+	}
+	currentIdentity, current := identityForWebView(c.webViews[paneID])
+	if !current || currentIdentity != identity {
+		c.revealMu.Unlock()
+		c.webViewsMu.RUnlock()
+		return
+	}
+	delete(c.pendingReveal, paneID)
+	delete(c.pendingRevealIdentity, paneID)
+	c.revealMu.Unlock()
+	c.webViewsMu.RUnlock()
 
-	wv := c.getWebViewLocked(paneID)
-	if wv == nil || wv.IsDestroyed() {
+	if wv.IsDestroyed() {
 		return
 	}
 
@@ -315,8 +357,7 @@ func (c *Coordinator) revealIfPending(ctx context.Context, paneID entity.PaneID,
 	// Record presentation state before notifying the UI. The callback may run
 	// while a WorkspaceView is being rebuilt, and the next PaneView must inherit
 	// this state even though the native widget was unparented during cleanup.
-	c.markWebViewRevealed(paneID)
-	if c.onWebViewShown != nil {
+	if c.markWebViewRevealed(paneID, wv) && c.onWebViewShown != nil {
 		c.onWebViewShown(paneID)
 	}
 }

--- a/internal/ui/coordinator/content/popup_test.go
+++ b/internal/ui/coordinator/content/popup_test.go
@@ -137,7 +137,7 @@ func newPopupCreateCoordinatorForTest(t *testing.T, popupID port.WebViewID) (con
 	parentWV.EXPECT().ID().Return(port.WebViewID(101)).Once()
 
 	popupWV := mocks.NewMockWebView(t)
-	popupWV.EXPECT().ID().Return(popupID).Once()
+	popupWV.EXPECT().ID().Return(popupID).Maybe()
 
 	factory := mocks.NewMockWebViewFactory(t)
 	factory.EXPECT().CreateRelated(mock.Anything, port.WebViewID(101)).Return(popupWV, nil).Once()
@@ -158,8 +158,8 @@ func TestHandlePopupCreate_PrimesPopupNavigationCapability(t *testing.T) {
 	parentWV.EXPECT().ID().Return(port.WebViewID(101)).Once()
 
 	popupWV := &popupNavigationWebViewStub{MockWebView: mocks.NewMockWebView(t)}
-	popupWV.EXPECT().ID().Return(port.WebViewID(149)).Once()
-	popupWV.EXPECT().Generation().Return(uint64(1)).Once()
+	popupWV.EXPECT().ID().Return(port.WebViewID(149)).Maybe()
+	popupWV.EXPECT().Generation().Return(uint64(1)).Maybe()
 	popupWV.EXPECT().SetCallbacks(mock.Anything).Once()
 
 	factory := mocks.NewMockWebViewFactory(t)
@@ -187,7 +187,7 @@ func TestHandlePopupCreate_PrimesPopupNavigationCapability(t *testing.T) {
 
 func TestHandlePopupCreate_RegistersPopupWebViewBeforeWorkspaceInsertion(t *testing.T) {
 	ctx, parentPaneID, parentWV, popupWV, c := newPopupCreateCoordinatorForTest(t, port.WebViewID(150))
-	popupWV.EXPECT().Generation().Return(uint64(1)).Once()
+	popupWV.EXPECT().Generation().Return(uint64(1)).Maybe()
 	popupWV.EXPECT().SetCallbacks(mock.Anything).Once()
 	popupWV.EXPECT().IsLoading().Return(false).Once()
 	popupWV.EXPECT().URI().Return("").Once()
@@ -211,7 +211,7 @@ func TestHandlePopupCreate_RegistersPopupWebViewBeforeWorkspaceInsertion(t *test
 
 func TestHandlePopupCreate_CleansUpPreRegisteredPopupWebViewWhenInsertionFails(t *testing.T) {
 	ctx, parentPaneID, parentWV, popupWV, c := newPopupCreateCoordinatorForTest(t, port.WebViewID(151))
-	popupWV.EXPECT().Generation().Return(uint64(1)).Once()
+	popupWV.EXPECT().Generation().Return(uint64(1)).Maybe()
 	popupWV.EXPECT().SetCallbacks(mock.Anything).Once()
 	popupWV.EXPECT().Destroy().Once()
 
@@ -238,8 +238,8 @@ func TestHandlePopupCreate_UsesRelatedWebViewWhenPopupDisablesJavaScriptAccess(t
 	parentWV.EXPECT().ID().Return(port.WebViewID(101)).Once()
 
 	popupWV := mocks.NewMockWebView(t)
-	popupWV.EXPECT().ID().Return(port.WebViewID(150)).Once()
-	popupWV.EXPECT().Generation().Return(uint64(1)).Once()
+	popupWV.EXPECT().ID().Return(port.WebViewID(150)).Maybe()
+	popupWV.EXPECT().Generation().Return(uint64(1)).Maybe()
 	popupWV.EXPECT().SetCallbacks(mock.Anything).Once()
 	popupWV.EXPECT().IsLoading().Return(false).Once()
 	popupWV.EXPECT().URI().Return("").Once()


### PR DESCRIPTION
## Summary
- preserve explicit WebView reveal state in the content coordinator
- pass reveal state through WorkspaceView/Panes during attachment instead of inferring it from GTK parentage
- add cleanup-then-reattach regression coverage and preserve unrevealed skeleton behavior

## Verification
- `go test -mod=vendor ./internal/ui/component ./internal/ui/coordinator/content -race`
- `go test -mod=vendor ./...`
- `make lint`
- `make test`
- `make check`
- `make build`
- `make staticcheck`
- `go vet ./...`

## Mandatory real-GUI retest (not performed in this PR)
1. Open two loaded WebViews in a stack; switch the active pane and trigger a layout rebuild/split cycle.
2. Repeat with two loaded WebViews in a split and switch the active pane before rebuilding.
3. Confirm each reused, already-revealed CEF view is parented and has no loading skeleton after reattach; confirm a newly-created, unrevealed pane still displays its skeleton until reveal.