### PR TITLE
fix(omnibox): always open standalone links in new window

### DIFF
--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -96,11 +96,28 @@ func launchModeFromArgs(args []string) (launchMode, string) {
 }
 
 func tryForwardBrowseURLToRunningInstance(ctx context.Context, relay port.BrowserLaunchRelay, browseURL string) (bool, error) {
+	return tryForwardBrowserURLToRunningInstance(ctx, relay, browseURL, func(ctx context.Context, url string) (bool, error) {
+		return relay.DeliverOpenExternalURL(ctx, url)
+	})
+}
+
+func tryForwardFreshWindowURLToRunningInstance(ctx context.Context, relay port.BrowserLaunchRelay, browseURL string) (bool, error) {
+	return tryForwardBrowserURLToRunningInstance(ctx, relay, browseURL, func(ctx context.Context, url string) (bool, error) {
+		return relay.DeliverOpenFreshWindow(ctx, url)
+	})
+}
+
+func tryForwardBrowserURLToRunningInstance(
+	ctx context.Context,
+	relay port.BrowserLaunchRelay,
+	browseURL string,
+	deliver func(context.Context, string) (bool, error),
+) (bool, error) {
 	if relay == nil {
 		return false, nil
 	}
 
-	delivered, err := relay.DeliverOpenExternalURL(ctx, browseURL)
+	delivered, err := deliver(ctx, browseURL)
 	if err != nil {
 		if delivered && errors.Is(err, desktop.ErrBrowserLaunchRelayUnconfirmed) {
 			return true, nil
@@ -193,7 +210,15 @@ func main() {
 		timing.configComplete = time.Now()
 		configureBrowserLaunchRelay(cfg)
 		startupURL := domainurl.ResolveBrowserStartupURL(browseURL)
-		if forwarded, err := tryForwardBrowseURLToRunningInstance(context.Background(), browserLaunchRelay, startupURL); err != nil {
+		freshWindow := os.Getenv(desktop.FreshWindowLaunchEnvVar) == "1"
+		if freshWindow {
+			_ = os.Unsetenv(desktop.FreshWindowLaunchEnvVar)
+		}
+		forward := tryForwardBrowseURLToRunningInstance
+		if freshWindow {
+			forward = tryForwardFreshWindowURLToRunningInstance
+		}
+		if forwarded, err := forward(context.Background(), browserLaunchRelay, startupURL); err != nil {
 			fmt.Fprintf(
 				os.Stderr,
 				"warning: failed to forward browse URL %q to a running instance, falling back to a new process: %v\n",
@@ -961,7 +986,7 @@ func buildUIDependencies(
 		},
 		LaunchExternalURL: desktop.LaunchExternalURL,
 		LaunchBrowserURL: func(navCtx context.Context, uri string) error {
-			return launchStandaloneBrowserURL(navCtx, browserLauncher.LaunchURL, uri)
+			return launchStandaloneBrowserURL(navCtx, browserLauncher.LaunchFreshWindowURL, uri)
 		},
 		BrowserLaunchRelay: browserLaunchRelay,
 		MigrationChecker:   config.NewMigrator(),

--- a/cmd/dumber/main_test.go
+++ b/cmd/dumber/main_test.go
@@ -256,6 +256,20 @@ func TestTryForwardBrowseURLToRunningInstance_ReturnsTrueOnRelayHit(t *testing.T
 	}
 }
 
+func TestTryForwardFreshWindowURLToRunningInstance_UsesFreshWindowRelayAction(t *testing.T) {
+	relay := mocks.NewMockBrowserLaunchRelay(t)
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, nil)
+
+	forwarded, err := tryForwardFreshWindowURLToRunningInstance(context.Background(), relay, "https://example.com")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !forwarded {
+		t.Fatal("expected fresh-window relay delivery to be forwarded")
+	}
+}
+
 func TestTryForwardBrowseURLToRunningInstance_ReturnsFalseOnRelayMiss(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
 	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(false, nil)

--- a/internal/application/port/browser_launch.go
+++ b/internal/application/port/browser_launch.go
@@ -5,12 +5,13 @@ import (
 	"io"
 )
 
-// BrowserWindowOpener opens an external URL.
+// BrowserWindowOpener opens browser URLs received through the launch relay.
 type BrowserWindowOpener interface {
 	OpenExternalURL(ctx context.Context, url string) error
+	OpenFreshWindow(ctx context.Context, url string) error
 }
 
-// BrowserLaunchRelay delivers external URL launch requests.
+// BrowserLaunchRelay delivers browser URL launch requests.
 type BrowserLaunchRelay interface {
 	// DeliverOpenExternalURL attempts to deliver a request to open an external URL.
 	// The bool reports whether the relay accepted the request; false means the
@@ -18,6 +19,9 @@ type BrowserLaunchRelay interface {
 	// An error may still be returned with delivered=true when the relay accepted
 	// the request but could not confirm completion before the caller timed out.
 	DeliverOpenExternalURL(ctx context.Context, url string) (bool, error)
+	// DeliverOpenFreshWindow attempts to deliver a request that must open in a
+	// new browser window, independently of external-link workspace settings.
+	DeliverOpenFreshWindow(ctx context.Context, url string) (bool, error)
 	Listen(ctx context.Context, opener BrowserWindowOpener) (io.Closer, error)
 }
 

--- a/internal/application/port/mocks/browser_launch.go
+++ b/internal/application/port/mocks/browser_launch.go
@@ -96,6 +96,63 @@ func (_c *MockBrowserWindowOpener_OpenExternalURL_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// OpenFreshWindow provides a mock function for the type MockBrowserWindowOpener
+func (_mock *MockBrowserWindowOpener) OpenFreshWindow(ctx context.Context, url string) error {
+	ret := _mock.Called(ctx, url)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OpenFreshWindow")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, url)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBrowserWindowOpener_OpenFreshWindow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OpenFreshWindow'
+type MockBrowserWindowOpener_OpenFreshWindow_Call struct {
+	*mock.Call
+}
+
+// OpenFreshWindow is a helper method to define mock.On call
+//   - ctx context.Context
+//   - url string
+func (_e *MockBrowserWindowOpener_Expecter) OpenFreshWindow(ctx any, url any) *MockBrowserWindowOpener_OpenFreshWindow_Call {
+	return &MockBrowserWindowOpener_OpenFreshWindow_Call{Call: _e.mock.On("OpenFreshWindow", ctx, url)}
+}
+
+func (_c *MockBrowserWindowOpener_OpenFreshWindow_Call) Run(run func(ctx context.Context, url string)) *MockBrowserWindowOpener_OpenFreshWindow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBrowserWindowOpener_OpenFreshWindow_Call) Return(err error) *MockBrowserWindowOpener_OpenFreshWindow_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBrowserWindowOpener_OpenFreshWindow_Call) RunAndReturn(run func(ctx context.Context, url string) error) *MockBrowserWindowOpener_OpenFreshWindow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockBrowserLaunchRelay creates a new instance of MockBrowserLaunchRelay. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockBrowserLaunchRelay(t interface {
@@ -185,6 +242,72 @@ func (_c *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call) Return(b bool, err
 }
 
 func (_c *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call) RunAndReturn(run func(ctx context.Context, url string) (bool, error)) *MockBrowserLaunchRelay_DeliverOpenExternalURL_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeliverOpenFreshWindow provides a mock function for the type MockBrowserLaunchRelay
+func (_mock *MockBrowserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url string) (bool, error) {
+	ret := _mock.Called(ctx, url)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeliverOpenFreshWindow")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, url)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, url)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, url)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeliverOpenFreshWindow'
+type MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call struct {
+	*mock.Call
+}
+
+// DeliverOpenFreshWindow is a helper method to define mock.On call
+//   - ctx context.Context
+//   - url string
+func (_e *MockBrowserLaunchRelay_Expecter) DeliverOpenFreshWindow(ctx any, url any) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
+	return &MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call{Call: _e.mock.On("DeliverOpenFreshWindow", ctx, url)}
+}
+
+func (_c *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call) Run(run func(ctx context.Context, url string)) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call) Return(b bool, err error) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call) RunAndReturn(run func(ctx context.Context, url string) (bool, error)) *MockBrowserLaunchRelay_DeliverOpenFreshWindow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/infrastructure/desktop/adapter.go
+++ b/internal/infrastructure/desktop/adapter.go
@@ -446,6 +446,10 @@ func NewSessionSpawner(ctx context.Context, spawnEnv port.SessionSpawnEnvironmen
 // RestoreSessionEnvVar is the environment variable used to pass session ID for restoration.
 const RestoreSessionEnvVar = "DUMBER_RESTORE_SESSION"
 
+// FreshWindowLaunchEnvVar marks a browse child that must open a fresh window
+// instead of applying external-link workspace placement.
+const FreshWindowLaunchEnvVar = "DUMBER_BROWSER_FRESH_WINDOW"
+
 const layerShellPreloadToken = "libgtk4" + "-layer-shell"
 
 // LaunchExternalURL opens a URL with the system's default handler (xdg-open on Linux).
@@ -466,6 +470,23 @@ func LaunchBrowserURL(uri string) {
 }
 
 func launchBrowserBrowseURL(uri string, resolveExecutablePath func() (string, error), spawnDetachedProcess func(*exec.Cmd) error) error {
+	return launchBrowserURL(uri, false, resolveExecutablePath, spawnDetachedProcess)
+}
+
+func launchBrowserFreshWindowURL(
+	uri string,
+	resolveExecutablePath func() (string, error),
+	spawnDetachedProcess func(*exec.Cmd) error,
+) error {
+	return launchBrowserURL(uri, true, resolveExecutablePath, spawnDetachedProcess)
+}
+
+func launchBrowserURL(
+	uri string,
+	freshWindow bool,
+	resolveExecutablePath func() (string, error),
+	spawnDetachedProcess func(*exec.Cmd) error,
+) error {
 	if resolveExecutablePath == nil {
 		resolveExecutablePath = getExecutablePath
 	}
@@ -479,7 +500,10 @@ func launchBrowserBrowseURL(uri string, resolveExecutablePath func() (string, er
 	}
 
 	cmd := exec.Command(execPath, "browse", uri)
-	cmd.Env = sanitizedChildEnv(os.Environ())
+	cmd.Env = withoutEnvKeys(sanitizedChildEnv(os.Environ()), FreshWindowLaunchEnvVar)
+	if freshWindow {
+		cmd.Env = append(cmd.Env, FreshWindowLaunchEnvVar+"=1")
+	}
 	if err := spawnDetachedProcess(cmd); err != nil {
 		return fmt.Errorf("failed to launch dumber browse for requested URL: %w", err)
 	}

--- a/internal/infrastructure/desktop/adapter_test.go
+++ b/internal/infrastructure/desktop/adapter_test.go
@@ -220,6 +220,21 @@ func TestLaunchBrowserBrowseURL_SpawnErrorDoesNotLeakURL(t *testing.T) {
 	}
 }
 
+func TestLaunchBrowserBrowseURL_ClearsFreshWindowMarker(t *testing.T) {
+	t.Setenv(FreshWindowLaunchEnvVar, "1")
+
+	err := launchBrowserBrowseURL(
+		"https://example.com",
+		func() (string, error) { return "/usr/bin/dumber", nil },
+		func(cmd *exec.Cmd) error {
+			assert.NotContains(t, cmd.Env, FreshWindowLaunchEnvVar+"=1")
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+}
+
 func TestSetAsDefaultBrowserAlsoUpdatesMimeHandlers(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", filepath.Join(os.Getenv("HOME"), ".local", "share"))

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -39,9 +39,14 @@ type browserLaunchRelay struct {
 }
 
 type browserLaunchRequest struct {
-	RequestID string `json:"request_id,omitempty"`
-	URL       string `json:"url"`
+	RequestID string              `json:"request_id,omitempty"`
+	URL       string              `json:"url"`
+	Action    browserLaunchAction `json:"action,omitempty"`
 }
+
+type browserLaunchAction string
+
+const browserLaunchActionOpenFreshWindow browserLaunchAction = "open-fresh-window"
 
 type browserLaunchResponse struct {
 	RequestID string `json:"request_id,omitempty"`
@@ -69,6 +74,14 @@ func NewBrowserLaunchRelay(ipc runtimeprofile.IPCPaths) port.BrowserLaunchRelay 
 }
 
 func (r *browserLaunchRelay) DeliverOpenExternalURL(ctx context.Context, url string) (bool, error) {
+	return r.deliver(ctx, url, "")
+}
+
+func (r *browserLaunchRelay) DeliverOpenFreshWindow(ctx context.Context, url string) (bool, error) {
+	return r.deliver(ctx, url, browserLaunchActionOpenFreshWindow)
+}
+
+func (r *browserLaunchRelay) deliver(ctx context.Context, url string, action browserLaunchAction) (bool, error) {
 	socketPath, err := r.socketPath()
 	if err != nil {
 		return false, err
@@ -93,7 +106,7 @@ func (r *browserLaunchRelay) DeliverOpenExternalURL(ctx context.Context, url str
 	if err := setBrowserLaunchConnDeadline(ctx, conn); err != nil {
 		return false, err
 	}
-	if err := json.NewEncoder(conn).Encode(browserLaunchRequest{RequestID: requestID, URL: url}); err != nil {
+	if err := json.NewEncoder(conn).Encode(browserLaunchRequest{RequestID: requestID, URL: url, Action: action}); err != nil {
 		return false, err
 	}
 
@@ -353,20 +366,27 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 		log.Debug().
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
-			Msg("browser launch relay calling external URL opener")
-		if err := opener.OpenExternalURL(ctx, request.URL); err != nil {
+			Msg("browser launch relay calling browser URL opener")
+		var err error
+		switch request.Action {
+		case browserLaunchActionOpenFreshWindow:
+			err = opener.OpenFreshWindow(ctx, request.URL)
+		default:
+			err = opener.OpenExternalURL(ctx, request.URL)
+		}
+		if err != nil {
 			log.Warn().Err(err).
 				Str("request_id", requestID).
 				Str("url_host", safeURLHost(request.URL)).
 				Dur("elapsed", time.Since(started)).
-				Msg("browser launch relay external URL opener failed")
+				Msg("browser launch relay browser URL opener failed")
 			return
 		}
 		log.Debug().
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
 			Dur("elapsed", time.Since(started)).
-			Msg("browser launch relay external URL opener returned success")
+			Msg("browser launch relay browser URL opener returned success")
 	}()
 }
 

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -21,6 +21,23 @@ func (f browserWindowOpenerFunc) OpenExternalURL(ctx context.Context, url string
 	return f(ctx, url)
 }
 
+func (f browserWindowOpenerFunc) OpenFreshWindow(ctx context.Context, url string) error {
+	return f(ctx, url)
+}
+
+type browserWindowOpener struct {
+	openExternalURL func(context.Context, string) error
+	openFreshWindow func(context.Context, string) error
+}
+
+func (o browserWindowOpener) OpenExternalURL(ctx context.Context, url string) error {
+	return o.openExternalURL(ctx, url)
+}
+
+func (o browserWindowOpener) OpenFreshWindow(ctx context.Context, url string) error {
+	return o.openFreshWindow(ctx, url)
+}
+
 func waitForSocket(t *testing.T, path string) {
 	t.Helper()
 
@@ -230,10 +247,16 @@ func TestBrowserLaunchRelay_DeliverOpenExternalURL_RoundTrip(t *testing.T) {
 	received := make(chan string, 1)
 	ctx := t.Context()
 
-	closer, err := relay.Listen(ctx, browserWindowOpenerFunc(func(_ context.Context, url string) error {
-		received <- url
-		return nil
-	}))
+	closer, err := relay.Listen(ctx, browserWindowOpener{
+		openExternalURL: func(_ context.Context, url string) error {
+			received <- url
+			return nil
+		},
+		openFreshWindow: func(context.Context, string) error {
+			t.Fatal("external URL relay request must preserve configured placement")
+			return nil
+		},
+	})
 	require.NoError(t, err)
 	defer closer.Close()
 
@@ -249,6 +272,38 @@ func TestBrowserLaunchRelay_DeliverOpenExternalURL_RoundTrip(t *testing.T) {
 		assert.Equal(t, "https://example.com/new", got)
 	case <-time.After(time.Second):
 		t.Fatal("expected opener to receive the URL")
+	}
+}
+
+func TestBrowserLaunchRelay_DeliverOpenFreshWindow_RoundTrip(t *testing.T) {
+	ipc := testIPC(shortTempDir(t))
+	relay := NewBrowserLaunchRelay(ipc)
+
+	freshWindows := make(chan string, 1)
+	ctx := t.Context()
+	closer, err := relay.Listen(ctx, browserWindowOpener{
+		openExternalURL: func(context.Context, string) error {
+			t.Fatal("external-link placement must not handle standalone omnibox navigation")
+			return nil
+		},
+		openFreshWindow: func(_ context.Context, url string) error {
+			freshWindows <- url
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	defer closer.Close()
+
+	waitForSocket(t, ipc.BrowserLaunchSocket)
+	delivered, err := relay.DeliverOpenFreshWindow(context.Background(), "https://example.com/omnibox")
+
+	require.NoError(t, err)
+	require.True(t, delivered)
+	select {
+	case got := <-freshWindows:
+		assert.Equal(t, "https://example.com/omnibox", got)
+	case <-time.After(time.Second):
+		t.Fatal("expected fresh-window opener to receive the URL")
 	}
 }
 

--- a/internal/infrastructure/desktop/browser_launcher.go
+++ b/internal/infrastructure/desktop/browser_launcher.go
@@ -13,7 +13,7 @@ import (
 // received the request, but the caller could not confirm that in time.
 var ErrBrowserLaunchUnconfirmed = errors.New("browser launch could not be confirmed")
 
-// BrowserLauncher opens URLs in a relay-first dumber browser instance.
+// BrowserLauncher opens standalone-omnibox URLs in a relay-first dumber browser instance.
 type BrowserLauncher struct {
 	relay                 port.BrowserLaunchRelay
 	resolveExecutablePath func() (string, error)
@@ -29,14 +29,16 @@ func NewBrowserLauncher(relay port.BrowserLaunchRelay) *BrowserLauncher {
 	}
 }
 
-// LaunchURL forwards the URL to a running instance when possible, otherwise spawns a new one.
-func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) error {
+// LaunchFreshWindowURL forwards the URL to a running instance when possible,
+// always requesting a new browser window. This keeps standalone omnibox
+// navigation independent from external-link workspace placement settings.
+func (l *BrowserLauncher) LaunchFreshWindowURL(ctx context.Context, url string) error {
 	if l == nil {
 		return errors.New("browser launcher is unavailable")
 	}
 
 	if l.relay != nil {
-		delivered, err := l.relay.DeliverOpenExternalURL(ctx, url)
+		delivered, err := l.relay.DeliverOpenFreshWindow(ctx, url)
 		if err != nil {
 			if delivered && errors.Is(err, ErrBrowserLaunchRelayUnconfirmed) {
 				return ErrBrowserLaunchUnconfirmed
@@ -48,7 +50,7 @@ func (l *BrowserLauncher) LaunchURL(ctx context.Context, url string) error {
 		}
 	}
 
-	if err := launchBrowserBrowseURL(url, l.resolveExecutablePath, l.startDetachedProcess); err != nil {
+	if err := launchBrowserFreshWindowURL(url, l.resolveExecutablePath, l.startDetachedProcess); err != nil {
 		return fmt.Errorf("launch dumber browse: %w", err)
 	}
 	return nil

--- a/internal/infrastructure/desktop/browser_launcher_test.go
+++ b/internal/infrastructure/desktop/browser_launcher_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBrowserLauncher_LaunchURL_ReturnsWithoutSpawningWhenRelayDelivers(t *testing.T) {
+func TestBrowserLauncher_LaunchFreshWindowURL_ReturnsWithoutSpawningWhenRelayDelivers(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(true, nil)
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, nil)
 
 	launcher := NewBrowserLauncher(relay)
 	spawned := false
@@ -26,15 +26,15 @@ func TestBrowserLauncher_LaunchURL_ReturnsWithoutSpawningWhenRelayDelivers(t *te
 		return nil
 	}
 
-	err := launcher.LaunchURL(context.Background(), "https://example.com")
+	err := launcher.LaunchFreshWindowURL(context.Background(), "https://example.com")
 
 	require.NoError(t, err)
 	assert.False(t, spawned)
 }
 
-func TestBrowserLauncher_LaunchURL_FallsBackToSpawnWhenRelayMisses(t *testing.T) {
+func TestBrowserLauncher_LaunchFreshWindowURL_FallsBackToSpawnWhenRelayMisses(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(false, nil)
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(false, nil)
 
 	launcher := NewBrowserLauncher(relay)
 	launcher.resolveExecutablePath = func() (string, error) {
@@ -47,17 +47,18 @@ func TestBrowserLauncher_LaunchURL_FallsBackToSpawnWhenRelayMisses(t *testing.T)
 		return nil
 	}
 
-	err := launcher.LaunchURL(context.Background(), "https://example.com")
+	err := launcher.LaunchFreshWindowURL(context.Background(), "https://example.com")
 
 	require.NoError(t, err)
 	require.NotNil(t, gotCmd)
 	assert.Equal(t, "/usr/bin/dumber", gotCmd.Path)
 	assert.Equal(t, []string{"/usr/bin/dumber", "browse", "https://example.com"}, gotCmd.Args)
+	assert.Contains(t, gotCmd.Env, FreshWindowLaunchEnvVar+"=1")
 }
 
-func TestBrowserLauncher_LaunchURL_ReturnsUnconfirmedErrorWhenRelayDeliveryIsAmbiguous(t *testing.T) {
+func TestBrowserLauncher_LaunchFreshWindowURL_ReturnsUnconfirmedErrorWhenRelayDeliveryIsAmbiguous(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
-	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(true, ErrBrowserLaunchRelayUnconfirmed)
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(true, ErrBrowserLaunchRelayUnconfirmed)
 
 	launcher := NewBrowserLauncher(relay)
 	launcher.resolveExecutablePath = func() (string, error) {
@@ -69,16 +70,16 @@ func TestBrowserLauncher_LaunchURL_ReturnsUnconfirmedErrorWhenRelayDeliveryIsAmb
 		return nil
 	}
 
-	err := launcher.LaunchURL(context.Background(), "https://example.com")
+	err := launcher.LaunchFreshWindowURL(context.Background(), "https://example.com")
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrBrowserLaunchUnconfirmed)
 }
 
-func TestBrowserLauncher_LaunchURL_PropagatesRelayError(t *testing.T) {
+func TestBrowserLauncher_LaunchFreshWindowURL_PropagatesRelayError(t *testing.T) {
 	relay := mocks.NewMockBrowserLaunchRelay(t)
 	wantErr := errors.New("relay exploded")
-	relay.EXPECT().DeliverOpenExternalURL(context.Background(), "https://example.com").Return(false, wantErr)
+	relay.EXPECT().DeliverOpenFreshWindow(context.Background(), "https://example.com").Return(false, wantErr)
 
 	launcher := NewBrowserLauncher(relay)
 	launcher.resolveExecutablePath = func() (string, error) {
@@ -90,17 +91,17 @@ func TestBrowserLauncher_LaunchURL_PropagatesRelayError(t *testing.T) {
 		return nil
 	}
 
-	err := launcher.LaunchURL(context.Background(), "https://example.com")
+	err := launcher.LaunchFreshWindowURL(context.Background(), "https://example.com")
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, wantErr)
 	assert.NotContains(t, err.Error(), "https://example.com")
 }
 
-func TestBrowserLauncher_LaunchURL_NilLauncherReturnsError(t *testing.T) {
+func TestBrowserLauncher_LaunchFreshWindowURL_NilLauncherReturnsError(t *testing.T) {
 	var launcher *BrowserLauncher
 
-	err := launcher.LaunchURL(context.Background(), "https://example.com")
+	err := launcher.LaunchFreshWindowURL(context.Background(), "https://example.com")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unavailable")

--- a/internal/ui/app_browser_launch_test.go
+++ b/internal/ui/app_browser_launch_test.go
@@ -51,6 +51,10 @@ func (r *testBrowserLaunchRelay) DeliverOpenExternalURL(context.Context, string)
 	return false, nil
 }
 
+func (r *testBrowserLaunchRelay) DeliverOpenFreshWindow(context.Context, string) (bool, error) {
+	return false, nil
+}
+
 func (r *testBrowserLaunchRelay) Listen(_ context.Context, opener port.BrowserWindowOpener) (io.Closer, error) {
 	r.listenCalls++
 	_ = opener

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -610,6 +610,67 @@ func (a *App) OpenExternalURL(ctx context.Context, url string) error {
 	return nil
 }
 
+func (a *App) OpenFreshWindow(ctx context.Context, url string) error {
+	log := logging.FromContext(ctx)
+	log.Debug().
+		Str("url_host", logging.SafeURLHost(url)).
+		Msg("ui: open fresh window dispatch requested")
+
+	dispatch := a.dispatchOnMainThread
+	if dispatch == nil {
+		dispatch = func(label string, fn func()) syncdispatch.SyncDispatchResult {
+			if fn != nil {
+				fn()
+			}
+			return syncdispatch.SyncDispatchResult{Label: label, Status: syncdispatch.SyncDispatchInline}
+		}
+	}
+
+	var openErr error
+	var windowCountBefore int
+	var windowCountAfter int
+	var hasTabCoord bool
+	var hasTabsUC bool
+	result := dispatch("ui.open_fresh_window", func() {
+		windowCountBefore = len(a.browserWindows)
+		hasTabCoord = a.tabCoord != nil
+		hasTabsUC = a.tabsUC != nil
+		log.Debug().
+			Str("url_host", logging.SafeURLHost(url)).
+			Int("window_count_before", windowCountBefore).
+			Bool("has_tab_coord", hasTabCoord).
+			Bool("has_tabs_uc", hasTabsUC).
+			Msg("ui: open fresh window main-thread work started")
+		openErr = a.openFreshWindow(ctx, url)
+		windowCountAfter = len(a.browserWindows)
+	})
+	if !result.Completed() {
+		log.Warn().
+			Str("url_host", logging.SafeURLHost(url)).
+			Dur("elapsed", result.Elapsed).
+			Str("dispatch_status", string(result.Status)).
+			Msg("ui: open fresh window skipped after main-thread dispatch did not complete")
+		return fmt.Errorf("main thread dispatch did not complete: %s", result.Status)
+	}
+	if openErr != nil {
+		log.Warn().Err(openErr).
+			Str("url_host", logging.SafeURLHost(url)).
+			Dur("elapsed", result.Elapsed).
+			Str("dispatch_status", string(result.Status)).
+			Int("window_count_after", windowCountAfter).
+			Msg("ui: open fresh window failed")
+		return openErr
+	}
+
+	log.Debug().
+		Str("url_host", logging.SafeURLHost(url)).
+		Dur("elapsed", result.Elapsed).
+		Str("dispatch_status", string(result.Status)).
+		Int("window_count_after", windowCountAfter).
+		Msg("ui: open fresh window completed")
+	return nil
+}
+
 func (a *App) openExternalURLOnMainThread(ctx context.Context, url string, cfg entity.RuntimeConfigSnapshot) error {
 	externalLinks := cfg.UI.Workspace.ExternalLinks
 	if externalLinks.Behavior == entity.ExternalLinkBehaviorWindowed || externalLinks.Behavior == "" {


### PR DESCRIPTION
## Summary
- preserve standalone omnibox navigation as an explicit fresh-window relay action
- keep ordinary external URL requests under workspace link-placement configuration
- preserve fresh-window intent across a relay-miss fallback child

## Verification
- make lint
- make test
- make check

Wrap-up review completed; CodeRabbit skipped per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser links opened from standalone navigation now launch in a fresh browser window.
  * Fresh-window launches are supported when forwarding links to an already running app.
  * Fresh-window behavior is independent of external-link workspace placement settings.

* **Bug Fixes**
  * Prevented fresh-window launch markers from affecting subsequent standard browser launches.

* **Tests**
  * Added coverage for fresh-window forwarding, relay behavior, fallback launching, and marker cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->