### PR TITLE
fix(theme): keep stacked pane titles and symbolic icons readable

### DIFF
--- a/internal/ui/theme/css.go
+++ b/internal/ui/theme/css.go
@@ -745,28 +745,21 @@ func generateStackedPaneCSS(p Palette) string {
 /* The title bar is now a Box with GestureClick, not wrapped in a button */
 .stacked-pane-titlebar {
 	background-color: var(--surface-variant);
+	color: var(--control-text);
 	border-bottom: 0.0625em solid var(--border);
 	padding: 0.25em 0.5em;
 	min-height: 1.5em;
 }
 
-/* Clickable title bar - hover styling */
-.stacked-pane-titlebar.stacked-pane-title-clickable {
-	transition: background-color 150ms ease-in-out;
-}
-
-.stacked-pane-titlebar.stacked-pane-title-clickable:hover {
-	background-color: shade(var(--surface-variant), 1.15);
-}
-
-/* Title bar content box */
+/* Keep the background stable so --control-text retains its contrast.
+ * Indicate hover with an underline and the active pane with an accent border. */
 .stacked-pane-titlebar.active {
-	background-color: shade(var(--surface-variant), 1.2);
 	border-left: 0.1875em solid var(--accent);
 }
 
 /* Favicon image in title bar */
 .stacked-pane-titlebar image {
+	color: var(--control-text);
 	min-width: 1em;
 	min-height: 1em;
 	margin-right: 0.375em;
@@ -774,14 +767,14 @@ func generateStackedPaneCSS(p Palette) string {
 
 /* Title text in title bar */
 .stacked-pane-titlebar label {
-	color: var(--text);
+	color: var(--control-text);
 	font-size: 0.75em;
 	font-weight: 400;
 }
 
 /* Hover effect on title bar label */
 .stacked-pane-titlebar.stacked-pane-title-clickable:hover label {
-	color: var(--accent);
+	text-decoration-line: underline;
 }
 
 /* Close button in stacked pane title bar */

--- a/internal/ui/theme/css_test.go
+++ b/internal/ui/theme/css_test.go
@@ -8,6 +8,45 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGenerateCSS_StackedTitlebarUsesReadableControlText(t *testing.T) {
+	tests := []struct {
+		name       string
+		background string
+		text       string
+		want       string
+	}{
+		{"dark background", "#775f79", "#3d303f", "#ffffff"},
+		{"light background", "#f0f0f0", "#dddddd", "#000000"},
+		{"readable configured text", "#282828", "#eeeeee", "#eeeeee"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			palette := DefaultLightPalette()
+			palette.SurfaceVariant = tt.background
+			palette.Text = tt.text
+			css := GenerateCSS(palette)
+
+			assert.Contains(t, css, "--control-text: "+tt.want+";")
+			for _, selector := range []string{
+				".stacked-pane-titlebar",
+				".stacked-pane-titlebar label",
+				".stacked-pane-titlebar image",
+			} {
+				block := regexp.MustCompile(regexp.QuoteMeta(selector) + `\s*\{[^}]*\}`).FindString(css)
+				assert.Contains(t, block, "color: var(--control-text);", selector)
+			}
+
+			// Hover and active states must not invalidate the computed contrast.
+			stackedCSS := generateStackedPaneCSS(palette)
+			assert.NotContains(t, stackedCSS, "shade(var(--surface-variant)")
+			hover := regexp.MustCompile(`\.stacked-pane-titlebar\.stacked-pane-title-clickable:hover label\s*\{[^}]*\}`).FindString(css)
+			assert.Contains(t, hover, "text-decoration-line: underline;")
+			assert.NotContains(t, hover, "color:")
+			assert.Contains(t, stackedCSS, "border-left: 0.1875em solid var(--accent);")
+		})
+	}
+}
+
 func TestGenerateCSS_UsesGTKFontForNativeWidgets(t *testing.T) {
 	css := GenerateCSSWithScaleAndFonts(DefaultDarkPalette(), 1.0, FontConfig{
 		SansFont:      "Fira Sans",


### PR DESCRIPTION
## Summary
- Reuse the contrast-aware `--control-text` from #387 for stacked webview title bars, labels, and symbolic icons. Site favicon images retain their original colors.
- Keep the background stable in active and hovered states so the computed contrast remains valid; retain the active accent border and use an underline for hover feedback.
- Add regression tests for dark/light backgrounds and already-readable configured text.

## Validation
- `go test ./internal/ui/theme` and `go vet ./internal/ui/theme` passed.
- `go fmt ./...` and `make lint` passed (0 issues).
- `make test` failed: native crash in `internal/ui/input`; not investigated in this scoped CSS change.
- `make check` blocked: `sqlc` is not installed.
- Native GTK visual verification remains to be done.
- No subagent reviews, as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved stacked pane title-bar readability across dark, light, and custom color palettes.
  - Active title bars now retain a consistent background and accent border.
  - Hover feedback uses label underlining without reducing text contrast.

- **Tests**
  - Added coverage to verify title-bar text readability and active-state styling across supported themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->