### PR TITLE
fix(theme): keep dark input text readable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MAIN_PATH=./cmd/dumber
 DIST_DIR=dist
 LOCAL_BIN_DIR?=$(HOME)/.local/bin
 TOOL_BIN_DIR?=$(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION?=v2.12.2
+GOLANGCI_LINT_VERSION?=v2.13.2
 STATICCHECK_VERSION?=v0.7.0
 
 # Detect number of CPU cores for parallel compilation
@@ -165,7 +165,8 @@ install-golangci-lint: ## Install pinned golangci-lint
 	# Build the pinned version with the active Go toolchain instead of using the
 	# upstream install.sh helper, which currently misidentifies release assets now
 	# that golangci-lint publishes sibling .sbom.json files for each tarball.
-	GOBIN=$(TOOL_BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	# Run outside this module so Go resolves the requested tool version independently.
+	cd "$${TMPDIR:-/tmp}" && GOBIN=$(TOOL_BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 install-staticcheck: ## Install pinned Staticcheck with the active Go toolchain
 	@echo "Installing staticcheck $(STATICCHECK_VERSION)..."

--- a/internal/ui/theme/css.go
+++ b/internal/ui/theme/css.go
@@ -287,7 +287,7 @@ entry.omnibox-entry,
 entry.omnibox-entry > text {
 	background-color: var(--surface-variant);
 	background-image: none;
-	color: var(--text);
+	color: var(--control-text);
 	caret-color: var(--accent);
 }
 
@@ -504,7 +504,7 @@ entry.omnibox-entry.omnibox-entry-bang-active:focus-visible > text {
 /* Ghost text autocomplete overlay - positioned to align with entry text */
 .omnibox-ghost {
 	font-size: 1em;
-	color: var(--muted);
+	color: alpha(var(--control-text), 0.65);
 	margin-top: -0.0625em; /* Nudge up 1px to align with entry text baseline */
 	background-color: transparent;
 }

--- a/internal/ui/theme/css.go
+++ b/internal/ui/theme/css.go
@@ -504,7 +504,7 @@ entry.omnibox-entry.omnibox-entry-bang-active:focus-visible > text {
 /* Ghost text autocomplete overlay - positioned to align with entry text */
 .omnibox-ghost {
 	font-size: 1em;
-	color: alpha(var(--control-text), 0.65);
+	color: var(--control-text);
 	margin-top: -0.0625em; /* Nudge up 1px to align with entry text baseline */
 	background-color: transparent;
 }

--- a/internal/ui/theme/css_test.go
+++ b/internal/ui/theme/css_test.go
@@ -122,6 +122,9 @@ func TestGenerateCSS_OmniboxSearchEntryUsesControlSurface(t *testing.T) {
 	if !entryRe.MatchString(css) {
 		t.Fatalf("expected omnibox entry and its text node to use the control surface fill and readable text")
 	}
+	ghostBlock := cssRuleBlock(t, css, ".omnibox-ghost")
+	assert.Contains(t, ghostBlock, "color: var(--control-text);")
+	assert.NotContains(t, ghostBlock, "alpha(var(--control-text)")
 	focusedEntryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry:focus[^\{]*,\s*entry\.omnibox-entry:focus-within[^\{]*,\s*entry\.omnibox-entry:focus-visible[^\{]*,\s*entry\.omnibox-entry:focus\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-within\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-visible\s*>\s*text\s*\{[^}]*background-color:\s*shade\(var\(--surface-variant\),\s*1\.08\);`)
 	if !focusedEntryRe.MatchString(css) {
 		t.Fatalf("expected focused omnibox entry text node to keep a distinct control-surface fill")

--- a/internal/ui/theme/css_test.go
+++ b/internal/ui/theme/css_test.go
@@ -118,9 +118,9 @@ func TestGenerateCSS_OmniboxSearchEntryUsesControlSurface(t *testing.T) {
 	if !containerRe.MatchString(css) {
 		t.Fatalf("expected omnibox container to use the header surface color")
 	}
-	entryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry\s*,\s*entry\.omnibox-entry\s*>\s*text\s*\{[^}]*background-color:\s*var\(--surface-variant\);[^}]*background-image:\s*none;`)
+	entryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry\s*,\s*entry\.omnibox-entry\s*>\s*text\s*\{[^}]*background-color:\s*var\(--surface-variant\);[^}]*background-image:\s*none;[^}]*color:\s*var\(--control-text\);`)
 	if !entryRe.MatchString(css) {
-		t.Fatalf("expected omnibox entry and its text node to use the control surface fill")
+		t.Fatalf("expected omnibox entry and its text node to use the control surface fill and readable text")
 	}
 	focusedEntryRe := regexp.MustCompile(`(?s)entry\.omnibox-entry:focus[^\{]*,\s*entry\.omnibox-entry:focus-within[^\{]*,\s*entry\.omnibox-entry:focus-visible[^\{]*,\s*entry\.omnibox-entry:focus\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-within\s*>\s*text[^\{]*,\s*entry\.omnibox-entry:focus-visible\s*>\s*text\s*\{[^}]*background-color:\s*shade\(var\(--surface-variant\),\s*1\.08\);`)
 	if !focusedEntryRe.MatchString(css) {

--- a/internal/ui/theme/palette.go
+++ b/internal/ui/theme/palette.go
@@ -3,6 +3,7 @@ package theme
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 
@@ -267,6 +268,7 @@ func (p Palette) ToCSSVars() string {
 	sb.WriteString("  --bg: " + p.Background + ";\n")
 	sb.WriteString("  --surface: " + p.Surface + ";\n")
 	sb.WriteString("  --surface-variant: " + p.SurfaceVariant + ";\n")
+	sb.WriteString("  --control-text: " + readableTextColor(p.SurfaceVariant, p.Text) + ";\n")
 	sb.WriteString("  --text: " + p.Text + ";\n")
 	sb.WriteString("  --muted: " + p.Muted + ";\n")
 	sb.WriteString("  --accent: " + p.Accent + ";\n")
@@ -275,6 +277,39 @@ func (p Palette) ToCSSVars() string {
 	sb.WriteString("  --warning: " + p.Warning + ";\n")
 	sb.WriteString("  --destructive: " + p.Destructive + ";\n")
 	return sb.String()
+}
+
+const minimumReadableContrast = 4.5
+
+func readableTextColor(background, preferred string) string {
+	if contrastRatio(background, preferred) >= minimumReadableContrast {
+		return preferred
+	}
+	if contrastRatio(background, "#ffffff") >= contrastRatio(background, "#000000") {
+		return "#ffffff"
+	}
+	return "#000000"
+}
+
+func contrastRatio(first, second string) float64 {
+	firstLuminance := relativeLuminance(first)
+	secondLuminance := relativeLuminance(second)
+	if firstLuminance < secondLuminance {
+		firstLuminance, secondLuminance = secondLuminance, firstLuminance
+	}
+	return (firstLuminance + 0.05) / (secondLuminance + 0.05)
+}
+
+func relativeLuminance(color string) float64 {
+	r, g, b, _ := HexToRGBA(color)
+	linearize := func(channel float32) float64 {
+		value := float64(channel)
+		if value <= 0.04045 {
+			return value / 12.92
+		}
+		return math.Pow((value+0.055)/1.055, 2.4)
+	}
+	return 0.2126*linearize(r) + 0.7152*linearize(g) + 0.0722*linearize(b)
 }
 
 // ToWebCSSVars generates CSS custom properties for web UI (Tailwind compatibility).

--- a/internal/ui/theme/palette.go
+++ b/internal/ui/theme/palette.go
@@ -279,7 +279,18 @@ func (p Palette) ToCSSVars() string {
 	return sb.String()
 }
 
-const minimumReadableContrast = 4.5
+const (
+	minimumReadableContrast = 4.5
+	contrastLuminanceOffset = 0.05
+	sRGBLinearThreshold     = 0.04045
+	sRGBLinearDivisor       = 12.92
+	sRGBGammaOffset         = 0.055
+	sRGBGammaScale          = 1.055
+	sRGBGammaExponent       = 2.4
+	redLuminanceWeight      = 0.2126
+	greenLuminanceWeight    = 0.7152
+	blueLuminanceWeight     = 0.0722
+)
 
 func readableTextColor(background, preferred string) string {
 	if contrastRatio(background, preferred) >= minimumReadableContrast {
@@ -297,19 +308,21 @@ func contrastRatio(first, second string) float64 {
 	if firstLuminance < secondLuminance {
 		firstLuminance, secondLuminance = secondLuminance, firstLuminance
 	}
-	return (firstLuminance + 0.05) / (secondLuminance + 0.05)
+	return (firstLuminance + contrastLuminanceOffset) / (secondLuminance + contrastLuminanceOffset)
 }
 
 func relativeLuminance(color string) float64 {
 	r, g, b, _ := HexToRGBA(color)
 	linearize := func(channel float32) float64 {
 		value := float64(channel)
-		if value <= 0.04045 {
-			return value / 12.92
+		if value <= sRGBLinearThreshold {
+			return value / sRGBLinearDivisor
 		}
-		return math.Pow((value+0.055)/1.055, 2.4)
+		return math.Pow((value+sRGBGammaOffset)/sRGBGammaScale, sRGBGammaExponent)
 	}
-	return 0.2126*linearize(r) + 0.7152*linearize(g) + 0.0722*linearize(b)
+	return redLuminanceWeight*linearize(r) +
+		greenLuminanceWeight*linearize(g) +
+		blueLuminanceWeight*linearize(b)
 }
 
 // ToWebCSSVars generates CSS custom properties for web UI (Tailwind compatibility).

--- a/internal/ui/theme/palette_test.go
+++ b/internal/ui/theme/palette_test.go
@@ -1,0 +1,53 @@
+package theme
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadableTextColor(t *testing.T) {
+	tests := []struct {
+		name       string
+		background string
+		preferred  string
+		want       string
+	}{
+		{
+			name:       "keeps readable palette text",
+			background: "#282828",
+			preferred:  "#ffffff",
+			want:       "#ffffff",
+		},
+		{
+			name:       "uses light text on dark control",
+			background: "#775f79",
+			preferred:  "#3d303f",
+			want:       "#ffffff",
+		},
+		{
+			name:       "uses dark text on light control",
+			background: "#f0f0f0",
+			preferred:  "#dddddd",
+			want:       "#000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readableTextColor(tt.background, tt.preferred); got != tt.want {
+				t.Fatalf("readableTextColor(%q, %q) = %q, want %q", tt.background, tt.preferred, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPaletteToCSSVarsAddsReadableControlText(t *testing.T) {
+	palette := DefaultLightPalette()
+	palette.SurfaceVariant = "#775f79"
+	palette.Text = "#3d303f"
+
+	css := palette.ToCSSVars()
+	if !strings.Contains(css, "  --control-text: #ffffff;\n") {
+		t.Fatalf("ToCSSVars() did not add light control text for dark input background:\n%s", css)
+	}
+}


### PR DESCRIPTION
## Summary
- derive a dedicated GTK control text color from the input background
- preserve the configured text color when it meets WCAG contrast, otherwise switch to black or white
- apply the readable color to omnibox input and ghost text
- update golangci-lint to v2.13.2 for Go 1.27 support
- install the pinned linter outside the project module so Go resolves the requested version independently

## Testing
- `go test ./internal/ui/theme`
- `go vet ./internal/ui/theme`
- `make lint` with golangci-lint v2.13.2 — 0 issues
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved omnibox text readability across light and dark themes.
  * Added contrast-aware text color selection to meet accessibility contrast standards.
  * Improved visibility of autocomplete suggestions, including ghost text.
  * Ensured readable text colors are applied consistently across control surfaces.

* **Chores**
  * Updated the pinned linting tool version for improved code quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->