### PR TITLE
Fix GTK shortcut reload crash

### DIFF
--- a/internal/ui/input/global_shortcuts.go
+++ b/internal/ui/input/global_shortcuts.go
@@ -31,7 +31,6 @@ type GlobalShortcutHandler struct {
 	shortcutRefs          map[string]globalShortcutRegistration
 	lastDispatchAt        map[Action]time.Time
 	heldShortcuts         map[globalShortcutHoldKey]struct{}
-	shortcutAction        *gtk.NamedAction
 	globalAction          *gio.SimpleAction
 	globalActionCb        func(gio.SimpleAction, uintptr)
 	globalActionHandlerID uint
@@ -145,7 +144,6 @@ func (h *GlobalShortcutHandler) configureGlobalControllers() {
 	// Set global scope - this is the key to making shortcuts work
 	// even when WebView has focus.
 	h.controller.SetScope(gtk.ShortcutScopeGlobalValue)
-	h.shortcutAction = gtk.NewNamedAction(globalShortcutActionFullName)
 	h.globalAction = gio.NewSimpleAction(globalShortcutActionName, glib.NewVariantType("s"))
 	if h.globalAction != nil {
 		h.globalActionCb = func(_ gio.SimpleAction, parameter uintptr) {
@@ -218,13 +216,6 @@ func (h *GlobalShortcutHandler) registerShortcut(keyval uint, modifiers gdk.Modi
 		return false
 	}
 
-	if h.shortcutAction == nil {
-		logging.FromContext(h.ctx).Error().
-			Uint("keyval", keyval).
-			Msg("global shortcut action is unavailable")
-		return false
-	}
-
 	// Create trigger for this key combination.
 	trigger := gtk.NewKeyvalTrigger(keyval, modifiers)
 	if trigger == nil {
@@ -234,7 +225,17 @@ func (h *GlobalShortcutHandler) registerShortcut(keyval uint, modifiers gdk.Modi
 		return false
 	}
 
-	shortcut := gtk.NewShortcut(&trigger.ShortcutTrigger, &h.shortcutAction.ShortcutAction)
+	// GtkShortcut takes ownership of its action. Each shortcut needs its own
+	// named action even though they all dispatch through the same window action.
+	shortcutAction := gtk.NewNamedAction(globalShortcutActionFullName)
+	if shortcutAction == nil {
+		logging.FromContext(h.ctx).Error().
+			Uint("keyval", keyval).
+			Msg("failed to create global shortcut action")
+		return false
+	}
+
+	shortcut := gtk.NewShortcut(&trigger.ShortcutTrigger, &shortcutAction.ShortcutAction)
 	if shortcut == nil {
 		logging.FromContext(h.ctx).Error().
 			Uint("keyval", keyval).
@@ -634,7 +635,6 @@ func (h *GlobalShortcutHandler) detach(removeFromWindow bool) {
 	}
 	h.controller = nil
 	h.releaseController = nil
-	h.shortcutAction = nil
 	h.globalAction = nil
 	h.globalActionCb = nil
 	h.globalActionHandlerID = 0

--- a/internal/ui/input/global_shortcuts_test.go
+++ b/internal/ui/input/global_shortcuts_test.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -52,6 +53,71 @@ func TestGlobalShortcutHandlerCallbackBudgetIsIndependentOfShortcutCount(t *test
 	if got := h.estimatedPuregoCallbackBudget(); got != 2 {
 		t.Fatalf("callback budget with 57 shortcuts = %d, want 2", got)
 	}
+}
+
+func TestGlobalShortcutHandlerUsesDistinctNamedActionsAcrossReloads(t *testing.T) {
+	if !gtk.InitCheck() {
+		t.Skip("GTK native display prerequisite unavailable (gtk.InitCheck returned false)")
+	}
+	display := gdk.DisplayGetDefault()
+	if display == nil {
+		t.Skip("GTK native display prerequisite unavailable (no default GDK display)")
+	}
+	display.Unref()
+
+	appID := "com.dumber.GlobalShortcutHandlerTest"
+	app := gtk.NewApplication(&appID, gio.GApplicationNonUniqueValue)
+	if app == nil {
+		t.Fatal("gtk application creation failed")
+	}
+	registered, err := app.Register(nil)
+	if err != nil || !registered {
+		t.Fatalf("gtk application registration failed: registered=%t err=%v", registered, err)
+	}
+	window := gtk.NewApplicationWindow(app)
+	if window == nil {
+		t.Fatal("gtk application window creation failed")
+	}
+	h := NewGlobalShortcutHandler(context.Background(), window, nil, nil, nil, nil)
+	if h == nil {
+		t.Fatal("global shortcut handler creation failed")
+	}
+	t.Cleanup(func() {
+		h.Detach()
+		window.Destroy()
+		app.Unref()
+	})
+
+	assertDistinctShortcutActions := func() {
+		t.Helper()
+		shortcutCount := h.controller.GetNItems()
+		if shortcutCount < 2 {
+			t.Fatalf("shortcut count = %d, want at least 2", shortcutCount)
+		}
+		actions := make(map[uintptr]struct{}, shortcutCount)
+		for index := uint(0); index < shortcutCount; index++ {
+			shortcut := gtk.ShortcutNewFromInternalPtr(h.controller.GetItem(index))
+			if shortcut == nil {
+				t.Fatalf("shortcut %d was nil", index)
+			}
+			action := shortcut.GetAction()
+			if action == nil {
+				t.Fatalf("shortcut %d action was nil", index)
+			}
+			actions[action.GoPointer()] = struct{}{}
+			action.Unref()
+			shortcut.Unref()
+		}
+		if got := uint(len(actions)); got != shortcutCount {
+			t.Fatalf("distinct shortcut actions = %d, want %d", got, shortcutCount)
+		}
+	}
+
+	assertDistinctShortcutActions()
+	h.ReloadShortcuts(context.Background(), nil, nil)
+	assertDistinctShortcutActions()
+	h.ReloadShortcuts(context.Background(), nil, nil)
+	assertDistinctShortcutActions()
 }
 
 func TestGlobalShortcutIDIncludesBinding(t *testing.T) {
@@ -173,9 +239,6 @@ func TestGlobalShortcutHandlerDetachForDestroyClearsRetainedState(t *testing.T) 
 	}
 	if h.releaseController != nil {
 		t.Fatal("releaseController should be cleared during destroy detach")
-	}
-	if h.shortcutAction != nil {
-		t.Fatal("shortcutAction should be cleared during destroy detach")
 	}
 	if h.globalAction != nil {
 		t.Fatal("globalAction should be cleared during destroy detach")


### PR DESCRIPTION
## Summary

- Give every GTK shortcut its own owned named action.
- Add a native GTK regression test covering action ownership, repeated config shortcut reloads, and detach.

## Root cause

`gtk_shortcut_new` takes ownership of the action. Reusing one named action across all shortcuts caused controller removal during runtime config reload to unref freed GObject memory and crash the browser.

## Validation

- `go test -race ./internal/ui/input -count=1`
- `xvfb-run -a go test ./internal/ui/input -run TestGlobalShortcutHandlerUsesDistinctNamedActionsAcrossReloads -count=1 -v`
- `make lint`
- `make test`
- `make check`