### PR TITLE
chore(deps): bump purego-cef2gtk to v0.9.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.9.0
+	github.com/bnema/purego-cef2gtk v0.9.1
 	github.com/bnema/purego-pipewire v0.1.5
 	github.com/bnema/purego-sqlite v0.1.4
 	github.com/bnema/purego-webp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.9.0 h1:i1jdYIHFO6y6eAhzQ4Djy1t9z1GyH5ZrgR18f6C92Gc=
-github.com/bnema/purego-cef2gtk v0.9.0/go.mod h1:EqgpNih2djBXD9j7R5gs+gZcdQxzSgkYF3rf7eC+5zo=
+github.com/bnema/purego-cef2gtk v0.9.1 h1:Th7nIL1AGr369ejOOX82ltBGZ9v3JnJDs0ubUrA94J8=
+github.com/bnema/purego-cef2gtk v0.9.1/go.mod h1:EqgpNih2djBXD9j7R5gs+gZcdQxzSgkYF3rf7eC+5zo=
 github.com/bnema/purego-pipewire v0.1.5 h1:wQQF2uHt/kVV3qOkdSE1CV0noQYkHS2+v9MXkgdjxEw=
 github.com/bnema/purego-pipewire v0.1.5/go.mod h1:dn9RGRtNteqIarb8gTv97VD/FQgur7ZJ1BE/Ub9NYSk=
 github.com/bnema/purego-sqlite v0.1.4 h1:h2DCsYT1/Ps13Ua4knUNQmT5Xgj6eRx+DrywNcnFNEU=


### PR DESCRIPTION
## Summary

- remove the local `purego-cef2gtk` replace used for testing
- use the released `github.com/bnema/purego-cef2gtk v0.9.1` module
- refresh `go.sum` checksums

Tests: `go test ./...`

@coderabbitai ignore