### PR TITLE
docs(readme): refresh project presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
-# Dumber
+<h1 align="center">Dumber</h1>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Go Report Card](https://goreportcard.com/badge/github.com/bnema/dumber)](https://goreportcard.com/report/github.com/bnema/dumber)
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License: MIT"></a>
+  <a href="https://github.com/bnema/dumber/releases"><img src="https://img.shields.io/badge/platform-Linux%20Wayland%20only-blue?style=flat-square" alt="Platform: Linux Wayland only"></a>
+  <a href="https://github.com/bnema/dumber/commits/main"><img src="https://badgen.net/github/last-commit/bnema/dumber/main?icon=github" alt="Last commit"></a>
+  <a href="https://github.com/bnema/dumber/stargazers"><img src="https://badgen.net/github/stars/bnema/dumber?icon=github" alt="GitHub stars"></a>
+</p>
+
+<p align="center">A keyboard-driven, pane-based web browser for Linux Wayland.</p>
+
+<p align="center"><a href="https://bnema.dev/dumber">Website</a> · <a href="https://bnema.dev/dumber/docs">Documentation</a> · <a href="https://bnema.dev/dumber/docs/reference/keybindings">Keybindings</a></p>
 
 Dumber is a keyboard-driven web browser, built around panes, workspaces, and modal controls.
 
 Tabs contain workspaces. Workspaces contain panes. Panes can be split, stacked, moved, resized, and closed from the keyboard.
 
 The layout model is inspired by terminal multiplexers such as Zellij and tmux, but applied to web browsing this is particularly suited for Wayland compositors such as Niri or Hyprland.
-
-[Website](https://dumber.bnema.dev) · [Documentation](https://dumber.bnema.dev/docs) · [Keybindings](https://dumber.bnema.dev/docs/reference/keybindings)
 
 ## Demo
 
@@ -70,7 +77,7 @@ The browser chrome stays out of the way by default. Open the omnibox when you wa
 ### Install script
 
 ```bash
-curl -fsSL https://dumber.bnema.dev/install | sh
+curl -fsSL https://raw.githubusercontent.com/bnema/dumber/main/install.sh | sh
 dumber browse
 ```
 
@@ -89,7 +96,7 @@ flatpak install --user dumber.flatpak
 flatpak run dev.bnema.Dumber browse
 ```
 
-For dependencies, distribution notes, and troubleshooting, see the [installation documentation](https://dumber.bnema.dev/docs).
+For dependencies, distribution notes, and troubleshooting, see the [installation documentation](https://bnema.dev/dumber/docs).
 
 ## Keyboard modes
 
@@ -112,7 +119,7 @@ The floating pane is a temporary browser pane that can be toggled without changi
 - Profile shortcuts such as `Alt+G` are optional and configured under `workspace.floating_pane.profiles`.
 - Some `Alt+<key>` bindings may conflict with browser-engine shortcuts or desktop-level handlers.
 
-See the [floating pane reference](https://dumber.bnema.dev/docs/reference/floating-pane) for setup and behavior details.
+See the [floating pane reference](https://bnema.dev/dumber/docs/reference/floating-pane) for setup and behavior details.
 
 ## Configuration
 
@@ -126,7 +133,7 @@ type = "cef"
 enabled = true
 ```
 
-The config reloads while Dumber is running. See the [configuration documentation](https://dumber.bnema.dev/docs) for all options.
+The config reloads while Dumber is running. See the [configuration documentation](https://bnema.dev/dumber/docs) for all options.
 
 ## Browser engine
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ## Quick Install (Linux x86_64)
 
 ```bash
-curl -fsSL https://dumber.bnema.dev/install | bash
+curl -fsSL https://raw.githubusercontent.com/bnema/dumber/main/install.sh | bash
 ```
 
 Installs to `~/.local/bin` if available, otherwise `/usr/local/bin` (requires sudo).
@@ -13,19 +13,19 @@ Installs to `~/.local/bin` if available, otherwise `/usr/local/bin` (requires su
 Install a specific version:
 
 ```bash
-DUMBER_VERSION=v0.26.2 curl -fsSL https://dumber.bnema.dev/install | bash
+DUMBER_VERSION=v0.26.2 curl -fsSL https://raw.githubusercontent.com/bnema/dumber/main/install.sh | bash
 ```
 
 Install the latest prerelease:
 
 ```bash
-DUMBER_PRERELEASE=1 curl -fsSL https://dumber.bnema.dev/install | bash
+DUMBER_PRERELEASE=1 curl -fsSL https://raw.githubusercontent.com/bnema/dumber/main/install.sh | bash
 ```
 
 Combine both to install a specific prerelease:
 
 ```bash
-DUMBER_VERSION=v0.27.0-rc.1 DUMBER_PRERELEASE=1 curl -fsSL https://dumber.bnema.dev/install | bash
+DUMBER_VERSION=v0.27.0-rc.1 DUMBER_PRERELEASE=1 curl -fsSL https://raw.githubusercontent.com/bnema/dumber/main/install.sh | bash
 ```
 
 ## Flatpak

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Dumber installer script
-# Usage: curl -fsSL https://dumber.bnema.dev/install | sh
-# Usage with pre-release: curl -fsSL https://dumber.bnema.dev/install | DUMBER_PRERELEASE=1 sh
+# Usage: curl -fsSL https://raw.githubusercontent.com/bnema/dumber/main/install.sh | sh
+# Usage with pre-release: curl -fsSL https://raw.githubusercontent.com/bnema/dumber/main/install.sh | DUMBER_PRERELEASE=1 sh
 
 REPO="bnema/dumber"
 VERSION="${DUMBER_VERSION:-latest}"

--- a/internal/ui/component/omnibox_navigation_state_test.go
+++ b/internal/ui/component/omnibox_navigation_state_test.go
@@ -73,7 +73,7 @@ func TestEffectiveSearchQuery(t *testing.T) {
 		hasGhost  bool
 		want      string
 	}{
-		{name: "uses typed input when ghost visible", entryText: "dumber.bnema.dev", realInput: "dumb", hasGhost: true, want: "dumb"},
+		{name: "uses typed input when ghost visible", entryText: "bnema.dev/dumber", realInput: "dumb", hasGhost: true, want: "dumb"},
 		{name: "falls back to entry when no ghost", entryText: "dumb", realInput: "dumb", hasGhost: false, want: "dumb"},
 		{name: "uses entry when real input unavailable", entryText: "dumb", realInput: "", hasGhost: true, want: "dumb"},
 	}
@@ -136,8 +136,8 @@ func TestResolveTargetURLForSelection(t *testing.T) {
 		{URL: "https://github.com/bnema/dumber/issues"},
 	}
 	favorites := []Favorite{
-		{URL: "https://dumber.bnema.dev"},
-		{URL: "https://docs.dumber.bnema.dev"},
+		{URL: "https://bnema.dev/dumber"},
+		{URL: "https://bnema.dev/dumber/docs"},
 	}
 
 	tests := []struct {
@@ -148,7 +148,7 @@ func TestResolveTargetURLForSelection(t *testing.T) {
 		wantURL string
 	}{
 		{name: "history index", mode: ViewModeHistory, index: 1, limit: 10, wantURL: "https://github.com/bnema/dumber/pulls"},
-		{name: "favorites index", mode: ViewModeFavorites, index: 0, limit: 10, wantURL: "https://dumber.bnema.dev"},
+		{name: "favorites index", mode: ViewModeFavorites, index: 0, limit: 10, wantURL: "https://bnema.dev/dumber"},
 		{name: "invalid index", mode: ViewModeHistory, index: 99, limit: 10, wantURL: ""},
 		{name: "history index beyond visible limit is hidden", mode: ViewModeHistory, index: 2, limit: 2, wantURL: ""},
 		{name: "favorites index beyond visible limit is hidden", mode: ViewModeFavorites, index: 1, limit: 1, wantURL: ""},
@@ -170,8 +170,8 @@ func TestSelectedTargetURL(t *testing.T) {
 		{URL: "https://github.com/bnema/dumber/pulls"},
 	}
 	favorites := []Favorite{
-		{URL: "https://dumber.bnema.dev"},
-		{URL: "https://docs.dumber.bnema.dev"},
+		{URL: "https://bnema.dev/dumber"},
+		{URL: "https://bnema.dev/dumber/docs"},
 	}
 
 	tests := []struct {
@@ -184,7 +184,7 @@ func TestSelectedTargetURL(t *testing.T) {
 	}{
 		{name: "negative index is not explicit selection", mode: ViewModeHistory, index: -1, limit: 10, wantURL: "", wantBool: false},
 		{name: "history selection is explicit", mode: ViewModeHistory, index: 0, limit: 10, wantURL: "https://github.com/bnema/dumber", wantBool: true},
-		{name: "favorites selection is explicit", mode: ViewModeFavorites, index: 0, limit: 10, wantURL: "https://dumber.bnema.dev", wantBool: true},
+		{name: "favorites selection is explicit", mode: ViewModeFavorites, index: 0, limit: 10, wantURL: "https://bnema.dev/dumber", wantBool: true},
 		{name: "hidden history selection is ignored", mode: ViewModeHistory, index: 1, limit: 1, wantURL: "", wantBool: true},
 		{name: "hidden favorites selection is ignored", mode: ViewModeFavorites, index: 1, limit: 1, wantURL: "", wantBool: true},
 	}


### PR DESCRIPTION
## Summary
- center the README project header and navigation
- add repository-status badges matching the vev presentation
- update Dumber website and documentation links to `bnema.dev/dumber`
- use the GitHub-hosted installer because `bnema.dev/dumber/install` is not available
- update omnibox fixture URLs for the new site paths

## Verification
- `git diff --check`
- `GOFLAGS=-mod=mod go test ./internal/ui/component`
- confirmed the site, documentation, and installer URLs return HTTP 200

@coderabbitai ignore