### PR TITLE
fix: invalidate stale split ratio callbacks

### DIFF
--- a/internal/ui/layout/split.go
+++ b/internal/ui/layout/split.go
@@ -23,6 +23,7 @@ type SplitView struct {
 	onRatioChanged      func(ratio float64)
 	pendingNotifyRatio  float64
 	notifyDebounceTimer *time.Timer
+	notifyGeneration    uint64
 	tickCallbackID      uint
 	cleanedUp           bool
 
@@ -39,6 +40,9 @@ const maxRetryFrames = 120
 const notifyPositionDebounceDelay = 100 * time.Millisecond
 const notifyPositionSuppressAfterApplyDelay = 50 * time.Millisecond
 const splitAllocationSettledTolerance = 2
+
+// idleAdd is a seam for scheduling work on GLib's main loop.
+var idleAdd = glib.IdleAdd
 
 func childAllocation(widget Widget) (int, int) {
 	if widget == nil {
@@ -153,25 +157,42 @@ func NewSplitView(
 		ratio := clampRatio(float64(position) / float64(totalSize))
 
 		sv.mu.Lock()
+		if sv.cleanedUp {
+			sv.mu.Unlock()
+			return
+		}
 		sv.ratio = ratio
 		sv.pendingNotifyRatio = ratio
-		onRatioChanged := sv.onRatioChanged
+		sv.notifyGeneration++
+		generation := sv.notifyGeneration
 
 		if sv.notifyDebounceTimer != nil {
 			sv.notifyDebounceTimer.Stop()
 		}
 		sv.notifyDebounceTimer = time.AfterFunc(notifyPositionDebounceDelay, func() {
-			if onRatioChanged == nil {
+			sv.mu.RLock()
+			valid := !sv.cleanedUp && generation == sv.notifyGeneration
+			sv.mu.RUnlock()
+			if !valid {
 				return
 			}
+
 			cb := glib.SourceFunc(func(_ uintptr) bool {
 				sv.mu.RLock()
+				if sv.cleanedUp || generation != sv.notifyGeneration {
+					sv.mu.RUnlock()
+					return false
+				}
+				onRatioChanged := sv.onRatioChanged
 				pending := sv.pendingNotifyRatio
 				sv.mu.RUnlock()
-				onRatioChanged(pending)
+
+				if onRatioChanged != nil {
+					onRatioChanged(pending)
+				}
 				return false
 			})
-			glib.IdleAdd(&cb, 0)
+			idleAdd(&cb, 0)
 		})
 
 		sv.mu.Unlock()
@@ -219,18 +240,23 @@ func NewSplitView(
 // tree rebuild and GTK teardown can both reach the same view.
 func (sv *SplitView) Cleanup() {
 	sv.mu.Lock()
-	defer sv.mu.Unlock()
 	if sv.cleanedUp {
+		sv.mu.Unlock()
 		return
 	}
 	sv.cleanedUp = true
+	sv.notifyGeneration++
+	sv.onRatioChanged = nil
 	if sv.notifyDebounceTimer != nil {
 		sv.notifyDebounceTimer.Stop()
 		sv.notifyDebounceTimer = nil
 	}
-	if sv.tickCallbackID != 0 {
-		sv.paned.RemoveTickCallback(sv.tickCallbackID)
-		sv.tickCallbackID = 0
+	tickCallbackID := sv.tickCallbackID
+	sv.tickCallbackID = 0
+	sv.mu.Unlock()
+
+	if tickCallbackID != 0 {
+		sv.paned.RemoveTickCallback(tickCallbackID)
 	}
 }
 

--- a/internal/ui/layout/split.go
+++ b/internal/ui/layout/split.go
@@ -21,7 +21,7 @@ type SplitView struct {
 	logger      zerolog.Logger
 
 	onRatioChanged      func(ratio float64)
-	pendingNotifyRatio  float64
+	idleAdd             func(*glib.SourceFunc, uintptr) uint
 	notifyDebounceTimer *time.Timer
 	notifyGeneration    uint64
 	tickCallbackID      uint
@@ -40,9 +40,6 @@ const maxRetryFrames = 120
 const notifyPositionDebounceDelay = 100 * time.Millisecond
 const notifyPositionSuppressAfterApplyDelay = 50 * time.Millisecond
 const splitAllocationSettledTolerance = 2
-
-// idleAdd is a seam for scheduling work on GLib's main loop.
-var idleAdd = glib.IdleAdd
 
 func childAllocation(widget Widget) (int, int) {
 	if widget == nil {
@@ -115,6 +112,7 @@ func NewSplitView(
 		endChild:    endChild,
 		ratio:       clampRatio(ratio),
 		logger:      log.With().Str("component", "split-view").Logger(),
+		idleAdd:     glib.IdleAdd,
 	}
 
 	// Set children
@@ -162,7 +160,6 @@ func NewSplitView(
 			return
 		}
 		sv.ratio = ratio
-		sv.pendingNotifyRatio = ratio
 		sv.notifyGeneration++
 		generation := sv.notifyGeneration
 
@@ -184,15 +181,14 @@ func NewSplitView(
 					return false
 				}
 				onRatioChanged := sv.onRatioChanged
-				pending := sv.pendingNotifyRatio
 				sv.mu.RUnlock()
 
 				if onRatioChanged != nil {
-					onRatioChanged(pending)
+					onRatioChanged(ratio)
 				}
 				return false
 			})
-			idleAdd(&cb, 0)
+			sv.idleAdd(&cb, 0)
 		})
 
 		sv.mu.Unlock()

--- a/internal/ui/layout/split_notify_cleanup_test.go
+++ b/internal/ui/layout/split_notify_cleanup_test.go
@@ -1,0 +1,105 @@
+package layout
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/puregotk/v4/glib"
+)
+
+// notifyingPaned only implements the SplitView interactions exercised below.
+// Embedding the interface supplies the unused methods.
+type notifyingPaned struct {
+	PanedWidget
+	position int
+	notify   func()
+}
+
+func (p *notifyingPaned) SetResizeStartChild(bool)             {}
+func (p *notifyingPaned) SetResizeEndChild(bool)               {}
+func (p *notifyingPaned) SetVisible(bool)                      {}
+func (p *notifyingPaned) ConnectNotifyPosition(fn func()) uint { p.notify = fn; return 0 }
+func (p *notifyingPaned) GetAllocatedWidth() int               { return 100 }
+func (p *notifyingPaned) GetPosition() int                     { return p.position }
+func (p *notifyingPaned) SetPosition(position int)             { p.position = position }
+
+type notifyingFactory struct {
+	WidgetFactory
+	paned PanedWidget
+}
+
+func (f notifyingFactory) NewPaned(Orientation) PanedWidget { return f.paned }
+
+func newNotifyingSplitView(t *testing.T) (*SplitView, func(int)) {
+	t.Helper()
+
+	paned := &notifyingPaned{}
+	sv := NewSplitView(context.Background(), notifyingFactory{paned: paned}, OrientationHorizontal, nil, nil, 0)
+	sv.mu.Lock()
+	sv.suppressNotifyUntil = time.Time{}
+	sv.mu.Unlock()
+	require.NotNil(t, paned.notify)
+	return sv, func(nextPosition int) {
+		paned.position = nextPosition
+		paned.notify()
+	}
+}
+
+func receiveQueuedIdle(t *testing.T, queued <-chan *glib.SourceFunc) *glib.SourceFunc {
+	t.Helper()
+	select {
+	case source := <-queued:
+		return source
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for debounce to queue idle callback")
+		return nil
+	}
+}
+
+func TestSplitViewQueuedRatioCallbackDoesNotRunAfterCleanup(t *testing.T) {
+	queued := make(chan *glib.SourceFunc, 1)
+	previousIdleAdd := idleAdd
+	idleAdd = func(source *glib.SourceFunc, _ uintptr) uint {
+		queued <- source
+		return 1
+	}
+	t.Cleanup(func() { idleAdd = previousIdleAdd })
+
+	sv, notify := newNotifyingSplitView(t)
+	var calls atomic.Int32
+	sv.SetOnRatioChanged(func(float64) { calls.Add(1) })
+
+	notify(25)
+	source := receiveQueuedIdle(t, queued) // Debounce has fired and queued this work.
+	sv.Cleanup()
+	(*source)(0) // Run the queued GLib closure after cleanup.
+
+	require.Zero(t, calls.Load(), "cleanup must invalidate queued ratio callbacks")
+}
+
+func TestSplitViewSupersededRatioCallbackDeliversOnlyLatestValueOnce(t *testing.T) {
+	queued := make(chan *glib.SourceFunc, 2)
+	previousIdleAdd := idleAdd
+	idleAdd = func(source *glib.SourceFunc, _ uintptr) uint {
+		queued <- source
+		return 1
+	}
+	t.Cleanup(func() { idleAdd = previousIdleAdd })
+
+	sv, notify := newNotifyingSplitView(t)
+	var ratios []float64
+	sv.SetOnRatioChanged(func(ratio float64) { ratios = append(ratios, ratio) })
+
+	notify(20)
+	first := receiveQueuedIdle(t, queued)
+	notify(80)
+	second := receiveQueuedIdle(t, queued)
+	(*first)(0)
+	(*second)(0)
+
+	require.Equal(t, []float64{0.8}, ratios)
+}

--- a/internal/ui/layout/split_notify_cleanup_test.go
+++ b/internal/ui/layout/split_notify_cleanup_test.go
@@ -60,16 +60,17 @@ func receiveQueuedIdle(t *testing.T, queued <-chan *glib.SourceFunc) *glib.Sourc
 	}
 }
 
-func TestSplitViewQueuedRatioCallbackDoesNotRunAfterCleanup(t *testing.T) {
-	queued := make(chan *glib.SourceFunc, 1)
-	previousIdleAdd := idleAdd
-	idleAdd = func(source *glib.SourceFunc, _ uintptr) uint {
+func setIdleScheduler(sv *SplitView, queued chan<- *glib.SourceFunc) {
+	sv.idleAdd = func(source *glib.SourceFunc, _ uintptr) uint {
 		queued <- source
 		return 1
 	}
-	t.Cleanup(func() { idleAdd = previousIdleAdd })
+}
 
+func TestSplitViewQueuedRatioCallbackDoesNotRunAfterCleanup(t *testing.T) {
+	queued := make(chan *glib.SourceFunc, 1)
 	sv, notify := newNotifyingSplitView(t)
+	setIdleScheduler(sv, queued)
 	var calls atomic.Int32
 	sv.SetOnRatioChanged(func(float64) { calls.Add(1) })
 
@@ -83,14 +84,8 @@ func TestSplitViewQueuedRatioCallbackDoesNotRunAfterCleanup(t *testing.T) {
 
 func TestSplitViewSupersededRatioCallbackDeliversOnlyLatestValueOnce(t *testing.T) {
 	queued := make(chan *glib.SourceFunc, 2)
-	previousIdleAdd := idleAdd
-	idleAdd = func(source *glib.SourceFunc, _ uintptr) uint {
-		queued <- source
-		return 1
-	}
-	t.Cleanup(func() { idleAdd = previousIdleAdd })
-
 	sv, notify := newNotifyingSplitView(t)
+	setIdleScheduler(sv, queued)
 	var ratios []float64
 	sv.SetOnRatioChanged(func(ratio float64) { ratios = append(ratios, ratio) })
 
@@ -102,4 +97,27 @@ func TestSplitViewSupersededRatioCallbackDeliversOnlyLatestValueOnce(t *testing.
 	(*second)(0)
 
 	require.Equal(t, []float64{0.8}, ratios)
+}
+
+func TestSplitViewIdleSchedulersAreInstanceScoped(t *testing.T) {
+	firstQueued := make(chan *glib.SourceFunc, 1)
+	secondQueued := make(chan *glib.SourceFunc, 1)
+	first, firstNotify := newNotifyingSplitView(t)
+	second, secondNotify := newNotifyingSplitView(t)
+	setIdleScheduler(first, firstQueued)
+	setIdleScheduler(second, secondQueued)
+
+	firstNotify(20)
+	secondNotify(80)
+
+	firstSource := receiveQueuedIdle(t, firstQueued)
+	secondSource := receiveQueuedIdle(t, secondQueued)
+	var firstCalls, secondCalls atomic.Int32
+	first.SetOnRatioChanged(func(float64) { firstCalls.Add(1) })
+	second.SetOnRatioChanged(func(float64) { secondCalls.Add(1) })
+	(*firstSource)(0)
+	(*secondSource)(0)
+
+	require.Equal(t, int32(1), firstCalls.Load())
+	require.Equal(t, int32(1), secondCalls.Load())
 }


### PR DESCRIPTION
## Summary
- invalidate queued split ratio idle work by debounce generation and cleanup state
- clear the ratio callback during idempotent cleanup and release GTK tick callbacks outside the state lock
- add deterministic coverage for queued-after-cleanup work and superseded delivery

## Validation
- /usr/bin/go test ./internal/ui/layout -run `TestSplitView(QueuedRatioCallbackDoesNotRunAfterCleanup|SupersededRatioCallbackDeliversOnlyLatestValueOnce)` -count=1
- /usr/bin/go test -race ./internal/ui/layout -count=10
- make lint
- make test
- make staticcheck
- go vet ./...
- make build
- make check