### PR TITLE
fix(deps): update cef2gtk clipboard integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.9.1
+	github.com/bnema/purego-cef2gtk v0.9.2
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.9.1 h1:Th7nIL1AGr369ejOOX82ltBGZ9v3JnJDs0ubUrA94J8=
-github.com/bnema/purego-cef2gtk v0.9.1/go.mod h1:EqgpNih2djBXD9j7R5gs+gZcdQxzSgkYF3rf7eC+5zo=
+github.com/bnema/purego-cef2gtk v0.9.2 h1:ImRFMhB47YIuIz6uCysbMdnXfQh5CjMIDpwz0+OBjfU=
+github.com/bnema/purego-cef2gtk v0.9.2/go.mod h1:EqgpNih2djBXD9j7R5gs+gZcdQxzSgkYF3rf7eC+5zo=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=


### PR DESCRIPTION
## Summary

- update `purego-cef2gtk` from v0.9.1 to v0.9.2
- restore GTK clipboard paste in CEF OSR
- synchronize pasted values with controlled forms, including password inputs

## Verification

- tested password-field paste and immediate form submission locally
- `go test ./internal/infrastructure/cef -run 'TestWebView|TestInput|TestClipboard|TestContentInjector' -count=1`\n- `make build-quick`\n\n@coderabbitai ignore