### PR TITLE
fix(webview): harden reviewed bridge paths

### DIFF
--- a/internal/infrastructure/webkit/messaging.go
+++ b/internal/infrastructure/webkit/messaging.go
@@ -282,7 +282,7 @@ func decodeScriptMessage(valuePtr uintptr, log zerolog.Logger) (Message, bool) {
 
 	var msg Message
 	if err := json.Unmarshal([]byte(rawJSON), &msg); err != nil {
-		log.Warn().Err(err).Str("json", rawJSON).Msg("failed to unmarshal script message")
+		log.Warn().Err(err).Int("json_len", len(rawJSON)).Msg("failed to unmarshal script message")
 		return Message{}, false
 	}
 	return msg, true
@@ -305,14 +305,15 @@ func (r *MessageRouter) handleAllowlistedBridgeMessage(senderWV *WebView, msg Me
 		Editable bool   `json:"editable"`
 		Token    string `json:"token"`
 	}
+	log := logging.FromContext(r.baseContext())
 	if len(msg.Payload) != 0 {
 		if err := json.Unmarshal(msg.Payload, &payload); err != nil {
-			logging.FromContext(r.baseCtx).Warn().Err(err).Str("type", msg.Type).Msg("failed to decode allowlisted bridge payload")
+			log.Warn().Err(err).Str("type", msg.Type).Msg("failed to decode allowlisted bridge payload")
 			return true
 		}
 	}
 	if payload.Token == "" || !senderWV.matchesEditableFocusBridgeToken(payload.Token) {
-		logging.FromContext(r.baseCtx).Warn().Str("type", msg.Type).Msg("rejecting allowlisted bridge message with invalid token")
+		log.Warn().Str("type", msg.Type).Msg("rejecting allowlisted bridge message with invalid token")
 		return true
 	}
 	senderWV.dispatchEditableFocusChanged(payload.Editable)

--- a/internal/infrastructure/webkit/pool.go
+++ b/internal/infrastructure/webkit/pool.go
@@ -179,7 +179,9 @@ func (p *WebViewPool) Acquire(ctx context.Context) (*WebView, error) {
 
 			// Ensure frontend is attached even if this WebView was pooled before injection was configured.
 			alreadyAttached := wv.FrontendAttached()
-			_ = wv.AttachFrontend(ctx, p.injector, p.router)
+			if err := wv.AttachFrontend(ctx, p.injector, p.router); err != nil {
+				log.Warn().Err(err).Uint64("id", uint64(wv.ID())).Msg("failed to attach frontend to pooled webview")
+			}
 			// Reinjection is only for already-attached reuse after ResetForPoolReuse.
 			// First AttachFrontend already injected; avoid an immediate double inject.
 			if needsFrontendReinjectionOnAcquire(alreadyAttached) && p.injector != nil && wv.ucm != nil {

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -1009,7 +1009,7 @@ func TestTestShellToasterCleanupCancelsAutoDismiss(t *testing.T) {
 	toaster.CancelAutoDismiss()
 
 	mainContext := glib.MainContextDefault()
-	deadline := time.Now().Add(component.ToastBriefDurationMs + 100*time.Millisecond)
+	deadline := time.Now().Add(component.ToastBriefDurationMs + 600*time.Millisecond)
 	for time.Now().Before(deadline) {
 		for mainContext.Pending() {
 			mainContext.Iteration(false)


### PR DESCRIPTION
## Summary
- avoid logging page-controlled script-message JSON on decode failures
- use the synchronized message-router context and surface pooled frontend attachment failures
- make toaster cancellation coverage wait beyond the dismissal delay

## Validation
- `go test ./internal/infrastructure/webkit ./internal/ui`
- `make test`
- `make lint`
- `make check`
- `git diff --check`

@coderabbitai ignore