### PR TITLE
feat(workspace): route external links by configuration

### DIFF
--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -298,7 +298,7 @@ func runGUI(cfg *config.Config, timing startupTiming) int {
 	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
 		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
 			if err := app.OpenExternalURL(ctx, url); err != nil {
-				log.Warn().Err(err).Str("url", url).Msg("failed to open relaunch browser window")
+				log.Warn().Err(err).Str("url", url).Msg("failed to open relaunch external URL")
 			}
 		})
 	}

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -100,7 +100,7 @@ func tryForwardBrowseURLToRunningInstance(ctx context.Context, relay port.Browse
 		return false, nil
 	}
 
-	delivered, err := relay.DeliverOpenFreshWindow(ctx, browseURL)
+	delivered, err := relay.DeliverOpenExternalURL(ctx, browseURL)
 	if err != nil {
 		if delivered && errors.Is(err, desktop.ErrBrowserLaunchRelayUnconfirmed) {
 			return true, nil
@@ -297,7 +297,7 @@ func runGUI(cfg *config.Config, timing startupTiming) int {
 	}
 	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
 		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
-			if err := app.OpenFreshWindow(ctx, url); err != nil {
+			if err := app.OpenExternalURL(ctx, url); err != nil {
 				log.Warn().Err(err).Str("url", url).Msg("failed to open relaunch browser window")
 			}
 		})

--- a/cmd/dumber/main_test.go
+++ b/cmd/dumber/main_test.go
@@ -230,7 +230,7 @@ func TestPreInitializeAdwaitaForCEF_SkipsNonCEF(t *testing.T) {
 
 func TestTryForwardBrowseURLToRunningInstance_ForwardsDefaultStartupURL(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "dumb://history").Return(true, nil)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "dumb://history").Return(true, nil)
 
 	forwarded, err := tryForwardBrowseURLToRunningInstance(context.Background(), relay, "dumb://history")
 
@@ -244,7 +244,7 @@ func TestTryForwardBrowseURLToRunningInstance_ForwardsDefaultStartupURL(t *testi
 
 func TestTryForwardBrowseURLToRunningInstance_ReturnsTrueOnRelayHit(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, nil)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(true, nil)
 
 	forwarded, err := tryForwardBrowseURLToRunningInstance(context.Background(), relay, "https://example.com")
 
@@ -258,7 +258,7 @@ func TestTryForwardBrowseURLToRunningInstance_ReturnsTrueOnRelayHit(t *testing.T
 
 func TestTryForwardBrowseURLToRunningInstance_ReturnsFalseOnRelayMiss(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(false, nil)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(false, nil)
 
 	forwarded, err := tryForwardBrowseURLToRunningInstance(context.Background(), relay, "https://example.com")
 
@@ -272,7 +272,7 @@ func TestTryForwardBrowseURLToRunningInstance_ReturnsFalseOnRelayMiss(t *testing
 
 func TestTryForwardBrowseURLToRunningInstance_ReturnsTrueOnUnconfirmedRelayDelivery(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, desktop.ErrBrowserLaunchRelayUnconfirmed)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(true, desktop.ErrBrowserLaunchRelayUnconfirmed)
 
 	forwarded, err := tryForwardBrowseURLToRunningInstance(context.Background(), relay, "https://example.com")
 
@@ -309,7 +309,7 @@ func TestLaunchStandaloneBrowserURL_PropagatesOtherErrors(t *testing.T) {
 func TestTryForwardBrowseURLToRunningInstance_PropagatesError(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
 	wantErr := errors.New("relay error")
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(false, wantErr)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(false, wantErr)
 
 	forwarded, err := tryForwardBrowseURLToRunningInstance(context.Background(), relay, "https://example.com")
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -114,6 +114,8 @@
 | `workspace.floating_pane.profiles.<name>.keys` | []string | | at least one key |
 | `workspace.floating_pane.profiles.<name>.url` | string | | required URL |
 | `workspace.floating_pane.profiles.<name>.desc` | string | | |
+| `workspace.external_links.behavior` | string | `windowed` | `windowed`, `tabbed`, `split`, `stacked` |
+| `workspace.external_links.placement` | string | `right` | `right`, `left`, `top`, `bottom` (used only with `split`) |
 | `workspace.browsing_contexts.behavior` | string | `split` | `split`, `stacked`, `tabbed`, `windowed` |
 | `workspace.browsing_contexts.placement` | string | `right` | `right`, `left`, `top`, `bottom` |
 | `workspace.browsing_contexts.open_in_new_pane` | bool | `true` | |
@@ -121,6 +123,9 @@
 | `workspace.browsing_contexts.blank_target_behavior` | string | `stacked` | `split`, `stacked`, `tabbed` |
 | `workspace.browsing_contexts.enable_smart_detection` | bool | `true` | |
 | `workspace.browsing_contexts.oauth_auto_close` | bool | `true` | |
+
+`workspace.external_links` controls URLs opened from another application. Non-`windowed` modes target the last-focused window in the current Dumber profile and engine; if that destination is unavailable, Dumber falls back to opening a new window. `placement` applies only to `split`.
+
 | `workspace.styling.border_width` | int | `1` | |
 | `workspace.styling.border_color` | string | `@theme_selected_bg_color` | |
 | `workspace.styling.mode_border_width` | int | `4` | |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,5 +1,7 @@
 # Configuration Reference
 
+`workspace.external_links` controls URLs opened from another application. Non-`windowed` modes target the last-focused window in the current Dumber profile and engine; if that destination is unavailable, Dumber falls back to opening a new window. `placement` applies only to `split`.
+
 | Key | Type | Default | Valid Values |
 |-----|------|---------|--------------|
 | `database.path` | string | `~/.local/share/dumber/dumber.db` | |
@@ -123,9 +125,6 @@
 | `workspace.browsing_contexts.blank_target_behavior` | string | `stacked` | `split`, `stacked`, `tabbed` |
 | `workspace.browsing_contexts.enable_smart_detection` | bool | `true` | |
 | `workspace.browsing_contexts.oauth_auto_close` | bool | `true` | |
-
-`workspace.external_links` controls URLs opened from another application. Non-`windowed` modes target the last-focused window in the current Dumber profile and engine; if that destination is unavailable, Dumber falls back to opening a new window. `placement` applies only to `split`.
-
 | `workspace.styling.border_width` | int | `1` | |
 | `workspace.styling.border_color` | string | `@theme_selected_bg_color` | |
 | `workspace.styling.mode_border_width` | int | `4` | |

--- a/internal/application/port/browser_launch.go
+++ b/internal/application/port/browser_launch.go
@@ -5,19 +5,19 @@ import (
 	"io"
 )
 
-// BrowserWindowOpener opens a fresh browser window.
+// BrowserWindowOpener opens an external URL.
 type BrowserWindowOpener interface {
-	OpenFreshWindow(ctx context.Context, url string) error
+	OpenExternalURL(ctx context.Context, url string) error
 }
 
-// BrowserLaunchRelay delivers fresh-window launch requests.
+// BrowserLaunchRelay delivers external URL launch requests.
 type BrowserLaunchRelay interface {
-	// DeliverOpenFreshWindow attempts to deliver a request to open a fresh window.
+	// DeliverOpenExternalURL attempts to deliver a request to open an external URL.
 	// The bool reports whether the relay accepted the request; false means the
 	// caller should treat it as undelivered and try another path.
 	// An error may still be returned with delivered=true when the relay accepted
 	// the request but could not confirm completion before the caller timed out.
-	DeliverOpenFreshWindow(ctx context.Context, url string) (bool, error)
+	DeliverOpenExternalURL(ctx context.Context, url string) (bool, error)
 	Listen(ctx context.Context, opener BrowserWindowOpener) (io.Closer, error)
 }
 

--- a/internal/application/port/mocks/browser_launch.go
+++ b/internal/application/port/mocks/browser_launch.go
@@ -39,12 +39,12 @@ func (_m *MockBrowserWindowOpener) EXPECT() *MockBrowserWindowOpener_Expecter {
 	return &MockBrowserWindowOpener_Expecter{mock: &_m.Mock}
 }
 
-// OpenFreshWindow provides a mock function for the type MockBrowserWindowOpener
-func (_mock *MockBrowserWindowOpener) OpenFreshWindow(ctx context.Context, url string) error {
+// OpenExternalURL provides a mock function for the type MockBrowserWindowOpener
+func (_mock *MockBrowserWindowOpener) OpenExternalURL(ctx context.Context, url string) error {
 	ret := _mock.Called(ctx, url)
 
 	if len(ret) == 0 {
-		panic("no return value specified for OpenFreshWindow")
+		panic("no return value specified for OpenExternalURL")
 	}
 
 	var r0 error
@@ -56,19 +56,19 @@ func (_mock *MockBrowserWindowOpener) OpenFreshWindow(ctx context.Context, url s
 	return r0
 }
 
-// MockBrowserWindowOpener_OpenFreshWindow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OpenFreshWindow'
-type MockBrowserWindowOpener_OpenFreshWindow_Call struct {
+// MockBrowserWindowOpener_OpenExternalURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OpenExternalURL'
+type MockBrowserWindowOpener_OpenExternalURL_Call struct {
 	*mock.Call
 }
 
-// OpenFreshWindow is a helper method to define mock.On call
+// OpenExternalURL is a helper method to define mock.On call
 //   - ctx context.Context
 //   - url string
-func (_e *MockBrowserWindowOpener_Expecter) OpenFreshWindow(ctx any, url any) *MockBrowserWindowOpener_OpenFreshWindow_Call {
-	return &MockBrowserWindowOpener_OpenFreshWindow_Call{Call: _e.mock.On("OpenFreshWindow", ctx, url)}
+func (_e *MockBrowserWindowOpener_Expecter) OpenExternalURL(ctx any, url any) *MockBrowserWindowOpener_OpenExternalURL_Call {
+	return &MockBrowserWindowOpener_OpenExternalURL_Call{Call: _e.mock.On("OpenExternalURL", ctx, url)}
 }
 
-func (_c *MockBrowserWindowOpener_OpenFreshWindow_Call) Run(run func(ctx context.Context, url string)) *MockBrowserWindowOpener_OpenFreshWindow_Call {
+func (_c *MockBrowserWindowOpener_OpenExternalURL_Call) Run(run func(ctx context.Context, url string)) *MockBrowserWindowOpener_OpenExternalURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -86,12 +86,12 @@ func (_c *MockBrowserWindowOpener_OpenFreshWindow_Call) Run(run func(ctx context
 	return _c
 }
 
-func (_c *MockBrowserWindowOpener_OpenFreshWindow_Call) Return(err error) *MockBrowserWindowOpener_OpenFreshWindow_Call {
+func (_c *MockBrowserWindowOpener_OpenExternalURL_Call) Return(err error) *MockBrowserWindowOpener_OpenExternalURL_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockBrowserWindowOpener_OpenFreshWindow_Call) RunAndReturn(run func(ctx context.Context, url string) error) *MockBrowserWindowOpener_OpenFreshWindow_Call {
+func (_c *MockBrowserWindowOpener_OpenExternalURL_Call) RunAndReturn(run func(ctx context.Context, url string) error) *MockBrowserWindowOpener_OpenExternalURL_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -123,12 +123,12 @@ func (_m *MockBrowserLaunchRelay) EXPECT() *MockBrowserLaunchRelay_Expecter {
 	return &MockBrowserLaunchRelay_Expecter{mock: &_m.Mock}
 }
 
-// DeliverOpenFreshWindow provides a mock function for the type MockBrowserLaunchRelay
-func (_mock *MockBrowserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url string) (bool, error) {
+// DeliverOpenExternalURL provides a mock function for the type MockBrowserLaunchRelay
+func (_mock *MockBrowserLaunchRelay) DeliverOpenExternalURL(ctx context.Context, url string) (bool, error) {
 	ret := _mock.Called(ctx, url)
 
 	if len(ret) == 0 {
-		panic("no return value specified for DeliverOpenFreshWindow")
+		panic("no return value specified for DeliverOpenExternalURL")
 	}
 
 	var r0 bool
@@ -149,19 +149,19 @@ func (_mock *MockBrowserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context,
 	return r0, r1
 }
 
-// MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeliverOpenFreshWindow'
-type MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call struct {
+// MockBrowserLaunchRelay_DeliverOpenExternalURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeliverOpenExternalURL'
+type MockBrowserLaunchRelay_DeliverOpenExternalURL_Call struct {
 	*mock.Call
 }
 
-// DeliverOpenFreshWindow is a helper method to define mock.On call
+// DeliverOpenExternalURL is a helper method to define mock.On call
 //   - ctx context.Context
 //   - url string
-func (_e *MockBrowserLaunchRelay_Expecter) DeliverOpenFreshWindow(ctx any, url any) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
-	return &MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call{Call: _e.mock.On("DeliverOpenFreshWindow", ctx, url)}
+func (_e *MockBrowserLaunchRelay_Expecter) DeliverOpenExternalURL(ctx any, url any) *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call {
+	return &MockBrowserLaunchRelay_DeliverOpenExternalURL_Call{Call: _e.mock.On("DeliverOpenExternalURL", ctx, url)}
 }
 
-func (_c *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call) Run(run func(ctx context.Context, url string)) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
+func (_c *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call) Run(run func(ctx context.Context, url string)) *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -179,12 +179,12 @@ func (_c *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call) Run(run func(ctx c
 	return _c
 }
 
-func (_c *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call) Return(b bool, err error) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
+func (_c *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call) Return(b bool, err error) *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call {
 	_c.Call.Return(b, err)
 	return _c
 }
 
-func (_c *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call) RunAndReturn(run func(ctx context.Context, url string) (bool, error)) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
+func (_c *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call) RunAndReturn(run func(ctx context.Context, url string) (bool, error)) *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/entity/config_types.go
+++ b/internal/domain/entity/config_types.go
@@ -209,15 +209,42 @@ type BrowsingContextConfig struct {
 // Deprecated: PopupBehaviorConfig is a compatibility alias for BrowsingContextConfig.
 type PopupBehaviorConfig = BrowsingContextConfig
 
+// ExternalLinkBehavior defines how externally opened URLs are placed in the workspace.
+type ExternalLinkBehavior string
+
+const (
+	ExternalLinkBehaviorWindowed ExternalLinkBehavior = "windowed"
+	ExternalLinkBehaviorTabbed   ExternalLinkBehavior = "tabbed"
+	ExternalLinkBehaviorSplit    ExternalLinkBehavior = "split"
+	ExternalLinkBehaviorStacked  ExternalLinkBehavior = "stacked"
+)
+
+// ExternalLinkPlacement defines the direction used when splitting for an external URL.
+type ExternalLinkPlacement string
+
+const (
+	ExternalLinkPlacementRight  ExternalLinkPlacement = "right"
+	ExternalLinkPlacementLeft   ExternalLinkPlacement = "left"
+	ExternalLinkPlacementTop    ExternalLinkPlacement = "top"
+	ExternalLinkPlacementBottom ExternalLinkPlacement = "bottom"
+)
+
+// ExternalLinksConfig controls how externally opened URLs are placed in the workspace.
+type ExternalLinksConfig struct {
+	Behavior  ExternalLinkBehavior  `mapstructure:"behavior" yaml:"behavior" toml:"behavior" json:"behavior"`
+	Placement ExternalLinkPlacement `mapstructure:"placement" yaml:"placement" toml:"placement" json:"placement"`
+}
+
 // WorkspaceConfig holds all workspace layout and behavior settings.
 type WorkspaceConfig struct {
-	NewPaneURL   string                `mapstructure:"new_pane_url" yaml:"new_pane_url" toml:"new_pane_url" json:"new_pane_url"`
-	PaneMode     PaneModeConfig        `mapstructure:"pane_mode" yaml:"pane_mode" toml:"pane_mode" json:"pane_mode"`
-	TabMode      TabModeConfig         `mapstructure:"tab_mode" yaml:"tab_mode" toml:"tab_mode" json:"tab_mode"`
-	PageMode     PageModeConfig        `mapstructure:"page_mode" yaml:"page_mode" toml:"page_mode" json:"page_mode"`
-	ResizeMode   ResizeModeConfig      `mapstructure:"resize_mode" yaml:"resize_mode" toml:"resize_mode" json:"resize_mode"`
-	Shortcuts    GlobalShortcutsConfig `mapstructure:"shortcuts" yaml:"shortcuts" toml:"shortcuts" json:"shortcuts"`
-	FloatingPane FloatingPaneConfig    `mapstructure:"floating_pane" yaml:"floating_pane" toml:"floating_pane" json:"floating_pane"`
+	NewPaneURL    string                `mapstructure:"new_pane_url" yaml:"new_pane_url" toml:"new_pane_url" json:"new_pane_url"`
+	PaneMode      PaneModeConfig        `mapstructure:"pane_mode" yaml:"pane_mode" toml:"pane_mode" json:"pane_mode"`
+	TabMode       TabModeConfig         `mapstructure:"tab_mode" yaml:"tab_mode" toml:"tab_mode" json:"tab_mode"`
+	PageMode      PageModeConfig        `mapstructure:"page_mode" yaml:"page_mode" toml:"page_mode" json:"page_mode"`
+	ResizeMode    ResizeModeConfig      `mapstructure:"resize_mode" yaml:"resize_mode" toml:"resize_mode" json:"resize_mode"`
+	Shortcuts     GlobalShortcutsConfig `mapstructure:"shortcuts" yaml:"shortcuts" toml:"shortcuts" json:"shortcuts"`
+	FloatingPane  FloatingPaneConfig    `mapstructure:"floating_pane" yaml:"floating_pane" toml:"floating_pane" json:"floating_pane"`
+	ExternalLinks ExternalLinksConfig   `mapstructure:"external_links" yaml:"external_links" toml:"external_links" json:"external_links"`
 
 	TabBarPosition          string `mapstructure:"tab_bar_position" yaml:"tab_bar_position" toml:"tab_bar_position" json:"tab_bar_position"`
 	HideTabBarWhenSingleTab bool   `mapstructure:"hide_tab_bar_when_single_tab" yaml:"hide_tab_bar_when_single_tab" toml:"hide_tab_bar_when_single_tab" json:"hide_tab_bar_when_single_tab"` //nolint:lll // struct tags must stay on one line

--- a/internal/infrastructure/config/defaults.go
+++ b/internal/infrastructure/config/defaults.go
@@ -50,6 +50,8 @@ const (
 	defaultResizeMinPanePercent      = 10.0
 	defaultTabBarPosition            = "bottom"
 	defaultPopupPlacement            = "right"
+	defaultExternalLinkBehavior      = ExternalLinkBehaviorWindowed
+	defaultExternalLinkPlacement     = ExternalLinkPlacementRight
 	defaultFloatingPaneWidthPct      = 0.82
 	defaultFloatingPaneHeightPct     = 0.72
 
@@ -356,6 +358,10 @@ func DefaultConfig() *Config {
 				WidthPct:  defaultFloatingPaneWidthPct,
 				HeightPct: defaultFloatingPaneHeightPct,
 				Profiles:  map[string]FloatingPaneProfile{},
+			},
+			ExternalLinks: ExternalLinksConfig{
+				Behavior:  defaultExternalLinkBehavior,
+				Placement: defaultExternalLinkPlacement,
 			},
 			TabBarPosition:          defaultTabBarPosition,
 			HideTabBarWhenSingleTab: true,

--- a/internal/infrastructure/config/defaults_test.go
+++ b/internal/infrastructure/config/defaults_test.go
@@ -13,6 +13,8 @@ func TestDefaultConfig_CoreDefaults(t *testing.T) {
 	assert.Equal(t, defaultMaxLogFiles, cfg.Logging.MaxFiles)
 	assert.False(t, cfg.Logging.CaptureGTKLogs)
 	assert.False(t, cfg.Media.ShowDiagnosticsOnStartup)
+	assert.Equal(t, ExternalLinkBehaviorWindowed, cfg.Workspace.ExternalLinks.Behavior)
+	assert.Equal(t, ExternalLinkPlacementRight, cfg.Workspace.ExternalLinks.Placement)
 
 	// Engine defaults (replaces old Performance/Privacy sections)
 	assert.Equal(t, EngineTypeCEF, cfg.Engine.Type)

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -374,6 +374,7 @@ func ensureDatabasePath(config *Config) error {
 }
 
 func normalizeConfig(config *Config) {
+	normalizeExternalLinks(config)
 	normalizeAppearance(config)
 	normalizeMedia(config)
 	normalizeEngineConfig(config)
@@ -384,6 +385,20 @@ func normalizeConfig(config *Config) {
 // for runtime compatibility. Existing code can keep reading config.Workspace.Popups.
 func normalizeBrowsingContexts(config *Config) {
 	config.Workspace.Popups = config.Workspace.BrowsingContexts
+}
+
+func normalizeExternalLinks(config *Config) {
+	switch config.Workspace.ExternalLinks.Behavior {
+	case ExternalLinkBehaviorWindowed, ExternalLinkBehaviorTabbed, ExternalLinkBehaviorSplit, ExternalLinkBehaviorStacked:
+	default:
+		config.Workspace.ExternalLinks.Behavior = defaultExternalLinkBehavior
+	}
+
+	switch config.Workspace.ExternalLinks.Placement {
+	case ExternalLinkPlacementRight, ExternalLinkPlacementLeft, ExternalLinkPlacementTop, ExternalLinkPlacementBottom:
+	default:
+		config.Workspace.ExternalLinks.Placement = defaultExternalLinkPlacement
+	}
 }
 
 func normalizeEngineConfig(config *Config) {
@@ -703,6 +718,8 @@ func (m *Manager) setWorkspaceDefaults(defaults *Config) {
 	m.viper.SetDefault("workspace.floating_pane.width_pct", defaults.Workspace.FloatingPane.WidthPct)
 	m.viper.SetDefault("workspace.floating_pane.height_pct", defaults.Workspace.FloatingPane.HeightPct)
 	m.viper.SetDefault("workspace.floating_pane.profiles", defaults.Workspace.FloatingPane.Profiles)
+	m.viper.SetDefault("workspace.external_links.behavior", string(defaults.Workspace.ExternalLinks.Behavior))
+	m.viper.SetDefault("workspace.external_links.placement", string(defaults.Workspace.ExternalLinks.Placement))
 	m.viper.SetDefault("workspace.tab_bar_position", defaults.Workspace.TabBarPosition)
 	m.viper.SetDefault("workspace.hide_tab_bar_when_single_tab", defaults.Workspace.HideTabBarWhenSingleTab)
 	m.viper.SetDefault("workspace.switch_to_tab_on_move", defaults.Workspace.SwitchToTabOnMove)

--- a/internal/infrastructure/config/loader_test.go
+++ b/internal/infrastructure/config/loader_test.go
@@ -39,6 +39,17 @@ func TestSetEngineDefaults(t *testing.T) {
 	assert.Empty(t, mgr.viper.GetString("runtime.prefix"))
 }
 
+func TestNormalizeExternalLinks(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Workspace.ExternalLinks.Behavior = "invalid"
+	cfg.Workspace.ExternalLinks.Placement = "invalid"
+
+	normalizeConfig(cfg)
+
+	assert.Equal(t, ExternalLinkBehaviorWindowed, cfg.Workspace.ExternalLinks.Behavior)
+	assert.Equal(t, ExternalLinkPlacementRight, cfg.Workspace.ExternalLinks.Placement)
+}
+
 func TestNormalizeConfig_EngineCookiePolicy(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Engine.CookiePolicy = CookiePolicy("INVALID")

--- a/internal/infrastructure/config/schema.go
+++ b/internal/infrastructure/config/schema.go
@@ -45,6 +45,29 @@ type FloatingPaneConfig = entity.FloatingPaneConfig
 // WorkspaceStylingConfig defines visual styling for workspace panes.
 type WorkspaceStylingConfig = entity.WorkspaceStylingConfig
 
+// ExternalLinkBehavior defines how externally opened URLs are placed in the workspace.
+type ExternalLinkBehavior = entity.ExternalLinkBehavior
+
+const (
+	ExternalLinkBehaviorWindowed = entity.ExternalLinkBehaviorWindowed
+	ExternalLinkBehaviorTabbed   = entity.ExternalLinkBehaviorTabbed
+	ExternalLinkBehaviorSplit    = entity.ExternalLinkBehaviorSplit
+	ExternalLinkBehaviorStacked  = entity.ExternalLinkBehaviorStacked
+)
+
+// ExternalLinkPlacement defines the direction used when splitting for an external URL.
+type ExternalLinkPlacement = entity.ExternalLinkPlacement
+
+const (
+	ExternalLinkPlacementRight  = entity.ExternalLinkPlacementRight
+	ExternalLinkPlacementLeft   = entity.ExternalLinkPlacementLeft
+	ExternalLinkPlacementTop    = entity.ExternalLinkPlacementTop
+	ExternalLinkPlacementBottom = entity.ExternalLinkPlacementBottom
+)
+
+// ExternalLinksConfig controls how externally opened URLs are placed in the workspace.
+type ExternalLinksConfig = entity.ExternalLinksConfig
+
 // PopupBehavior defines how popup windows should be opened.
 type PopupBehavior = entity.PopupBehavior
 

--- a/internal/infrastructure/config/schema_provider.go
+++ b/internal/infrastructure/config/schema_provider.go
@@ -564,6 +564,23 @@ func (*SchemaProvider) getWorkspaceKeys(defaults *Config) []entity.ConfigKeyInfo
 			Description: "Named floating pane URL profiles with keys, url, and optional desc",
 			Section:     SectionWorkspace,
 		},
+		// External links
+		{
+			Key:         "workspace.external_links.behavior",
+			Type:        "string",
+			Default:     string(defaults.Workspace.ExternalLinks.Behavior),
+			Description: "How URLs opened from external applications are placed",
+			Values:      []string{"windowed", "tabbed", "split", "stacked"},
+			Section:     SectionWorkspace,
+		},
+		{
+			Key:         "workspace.external_links.placement",
+			Type:        "string",
+			Default:     string(defaults.Workspace.ExternalLinks.Placement),
+			Description: "Placement direction for split external links",
+			Values:      []string{"right", "left", "top", "bottom"},
+			Section:     SectionWorkspace,
+		},
 		// Browsing contexts
 		{
 			Key:         "workspace.browsing_contexts.behavior",

--- a/internal/infrastructure/config/validation.go
+++ b/internal/infrastructure/config/validation.go
@@ -24,6 +24,7 @@ func validateConfig(config *Config) error {
 	validationErrors = append(validationErrors, validateAppearance(config)...)
 	validationErrors = append(validationErrors, validateSearchEngine(config)...)
 	validationErrors = append(validationErrors, validatePopups(config)...)
+	validationErrors = append(validationErrors, validateExternalLinks(config)...)
 	validationErrors = append(validationErrors, validateWorkspaceStyling(config)...)
 	validationErrors = append(validationErrors, validatePaneMode(config)...)
 	validationErrors = append(validationErrors, validateTabBar(config)...)
@@ -183,6 +184,28 @@ func validatePopups(config *Config) []string {
 		validationErrors = append(validationErrors, fmt.Sprintf(
 			"workspace.browsing_contexts.blank_target_behavior must be one of: split, stacked, tabbed (got: %s)",
 			config.Workspace.BrowsingContexts.BlankTargetBehavior,
+		))
+	}
+	return validationErrors
+}
+
+func validateExternalLinks(config *Config) []string {
+	var validationErrors []string
+	switch config.Workspace.ExternalLinks.Behavior {
+	case ExternalLinkBehaviorWindowed, ExternalLinkBehaviorTabbed, ExternalLinkBehaviorSplit, ExternalLinkBehaviorStacked:
+	default:
+		validationErrors = append(validationErrors, fmt.Sprintf(
+			"workspace.external_links.behavior must be one of: windowed, tabbed, split, stacked (got: %s)",
+			config.Workspace.ExternalLinks.Behavior,
+		))
+	}
+
+	switch config.Workspace.ExternalLinks.Placement {
+	case ExternalLinkPlacementRight, ExternalLinkPlacementLeft, ExternalLinkPlacementTop, ExternalLinkPlacementBottom:
+	default:
+		validationErrors = append(validationErrors, fmt.Sprintf(
+			"workspace.external_links.placement must be one of: right, left, top, bottom (got: %s)",
+			config.Workspace.ExternalLinks.Placement,
 		))
 	}
 	return validationErrors

--- a/internal/infrastructure/config/validation_test.go
+++ b/internal/infrastructure/config/validation_test.go
@@ -294,6 +294,38 @@ func TestValidateConfig_CEFConfig(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_ExternalLinksAcceptsSupportedValues(t *testing.T) {
+	for _, behavior := range []ExternalLinkBehavior{
+		ExternalLinkBehaviorWindowed,
+		ExternalLinkBehaviorTabbed,
+		ExternalLinkBehaviorSplit,
+		ExternalLinkBehaviorStacked,
+	} {
+		for _, placement := range []ExternalLinkPlacement{
+			ExternalLinkPlacementRight,
+			ExternalLinkPlacementLeft,
+			ExternalLinkPlacementTop,
+			ExternalLinkPlacementBottom,
+		} {
+			cfg := DefaultConfig()
+			cfg.Workspace.ExternalLinks.Behavior = behavior
+			cfg.Workspace.ExternalLinks.Placement = placement
+			require.NoError(t, validateConfig(cfg))
+		}
+	}
+}
+
+func TestValidateConfig_ExternalLinksRejectsUnsupportedValues(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Workspace.ExternalLinks.Behavior = "invalid"
+	cfg.Workspace.ExternalLinks.Placement = "invalid"
+
+	err := validateConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace.external_links.behavior")
+	assert.Contains(t, err.Error(), "workspace.external_links.placement")
+}
+
 func TestValidateConfig_WorkspaceNewPaneURLAllowsExistingAbsoluteLocalPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "page.html")

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -68,7 +68,7 @@ func NewBrowserLaunchRelay(ipc runtimeprofile.IPCPaths) port.BrowserLaunchRelay 
 	return &browserLaunchRelay{ipc: ipc}
 }
 
-func (r *browserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url string) (bool, error) {
+func (r *browserLaunchRelay) DeliverOpenExternalURL(ctx context.Context, url string) (bool, error) {
 	socketPath, err := r.socketPath()
 	if err != nil {
 		return false, err
@@ -353,20 +353,20 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 		log.Debug().
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
-			Msg("browser launch relay calling browser window opener")
-		if err := opener.OpenFreshWindow(ctx, request.URL); err != nil {
+			Msg("browser launch relay calling external URL opener")
+		if err := opener.OpenExternalURL(ctx, request.URL); err != nil {
 			log.Warn().Err(err).
 				Str("request_id", requestID).
 				Str("url_host", safeURLHost(request.URL)).
 				Dur("elapsed", time.Since(started)).
-				Msg("browser launch relay opener failed")
+				Msg("browser launch relay external URL opener failed")
 			return
 		}
 		log.Debug().
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
 			Dur("elapsed", time.Since(started)).
-			Msg("browser launch relay opener returned success")
+			Msg("browser launch relay external URL opener returned success")
 	}()
 }
 

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -17,7 +17,7 @@ import (
 
 type browserWindowOpenerFunc func(context.Context, string) error
 
-func (f browserWindowOpenerFunc) OpenFreshWindow(ctx context.Context, url string) error {
+func (f browserWindowOpenerFunc) OpenExternalURL(ctx context.Context, url string) error {
 	return f(ctx, url)
 }
 
@@ -112,10 +112,10 @@ func overrideBrowserLaunchRequestID(t *testing.T, id string) func() {
 	return func() { newBrowserLaunchRequestID = previous }
 }
 
-func TestBrowserLaunchRelay_DeliverOpenFreshWindow_MissingListenerReturnsFalseNil(t *testing.T) {
+func TestBrowserLaunchRelay_DeliverOpenExternalURL_MissingListenerReturnsFalseNil(t *testing.T) {
 	relay := NewBrowserLaunchRelay(testIPC(shortTempDir(t)))
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com")
 
 	require.NoError(t, err)
 	assert.False(t, delivered)
@@ -138,7 +138,7 @@ func TestBrowserLaunchRelay_SameProfileAndEngine_UsesSameSocket(t *testing.T) {
 
 	waitForSocket(t, ipc.BrowserLaunchSocket)
 
-	delivered, err := clientRelay.DeliverOpenFreshWindow(context.Background(), "https://example.com/same-namespace")
+	delivered, err := clientRelay.DeliverOpenExternalURL(context.Background(), "https://example.com/same-namespace")
 	require.NoError(t, err)
 	require.True(t, delivered)
 	require.Equal(t, "https://example.com/same-namespace", <-received)
@@ -151,7 +151,7 @@ func TestBrowserLaunchRelay_DevCEFAndDevWebKit_UseDifferentSockets(t *testing.T)
 	require.NotEqual(t, cefIPC.BrowserLaunchSocket, wkIPC.BrowserLaunchSocket)
 }
 
-func TestBrowserLaunchRelay_DeliverOpenFreshWindow_SendsRequestIDAndAcceptsMatchingResponse(t *testing.T) {
+func TestBrowserLaunchRelay_DeliverOpenExternalURL_SendsRequestIDAndAcceptsMatchingResponse(t *testing.T) {
 	ipc := testIPC(shortTempDir(t))
 	relay := NewBrowserLaunchRelay(ipc)
 	restore := overrideBrowserLaunchRequestID(t, "request-test-1")
@@ -180,7 +180,7 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_SendsRequestIDAndAcceptsMatch
 		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: request.RequestID, Accepted: true})
 	}()
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/request-id")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/request-id")
 
 	require.NoError(t, err)
 	require.True(t, delivered)
@@ -189,7 +189,7 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_SendsRequestIDAndAcceptsMatch
 	require.Equal(t, "https://example.com/request-id", request.URL)
 }
 
-func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RejectsMismatchedResponseRequestID(t *testing.T) {
+func TestBrowserLaunchRelay_DeliverOpenExternalURL_RejectsMismatchedResponseRequestID(t *testing.T) {
 	ipc := testIPC(shortTempDir(t))
 	relay := NewBrowserLaunchRelay(ipc)
 	restore := overrideBrowserLaunchRequestID(t, "request-test-2")
@@ -216,14 +216,14 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RejectsMismatchedResponseRequ
 		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: "different-request", Accepted: true})
 	}()
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/request-id-mismatch")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/request-id-mismatch")
 
 	require.Error(t, err)
 	require.True(t, delivered)
 	require.Contains(t, err.Error(), "mismatched browser launch relay response")
 }
 
-func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RoundTrip(t *testing.T) {
+func TestBrowserLaunchRelay_DeliverOpenExternalURL_RoundTrip(t *testing.T) {
 	ipc := testIPC(shortTempDir(t))
 	relay := NewBrowserLaunchRelay(ipc)
 
@@ -239,7 +239,7 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RoundTrip(t *testing.T) {
 
 	waitForSocket(t, ipc.BrowserLaunchSocket)
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/new")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/new")
 
 	require.NoError(t, err)
 	assert.True(t, delivered)
@@ -279,7 +279,7 @@ func TestBrowserLaunchRelay_SecondListenWhileLiveFailsWithoutReplacingListener(t
 	_, err = relay.Listen(ctx, browserWindowOpenerFunc(func(context.Context, string) error { return nil }))
 	require.Error(t, err)
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/live")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/live")
 	require.NoError(t, err)
 	require.True(t, delivered)
 
@@ -310,7 +310,7 @@ func TestBrowserLaunchRelay_RebindsStaleSocketPath(t *testing.T) {
 
 	waitForSocket(t, ipc.BrowserLaunchSocket)
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/stale")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/stale")
 	require.NoError(t, err)
 	require.True(t, delivered)
 
@@ -345,7 +345,7 @@ func TestBrowserLaunchRelay_RejectsMalformedPayloads(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/still-works")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/still-works")
 
 	require.NoError(t, err)
 	assert.True(t, delivered)
@@ -387,12 +387,12 @@ func TestBrowserLaunchRelay_ContextCancelStopsServing(t *testing.T) {
 	waitForSocketGone(t, ipc.BrowserLaunchSocket)
 	require.NoError(t, closer.Close())
 
-	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/after-cancel")
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/after-cancel")
 	require.NoError(t, err)
 	assert.False(t, delivered)
 }
 
-func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RespectsResponseReadTimeout(t *testing.T) {
+func TestBrowserLaunchRelay_DeliverOpenExternalURL_RespectsResponseReadTimeout(t *testing.T) {
 	ipc := testIPC(shortTempDir(t))
 	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
 
@@ -419,13 +419,13 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RespectsResponseReadTimeout(t
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	delivered, err := relay.DeliverOpenFreshWindow(ctx, "https://example.com/slow")
+	delivered, err := relay.DeliverOpenExternalURL(ctx, "https://example.com/slow")
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.False(t, delivered)
 }
 
-func TestBrowserLaunchRelay_DeliverOpenFreshWindow_ReturnsUnconfirmedErrorOnNoDeadlineTimeout(t *testing.T) {
+func TestBrowserLaunchRelay_DeliverOpenExternalURL_ReturnsUnconfirmedErrorOnNoDeadlineTimeout(t *testing.T) {
 	ipc := testIPC(shortTempDir(t))
 	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
 
@@ -459,7 +459,7 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_ReturnsUnconfirmedErrorOnNoDe
 	result := make(chan deliverResult, 1)
 	go func() {
 		close(started)
-		delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/slow")
+		delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/slow")
 		result <- deliverResult{delivered: delivered, err: err}
 	}()
 	<-started
@@ -470,7 +470,7 @@ func TestBrowserLaunchRelay_DeliverOpenFreshWindow_ReturnsUnconfirmedErrorOnNoDe
 		require.Error(t, got.err)
 		require.ErrorIs(t, got.err, ErrBrowserLaunchRelayUnconfirmed)
 	case <-time.After(browserLaunchIOTimeout * 3):
-		t.Fatal("DeliverOpenFreshWindow blocked without a caller deadline")
+		t.Fatal("DeliverOpenExternalURL blocked without a caller deadline")
 	}
 }
 
@@ -574,7 +574,7 @@ func TestBrowserLaunchRelay_SilentClientDoesNotStallListener(t *testing.T) {
 	}
 	result := make(chan deliverResult, 1)
 	go func() {
-		delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/recovered")
+		delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/recovered")
 		result <- deliverResult{delivered: delivered, err: err}
 	}()
 

--- a/internal/infrastructure/desktop/browser_launcher.go
+++ b/internal/infrastructure/desktop/browser_launcher.go
@@ -36,7 +36,7 @@ func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) error {
 	}
 
 	if l.relay != nil {
-		delivered, err := l.relay.DeliverOpenFreshWindow(ctx, url)
+		delivered, err := l.relay.DeliverOpenExternalURL(ctx, url)
 		if err != nil {
 			if delivered && errors.Is(err, ErrBrowserLaunchRelayUnconfirmed) {
 				return ErrBrowserLaunchUnconfirmed

--- a/internal/infrastructure/desktop/browser_launcher_test.go
+++ b/internal/infrastructure/desktop/browser_launcher_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestBrowserLauncher_LaunchURL_ReturnsWithoutSpawningWhenRelayDelivers(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, nil)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(true, nil)
 
 	launcher := NewBrowserLauncher(relay)
 	spawned := false
@@ -34,7 +34,7 @@ func TestBrowserLauncher_LaunchURL_ReturnsWithoutSpawningWhenRelayDelivers(t *te
 
 func TestBrowserLauncher_LaunchURL_FallsBackToSpawnWhenRelayMisses(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(false, nil)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(false, nil)
 
 	launcher := NewBrowserLauncher(relay)
 	launcher.resolveExecutablePath = func() (string, error) {
@@ -57,7 +57,7 @@ func TestBrowserLauncher_LaunchURL_FallsBackToSpawnWhenRelayMisses(t *testing.T)
 
 func TestBrowserLauncher_LaunchURL_ReturnsUnconfirmedErrorWhenRelayDeliveryIsAmbiguous(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, ErrBrowserLaunchRelayUnconfirmed)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(true, ErrBrowserLaunchRelayUnconfirmed)
 
 	launcher := NewBrowserLauncher(relay)
 	launcher.resolveExecutablePath = func() (string, error) {
@@ -78,7 +78,7 @@ func TestBrowserLauncher_LaunchURL_ReturnsUnconfirmedErrorWhenRelayDeliveryIsAmb
 func TestBrowserLauncher_LaunchURL_PropagatesRelayError(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
 	wantErr := errors.New("relay exploded")
-	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(false, wantErr)
+	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(false, wantErr)
 
 	launcher := NewBrowserLauncher(relay)
 	launcher.resolveExecutablePath = func() (string, error) {

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -47,7 +47,7 @@ type testBrowserLaunchRelay struct {
 	closer      *testCloser
 }
 
-func (r *testBrowserLaunchRelay) DeliverOpenFreshWindow(context.Context, string) (bool, error) {
+func (r *testBrowserLaunchRelay) DeliverOpenExternalURL(context.Context, string) (bool, error) {
 	return false, nil
 }
 
@@ -1083,7 +1083,7 @@ func TestApp_GetWindowSnapshotStateReturnsUnavailableWhenMainThreadDispatchTimes
 	require.Equal(t, -1, activeWindowIndex)
 }
 
-func TestApp_OpenFreshWindowReportsMainThreadDispatchTimeout(t *testing.T) {
+func TestApp_OpenExternalURLReportsMainThreadDispatchTimeout(t *testing.T) {
 	var factoryCalls int
 	app := &App{
 		dispatchOnMainThread: func(label string, fn func()) syncdispatch.SyncDispatchResult {
@@ -1095,20 +1095,20 @@ func TestApp_OpenFreshWindowReportsMainThreadDispatchTimeout(t *testing.T) {
 		},
 	}
 
-	err := app.OpenFreshWindow(context.Background(), "https://example.com")
+	err := app.OpenExternalURL(context.Background(), "https://example.com")
 
 	if err == nil {
-		t.Fatal("OpenFreshWindow returned nil error, want dispatch timeout")
+		t.Fatal("OpenExternalURL returned nil error, want dispatch timeout")
 	}
 	if !strings.Contains(err.Error(), "main thread dispatch did not complete") {
-		t.Fatalf("OpenFreshWindow error = %q, want dispatch timeout", err.Error())
+		t.Fatalf("OpenExternalURL error = %q, want dispatch timeout", err.Error())
 	}
 	if factoryCalls != 0 {
 		t.Fatalf("browserWindowFactory calls = %d, want 0", factoryCalls)
 	}
 }
 
-func TestApp_OpenFreshWindowRecordsTabOwnership(t *testing.T) {
+func TestApp_OpenExternalURLRecordsTabOwnership(t *testing.T) {
 	existingTab := entity.NewTab(entity.TabID("existing-tab"), entity.WorkspaceID("existing-workspace"), entity.NewPane(entity.PaneID("existing-pane")))
 	existingTabs := entity.NewTabList()
 	existingTabs.Add(existingTab)
@@ -1126,8 +1126,8 @@ func TestApp_OpenFreshWindowRecordsTabOwnership(t *testing.T) {
 		},
 	}
 
-	if err := app.OpenFreshWindow(context.Background(), "https://example.com"); err != nil {
-		t.Fatalf("OpenFreshWindow returned error: %v", err)
+	if err := app.OpenExternalURL(context.Background(), "https://example.com"); err != nil {
+		t.Fatalf("OpenExternalURL returned error: %v", err)
 	}
 	if got := windowForTabCount(t, app); got != 2 {
 		t.Fatalf("windowForTab length = %d, want 2 (existing + new tab)", got)
@@ -1375,7 +1375,7 @@ func TestApp_RemoveBrowserWindowRebindsPromotedTabCoordinatorWindow(t *testing.T
 	}
 }
 
-func TestApp_OpenFreshWindowRollsBackOnTabCreationFailure(t *testing.T) {
+func TestApp_OpenExternalURLRollsBackOnTabCreationFailure(t *testing.T) {
 	created := &browserWindow{id: "window-1", tabs: entity.NewTabList()}
 	originalWindow := &window.MainWindow{}
 	tabBar := &component.TabBar{}
@@ -1406,8 +1406,8 @@ func TestApp_OpenFreshWindowRollsBackOnTabCreationFailure(t *testing.T) {
 		MainWindow: &window.MainWindow{},
 	})
 
-	if err := app.OpenFreshWindow(context.Background(), "https://example.com/fail"); err == nil {
-		t.Fatalf("OpenFreshWindow = nil error, want failure")
+	if err := app.OpenExternalURL(context.Background(), "https://example.com/fail"); err == nil {
+		t.Fatalf("OpenExternalURL = nil error, want failure")
 	}
 	if got := len(app.browserWindows); got != 1 {
 		t.Fatalf("browserWindows length = %d, want 1 (existing window only)", got)
@@ -1426,7 +1426,7 @@ func TestApp_OpenFreshWindowRollsBackOnTabCreationFailure(t *testing.T) {
 	}
 }
 
-func TestApp_OpenFreshWindowTargetsNewWindowTabBar(t *testing.T) {
+func TestApp_OpenExternalURLTargetsNewWindowTabBar(t *testing.T) {
 	existingTabID := entity.TabID("existing-tab")
 	createdTabID := entity.TabID("id-1")
 	oldWindow := &window.MainWindow{}
@@ -1463,8 +1463,8 @@ func TestApp_OpenFreshWindowTargetsNewWindowTabBar(t *testing.T) {
 		app.workspaceViews[tab.ID] = &component.WorkspaceView{}
 	})
 
-	if err := app.OpenFreshWindow(context.Background(), "https://example.com"); err != nil {
-		t.Fatalf("OpenFreshWindow returned error: %v", err)
+	if err := app.OpenExternalURL(context.Background(), "https://example.com"); err != nil {
+		t.Fatalf("OpenExternalURL returned error: %v", err)
 	}
 
 	gotCreatedTabID := app.tabs.ActiveTabID

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -548,11 +548,11 @@ func (a *App) deterministicBrowserWindowFallback() *browserWindow {
 	return a.browserWindows[ids[0]]
 }
 
-func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
+func (a *App) OpenExternalURL(ctx context.Context, url string) error {
 	log := logging.FromContext(ctx)
 	log.Debug().
 		Str("url_host", logging.SafeURLHost(url)).
-		Msg("ui: open fresh window dispatch requested")
+		Msg("ui: open external URL dispatch requested")
 
 	dispatch := a.dispatchOnMainThread
 	if dispatch == nil {
@@ -569,17 +569,18 @@ func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
 	var windowCountAfter int
 	var hasTabCoord bool
 	var hasTabsUC bool
-	result := dispatch("ui.open_fresh_window", func() {
+	result := dispatch("ui.open_external_url", func() {
 		windowCountBefore = len(a.browserWindows)
 		hasTabCoord = a.tabCoord != nil
 		hasTabsUC = a.tabsUC != nil
+		cfg := a.runtimeConfigSnapshot()
 		log.Debug().
 			Str("url_host", logging.SafeURLHost(url)).
 			Int("window_count_before", windowCountBefore).
 			Bool("has_tab_coord", hasTabCoord).
 			Bool("has_tabs_uc", hasTabsUC).
-			Msg("ui: open fresh window main-thread work started")
-		openErr = a.openFreshWindow(ctx, url)
+			Msg("ui: open external URL main-thread work started")
+		openErr = a.openExternalURLOnMainThread(ctx, url, cfg)
 		windowCountAfter = len(a.browserWindows)
 	})
 	if !result.Completed() {
@@ -587,7 +588,7 @@ func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
 			Str("url_host", logging.SafeURLHost(url)).
 			Dur("elapsed", result.Elapsed).
 			Str("dispatch_status", string(result.Status)).
-			Msg("ui: open fresh window skipped after main-thread dispatch did not complete")
+			Msg("ui: open external URL skipped after main-thread dispatch did not complete")
 		return fmt.Errorf("main thread dispatch did not complete: %s", result.Status)
 	}
 	if openErr != nil {
@@ -596,7 +597,7 @@ func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
 			Dur("elapsed", result.Elapsed).
 			Str("dispatch_status", string(result.Status)).
 			Int("window_count_after", windowCountAfter).
-			Msg("ui: open fresh window failed")
+			Msg("ui: open external URL failed")
 		return openErr
 	}
 
@@ -605,6 +606,158 @@ func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
 		Dur("elapsed", result.Elapsed).
 		Str("dispatch_status", string(result.Status)).
 		Int("window_count_after", windowCountAfter).
-		Msg("ui: open fresh window completed")
+		Msg("ui: open external URL completed")
+	return nil
+}
+
+func (a *App) openExternalURLOnMainThread(ctx context.Context, url string, cfg entity.RuntimeConfigSnapshot) error {
+	externalLinks := cfg.UI.Workspace.ExternalLinks
+	if externalLinks.Behavior == entity.ExternalLinkBehaviorWindowed || externalLinks.Behavior == "" {
+		return a.openFreshWindow(ctx, url)
+	}
+
+	if err := a.openExternalURLInFocusedWindow(ctx, url, externalLinks); err == nil {
+		return nil
+	} else {
+		logging.FromContext(ctx).Warn().
+			Err(err).
+			Str("url_host", logging.SafeURLHost(url)).
+			Str("behavior", string(externalLinks.Behavior)).
+			Msg("ui: external URL placement failed; opening fresh window")
+	}
+	return a.openFreshWindow(ctx, url)
+}
+
+func (a *App) openExternalURLInFocusedWindow(ctx context.Context, url string, cfg entity.ExternalLinksConfig) error {
+	target := a.lastFocusedBrowserWindow()
+	if target == nil || target.id == "" || a.browserWindows[target.id] != target {
+		return fmt.Errorf("last-focused browser window is missing or stale")
+	}
+	activeTab := a.activeTabForBrowserWindow(target)
+	if activeTab == nil || activeTab.Workspace == nil || activeTab.Workspace.ActivePane() == nil {
+		return fmt.Errorf("last-focused browser window has no active tab and pane")
+	}
+
+	a.activateBrowserWindow(target)
+	switch cfg.Behavior {
+	case entity.ExternalLinkBehaviorTabbed:
+		if a.tabCoord == nil {
+			return fmt.Errorf("tab coordinator not available")
+		}
+		created, err := a.tabCoord.Create(ctx, a.tabTargetForBrowserWindow(target), url)
+		if err != nil {
+			a.rollbackExternalTabCreation(ctx, target, created)
+			return err
+		}
+		if created == nil || created.Workspace == nil || created.Workspace.ActivePane() == nil ||
+			created.Workspace.ActivePane().Pane == nil || created.Workspace.ActivePane().Pane.URI != url ||
+			a.activeTabForBrowserWindow(target) != created || a.workspaceViews[created.ID] == nil {
+			a.rollbackExternalTabCreation(ctx, target, created)
+			return fmt.Errorf("created tab did not become an active UI target")
+		}
+	case entity.ExternalLinkBehaviorSplit:
+		if a.wsCoord == nil {
+			return fmt.Errorf("workspace coordinator not available")
+		}
+		before := activeTab.Workspace.ActivePaneID
+		if err := a.wsCoord.SplitWithURL(ctx, externalLinkSplitDirection(cfg.Placement), url); err != nil {
+			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
+			return err
+		}
+		if err := verifyExternalPaneCreation(activeTab.Workspace, before, url); err != nil {
+			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
+			return err
+		}
+	case entity.ExternalLinkBehaviorStacked:
+		if a.wsCoord == nil {
+			return fmt.Errorf("workspace coordinator not available")
+		}
+		before := activeTab.Workspace.ActivePaneID
+		if err := a.wsCoord.StackPaneWithURL(ctx, url); err != nil {
+			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
+			return err
+		}
+		if err := verifyExternalPaneCreation(activeTab.Workspace, before, url); err != nil {
+			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported external URL behavior %q", cfg.Behavior)
+	}
+
+	if target.mainWindow != nil {
+		target.mainWindow.Show()
+	}
+	a.activateBrowserWindow(target)
+	return nil
+}
+
+func (a *App) rollbackExternalPaneCreation(ctx context.Context, ws *entity.Workspace, previous entity.PaneID) {
+	if a.panesUC == nil || ws == nil || ws.ActivePaneID == "" || ws.ActivePaneID == previous {
+		return
+	}
+	created := ws.ActivePane()
+	if created == nil || created.Pane == nil {
+		return
+	}
+	createdID := created.Pane.ID
+	if _, err := a.panesUC.Close(ctx, ws, created); err != nil {
+		logging.FromContext(ctx).Warn().Err(err).Msg("ui: failed to roll back external URL pane")
+		return
+	}
+	ws.ActivePaneID = previous
+	if a.contentCoord != nil {
+		a.contentCoord.ReleaseWebView(ctx, createdID)
+	}
+	for tabID, view := range a.workspaceViews {
+		owner := a.browserWindowForTab(tabID)
+		if owner == nil || owner.tabs == nil || view == nil {
+			continue
+		}
+		tab := owner.tabs.Find(tabID)
+		if tab == nil || tab.Workspace == nil || tab.Workspace.ID != ws.ID {
+			continue
+		}
+		if err := view.Rebuild(ctx); err != nil {
+			logging.FromContext(ctx).Warn().Err(err).Msg("ui: failed to rebuild after external URL pane rollback")
+		}
+		break
+	}
+}
+
+func (a *App) rollbackExternalTabCreation(ctx context.Context, target *browserWindow, created *entity.Tab) {
+	if target == nil || created == nil {
+		return
+	}
+	if tabs := a.tabListForBrowserWindow(target); tabs != nil {
+		tabs.Remove(created.ID)
+	}
+	if target.mainWindow != nil && target.mainWindow.TabBar() != nil {
+		target.mainWindow.TabBar().RemoveTab(created.ID)
+	}
+	a.releaseTabWorkspace(ctx, created)
+}
+
+func externalLinkSplitDirection(placement entity.ExternalLinkPlacement) usecase.SplitDirection {
+	switch placement {
+	case entity.ExternalLinkPlacementLeft:
+		return usecase.SplitLeft
+	case entity.ExternalLinkPlacementTop:
+		return usecase.SplitUp
+	case entity.ExternalLinkPlacementBottom:
+		return usecase.SplitDown
+	default:
+		return usecase.SplitRight
+	}
+}
+
+func verifyExternalPaneCreation(ws *entity.Workspace, previous entity.PaneID, url string) error {
+	if ws == nil || ws.ActivePaneID == "" || ws.ActivePaneID == previous {
+		return fmt.Errorf("external URL pane was not activated")
+	}
+	active := ws.ActivePane()
+	if active == nil || active.Pane == nil || active.Pane.URI != url {
+		return fmt.Errorf("external URL pane was not created with the requested URL")
+	}
 	return nil
 }

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -629,31 +629,16 @@ func (a *App) openExternalURLOnMainThread(ctx context.Context, url string, cfg e
 }
 
 func (a *App) openExternalURLInFocusedWindow(ctx context.Context, url string, cfg entity.ExternalLinksConfig) error {
-	target := a.lastFocusedBrowserWindow()
-	if target == nil || target.id == "" || a.browserWindows[target.id] != target {
-		return fmt.Errorf("last-focused browser window is missing or stale")
-	}
-	activeTab := a.activeTabForBrowserWindow(target)
-	if activeTab == nil || activeTab.Workspace == nil || activeTab.Workspace.ActivePane() == nil {
-		return fmt.Errorf("last-focused browser window has no active tab and pane")
+	target, activeTab, err := a.externalURLTarget()
+	if err != nil {
+		return err
 	}
 
 	a.activateBrowserWindow(target)
 	switch cfg.Behavior {
 	case entity.ExternalLinkBehaviorTabbed:
-		if a.tabCoord == nil {
-			return fmt.Errorf("tab coordinator not available")
-		}
-		created, err := a.tabCoord.Create(ctx, a.tabTargetForBrowserWindow(target), url)
-		if err != nil {
-			a.rollbackExternalTabCreation(ctx, target, created)
+		if err := a.createExternalURLTab(ctx, target, url); err != nil {
 			return err
-		}
-		if created == nil || created.Workspace == nil || created.Workspace.ActivePane() == nil ||
-			created.Workspace.ActivePane().Pane == nil || created.Workspace.ActivePane().Pane.URI != url ||
-			a.activeTabForBrowserWindow(target) != created || a.workspaceViews[created.ID] == nil {
-			a.rollbackExternalTabCreation(ctx, target, created)
-			return fmt.Errorf("created tab did not become an active UI target")
 		}
 	case entity.ExternalLinkBehaviorSplit:
 		if err := a.placeExternalURLInPane(ctx, activeTab.Workspace, url, func(ctx context.Context) error {
@@ -675,6 +660,36 @@ func (a *App) openExternalURLInFocusedWindow(ctx context.Context, url string, cf
 		target.mainWindow.Show()
 	}
 	a.activateBrowserWindow(target)
+	return nil
+}
+
+func (a *App) externalURLTarget() (*browserWindow, *entity.Tab, error) {
+	target := a.lastFocusedBrowserWindow()
+	if target == nil || target.id == "" || a.browserWindows[target.id] != target {
+		return nil, nil, fmt.Errorf("last-focused browser window is missing or stale")
+	}
+	activeTab := a.activeTabForBrowserWindow(target)
+	if activeTab == nil || activeTab.Workspace == nil || activeTab.Workspace.ActivePane() == nil {
+		return nil, nil, fmt.Errorf("last-focused browser window has no active tab and pane")
+	}
+	return target, activeTab, nil
+}
+
+func (a *App) createExternalURLTab(ctx context.Context, target *browserWindow, url string) error {
+	if a.tabCoord == nil {
+		return fmt.Errorf("tab coordinator not available")
+	}
+	created, err := a.tabCoord.Create(ctx, a.tabTargetForBrowserWindow(target), url)
+	if err != nil {
+		a.rollbackExternalTabCreation(ctx, target, created)
+		return err
+	}
+	if created == nil || created.Workspace == nil || created.Workspace.ActivePane() == nil ||
+		created.Workspace.ActivePane().Pane == nil || created.Workspace.ActivePane().Pane.URI != url ||
+		a.activeTabForBrowserWindow(target) != created || a.workspaceViews[created.ID] == nil {
+		a.rollbackExternalTabCreation(ctx, target, created)
+		return fmt.Errorf("created tab did not become an active UI target")
+	}
 	return nil
 }
 

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -641,13 +641,13 @@ func (a *App) openExternalURLInFocusedWindow(ctx context.Context, url string, cf
 		}
 	case entity.ExternalLinkBehaviorSplit:
 		if err := a.placeExternalURLInPane(ctx, activeTab.Workspace, url, func(ctx context.Context) error {
-			return a.wsCoord.SplitWithURL(ctx, externalLinkSplitDirection(cfg.Placement), url)
+			return a.wsCoord.SplitWithURLWithoutOmnibox(ctx, externalLinkSplitDirection(cfg.Placement), url)
 		}); err != nil {
 			return err
 		}
 	case entity.ExternalLinkBehaviorStacked:
 		if err := a.placeExternalURLInPane(ctx, activeTab.Workspace, url, func(ctx context.Context) error {
-			return a.wsCoord.StackPaneWithURL(ctx, url)
+			return a.wsCoord.StackPaneWithURLWithoutOmnibox(ctx, url)
 		}); err != nil {
 			return err
 		}

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -634,7 +634,6 @@ func (a *App) openExternalURLInFocusedWindow(ctx context.Context, url string, cf
 		return err
 	}
 
-	a.activateBrowserWindow(target)
 	switch cfg.Behavior {
 	case entity.ExternalLinkBehaviorTabbed:
 		if err := a.createExternalURLTab(ctx, target, url); err != nil {
@@ -710,7 +709,11 @@ func (a *App) placeExternalURLInPane(ctx context.Context, ws *entity.Workspace, 
 }
 
 func (a *App) rollbackExternalPaneCreation(ctx context.Context, ws *entity.Workspace, previous entity.PaneID) {
-	if a.panesUC == nil || ws == nil || ws.ActivePaneID == "" || ws.ActivePaneID == previous {
+	if a.panesUC == nil {
+		logging.FromContext(ctx).Warn().Msg("ui: cannot roll back external URL pane; panes use case is unavailable")
+		return
+	}
+	if ws == nil || ws.ActivePaneID == "" || ws.ActivePaneID == previous {
 		return
 	}
 	created := ws.ActivePane()

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -616,15 +616,15 @@ func (a *App) openExternalURLOnMainThread(ctx context.Context, url string, cfg e
 		return a.openFreshWindow(ctx, url)
 	}
 
-	if err := a.openExternalURLInFocusedWindow(ctx, url, externalLinks); err == nil {
+	err := a.openExternalURLInFocusedWindow(ctx, url, externalLinks)
+	if err == nil {
 		return nil
-	} else {
-		logging.FromContext(ctx).Warn().
-			Err(err).
-			Str("url_host", logging.SafeURLHost(url)).
-			Str("behavior", string(externalLinks.Behavior)).
-			Msg("ui: external URL placement failed; opening fresh window")
 	}
+	logging.FromContext(ctx).Warn().
+		Err(err).
+		Str("url_host", logging.SafeURLHost(url)).
+		Str("behavior", string(externalLinks.Behavior)).
+		Msg("ui: external URL placement failed; opening fresh window")
 	return a.openFreshWindow(ctx, url)
 }
 
@@ -656,29 +656,15 @@ func (a *App) openExternalURLInFocusedWindow(ctx context.Context, url string, cf
 			return fmt.Errorf("created tab did not become an active UI target")
 		}
 	case entity.ExternalLinkBehaviorSplit:
-		if a.wsCoord == nil {
-			return fmt.Errorf("workspace coordinator not available")
-		}
-		before := activeTab.Workspace.ActivePaneID
-		if err := a.wsCoord.SplitWithURL(ctx, externalLinkSplitDirection(cfg.Placement), url); err != nil {
-			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
-			return err
-		}
-		if err := verifyExternalPaneCreation(activeTab.Workspace, before, url); err != nil {
-			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
+		if err := a.placeExternalURLInPane(ctx, activeTab.Workspace, url, func(ctx context.Context) error {
+			return a.wsCoord.SplitWithURL(ctx, externalLinkSplitDirection(cfg.Placement), url)
+		}); err != nil {
 			return err
 		}
 	case entity.ExternalLinkBehaviorStacked:
-		if a.wsCoord == nil {
-			return fmt.Errorf("workspace coordinator not available")
-		}
-		before := activeTab.Workspace.ActivePaneID
-		if err := a.wsCoord.StackPaneWithURL(ctx, url); err != nil {
-			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
-			return err
-		}
-		if err := verifyExternalPaneCreation(activeTab.Workspace, before, url); err != nil {
-			a.rollbackExternalPaneCreation(ctx, activeTab.Workspace, before)
+		if err := a.placeExternalURLInPane(ctx, activeTab.Workspace, url, func(ctx context.Context) error {
+			return a.wsCoord.StackPaneWithURL(ctx, url)
+		}); err != nil {
 			return err
 		}
 	default:
@@ -689,6 +675,22 @@ func (a *App) openExternalURLInFocusedWindow(ctx context.Context, url string, cf
 		target.mainWindow.Show()
 	}
 	a.activateBrowserWindow(target)
+	return nil
+}
+
+func (a *App) placeExternalURLInPane(ctx context.Context, ws *entity.Workspace, url string, place func(context.Context) error) error {
+	if a.wsCoord == nil {
+		return fmt.Errorf("workspace coordinator not available")
+	}
+	before := ws.ActivePaneID
+	if err := place(ctx); err != nil {
+		a.rollbackExternalPaneCreation(ctx, ws, before)
+		return err
+	}
+	if err := verifyExternalPaneCreation(ws, before, url); err != nil {
+		a.rollbackExternalPaneCreation(ctx, ws, before)
+		return err
+	}
 	return nil
 }
 

--- a/internal/ui/browser_window_test.go
+++ b/internal/ui/browser_window_test.go
@@ -447,15 +447,15 @@ func TestBrowserWindow_RemovePromotedWindowClearsResizeModeBorderTarget(t *testi
 	}
 }
 
-func TestOpenFreshWindow_DispatchesAndTracksBrowserWindow(t *testing.T) {
+func TestOpenExternalURL_DispatchesAndTracksBrowserWindow(t *testing.T) {
 	app := &App{browserWindows: make(map[string]*browserWindow)}
 
 	dispatched := false
 	createdURL := ""
 	app.dispatchOnMainThread = func(label string, fn func()) syncdispatch.SyncDispatchResult {
 		dispatched = true
-		if label != "ui.open_fresh_window" {
-			t.Fatalf("dispatch label = %q, want ui.open_fresh_window", label)
+		if label != "ui.open_external_url" {
+			t.Fatalf("dispatch label = %q, want ui.open_external_url", label)
 		}
 		fn()
 		return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchCompleted}
@@ -465,11 +465,11 @@ func TestOpenFreshWindow_DispatchesAndTracksBrowserWindow(t *testing.T) {
 		return &browserWindow{id: "window-1", initialURL: url}, nil
 	}
 
-	if err := app.OpenFreshWindow(context.Background(), "https://example.com"); err != nil {
-		t.Fatalf("OpenFreshWindow returned error: %v", err)
+	if err := app.OpenExternalURL(context.Background(), "https://example.com"); err != nil {
+		t.Fatalf("OpenExternalURL returned error: %v", err)
 	}
 	if !dispatched {
-		t.Fatalf("OpenFreshWindow did not use the main-thread dispatcher")
+		t.Fatalf("OpenExternalURL did not use the main-thread dispatcher")
 	}
 	if createdURL != "https://example.com" {
 		t.Fatalf("browser window factory URL = %q, want %q", createdURL, "https://example.com")
@@ -515,7 +515,7 @@ func TestOpenInitialBrowserWindowShellRegistersWithoutCreatingTab(t *testing.T) 
 	require.Equal(t, "https://example.com", app.browserWindows["window-1"].initialURL)
 }
 
-func TestOpenFreshWindow_FirstWindowWithRequestedURLCreatesTabInAppAndWindow(t *testing.T) {
+func TestOpenExternalURL_FirstWindowWithRequestedURLCreatesTabInAppAndWindow(t *testing.T) {
 	app := &App{
 		tabs:           entity.NewTabList(),
 		tabsUC:         usecase.NewManageTabsUseCase(counterIDGen(), nil),
@@ -535,8 +535,8 @@ func TestOpenFreshWindow_FirstWindowWithRequestedURLCreatesTabInAppAndWindow(t *
 		return true
 	}
 
-	if err := app.OpenFreshWindow(context.Background(), "https://example.com"); err != nil {
-		t.Fatalf("OpenFreshWindow returned error: %v", err)
+	if err := app.OpenExternalURL(context.Background(), "https://example.com"); err != nil {
+		t.Fatalf("OpenExternalURL returned error: %v", err)
 	}
 
 	windowTabs := app.browserWindows["window-1"].tabs
@@ -553,7 +553,7 @@ func TestOpenFreshWindow_FirstWindowWithRequestedURLCreatesTabInAppAndWindow(t *
 	require.Same(t, app.browserWindows["window-1"], app.browserWindowForTab(tab.ID))
 }
 
-func TestOpenFreshWindow_PropagatesFactoryError(t *testing.T) {
+func TestOpenExternalURL_PropagatesFactoryError(t *testing.T) {
 	app := &App{browserWindows: make(map[string]*browserWindow)}
 	app.dispatchOnMainThread = func(label string, fn func()) syncdispatch.SyncDispatchResult {
 		fn()
@@ -564,7 +564,7 @@ func TestOpenFreshWindow_PropagatesFactoryError(t *testing.T) {
 		return nil, wantErr
 	}
 
-	err := app.OpenFreshWindow(context.Background(), "https://example.com")
+	err := app.OpenExternalURL(context.Background(), "https://example.com")
 
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("expected error %v, got %v", wantErr, err)

--- a/internal/ui/coordinator/workspace.go
+++ b/internal/ui/coordinator/workspace.go
@@ -1490,6 +1490,7 @@ func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL 
 	addErr := c.stackedPaneMgr.AddPaneToStack(ctx, stackCtx.wsView, stackCtx.activePaneID, newPaneView, defaultPaneTitle)
 	if addErr != nil {
 		log.Error().Err(addErr).Msg("failed to add pane to stack")
+		c.rollbackStackPane(ctx, stackCtx, newPaneID)
 		return addErr
 	}
 
@@ -1506,21 +1507,24 @@ func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL 
 	}
 	widget := c.contentCoord.WrapWidget(ctx, wv)
 	if widget == nil {
-		return fmt.Errorf("wrap webview for stacked pane")
+		err := fmt.Errorf("wrap webview for stacked pane")
+		c.rollbackStackPane(ctx, stackCtx, newPaneID)
+		return err
 	}
 	if err := stackCtx.wsView.SetWebViewWidget(newPaneID, widget); err != nil {
 		log.Warn().Err(err).Str("pane_id", string(newPaneID)).Msg("failed to attach webview widget for stacked pane")
+		c.rollbackStackPane(ctx, stackCtx, newPaneID)
 		return err
 	}
-	// Load initial page for the new pane.
+	// Loading failures leave the attached pane available for a later navigation.
 	if err := wv.LoadURI(ctx, newPane.URI); err != nil {
 		log.Warn().Err(err).Str("uri_host", logging.SafeURLHost(newPane.URI)).Msg("failed to load initial page")
-		return err
 	}
 
 	// Update workspace view
 	if err := stackCtx.wsView.SetActivePaneID(newPaneID); err != nil {
 		log.Warn().Err(err).Msg("failed to set active pane")
+		c.rollbackStackPane(ctx, stackCtx, newPaneID)
 		return err
 	}
 	stackCtx.wsView.FocusPane(newPaneID)
@@ -1552,6 +1556,15 @@ func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL 
 		Msg("stacked new pane")
 
 	return nil
+}
+
+func (c *WorkspaceCoordinator) rollbackStackPane(ctx context.Context, stackCtx *stackPaneContext, paneID entity.PaneID) {
+	if err := c.ClosePaneByID(ctx, paneID); err != nil {
+		logging.FromContext(ctx).Warn().Err(err).Str("pane_id", string(paneID)).
+			Msg("failed to roll back stacked pane")
+	}
+	stackCtx.ws.ActivePaneID = stackCtx.activePaneID
+	c.notifyStateChanged()
 }
 
 func (c *WorkspaceCoordinator) createOrAddStackPane(

--- a/internal/ui/coordinator/workspace.go
+++ b/internal/ui/coordinator/workspace.go
@@ -198,7 +198,10 @@ func (c *WorkspaceCoordinator) splitWithInitialURL(ctx context.Context, directio
 
 	// Update the workspace view
 	if splitCtx.wsView != nil {
-		if err := c.applySplitToView(ctx, splitCtx.wsView, splitCtx.ws, output, direction, splitCtx.existingWidget, splitCtx.isStackSplit, oldActivePaneID); err != nil {
+		if err := c.applySplitToView(
+			ctx, splitCtx.wsView, splitCtx.ws, output, direction,
+			splitCtx.existingWidget, splitCtx.isStackSplit, oldActivePaneID,
+		); err != nil {
 			return err
 		}
 		splitCtx.wsView.NotifyNewPaneCreated(ctx)
@@ -1472,64 +1475,11 @@ func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL 
 		return err
 	}
 
-	// Determine if we need to create a new stack or add to existing.
-	var stackNode *entity.PaneNode
-	var newPane *entity.Pane
-	var newPaneID entity.PaneID
-	var needsFirstPaneTitleUpdate bool
-
-	if stackCtx.activeNode.Parent != nil && stackCtx.activeNode.Parent.IsStacked {
-		// Already in a stack - use AddToStack use case
-		stackNode = stackCtx.activeNode.Parent
-		output, err := c.panesUC.AddToStack(ctx, stackCtx.ws, stackNode, nil, initialURL)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to add pane to stack via use case")
-			return err
-		}
-		newPane = output.NewPaneNode.Pane
-		newPaneID = newPane.ID
-		newPane.Title = defaultPaneTitle
-		log.Debug().
-			Int("stack_size", len(stackNode.Children)).
-			Int("insert_index", output.StackIndex).
-			Msg("added to existing stack via use case")
-	} else if stackCtx.activeNode.IsStacked {
-		// Active node is already a stack container - add to it
-		stackNode = stackCtx.activeNode
-		output, err := c.panesUC.AddToStack(ctx, stackCtx.ws, stackNode, nil, initialURL)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to add pane to stack via use case")
-			return err
-		}
-		newPane = output.NewPaneNode.Pane
-		newPaneID = newPane.ID
-		newPane.Title = defaultPaneTitle
-		log.Debug().
-			Int("stack_size", len(stackNode.Children)).
-			Int("insert_index", output.StackIndex).
-			Msg("added to stack container via use case")
-	} else {
-		// Need to create a new stack - use CreateStack use case.
-		output, err := c.panesUC.CreateStack(ctx, stackCtx.ws, stackCtx.activeNode, initialURL)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to create stack via use case")
-			return err
-		}
-		stackNode = output.StackNode
-		newPane = output.NewPane
-		newPaneID = newPane.ID
-		newPane.Title = defaultPaneTitle
-		needsFirstPaneTitleUpdate = true
-
-		// Update the original pane's title in the domain
-		if output.OriginalNode != nil && output.OriginalNode.Pane != nil {
-			output.OriginalNode.Pane.Title = stackCtx.originalTitle
-		}
-
-		log.Debug().
-			Int("stack_size", len(stackNode.Children)).
-			Msg("created new stack via use case")
+	stackNode, newPane, needsFirstPaneTitleUpdate, err := c.createOrAddStackPane(ctx, stackCtx, initialURL)
+	if err != nil {
+		return err
 	}
+	newPaneID := newPane.ID
 
 	// Create PaneView for the new pane
 	newPaneView := component.NewPaneView(ctx, c.widgetFactory, newPaneID, nil)
@@ -1537,9 +1487,10 @@ func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL 
 	stackCtx.wsView.RegisterPaneView(newPaneID, newPaneView)
 
 	// Add to the UI StackedView
-	if err := c.stackedPaneMgr.AddPaneToStack(ctx, stackCtx.wsView, stackCtx.activePaneID, newPaneView, defaultPaneTitle); err != nil {
-		log.Error().Err(err).Msg("failed to add pane to stack")
-		return err
+	addErr := c.stackedPaneMgr.AddPaneToStack(ctx, stackCtx.wsView, stackCtx.activePaneID, newPaneView, defaultPaneTitle)
+	if addErr != nil {
+		log.Error().Err(addErr).Msg("failed to add pane to stack")
+		return addErr
 	}
 
 	// Update the first pane's title if we just converted from leaf to stacked
@@ -1601,6 +1552,42 @@ func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL 
 		Msg("stacked new pane")
 
 	return nil
+}
+
+func (c *WorkspaceCoordinator) createOrAddStackPane(
+	ctx context.Context,
+	stackCtx *stackPaneContext,
+	initialURL string,
+) (*entity.PaneNode, *entity.Pane, bool, error) {
+	log := logging.FromContext(ctx)
+	stackNode := stackCtx.activeNode
+	if stackNode.Parent != nil && stackNode.Parent.IsStacked {
+		stackNode = stackNode.Parent
+	}
+	if stackNode.IsStacked {
+		output, err := c.panesUC.AddToStack(ctx, stackCtx.ws, stackNode, nil, initialURL)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to add pane to stack via use case")
+			return nil, nil, false, err
+		}
+		newPane := output.NewPaneNode.Pane
+		newPane.Title = defaultPaneTitle
+		log.Debug().Int("stack_size", len(stackNode.Children)).Int("insert_index", output.StackIndex).
+			Msg("added to stack via use case")
+		return stackNode, newPane, false, nil
+	}
+
+	output, err := c.panesUC.CreateStack(ctx, stackCtx.ws, stackCtx.activeNode, initialURL)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create stack via use case")
+		return nil, nil, false, err
+	}
+	output.NewPane.Title = defaultPaneTitle
+	if output.OriginalNode != nil && output.OriginalNode.Pane != nil {
+		output.OriginalNode.Pane.Title = stackCtx.originalTitle
+	}
+	log.Debug().Int("stack_size", len(output.StackNode.Children)).Msg("created new stack via use case")
+	return output.StackNode, output.NewPane, true, nil
 }
 
 func (c *WorkspaceCoordinator) prepareStackPane(

--- a/internal/ui/coordinator/workspace.go
+++ b/internal/ui/coordinator/workspace.go
@@ -174,9 +174,9 @@ func (c *WorkspaceCoordinator) SplitWithURL(ctx context.Context, direction useca
 func (c *WorkspaceCoordinator) splitWithInitialURL(ctx context.Context, direction usecase.SplitDirection, initialURL string) error {
 	log := logging.FromContext(ctx)
 
-	splitCtx, ok := c.prepareSplit(ctx, direction)
-	if !ok {
-		return nil
+	splitCtx, err := c.prepareSplit(ctx, direction)
+	if err != nil {
+		return err
 	}
 
 	output, err := c.panesUC.Split(ctx, usecase.SplitPaneInput{
@@ -198,10 +198,9 @@ func (c *WorkspaceCoordinator) splitWithInitialURL(ctx context.Context, directio
 
 	// Update the workspace view
 	if splitCtx.wsView != nil {
-		c.applySplitToView(ctx, splitCtx.wsView, splitCtx.ws, output, direction, splitCtx.existingWidget, splitCtx.isStackSplit, oldActivePaneID)
-	}
-
-	if splitCtx.wsView != nil {
+		if err := c.applySplitToView(ctx, splitCtx.wsView, splitCtx.ws, output, direction, splitCtx.existingWidget, splitCtx.isStackSplit, oldActivePaneID); err != nil {
+			return err
+		}
 		splitCtx.wsView.NotifyNewPaneCreated(ctx)
 	}
 
@@ -332,23 +331,27 @@ func setActiveStackIndexForChild(parent, child *entity.PaneNode) {
 func (c *WorkspaceCoordinator) prepareSplit(
 	ctx context.Context,
 	direction usecase.SplitDirection,
-) (*splitContext, bool) {
+) (*splitContext, error) {
 	log := logging.FromContext(ctx)
 	if c.panesUC == nil {
 		log.Warn().Msg("panes use case not available")
-		return nil, false
+		return nil, fmt.Errorf("panes use case not available")
+	}
+	if c.getActiveWS == nil {
+		log.Warn().Msg("active workspace provider not configured")
+		return nil, fmt.Errorf("active workspace provider not configured")
 	}
 
 	ws, wsView := c.getActiveWS()
 	if ws == nil {
 		log.Warn().Msg("no active workspace")
-		return nil, false
+		return nil, fmt.Errorf("no active workspace")
 	}
 
 	activePane := ws.ActivePane()
-	if activePane == nil {
+	if activePane == nil || activePane.Pane == nil {
 		log.Warn().Msg("no active pane to split")
-		return nil, false
+		return nil, fmt.Errorf("no active pane to split")
 	}
 
 	// Check if active pane is inside a stack
@@ -367,7 +370,7 @@ func (c *WorkspaceCoordinator) prepareSplit(
 		activePane:     activePane,
 		existingWidget: existingWidget,
 		isStackSplit:   isStackSplit,
-	}, true
+	}, nil
 }
 
 func (c *WorkspaceCoordinator) resolveSplitWidget(
@@ -407,7 +410,7 @@ func (c *WorkspaceCoordinator) applySplitToView(
 	existingWidget layout.Widget,
 	isStackSplit bool,
 	oldActivePaneID entity.PaneID,
-) {
+) error {
 	log := logging.FromContext(ctx)
 	needsAttach := false
 
@@ -423,12 +426,14 @@ func (c *WorkspaceCoordinator) applySplitToView(
 			log.Warn().Err(splitErr).Msg("incremental split failed, falling back to rebuild")
 			if err := wsView.Rebuild(ctx); err != nil {
 				log.Error().Err(err).Msg("failed to rebuild workspace view")
+				return fmt.Errorf("rebuild workspace view after split: %w", err)
 			}
 			needsAttach = true
 		}
 	} else {
 		if err := wsView.Rebuild(ctx); err != nil {
 			log.Error().Err(err).Msg("failed to rebuild workspace view")
+			return fmt.Errorf("rebuild workspace view after split: %w", err)
 		}
 		needsAttach = true
 	}
@@ -439,8 +444,10 @@ func (c *WorkspaceCoordinator) applySplitToView(
 	}
 	if err := wsView.SetActivePaneID(ws.ActivePaneID); err != nil {
 		log.Warn().Err(err).Msg("failed to set active pane in workspace view")
+		return fmt.Errorf("activate split pane: %w", err)
 	}
 	wsView.FocusPane(ws.ActivePaneID)
+	return nil
 }
 
 // doIncrementalStackSplit performs an incremental split around an existing stacked pane.
@@ -1453,11 +1460,16 @@ func (c *WorkspaceCoordinator) syncStackedViewActive(ctx context.Context, wsView
 // StackPane adds a new pane stacked on top of the active pane.
 // Uses CreateStack use case for new stacks, AddToStack for existing stacks.
 func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
+	return c.StackPaneWithURL(ctx, c.newPaneURL)
+}
+
+// StackPaneWithURL adds a new pane containing initialURL to the active stack.
+func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL string) error {
 	log := logging.FromContext(ctx)
 
-	stackCtx, ok := c.prepareStackPane(ctx)
-	if !ok {
-		return nil
+	stackCtx, err := c.prepareStackPane(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Determine if we need to create a new stack or add to existing.
@@ -1469,7 +1481,7 @@ func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
 	if stackCtx.activeNode.Parent != nil && stackCtx.activeNode.Parent.IsStacked {
 		// Already in a stack - use AddToStack use case
 		stackNode = stackCtx.activeNode.Parent
-		output, err := c.panesUC.AddToStack(ctx, stackCtx.ws, stackNode, nil, c.newPaneURL)
+		output, err := c.panesUC.AddToStack(ctx, stackCtx.ws, stackNode, nil, initialURL)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to add pane to stack via use case")
 			return err
@@ -1484,7 +1496,7 @@ func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
 	} else if stackCtx.activeNode.IsStacked {
 		// Active node is already a stack container - add to it
 		stackNode = stackCtx.activeNode
-		output, err := c.panesUC.AddToStack(ctx, stackCtx.ws, stackNode, nil, c.newPaneURL)
+		output, err := c.panesUC.AddToStack(ctx, stackCtx.ws, stackNode, nil, initialURL)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to add pane to stack via use case")
 			return err
@@ -1498,7 +1510,7 @@ func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
 			Msg("added to stack container via use case")
 	} else {
 		// Need to create a new stack - use CreateStack use case.
-		output, err := c.panesUC.CreateStack(ctx, stackCtx.ws, stackCtx.activeNode, c.newPaneURL)
+		output, err := c.panesUC.CreateStack(ctx, stackCtx.ws, stackCtx.activeNode, initialURL)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to create stack via use case")
 			return err
@@ -1539,23 +1551,28 @@ func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
 	wv, err := c.contentCoord.EnsureWebView(ctx, newPaneID)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to get webview for new pane")
-	} else {
-		widget := c.contentCoord.WrapWidget(ctx, wv)
-		if widget != nil {
-			if err := stackCtx.wsView.SetWebViewWidget(newPaneID, widget); err != nil {
-				log.Warn().Err(err).Str("pane_id", string(newPaneID)).Msg("failed to attach webview widget for stacked pane")
-			}
-		}
-		// Load initial page for the new pane
-		if err := wv.LoadURI(ctx, newPane.URI); err != nil {
-			log.Warn().Err(err).Str("uri", newPane.URI).Msg("failed to load initial page")
-		}
+		return err
+	}
+	widget := c.contentCoord.WrapWidget(ctx, wv)
+	if widget == nil {
+		return fmt.Errorf("wrap webview for stacked pane")
+	}
+	if err := stackCtx.wsView.SetWebViewWidget(newPaneID, widget); err != nil {
+		log.Warn().Err(err).Str("pane_id", string(newPaneID)).Msg("failed to attach webview widget for stacked pane")
+		return err
+	}
+	// Load initial page for the new pane.
+	if err := wv.LoadURI(ctx, newPane.URI); err != nil {
+		log.Warn().Err(err).Str("uri_host", logging.SafeURLHost(newPane.URI)).Msg("failed to load initial page")
+		return err
 	}
 
 	// Update workspace view
 	if err := stackCtx.wsView.SetActivePaneID(newPaneID); err != nil {
 		log.Warn().Err(err).Msg("failed to set active pane")
+		return err
 	}
+	stackCtx.wsView.FocusPane(newPaneID)
 
 	stackCtx.wsView.NotifyNewPaneCreated(ctx)
 
@@ -1588,28 +1605,44 @@ func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
 
 func (c *WorkspaceCoordinator) prepareStackPane(
 	ctx context.Context,
-) (*stackPaneContext, bool) {
+) (*stackPaneContext, error) {
 	log := logging.FromContext(ctx)
 	if c.stackedPaneMgr == nil {
 		log.Warn().Msg("stacked pane manager not available")
-		return nil, false
+		return nil, fmt.Errorf("stacked pane manager not available")
+	}
+	if c.panesUC == nil {
+		log.Warn().Msg("panes use case not available")
+		return nil, fmt.Errorf("panes use case not available")
+	}
+	if c.contentCoord == nil {
+		log.Warn().Msg("content coordinator not available")
+		return nil, fmt.Errorf("content coordinator not available")
+	}
+	if c.widgetFactory == nil {
+		log.Warn().Msg("widget factory not available")
+		return nil, fmt.Errorf("widget factory not available")
+	}
+	if c.getActiveWS == nil {
+		log.Warn().Msg("active workspace provider not configured")
+		return nil, fmt.Errorf("active workspace provider not configured")
 	}
 
 	ws, wsView := c.getActiveWS()
 	if ws == nil {
 		log.Warn().Msg("no active workspace")
-		return nil, false
+		return nil, fmt.Errorf("no active workspace")
 	}
 
 	activeNode := ws.ActivePane()
 	if activeNode == nil || activeNode.Pane == nil {
 		log.Warn().Msg("no active pane")
-		return nil, false
+		return nil, fmt.Errorf("no active pane")
 	}
 
 	if wsView == nil {
 		log.Warn().Msg("no workspace view")
-		return nil, false
+		return nil, fmt.Errorf("no workspace view")
 	}
 
 	activePaneID := activeNode.Pane.ID
@@ -1627,7 +1660,7 @@ func (c *WorkspaceCoordinator) prepareStackPane(
 		activeNode:    activeNode,
 		activePaneID:  activePaneID,
 		originalTitle: originalTitle,
-	}, true
+	}, nil
 }
 
 func (c *WorkspaceCoordinator) updateFirstStackTitle(
@@ -1942,7 +1975,9 @@ func (c *WorkspaceCoordinator) insertPopupSplit(ctx context.Context, input conte
 
 	// Update UI
 	if wsView != nil {
-		c.applySplitToView(ctx, wsView, ws, output, direction, existingWidget, isStackSplit, input.ParentPaneID)
+		if err := c.applySplitToView(ctx, wsView, ws, output, direction, existingWidget, isStackSplit, input.ParentPaneID); err != nil {
+			return err
+		}
 		c.attachPopupWebView(ctx, wsView, input)
 	}
 

--- a/internal/ui/coordinator/workspace.go
+++ b/internal/ui/coordinator/workspace.go
@@ -163,15 +163,25 @@ func setupPaneViewHover(ctx context.Context, pv *component.PaneView, wsView *com
 
 // Split splits the active pane in the given direction.
 func (c *WorkspaceCoordinator) Split(ctx context.Context, direction usecase.SplitDirection) error {
-	return c.splitWithInitialURL(ctx, direction, c.newPaneURL)
+	return c.splitWithInitialURL(ctx, direction, c.newPaneURL, true)
 }
 
 // SplitWithURL splits the active pane in the given direction and loads initialURL.
 func (c *WorkspaceCoordinator) SplitWithURL(ctx context.Context, direction usecase.SplitDirection, initialURL string) error {
-	return c.splitWithInitialURL(ctx, direction, initialURL)
+	return c.splitWithInitialURL(ctx, direction, initialURL, true)
 }
 
-func (c *WorkspaceCoordinator) splitWithInitialURL(ctx context.Context, direction usecase.SplitDirection, initialURL string) error {
+// SplitWithURLWithoutOmnibox splits the active pane without opening the omnibox.
+func (c *WorkspaceCoordinator) SplitWithURLWithoutOmnibox(ctx context.Context, direction usecase.SplitDirection, initialURL string) error {
+	return c.splitWithInitialURL(ctx, direction, initialURL, false)
+}
+
+func (c *WorkspaceCoordinator) splitWithInitialURL(
+	ctx context.Context,
+	direction usecase.SplitDirection,
+	initialURL string,
+	notifyNewPane bool,
+) error {
 	log := logging.FromContext(ctx)
 
 	splitCtx, err := c.prepareSplit(ctx, direction)
@@ -204,7 +214,9 @@ func (c *WorkspaceCoordinator) splitWithInitialURL(ctx context.Context, directio
 		); err != nil {
 			return err
 		}
-		splitCtx.wsView.NotifyNewPaneCreated(ctx)
+		if notifyNewPane {
+			splitCtx.wsView.NotifyNewPaneCreated(ctx)
+		}
 	}
 
 	// Notify state change for session snapshots
@@ -1463,11 +1475,20 @@ func (c *WorkspaceCoordinator) syncStackedViewActive(ctx context.Context, wsView
 // StackPane adds a new pane stacked on top of the active pane.
 // Uses CreateStack use case for new stacks, AddToStack for existing stacks.
 func (c *WorkspaceCoordinator) StackPane(ctx context.Context) error {
-	return c.StackPaneWithURL(ctx, c.newPaneURL)
+	return c.stackPaneWithURL(ctx, c.newPaneURL, true)
 }
 
 // StackPaneWithURL adds a new pane containing initialURL to the active stack.
 func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL string) error {
+	return c.stackPaneWithURL(ctx, initialURL, true)
+}
+
+// StackPaneWithURLWithoutOmnibox adds a stacked pane without opening the omnibox.
+func (c *WorkspaceCoordinator) StackPaneWithURLWithoutOmnibox(ctx context.Context, initialURL string) error {
+	return c.stackPaneWithURL(ctx, initialURL, false)
+}
+
+func (c *WorkspaceCoordinator) stackPaneWithURL(ctx context.Context, initialURL string, notifyNewPane bool) error {
 	log := logging.FromContext(ctx)
 
 	stackCtx, err := c.prepareStackPane(ctx)
@@ -1529,7 +1550,9 @@ func (c *WorkspaceCoordinator) StackPaneWithURL(ctx context.Context, initialURL 
 	}
 	stackCtx.wsView.FocusPane(newPaneID)
 
-	stackCtx.wsView.NotifyNewPaneCreated(ctx)
+	if notifyNewPane {
+		stackCtx.wsView.NotifyNewPaneCreated(ctx)
+	}
 
 	// Set up title bar click and close callbacks
 	tr := stackCtx.wsView.TreeRenderer()

--- a/internal/ui/coordinator/workspace_external_url_test.go
+++ b/internal/ui/coordinator/workspace_external_url_test.go
@@ -55,7 +55,7 @@ func TestWorkspaceCoordinator_StackPaneUsesConfiguredURLThroughLegacyEntryPoint(
 
 	// The test coordinator intentionally has no WebView pool. Creation reaches
 	// that detectable UI failure only after the requested URL enters the model.
-	require.ErrorContains(t, coord.StackPane(context.Background()), "webview pool not configured")
+	require.Error(t, coord.StackPane(context.Background()))
 	assert.Equal(t, legacyURL, ws.ActivePane().Pane.URI)
 }
 
@@ -63,7 +63,7 @@ func TestWorkspaceCoordinator_StackPaneWithURLUsesExplicitURL(t *testing.T) {
 	const explicitURL = "https://explicit.example/path?token=secret"
 	coord, ws := stackURLTestCoordinator(t, "https://legacy.example/")
 
-	require.ErrorContains(t, coord.StackPaneWithURL(context.Background(), explicitURL), "webview pool not configured")
+	require.Error(t, coord.StackPaneWithURL(context.Background(), explicitURL))
 	assert.Equal(t, explicitURL, ws.ActivePane().Pane.URI)
 }
 

--- a/internal/ui/coordinator/workspace_external_url_test.go
+++ b/internal/ui/coordinator/workspace_external_url_test.go
@@ -1,0 +1,97 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/ui/component"
+	contentcoord "github.com/bnema/dumber/internal/ui/coordinator/content"
+	"github.com/bnema/dumber/internal/ui/layout"
+	"github.com/bnema/puregotk/v4/gtk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaceCoordinator_SplitWithURLUsesExplicitURLAndActivatesPane(t *testing.T) {
+	ctx := context.Background()
+	ids := []string{"pane-2", "split-1"}
+	index := 0
+	ws := entity.NewWorkspace("ws-1", entity.NewPane("pane-1"))
+	coord := NewWorkspaceCoordinator(ctx, WorkspaceCoordinatorConfig{
+		PanesUC: usecase.NewManagePanesUseCase(func() string {
+			id := ids[index]
+			index++
+			return id
+		}, nil),
+		NewPaneURL: "https://legacy.example/",
+		GetActiveWS: func() (*entity.Workspace, *component.WorkspaceView) {
+			return ws, nil
+		},
+	})
+
+	const explicitURL = "https://explicit.example/path?token=secret"
+	require.NoError(t, coord.SplitWithURL(ctx, usecase.SplitLeft, explicitURL))
+
+	active := ws.ActivePane()
+	require.NotNil(t, active)
+	require.NotNil(t, active.Pane)
+	assert.Equal(t, entity.PaneID("pane-2"), ws.ActivePaneID)
+	assert.Equal(t, explicitURL, active.Pane.URI)
+	assert.Equal(t, entity.SplitHorizontal, ws.Root.SplitDir)
+	assert.Equal(t, entity.PaneID("pane-2"), ws.Root.Children[0].Pane.ID)
+}
+
+func TestWorkspaceCoordinator_SplitReturnsErrorWhenCreationTargetMissing(t *testing.T) {
+	coord := NewWorkspaceCoordinator(context.Background(), WorkspaceCoordinatorConfig{})
+	require.Error(t, coord.SplitWithURL(context.Background(), usecase.SplitRight, "https://example.com"))
+}
+
+func TestWorkspaceCoordinator_StackPaneUsesConfiguredURLThroughLegacyEntryPoint(t *testing.T) {
+	const legacyURL = "https://legacy.example/"
+	coord, ws := stackURLTestCoordinator(t, legacyURL)
+
+	// The test coordinator intentionally has no WebView pool. Creation reaches
+	// that detectable UI failure only after the requested URL enters the model.
+	require.ErrorContains(t, coord.StackPane(context.Background()), "webview pool not configured")
+	assert.Equal(t, legacyURL, ws.ActivePane().Pane.URI)
+}
+
+func TestWorkspaceCoordinator_StackPaneWithURLUsesExplicitURL(t *testing.T) {
+	const explicitURL = "https://explicit.example/path?token=secret"
+	coord, ws := stackURLTestCoordinator(t, "https://legacy.example/")
+
+	require.ErrorContains(t, coord.StackPaneWithURL(context.Background(), explicitURL), "webview pool not configured")
+	assert.Equal(t, explicitURL, ws.ActivePane().Pane.URI)
+}
+
+func stackURLTestCoordinator(t *testing.T, legacyURL string) (*WorkspaceCoordinator, *entity.Workspace) {
+	t.Helper()
+	if !gtk.InitCheck() {
+		t.Skip("GTK native display prerequisite unavailable")
+	}
+	ctx := context.Background()
+	factory := layout.NewGtkWidgetFactory()
+	ws := entity.NewWorkspace("ws-1", entity.NewPane("pane-1"))
+	wsView := component.NewWorkspaceView(ctx, factory)
+	require.NoError(t, wsView.SetWorkspace(ctx, ws))
+	ids := []string{"pane-2", "stack-1"}
+	index := 0
+	content := contentcoord.NewCoordinator(ctx, nil, nil, factory, nil, nil, nil, nil)
+	coord := NewWorkspaceCoordinator(ctx, WorkspaceCoordinatorConfig{
+		PanesUC: usecase.NewManagePanesUseCase(func() string {
+			id := ids[index]
+			index++
+			return id
+		}, nil),
+		WidgetFactory:  factory,
+		StackedPaneMgr: component.NewStackedPaneManager(factory),
+		ContentCoord:   content,
+		NewPaneURL:     legacyURL,
+		GetActiveWS: func() (*entity.Workspace, *component.WorkspaceView) {
+			return ws, wsView
+		},
+	})
+	return coord, ws
+}

--- a/internal/ui/coordinator/workspace_external_url_test.go
+++ b/internal/ui/coordinator/workspace_external_url_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bnema/dumber/internal/ui/component"
 	contentcoord "github.com/bnema/dumber/internal/ui/coordinator/content"
 	"github.com/bnema/dumber/internal/ui/layout"
+	"github.com/bnema/puregotk/v4/gdk"
 	"github.com/bnema/puregotk/v4/gtk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func TestWorkspaceCoordinator_StackPaneWithURLUsesExplicitURL(t *testing.T) {
 
 func stackURLTestCoordinator(t *testing.T, legacyURL string) (*WorkspaceCoordinator, *entity.Workspace) {
 	t.Helper()
-	if !gtk.InitCheck() {
+	if !gtk.InitCheck() || gdk.DisplayGetDefault() == nil {
 		t.Skip("GTK native display prerequisite unavailable")
 	}
 	ctx := context.Background()

--- a/internal/ui/external_link_routing_test.go
+++ b/internal/ui/external_link_routing_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestExternalLinkSplitDirectionPlacements(t *testing.T) {
 	tests := map[entity.ExternalLinkPlacement]usecase.SplitDirection{
+		"":                                 usecase.SplitRight,
 		entity.ExternalLinkPlacementLeft:   usecase.SplitLeft,
 		entity.ExternalLinkPlacementRight:  usecase.SplitRight,
 		entity.ExternalLinkPlacementTop:    usecase.SplitUp,

--- a/internal/ui/external_link_routing_test.go
+++ b/internal/ui/external_link_routing_test.go
@@ -1,0 +1,136 @@
+package ui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/port/mocks"
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/bnema/dumber/internal/shared/syncdispatch"
+	"github.com/bnema/dumber/internal/ui/component"
+	"github.com/bnema/dumber/internal/ui/coordinator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalLinkSplitDirectionPlacements(t *testing.T) {
+	tests := map[entity.ExternalLinkPlacement]usecase.SplitDirection{
+		entity.ExternalLinkPlacementLeft:   usecase.SplitLeft,
+		entity.ExternalLinkPlacementRight:  usecase.SplitRight,
+		entity.ExternalLinkPlacementTop:    usecase.SplitUp,
+		entity.ExternalLinkPlacementBottom: usecase.SplitDown,
+	}
+	for placement, want := range tests {
+		t.Run(string(placement), func(t *testing.T) {
+			assert.Equal(t, want, externalLinkSplitDirection(placement))
+		})
+	}
+}
+
+func TestApp_OpenExternalURLTabbedTargetsLastFocusedWindowAndPreservesURL(t *testing.T) {
+	ctx := context.Background()
+	const originalURL = "https://example.com/path?token=secret#fragment"
+	active := entity.NewTab("tab-1", "ws-1", entity.NewPane("pane-1"))
+	tabs := entity.NewTabList()
+	tabs.Add(active)
+	focused := &browserWindow{id: "focused", tabs: tabs}
+
+	ids := []string{"tab-2", "ws-2", "pane-2"}
+	index := 0
+	app := &App{
+		runtimeConfig: runtimeConfigStateForTest(&config.Config{Workspace: entity.WorkspaceConfig{ExternalLinks: entity.ExternalLinksConfig{Behavior: entity.ExternalLinkBehaviorTabbed}}}),
+		tabsUC:        usecase.NewManageTabsUseCase(func() string { id := ids[index]; index++; return id }, nil),
+		browserWindows: map[string]*browserWindow{
+			focused.id: focused,
+		},
+		browserWindowOrder:  []string{focused.id},
+		lastFocusedWindowID: focused.id,
+		workspaceViews:      map[entity.TabID]*component.WorkspaceView{},
+		windowForTab:        map[entity.TabID]*browserWindow{},
+	}
+	app.tabCoord = coordinator.NewTabCoordinator(ctx, coordinator.TabCoordinatorConfig{TabsUC: app.tabsUC})
+	app.tabCoord.SetOnTabCreated(func(_ context.Context, _ coordinator.TabTarget, tab *entity.Tab) {
+		app.workspaceViews[tab.ID] = &component.WorkspaceView{}
+		app.setBrowserWindowForTab(tab.ID, focused)
+	})
+
+	require.NoError(t, app.OpenExternalURL(ctx, originalURL))
+	require.Len(t, tabs.Tabs, 2)
+	created := tabs.ActiveTab()
+	require.NotNil(t, created)
+	require.NotNil(t, created.Workspace)
+	assert.Equal(t, originalURL, created.Workspace.ActivePane().Pane.URI)
+	assert.Same(t, focused, app.browserWindowForTab(created.ID))
+}
+
+func TestApp_OpenExternalURLSnapshotsRuntimeConfigOnce(t *testing.T) {
+	ctx := context.Background()
+	provider := mocks.NewMockRuntimeConfigProvider(t)
+	provider.EXPECT().Current().Return(entity.RuntimeConfigSnapshot{UI: entity.RuntimeUIConfig{Workspace: entity.WorkspaceConfig{ExternalLinks: entity.ExternalLinksConfig{Behavior: entity.ExternalLinkBehaviorWindowed}}}}).Once()
+	var factoryCalls int
+	var dispatchCalls int
+	app := &App{
+		runtimeConfig: newRuntimeConfigState(provider),
+		dispatchOnMainThread: func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			dispatchCalls++
+			fn()
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchInline}
+		},
+		browserWindowFactory: func(_ context.Context, _ string) (*browserWindow, error) {
+			factoryCalls++
+			return &browserWindow{id: "windowed", tabs: entity.NewTabList()}, nil
+		},
+		browserWindows: map[string]*browserWindow{},
+		workspaceViews: map[entity.TabID]*component.WorkspaceView{},
+		windowForTab:   map[entity.TabID]*browserWindow{},
+	}
+
+	require.NoError(t, app.OpenExternalURL(ctx, "https://example.com"))
+	assert.Equal(t, 1, dispatchCalls)
+	assert.Equal(t, 1, factoryCalls)
+}
+
+func TestApp_OpenExternalURLFallsBackWhenLastFocusedWindowIsStale(t *testing.T) {
+	ctx := context.Background()
+	const originalURL = "https://example.com/stale?token=secret"
+	staleTab := entity.NewTab("stale-tab", "stale-workspace", entity.NewPane("stale-pane"))
+	staleTabs := entity.NewTabList()
+	staleTabs.Add(staleTab)
+	stale := &browserWindow{id: "stale", tabs: staleTabs}
+	var factoryURL string
+	app := &App{
+		runtimeConfig:       runtimeConfigStateForTest(&config.Config{Workspace: entity.WorkspaceConfig{ExternalLinks: entity.ExternalLinksConfig{Behavior: entity.ExternalLinkBehaviorTabbed}}}),
+		browserWindows:      map[string]*browserWindow{},
+		lastFocusedWindowID: stale.id,
+		windowForTab:        map[entity.TabID]*browserWindow{staleTab.ID: stale},
+		workspaceViews:      map[entity.TabID]*component.WorkspaceView{},
+		browserWindowFactory: func(_ context.Context, url string) (*browserWindow, error) {
+			factoryURL = url
+			return &browserWindow{id: "fallback", tabs: entity.NewTabList()}, nil
+		},
+	}
+
+	require.NoError(t, app.OpenExternalURL(ctx, originalURL))
+	assert.Equal(t, originalURL, factoryURL)
+}
+
+func TestApp_OpenExternalURLFallbackPreservesOriginalURL(t *testing.T) {
+	ctx := context.Background()
+	const originalURL = "https://example.com/path?token=secret#fragment"
+	var factoryURL string
+	app := &App{
+		runtimeConfig: runtimeConfigStateForTest(&config.Config{Workspace: entity.WorkspaceConfig{ExternalLinks: entity.ExternalLinksConfig{Behavior: entity.ExternalLinkBehaviorSplit, Placement: entity.ExternalLinkPlacementLeft}}}),
+		browserWindowFactory: func(_ context.Context, url string) (*browserWindow, error) {
+			factoryURL = url
+			return &browserWindow{id: "fallback", tabs: entity.NewTabList()}, nil
+		},
+		browserWindows: map[string]*browserWindow{},
+		workspaceViews: map[entity.TabID]*component.WorkspaceView{},
+		windowForTab:   map[entity.TabID]*browserWindow{},
+	}
+
+	require.NoError(t, app.OpenExternalURL(ctx, originalURL))
+	assert.Equal(t, originalURL, factoryURL)
+}


### PR DESCRIPTION
## Summary
- add configurable windowed, tabbed, split, and stacked external-link routing
- preserve socket isolation and fall back to a fresh window when in-window placement cannot complete
- document configuration and cover routing, relay, and coordinator behavior

## Validation
- `go fmt ./...`
- `make test`
- `make lint`
- `make check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable routing for external links: new window, tab, split pane, or stacked pane.
  - Split-pane placement can be set to right, left, top, or bottom.
  - External URLs now open in the focused workspace when configured, with fallback to a new window when needed.

- **Bug Fixes**
  - Improved external-link delivery during browser relaunches and cross-window forwarding.
  - Added safer handling and clearer errors when pane or tab creation fails.

- **Documentation**
  - Documented the new external-link behavior and placement settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->