### PR TITLE
chore(cef): adopt reliable OSR input stack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/a-h/templ v0.3.1020
 	github.com/andybalholm/brotli v1.2.2
 	github.com/bnema/purego v0.11.0-bnema.4
-	github.com/bnema/purego-cef v0.14.1
-	github.com/bnema/purego-cef2gtk v0.8.5
+	github.com/bnema/purego-cef v0.14.2
+	github.com/bnema/purego-cef2gtk v0.9.0
 	github.com/bnema/purego-pipewire v0.1.5
 	github.com/bnema/purego-sqlite v0.1.4
 	github.com/bnema/purego-webp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -12,10 +12,10 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3kRprbs=
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
-github.com/bnema/purego-cef v0.14.1 h1:ZAlrGfFyk3Eel0Gct+ipzJnnNfpXfDX8NuoZfRKAKco=
-github.com/bnema/purego-cef v0.14.1/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.8.5 h1:Qwt9DkvCVBNN52dp1jikFU5B2Sg3dB16ayi/T4+2Bhg=
-github.com/bnema/purego-cef2gtk v0.8.5/go.mod h1:w/5Bjkm+ZaZbDIDS+ysC5qTBcpb8/WOeGDva8i39ocM=
+github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
+github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
+github.com/bnema/purego-cef2gtk v0.9.0 h1:i1jdYIHFO6y6eAhzQ4Djy1t9z1GyH5ZrgR18f6C92Gc=
+github.com/bnema/purego-cef2gtk v0.9.0/go.mod h1:EqgpNih2djBXD9j7R5gs+gZcdQxzSgkYF3rf7eC+5zo=
 github.com/bnema/purego-pipewire v0.1.5 h1:wQQF2uHt/kVV3qOkdSE1CV0noQYkHS2+v9MXkgdjxEw=
 github.com/bnema/purego-pipewire v0.1.5/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.4 h1:h2DCsYT1/Ps13Ua4knUNQmT5Xgj6eRx+DrywNcnFNEU=

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -118,6 +118,9 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
+	const upstreamVersion = "v0.8.5-0.20300102030405-bbd397409ebe"
+	const upstreamRevision = "bbd397409ebed75a5979c1e4566a2ef319f6a484"
+	goBin := collectorProvenanceGo(t, temp, upstreamVersion, upstreamRevision, "")
 	output := filepath.Join(temp, "artifacts")
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -129,6 +132,7 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"DUMBER_MACHINE_GPU_PROFILE=integrated-gpu",
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 	)
 	result, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "collector failed: %s", result)
@@ -144,9 +148,9 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 	}
 	for _, required := range []string{
 		`"measured_source_revision"`,
-		`"version": "v0.8.5"`,
+		`"version": "` + upstreamVersion + `"`,
 		`"tag": "v0.8.5"`,
-		`"revision": "b9fb46ef5c04ca0993943c5ca4b6f0fe83583304"`,
+		`"revision": "` + upstreamRevision + `"`,
 	} {
 		require.Contains(t, artifacts.String(), required)
 	}


### PR DESCRIPTION
## Summary

- update `purego-cef` to v0.14.2 for generated FFI pointer liveness and RefPtr transfer ownership
- update `purego-cef2gtk` to v0.9.0 for reliable OSR pointer handling and complete native GTK4/Wayland drag-and-drop
- make first-presentation collector provenance assertions deterministic by supplying controlled upstream module metadata

## Validation

- `go mod tidy -diff`
- `go mod verify`
- `go test -race ./... -count=1`
- `make check`
- `staticcheck ./...`
- `make build`
- binary module metadata confirms `purego-cef v0.14.2` and `purego-cef2gtk v0.9.0`
- manual Wayland/Vulkan validation for pointer reliability and inbound/outbound drag-and-drop

## Rollout

This PR targets `next` for an extended manual soak before promotion to `main`.
