### PR TITLE
perf(cef): cold-start critical path (Plan 01)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,11 @@ scripts/*
 !scripts/verify_purego_only.sh
 !scripts/stress_omnibox_callbacks.go
 !scripts/cef-gpu-diagnostics.sh
+!scripts/collect_first_presentation.sh
+!scripts/cef_runtime_probe.py
+!scripts/measure_cef_startup.py
+!scripts/test_measure_cef_startup.py
+!scripts/test_systemview_startup.py
 specs/
 templates/
 .serena/

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ scripts/*
 !scripts/cef_runtime_probe.py
 !scripts/measure_cef_startup.py
 !scripts/test_measure_cef_startup.py
+!scripts/generate_build_manifest.py
 !scripts/test_systemview_startup.py
 specs/
 templates/

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X m
 # package boundaries. Both are required — -l alone is insufficient.
 GCFLAGS=-gcflags 'all=-N -l'
 
+# VCS stamping for measured binaries. build-quick stays unstamped for fast
+# iteration; build-manifest forces stamping so the manifest binds the exact
+# built tree instead of the ambient checkout HEAD.
+BUILDVCS?=false
+
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -72,11 +77,12 @@ build-systemviews: generate-systemviews ## Build the WASM systemviews runtime
 build-quick: ## Build quickly for backend development
 	@echo "Building $(BINARY_NAME) $(VERSION) (quick)..."
 	@mkdir -p $(DIST_DIR)
-	GOFLAGS="$(NATIVE_GOFLAGS)" CGO_ENABLED=0 go build -buildvcs=false -p $(NPROCS) $(GCFLAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) $(MAIN_PATH)
+	GOFLAGS="$(NATIVE_GOFLAGS)" CGO_ENABLED=0 go build -buildvcs=$(BUILDVCS) -p $(NPROCS) $(GCFLAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) $(MAIN_PATH)
 	@rm -f $(DIST_DIR)/cef-helper
 	@echo "Build successful! Binary: $(DIST_DIR)/$(BINARY_NAME)"
 
-build-manifest: build-quick ## Generate the collector build manifest for dist/dumber
+build-manifest: ## Generate the collector build manifest for dist/dumber (VCS-stamped build)
+	@$(MAKE) build-quick BUILDVCS=true
 	@echo "Generating build manifest..."
 	python3 scripts/generate_build_manifest.py --binary $(DIST_DIR)/$(BINARY_NAME)
 	@echo "Manifest: $(DIST_DIR)/$(BINARY_NAME).manifest.json"

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,11 @@ build-quick: ## Build quickly for backend development
 	@rm -f $(DIST_DIR)/cef-helper
 	@echo "Build successful! Binary: $(DIST_DIR)/$(BINARY_NAME)"
 
+build-manifest: build-quick ## Generate the collector build manifest for dist/dumber
+	@echo "Generating build manifest..."
+	python3 scripts/generate_build_manifest.py --binary $(DIST_DIR)/$(BINARY_NAME)
+	@echo "Manifest: $(DIST_DIR)/$(BINARY_NAME).manifest.json"
+
 install-local: build-quick ## Install dumber to ~/.local/bin atomically
 	@echo "Installing $(BINARY_NAME) to $(LOCAL_BIN_DIR)..."
 	@mkdir -p $(LOCAL_BIN_DIR)

--- a/assets/webui_embed.go
+++ b/assets/webui_embed.go
@@ -21,3 +21,11 @@ var LogoSVG []byte
 //
 //go:embed logo-32.png
 var LogoPNG32 []byte
+
+// LogoPNG512 contains the dumber logo as 512x512 PNG for the loading
+// placeholder. The initial pane decodes this raster asset instead of SVG to
+// avoid XML parsing and rasterization on the critical path. LogoSVG remains
+// the source for desktop icon installation.
+//
+//go:embed logo-512.png
+var LogoPNG512 []byte

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bnema/dumber/internal/infrastructure/filesystem"
 	"github.com/bnema/dumber/internal/infrastructure/idle"
 	"github.com/bnema/dumber/internal/infrastructure/persistence/sqlite"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/bnema/dumber/internal/infrastructure/snapshot"
 	"github.com/bnema/dumber/internal/infrastructure/textinput"
@@ -173,7 +174,14 @@ func main() {
 	// invalidate frames retained across those boundaries and make the GC abort
 	// with "traceback did not unwind completely". Re-exec once so the runtime
 	// sees the safety setting before it creates any goroutine or CEF subprocess.
-	if err := ensureRuntimeSafety(); err != nil {
+	// The standalone omnibox may additionally need a layer-shell preload; both
+	// changes are computed together there so they cost at most one re-exec.
+	if omniboxCombinedLaunchEnvironment(os.Args) {
+		if err := ensureOmniboxLaunchEnvironment(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "dumber: %v\n", err)
+			os.Exit(1)
+		}
+	} else if err := ensureRuntimeSafety(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "dumber: %v\n", err)
 		os.Exit(1)
 	}
@@ -430,7 +438,84 @@ func preInitializeAdwaitaForCEF(cfg *config.Config, initResult *bootstrap.Parall
 	}
 }
 
+// omniboxCombinedLaunchEnvironment reports whether argv selects the
+// standalone omnibox outside a classified CEF helper subprocess. CEF helpers
+// keep safety-only handling and the early helper routing below; they are
+// excluded from omnibox preload handling.
+func omniboxCombinedLaunchEnvironment(args []string) bool {
+	if isCEFSubprocess(args) {
+		return false
+	}
+	mode, _ := launchModeFromArgs(args)
+	return mode == launchModeStandaloneOmnibox
+}
+
+// ensureOmniboxLaunchEnvironment computes safety (GODEBUG) and layer-shell
+// preload (LD_PRELOAD) changes together and applies at most one self-exec.
+// A safety-required exec failure is fatal; a preload-only exec failure keeps
+// the existing best-effort behavior and continues without preload.
+func ensureOmniboxLaunchEnvironment() error {
+	if isCEFSubprocess(os.Args) {
+		return ensureRuntimeSafety()
+	}
+	environ, safetyChange := process.MergeRuntimeSafety(os.Environ())
+	envMap := environSliceToMap(environ)
+	preloadChange := false
+	if bootstrap.ShouldPreloadLayerShell(envMap) {
+		if libraryPath := bootstrap.LayerShellLibraryPath(); libraryPath != "" {
+			envMap = bootstrap.LayerShellPreloadEnv(envMap, libraryPath)
+			environ = environMapToSlice(envMap)
+			preloadChange = true
+		}
+	}
+	if !safetyChange && !preloadChange {
+		return nil
+	}
+	execPath, err := resolveCurrentExecutable(os.Executable)
+	if err != nil {
+		if safetyChange {
+			return fmt.Errorf("resolve executable for launch environment re-exec: %w", err)
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to resolve standalone omnibox executable path: %v\n", err)
+		return nil
+	}
+	// #nosec G702 -- execPath comes from os.Executable(), not user input.
+	if err := syscall.Exec(execPath, os.Args, environ); err != nil {
+		if safetyChange {
+			return fmt.Errorf("launch environment re-exec: %w", err)
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to re-exec standalone omnibox with layer-shell preload: %v\n", err)
+		return nil
+	}
+	return nil
+}
+
+func environSliceToMap(environ []string) map[string]string {
+	env := make(map[string]string, len(environ))
+	for _, entry := range environ {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		env[key] = value
+	}
+	return env
+}
+
+func environMapToSlice(env map[string]string) []string {
+	envSlice := make([]string, 0, len(env))
+	for key, value := range env {
+		envSlice = append(envSlice, key+"="+value)
+	}
+	return envSlice
+}
+
 func maybeReexecStandaloneOmniboxWithLayerShell() {
+	// Classified CEF helpers never take the omnibox preload path; early
+	// helper routing in main owns those processes.
+	if isCEFSubprocess(os.Args) {
+		return
+	}
 	env := bootstrap.CurrentEnvMap()
 	if !bootstrap.ShouldPreloadLayerShell(env) {
 		return

--- a/cmd/dumber/main_test.go
+++ b/cmd/dumber/main_test.go
@@ -334,3 +334,25 @@ func TestTryForwardBrowseURLToRunningInstance_PropagatesError(t *testing.T) {
 		t.Fatal("expected forwarded to be false on error")
 	}
 }
+
+func TestOmniboxCombinedLaunchEnvironment(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "omnibox", args: []string{"dumber", "omnibox"}, want: true},
+		{name: "browse", args: []string{"dumber", "browse", "https://example.com"}, want: false},
+		{name: "cli", args: []string{"dumber"}, want: false},
+		{name: "cli with flags", args: []string{"dumber", "browse", "--help"}, want: false},
+		{name: "helper excluded", args: []string{"dumber", "--type=renderer"}, want: false},
+		{name: "helper with omnibox-like tail excluded", args: []string{"dumber", "--type", "renderer", "omnibox"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := omniboxCombinedLaunchEnvironment(tt.args); got != tt.want {
+				t.Fatalf("omniboxCombinedLaunchEnvironment(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/dumber/runtime_safety.go
+++ b/cmd/dumber/runtime_safety.go
@@ -3,55 +3,21 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 	"syscall"
+
+	"github.com/bnema/dumber/internal/infrastructure/process"
 )
 
 func environmentValue(environ []string, name string) string {
-	prefix := name + "="
-	for _, entry := range environ {
-		if strings.HasPrefix(entry, prefix) {
-			return strings.TrimPrefix(entry, prefix)
-		}
-	}
-	return ""
+	return process.EnvironmentValue(environ, name)
 }
 
 func replaceEnvironmentValue(environ []string, name, value string) []string {
-	prefix := name + "="
-	updated := make([]string, 0, len(environ)+1)
-	for _, entry := range environ {
-		if !strings.HasPrefix(entry, prefix) {
-			updated = append(updated, entry)
-		}
-	}
-	return append(updated, prefix+value)
+	return process.ReplaceEnvironmentValue(environ, name, value)
 }
 
 func runtimeSafetyEnvironment(environ []string) ([]string, bool) {
-	updated := append([]string(nil), environ...)
-	const setting = "gcshrinkstackoff"
-	parts := strings.Split(environmentValue(updated, "GODEBUG"), ",")
-	kept := make([]string, 0, len(parts)+1)
-	alreadySafe := false
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		key, value, found := strings.Cut(part, "=")
-		if key == setting {
-			alreadySafe = found && value == "1"
-			continue
-		}
-		kept = append(kept, part)
-	}
-	if alreadySafe {
-		return updated, false
-	}
-	kept = append(kept, setting+"=1")
-	updated = replaceEnvironmentValue(updated, "GODEBUG", strings.Join(kept, ","))
-	return updated, true
+	return process.MergeRuntimeSafety(environ)
 }
 
 func ensureRuntimeSafety() error {

--- a/cmd/dumber/runtime_safety.go
+++ b/cmd/dumber/runtime_safety.go
@@ -12,10 +12,6 @@ func environmentValue(environ []string, name string) string {
 	return process.EnvironmentValue(environ, name)
 }
 
-func replaceEnvironmentValue(environ []string, name, value string) []string {
-	return process.ReplaceEnvironmentValue(environ, name, value)
-}
-
 func runtimeSafetyEnvironment(environ []string) ([]string, bool) {
 	return process.MergeRuntimeSafety(environ)
 }

--- a/docs/first-presentation.md
+++ b/docs/first-presentation.md
@@ -82,6 +82,6 @@ the selected `github.com/bnema/purego-cef2gtk` version, tag, and full revision
 from that same binary-bound evidence; it never derives provenance from the
 collection checkout. The child processes receive exactly the selected runtime
 via `CEF_DIR`, never a conflicting inherited override. Branch selectors,
-replacement contamination, missing manifests, or missing origin metadata
+replacement contamination, version/manifest mismatches, or a missing manifest
 fail collection. A missing or incomplete timeline, non-DMABUF backend, or invalid
 run also fails collection.

--- a/docs/first-presentation.md
+++ b/docs/first-presentation.md
@@ -36,13 +36,21 @@ contract rather than this CEF trace.
 
 ## Reproducible collection
 
-Build the candidate, then run:
+Build the candidate and its build manifest, then run:
 
 ```bash
+DUMBER_CEF_DIR=/path/to/selected-cef-runtime \
 DUMBER_FIRST_PRESENTATION_BIN="$PWD/dist/dumber" \
+DUMBER_BUILD_MANIFEST="$PWD/dist/dumber.manifest.json" \
 DUMBER_MACHINE_GPU_PROFILE=integrated-gpu \
   scripts/collect_first_presentation.sh
 ```
+
+The manifest records the measured binary SHA-256, the 40-character source
+revision, and the selected `github.com/bnema/purego-cef2gtk` version plus its
+full 40-character revision. Generate it at build time; collection verifies the
+manifest against `go version -m` output for the measured binary and fails
+closed on missing or mismatched attribution.
 
 The collector is for the accelerated CEF/DMABUF/GTK contract above. By default
 each collection is a fresh directory below
@@ -52,8 +60,14 @@ not in the repository. `DUMBER_FIRST_PRESENTATION_OUTPUT` may override it only
 with a new absolute directory below an existing non-symlink parent. The
 collector never clears or reuses a caller-supplied path.
 
-The script requires the current display and the CEF 147 runtime at
-`~/.local/share/cef-147-runtime` (override with `DUMBER_CEF_DIR`). It performs
+The script requires the current display and an explicit `DUMBER_CEF_DIR`
+selecting the measured runtime; there is no default path or version.
+`scripts/cef_runtime_probe.py` runs in a separate bounded subprocess, opens
+only the selected `libcef.so` with standard-library ctypes, calls the
+header-verified `cef_version_info(int)` entries (0-7), and reports numeric
+version fields plus the library hash, never its path. The candidate must still
+pass its normal loader ABI/version validation; the probe never bypasses it.
+Runtimes below Chrome major 150 fail collection. It performs
 exactly five bounded launches with fresh XDG homes and CEF root cache, fixes the
 DMABUF/Vulkan renderer, and writes exactly `metadata.json`, `run-01.json`
 through `run-05.json`, and `baseline.json`. Metadata includes only coarse,
@@ -62,8 +76,12 @@ labels. Set `DUMBER_MACHINE_GPU_PROFILE` to one of `generic-gpu`,
 `integrated-gpu`, `discrete-gpu`, `hybrid-gpu`, `virtual-gpu`, or `unknown-gpu`;
 do not use a device model or other identifier. Publish only the seven reviewed
 JSON files to an external Gist. Raw logs and temporary XDG homes are removed and
-must not be published. `metadata.json` derives the selected
-`github.com/bnema/purego-cef2gtk` pseudo-version and its full immutable Git
-origin hash from Go module metadata; branch selectors or missing origin metadata
+must not be published. `metadata.json` binds the measured binary SHA-256 to
+its source revision via `go version -m` plus the build manifest, and records
+the selected `github.com/bnema/purego-cef2gtk` version, tag, and full revision
+from that same binary-bound evidence; it never derives provenance from the
+collection checkout. The child processes receive exactly the selected runtime
+via `CEF_DIR`, never a conflicting inherited override. Branch selectors,
+replacement contamination, missing manifests, or missing origin metadata
 fail collection. A missing or incomplete timeline, non-DMABUF backend, or invalid
 run also fails collection.

--- a/docs/first-presentation.md
+++ b/docs/first-presentation.md
@@ -48,9 +48,36 @@ DUMBER_MACHINE_GPU_PROFILE=integrated-gpu \
 
 The manifest records the measured binary SHA-256, the 40-character source
 revision, and the selected `github.com/bnema/purego-cef2gtk` version plus its
-full 40-character revision. Generate it at build time; collection verifies the
-manifest against `go version -m` output for the measured binary and fails
-closed on missing or mismatched attribution.
+full 40-character revision. Generate it at build time from the same tree
+that produced the binary; collection verifies the manifest against
+`go version -m` output for the measured binary and fails closed on missing
+or mismatched attribution.
+
+```bash
+make build-manifest
+# or, equivalently:
+python3 scripts/generate_build_manifest.py --binary dist/dumber
+```
+
+Manifest schema (JSON, sorted keys):
+
+```json
+{
+  "binary_sha256": "<hex sha256 of the measured binary>",
+  "source_revision": "<40-hex git revision of the built source>",
+  "modules": {
+    "github.com/bnema/purego-cef2gtk": {
+      "version": "<exact version from go version -m>",
+      "revision": "<40-hex git hash from go mod download origin>"
+    }
+  }
+}
+```
+
+The generator refuses binaries built with a `replace` directive, non-tag
+dependency versions, and missing source revisions. The default manifest
+path is `<binary>.manifest.json`, which is also the collector default
+(`DUMBER_BUILD_MANIFEST` overrides it).
 
 The collector is for the accelerated CEF/DMABUF/GTK contract above. By default
 each collection is a fresh directory below

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -1,6 +1,8 @@
 package cef
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -22,6 +24,12 @@ const validFirstPresentationLog = `{"message":"startup_trace: milestone","milest
 {"message":"startup_trace: milestone","milestone":"first_gtk_presentation","t_ms":7,"delta_ms":1}
 {"message":"startup_trace: first presentation","backend":"gdk-dmabuf","incomplete_reason":"","total_ms":7,"host":"alice"}`
 
+const (
+	testUpstreamVersion  = "v0.8.5-0.20300102030405-bbd397409ebe"
+	testUpstreamRevision = "bbd397409ebed75a5979c1e4566a2ef319f6a484"
+	testSourceRevision   = "0123456789abcdef0123456789abcdef01234567"
+)
+
 func TestFirstPresentationCollectorNeverRecursivelyDeletesCallerOutput(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
@@ -31,12 +39,26 @@ func TestFirstPresentationCollectorNeverRecursivelyDeletesCallerOutput(t *testin
 	require.NotContains(t, string(script), "rm -rf -- \"$output\"")
 }
 
+func TestFirstPresentationCollectorHasNoHardcodedRuntimeDefaults(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	script, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	require.NoError(t, err)
+	require.NotContains(t, string(script), "cef-147")
+	require.NotContains(t, string(script), `"version": "147"`)
+	require.NotContains(t, string(script), "go list -m")
+	require.NotContains(t, string(script), "go mod download")
+	require.NotContains(t, string(script), "-mod=mod")
+	require.Contains(t, string(script), "DUMBER_CEF_DIR must be set")
+	require.Contains(t, string(script), "cef_runtime_probe.py")
+	require.Contains(t, string(script), `CEF_DIR="$selected_cef_dir"`)
+}
+
 func TestFirstPresentationCollectorRejectsUnsafeOutputPaths(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 	home := filepath.Join(temp, "home")
@@ -112,15 +134,12 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
-
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-	const upstreamVersion = "v0.8.5-0.20300102030405-bbd397409ebe"
-	const upstreamRevision = "bbd397409ebed75a5979c1e4566a2ef319f6a484"
-	goBin := collectorProvenanceGo(t, temp, upstreamVersion, upstreamRevision, "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 	output := filepath.Join(temp, "artifacts")
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -129,6 +148,7 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 		"WAYLAND_DISPLAY=",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"DUMBER_MACHINE_GPU_PROFILE=integrated-gpu",
@@ -143,14 +163,16 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 		require.NoError(t, readErr)
 		artifacts.Write(artifactContents)
 	}
-	for _, forbidden := range []string{"/home/", temp, "alice", "machine_path", `"time"`} {
+	for _, forbidden := range []string{"/home/", temp, "alice", "machine_path", `"time"`, runtime, "libcef.so"} {
 		require.NotContainsf(t, artifacts.String(), forbidden, "committed artifact leaked %q", forbidden)
 	}
 	for _, required := range []string{
 		`"measured_source_revision"`,
-		`"version": "` + upstreamVersion + `"`,
+		`"version": "` + testUpstreamVersion + `"`,
 		`"tag": "v0.8.5"`,
-		`"revision": "` + upstreamRevision + `"`,
+		`"revision": "` + testUpstreamRevision + `"`,
+		`"chrome_major": 150`,
+		`"libcef_sha256"`,
 	} {
 		require.Contains(t, artifacts.String(), required)
 	}
@@ -176,16 +198,12 @@ func TestFirstPresentationCollectorDerivesSelectedImmutableModuleProvenance(t *t
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-	// This exact pseudo-version is deliberately newer than the former v0.8.4
-	// hardcode; the collector must report what the selected module says.
-	const version = "v0.8.5-0.20300102030405-bbd397409ebe"
-	const revision = "bbd397409ebed75a5979c1e4566a2ef319f6a484"
-	goBin := collectorProvenanceGo(t, temp, version, revision, "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 	output := filepath.Join(temp, "artifacts")
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -193,6 +211,7 @@ func TestFirstPresentationCollectorDerivesSelectedImmutableModuleProvenance(t *t
 		"DISPLAY=:test",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
@@ -207,14 +226,16 @@ func TestFirstPresentationCollectorDerivesSelectedImmutableModuleProvenance(t *t
 			Tag      string `json:"tag"`
 			Revision string `json:"revision"`
 		} `json:"upstream"`
+		MeasuredSourceRevision string `json:"measured_source_revision"`
 	}
 	contents, err := os.ReadFile(filepath.Join(output, "metadata.json"))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(contents, &metadata))
 	require.Equal(t, "github.com/bnema/purego-cef2gtk", metadata.Upstream.Module)
-	require.Equal(t, version, metadata.Upstream.Version)
+	require.Equal(t, testUpstreamVersion, metadata.Upstream.Version)
 	require.Equal(t, "v0.8.5", metadata.Upstream.Tag)
-	require.Equal(t, revision, metadata.Upstream.Revision)
+	require.Equal(t, testUpstreamRevision, metadata.Upstream.Revision)
+	require.Equal(t, testSourceRevision, metadata.MeasuredSourceRevision)
 
 	script, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	require.NoError(t, err)
@@ -226,20 +247,20 @@ func TestFirstPresentationCollectorRejectsNonImmutableModuleProvenanceWithoutLea
 	require.NoError(t, err)
 
 	for _, test := range []struct {
-		name, version, revision, ref string
+		name, version string
 	}{
-		{name: "branch selector", version: "main", ref: "main"},
-		{name: "missing origin", version: "v0.8.5-0.20300102030405-bbd397409ebe"},
-		{name: "named origin ref", version: "v0.8.5-0.20300102030405-bbd397409ebe", revision: "bbd397409ebed75a5979c1e4566a2ef319f6a484", ref: "main"},
+		{name: "branch selector", version: "main"},
+		{name: "devel version", version: "(devel)"},
+		{name: "missing patch", version: "v0.8"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			temp := t.TempDir()
-			runtime := filepath.Join(temp, "cef-147-runtime")
-			require.NoError(t, os.Mkdir(runtime, 0o755))
+			runtime := collectorFakeCEFRuntime(t, 150)
 			binary := filepath.Join(temp, "dumber")
 			require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-			goBin := collectorProvenanceGo(t, temp, test.version, test.revision, test.ref)
+			goBin := collectorFakeGo(t, temp, test.version, testSourceRevision, false)
+			manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 			output := filepath.Join(temp, "artifacts")
 			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 			cmd.Dir = repoRoot
@@ -247,6 +268,7 @@ func TestFirstPresentationCollectorRejectsNonImmutableModuleProvenanceWithoutLea
 				"DISPLAY=:test",
 				"DUMBER_CEF_DIR="+runtime,
 				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+				"DUMBER_BUILD_MANIFEST="+manifest,
 				"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 			)
@@ -262,55 +284,296 @@ func TestFirstPresentationCollectorRejectsNonImmutableModuleProvenanceWithoutLea
 	}
 }
 
-func collectorProvenanceGo(t *testing.T, temp, version, revision, ref string) string {
-	t.Helper()
-	infoPath := filepath.Join(temp, "module.info")
-	info := map[string]any{"Version": version}
-	if revision != "" {
-		info["Origin"] = map[string]string{
-			"VCS": "git", "URL": "https://github.com/bnema/purego-cef2gtk", "Hash": revision, "Ref": ref,
-		}
-	}
-	infoJSON, err := json.Marshal(info)
+func TestFirstPresentationCollectorRequiresExplicitRuntimeDir(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(infoPath, infoJSON, 0o600))
+	temp := t.TempDir()
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-	selectedJSON, err := json.Marshal(map[string]string{
-		"Path": "github.com/bnema/purego-cef2gtk", "Version": version,
-	})
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	env := envWithout("DUMBER_CEF_DIR")
+	env = append(env,
+		"DISPLAY=:test",
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+	)
+	cmd.Env = env
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted missing runtime dir: %s", result)
+	require.Contains(t, string(result), "DUMBER_CEF_DIR must be set")
+}
+
+func TestFirstPresentationCollectorIgnoresConflictingParentCEFDir(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
-	downloadedJSON, err := json.Marshal(map[string]string{
-		"Path": "github.com/bnema/purego-cef2gtk", "Version": version, "Info": infoPath,
-	})
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 150)
+	bogus := filepath.Join(temp, "bogus-runtime")
+	require.NoError(t, os.Mkdir(bogus, 0o755))
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	output := filepath.Join(temp, "artifacts")
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"CEF_DIR="+bogus,
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
+		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "collector failed with conflicting parent CEF_DIR: %s", result)
+	require.FileExists(t, filepath.Join(output, "metadata.json"))
+}
+
+func TestFirstPresentationCollectorRejectsProbeFailure(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
-	binDir := filepath.Join(temp, "bin")
-	require.NoError(t, os.Mkdir(binDir, 0o755))
+	temp := t.TempDir()
+	runtime := filepath.Join(temp, "empty-runtime")
+	require.NoError(t, os.Mkdir(runtime, 0o755))
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted missing runtime library: %s", result)
+	require.Contains(t, string(result), "CEF runtime probe failed")
+}
+
+func TestFirstPresentationCollectorRejectsUnsupportedRuntime(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 140)
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted unsupported runtime: %s", result)
+	require.Contains(t, string(result), "unsupported CEF runtime")
+}
+
+func TestFirstPresentationCollectorRequiresManifestWithoutEmbeddedVCS(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 150)
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, "", false)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+filepath.Join(temp, "missing-manifest.json"),
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted binary without VCS or manifest: %s", result)
+	require.Contains(t, string(result), "build manifest is required")
+}
+
+func TestFirstPresentationCollectorRejectsManifestMismatch(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name           string
+		sourceRevision string
+		depVersion     string
+		depRevision    string
+		mutateBinary   bool
+	}{
+		{name: "binary checkout mismatch", sourceRevision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", depVersion: testUpstreamVersion, depRevision: testUpstreamRevision},
+		{name: "dependency version mismatch", sourceRevision: testSourceRevision, depVersion: "v0.9.3", depRevision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+		{name: "dependency revision mismatch", sourceRevision: testSourceRevision, depVersion: testUpstreamVersion, depRevision: "cccccccccccccccccccccccccccccccccccccccc"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			temp := t.TempDir()
+			runtime := collectorFakeCEFRuntime(t, 150)
+			binary := filepath.Join(temp, "dumber")
+			require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+			goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+			manifest := collectorManifest(t, temp, binary, test.sourceRevision, test.depVersion, test.depRevision)
+			if test.mutateBinary {
+				require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog+"extra"), 0o755))
+			}
+			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+			cmd.Dir = repoRoot
+			cmd.Env = append(os.Environ(),
+				"DISPLAY=:test",
+				"DUMBER_CEF_DIR="+runtime,
+				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+				"DUMBER_BUILD_MANIFEST="+manifest,
+				"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+			)
+			result, err := cmd.CombinedOutput()
+			require.Errorf(t, err, "collector accepted mismatched manifest: %s", result)
+			require.Contains(t, string(result), "build manifest does not match")
+		})
+	}
+}
+
+func TestFirstPresentationCollectorRejectsReplacementContamination(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 150)
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, true)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted replacement contamination: %s", result)
+	require.Contains(t, string(result), "immutable module provenance is unavailable")
+}
+
+// collectorFakeGo fakes `go version -m <binary>` for the measured binary.
+// It never consults the current checkout module graph.
+func collectorFakeGo(t *testing.T, temp, depVersion, vcsRevision string, replacement bool) string {
+	t.Helper()
+	binDir := filepath.Join(temp, "gobin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	goBin := filepath.Join(binDir, "go")
+	depLine := fmt.Sprintf("dep\tgithub.com/bnema/purego-cef2gtk\t%s", depVersion)
+	if replacement {
+		depLine += " => ./local-override"
+	}
+	buildLine := ""
+	if vcsRevision != "" {
+		buildLine = fmt.Sprintf("build\tvcs.revision=%s", vcsRevision)
+	}
 	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "list" ] && [ "$2" = "-m" ] && [ "$3" = "-json" ] && [ "$4" = "github.com/bnema/purego-cef2gtk" ]; then
-  printf '%%s\n' '%s'
-  exit 0
-fi
-if [ "$1" = "mod" ] && [ "$2" = "download" ] && [ "$3" = "-json" ] && [ "$4" = "github.com/bnema/purego-cef2gtk@%s" ]; then
-  printf '%%s\n' '%s'
+if [ "$1" = "version" ] && [ "$2" = "-m" ]; then
+  printf '%%s\n' 'path\tgithub.com/bnema/dumber/cmd/dumber' 'mod\tgithub.com/bnema/dumber\t(devel)' '%s' '%s'
   exit 0
 fi
 exit 1
-`, selectedJSON, version, downloadedJSON)
+`, depLine, buildLine)
 	require.NoError(t, os.WriteFile(goBin, []byte(script), 0o755))
 	return goBin
+}
+
+// collectorProvenanceGo is retained for compatibility with earlier test
+// revisions; it delegates to the binary-bound fake.
+func collectorProvenanceGo(t *testing.T, temp, version, revision, ref string) string {
+	t.Helper()
+	_ = ref
+	return collectorFakeGo(t, temp, version, testSourceRevision, false)
+}
+
+func collectorManifest(t *testing.T, temp, binary, sourceRevision, depVersion, depRevision string) string {
+	t.Helper()
+	contents, err := os.ReadFile(binary)
+	require.NoError(t, err)
+	sum := sha256.Sum256(contents)
+	manifest := map[string]any{
+		"binary_sha256":   hex.EncodeToString(sum[:]),
+		"source_revision": sourceRevision,
+		"modules": map[string]any{
+			"github.com/bnema/purego-cef2gtk": map[string]string{
+				"version":  depVersion,
+				"revision": depRevision,
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	path := filepath.Join(temp, "build-manifest.json")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	return path
+}
+
+// collectorFakeCEFRuntime builds a tiny shared library exposing the
+// header-verified cef_version_info(int) entries with a controlled Chrome
+// major. It exercises the real ctypes probe path without copying a full
+// multi-hundred-megabyte runtime per test.
+func collectorFakeCEFRuntime(t *testing.T, chromeMajor int) string {
+	t.Helper()
+	runtime := t.TempDir()
+	source := fmt.Sprintf(`int cef_version_info(int entry) {
+  switch (entry) {
+    case 0: return 150;
+    case 1: return 0;
+    case 2: return 0;
+    case 3: return 0;
+    case 4: return %d;
+    case 5: return 0;
+    case 6: return 0;
+    case 7: return 0;
+    default: return 0;
+  }
+}
+`, chromeMajor)
+	src := filepath.Join(runtime, "fake_cef.c")
+	require.NoError(t, os.WriteFile(src, []byte(source), 0o600))
+	lib := filepath.Join(runtime, "libcef.so")
+	cmd := exec.Command("gcc", "-shared", "-fPIC", "-o", lib, src)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to build fake libcef: %s", out)
+	return runtime
 }
 
 func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 	stateHome := filepath.Join(temp, "state")
-	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -319,6 +582,7 @@ func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testin
 		"WAYLAND_DISPLAY=",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"DUMBER_MACHINE_GPU_PROFILE=integrated-gpu",
 		"XDG_STATE_HOME="+stateHome,
@@ -347,23 +611,19 @@ func envWithout(name string) []string {
 	return environment
 }
 
-func TestFirstPresentationCollectorReadsProvenanceWithScopedGitSafeDirectory(t *testing.T) {
+func TestFirstPresentationCollectorBindsBinaryNotCheckoutGit(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
-	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 	gitDir := filepath.Join(temp, "gitbin")
 	require.NoError(t, os.Mkdir(gitDir, 0o755))
 	git := filepath.Join(gitDir, "git")
 	require.NoError(t, os.WriteFile(git, []byte(`#!/bin/sh
-if [ "$1" = "-c" ] && [ "$2" = "safe.directory=$EXPECTED_SAFE_DIRECTORY" ] && [ "$3" = "rev-parse" ] && [ "$4" = "HEAD" ]; then
-  echo 0123456789abcdef0123456789abcdef01234567
-  exit 0
-fi
 echo "fatal: detected dubious ownership in repository" >&2
 exit 128
 `), 0o755))
@@ -375,13 +635,13 @@ exit 128
 		"DISPLAY=:test",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
-		"EXPECTED_SAFE_DIRECTORY="+repoRoot,
 		"PATH="+gitDir+":"+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 	)
 	result, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "collector failed: %s", result)
+	require.NoErrorf(t, err, "collector depends on checkout git: %s", result)
 
 	var metadata struct {
 		MeasuredSourceRevision string `json:"measured_source_revision"`
@@ -389,7 +649,7 @@ exit 128
 	contents, err := os.ReadFile(filepath.Join(output, "metadata.json"))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(contents, &metadata))
-	require.Equal(t, "0123456789abcdef0123456789abcdef01234567", metadata.MeasuredSourceRevision)
+	require.Equal(t, testSourceRevision, metadata.MeasuredSourceRevision)
 }
 
 func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
@@ -408,12 +668,12 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			temp := t.TempDir()
-			runtime := filepath.Join(temp, "cef-147-runtime")
-			require.NoError(t, os.Mkdir(runtime, 0o755))
+			runtime := collectorFakeCEFRuntime(t, 150)
 			binary := filepath.Join(temp, "dumber")
 			log := strings.Replace(validFirstPresentationLog, test.old, test.new, 1)
 			require.NoError(t, os.WriteFile(binary, collectorTestBinary(log), 0o755))
-			goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+			goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+			manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 
 			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 			cmd.Dir = repoRoot
@@ -421,6 +681,7 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 				"DISPLAY=:test",
 				"DUMBER_CEF_DIR="+runtime,
 				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+				"DUMBER_BUILD_MANIFEST="+manifest,
 				"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
 				"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -504,14 +504,6 @@ exit 1
 	return goBin
 }
 
-// collectorProvenanceGo is retained for compatibility with earlier test
-// revisions; it delegates to the binary-bound fake.
-func collectorProvenanceGo(t *testing.T, temp, version, revision, ref string) string {
-	t.Helper()
-	_ = ref
-	return collectorFakeGo(t, temp, version, testSourceRevision, false)
-}
-
 func collectorManifest(t *testing.T, temp, binary, sourceRevision, depVersion, depRevision string) string {
 	t.Helper()
 	contents, err := os.ReadFile(binary)

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -491,6 +491,7 @@ func collectorFakeGo(t *testing.T, temp, depVersion, vcsRevision string, replace
 	}
 	buildLine := ""
 	if vcsRevision != "" {
+		// Real `go version -m` format is "build vcs.revision=<hex>".
 		buildLine = fmt.Sprintf("build\tvcs.revision=%s", vcsRevision)
 	}
 	script := fmt.Sprintf(`#!/bin/sh

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -310,6 +310,7 @@ func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testin
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 	stateHome := filepath.Join(temp, "state")
+	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
 
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -321,6 +322,7 @@ func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testin
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"DUMBER_MACHINE_GPU_PROFILE=integrated-gpu",
 		"XDG_STATE_HOME="+stateHome,
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 	)
 	result, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "collector failed: %s", result)
@@ -353,7 +355,8 @@ func TestFirstPresentationCollectorReadsProvenanceWithScopedGitSafeDirectory(t *
 	require.NoError(t, os.Mkdir(runtime, 0o755))
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
-	gitDir := filepath.Join(temp, "bin")
+	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+	gitDir := filepath.Join(temp, "gitbin")
 	require.NoError(t, os.Mkdir(gitDir, 0o755))
 	git := filepath.Join(gitDir, "git")
 	require.NoError(t, os.WriteFile(git, []byte(`#!/bin/sh
@@ -375,7 +378,7 @@ exit 128
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"EXPECTED_SAFE_DIRECTORY="+repoRoot,
-		"PATH="+gitDir+":"+os.Getenv("PATH"),
+		"PATH="+gitDir+":"+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 	)
 	result, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "collector failed: %s", result)
@@ -410,6 +413,7 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 			binary := filepath.Join(temp, "dumber")
 			log := strings.Replace(validFirstPresentationLog, test.old, test.new, 1)
 			require.NoError(t, os.WriteFile(binary, collectorTestBinary(log), 0o755))
+			goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
 
 			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 			cmd.Dir = repoRoot
@@ -419,6 +423,7 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
 				"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
 				"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
+				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 			)
 			result, err := cmd.CombinedOutput()
 			require.Errorf(t, err, "collector accepted malformed timing artifact: %s", result)

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2006,19 +2006,6 @@ func (wv *WebView) schedulePendingNavigationReplay(attempt int) {
 	})
 }
 
-func (wv *WebView) replayPendingNavigation(attempt int) {
-	if wv == nil || wv.destroyed.Load() {
-		return
-	}
-	wv.mu.RLock()
-	intentID := wv.pendingIntentID
-	wv.mu.RUnlock()
-	if intentID == 0 {
-		return
-	}
-	wv.replayPendingNavigationForIntent(attempt, intentID)
-}
-
 // replayPendingNavigationForIntent submits at most one LoadURL per navigation
 // intent. Duplicate scheduled tasks for an already-issued intent return
 // without resubmitting; stale tasks for a replaced intent return as well.
@@ -2064,17 +2051,24 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 	currentURL := frame.GetURL()
 	if pendingURIEquivalent(currentURL, uri) {
 		wv.mu.Lock()
-		if wv.pendingIntentID == intentID {
+		submitted := wv.pendingIntentID == intentID && wv.pendingIssued
+		if submitted {
 			wv.clearPendingNavigationIfEquivalentLocked(uri)
 		}
 		wv.mu.Unlock()
-		if wv.ctx != nil {
-			logging.FromContext(wv.ctx).Debug().
-				Int("attempt", attempt).
-				Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
-				Msg("cef: pending navigation already active")
+		if submitted {
+			if wv.ctx != nil {
+				logging.FromContext(wv.ctx).Debug().
+					Int("attempt", attempt).
+					Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
+					Msg("cef: pending navigation already active")
+			}
+			return
 		}
-		return
+		// Unissued explicit intent for the current URL (e.g. a same-URL
+		// reload): browsers always bootstrap on about:blank, so this is a
+		// fresh request that must proceed to the claim below, not be
+		// cleared as already active.
 	}
 	// Claim submission only for the current unissued intent with a valid
 	// frame; see claimPendingNavigationSubmission. Mark issued before the

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2106,8 +2106,12 @@ const (
 // claimPendingNavigationSubmission re-reads state and claims submission for
 // intentID only when it is still the current unissued intent. Browsers are
 // correlated by identifier, matching codebase convention; all foreign calls
-// happen outside the state lock. The issued mark is set before the caller
-// performs the foreign LoadURL.
+// happen outside the state lock. The final claim additionally requires the
+// attached browser to still be the instance observed before the lock: a
+// replacement between the identifier check and the claim is reported as
+// replaced so the caller retries against the current browser instead of
+// marking the intent issued and submitting to a stale frame. The issued
+// mark is set before the caller performs the foreign LoadURL.
 func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID int32) (string, pendingClaimResult) {
 	wv.mu.RLock()
 	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
@@ -2123,6 +2127,12 @@ func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID i
 	defer wv.mu.Unlock()
 	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
 		return "", pendingClaimStale
+	}
+	// Interface identity comparison is safe here: attached browsers are
+	// always the pointer wrappers delivered by CEF callbacks (mocks are
+	// pointers as well), and no foreign call happens under the lock.
+	if wv.browser != currentBrowser {
+		return "", pendingClaimReplaced
 	}
 	wv.pendingIssued = true
 	uri := wv.pendingURI

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2081,12 +2081,31 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 		wv.schedulePendingNavigationReplay(attempt + 1)
 	case pendingClaimReady:
 		frame.LoadURL(submitURI)
+		wv.resubmitIfBrowserReplaced(attempt, intentID, browser)
 	}
 	if wv.ctx != nil {
 		logging.FromContext(wv.ctx).Debug().
 			Int("attempt", attempt).
 			Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
 			Msg("cef: replayed pending navigation")
+	}
+}
+
+// resubmitIfBrowserReplaced re-checks the attached browser after the
+// claim's foreign LoadURL: a replacement in between leaves the navigation on
+// a stale frame while the intent reads issued. Clearing the issuance while
+// the intent is still current keeps it replayable, and the retry goes to
+// the current browser instead of dropping the navigation. Instance
+// comparison follows the same pointer-wrapper convention as the claim.
+func (wv *WebView) resubmitIfBrowserReplaced(attempt int, intentID uint64, submitted purecef.Browser) {
+	wv.mu.Lock()
+	replaced := wv.pendingIntentID == intentID && wv.pendingIssued && wv.browser != submitted
+	if replaced {
+		wv.pendingIssued = false
+	}
+	wv.mu.Unlock()
+	if replaced {
+		wv.schedulePendingNavigationReplay(attempt + 1)
 	}
 }
 

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -179,9 +179,17 @@ type WebView struct {
 	initialBrowserCreateResizeHandled bool
 
 	// pendingURI is set when LoadURI is called before the browser exists.
+	// Each explicit navigation request installs a new monotonically increasing
+	// pendingIntentID (including repeated same-URL requests); lifecycle replay
+	// never creates an intent. pendingIssued tracks whether the current intent
+	// has been submitted via LoadURL; duplicate scheduled tasks for an issued
+	// intent return without resubmitting.
 	pendingURI          string
 	pendingURISetAt     time.Time
 	pendingURIStartedAt time.Time
+	pendingIntentID     uint64
+	pendingIssued       bool
+	pendingIntentNext   uint64
 
 	// GTK sync dispatch hooks are injectable for tests. Production uses the GTK
 	// default main context through runOnGTK and isOnGTKThread.
@@ -1905,11 +1913,17 @@ func (wv *WebView) pendingNavigationURI() string {
 func (wv *WebView) setPendingNavigationLocked(uri string, at time.Time) {
 	wv.pendingURI = uri
 	wv.pendingURIStartedAt = time.Time{}
+	wv.pendingIssued = false
 	if uri == "" {
 		wv.pendingURISetAt = time.Time{}
+		wv.pendingIntentID = 0
 		return
 	}
 	wv.pendingURISetAt = at
+	// Every explicit request installs a new intent, including repeated
+	// same-URL requests; lifecycle replay never calls this.
+	wv.pendingIntentNext++
+	wv.pendingIntentID = wv.pendingIntentNext
 }
 
 func (wv *WebView) markPendingNavigationStartedLocked(uri string, at time.Time) {
@@ -1924,6 +1938,8 @@ func (wv *WebView) clearPendingNavigationLocked() string {
 	wv.pendingURI = ""
 	wv.pendingURISetAt = time.Time{}
 	wv.pendingURIStartedAt = time.Time{}
+	wv.pendingIntentID = 0
+	wv.pendingIssued = false
 	return cleared
 }
 
@@ -1949,8 +1965,16 @@ func (wv *WebView) schedulePendingNavigationReplay(attempt int) {
 	if wv == nil || wv.destroyed.Load() {
 		return
 	}
+	// Capture the intent at schedule time; a rapid replacement installs a new
+	// intent and stale tasks for the old ID must return without submitting.
+	wv.mu.RLock()
+	intentID := wv.pendingIntentID
+	wv.mu.RUnlock()
+	if intentID == 0 {
+		return
+	}
 	task := cefNewTask(cefTaskFunc(func() {
-		wv.replayPendingNavigation(attempt)
+		wv.replayPendingNavigationForIntent(attempt, intentID)
 	}))
 	if task == nil {
 		return
@@ -1987,10 +2011,34 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 		return
 	}
 	wv.mu.RLock()
+	intentID := wv.pendingIntentID
+	wv.mu.RUnlock()
+	if intentID == 0 {
+		return
+	}
+	wv.replayPendingNavigationForIntent(attempt, intentID)
+}
+
+// replayPendingNavigationForIntent submits at most one LoadURL per navigation
+// intent. Duplicate scheduled tasks for an already-issued intent return
+// without resubmitting; stale tasks for a replaced intent return as well.
+// Missing-frame and task-post failures retry only that same intent ID.
+func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64) {
+	if wv == nil || wv.destroyed.Load() {
+		return
+	}
+	wv.mu.RLock()
 	uri := wv.pendingURI
 	browser := wv.browser
+	currentID := wv.pendingIntentID
+	issued := wv.pendingIssued
 	wv.mu.RUnlock()
-	if uri == "" || browser == nil {
+	if uri == "" || browser == nil || currentID == 0 || intentID != currentID {
+		return
+	}
+	if issued {
+		// Already submitted for this intent; a blank OnLoadEnd scheduling a
+		// second replay must not resubmit an in-flight navigation.
 		return
 	}
 	frame := browser.GetMainFrame()
@@ -2016,7 +2064,9 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 	currentURL := frame.GetURL()
 	if pendingURIEquivalent(currentURL, uri) {
 		wv.mu.Lock()
-		wv.clearPendingNavigationIfEquivalentLocked(uri)
+		if wv.pendingIntentID == intentID {
+			wv.clearPendingNavigationIfEquivalentLocked(uri)
+		}
 		wv.mu.Unlock()
 		if wv.ctx != nil {
 			logging.FromContext(wv.ctx).Debug().
@@ -2026,7 +2076,22 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 		}
 		return
 	}
+	// Re-read the current browser under the state lock and claim submission
+	// only for the current unissued intent with a valid frame. Mark issued
+	// before the foreign LoadURL, outside the lock.
 	wv.mu.Lock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		wv.mu.Unlock()
+		return
+	}
+	if wv.browser != browser {
+		// Browser was replaced between frame acquisition and claim; retry
+		// the same intent so the new browser is used at execution time.
+		wv.mu.Unlock()
+		wv.schedulePendingNavigationReplay(attempt + 1)
+		return
+	}
+	wv.pendingIssued = true
 	wv.markPendingNavigationStartedLocked(uri, time.Now())
 	wv.mu.Unlock()
 	frame.LoadURL(uri)

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2077,18 +2077,25 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 		return
 	}
 	// Re-read the current browser under the state lock and claim submission
-	// only for the current unissued intent with a valid frame. Mark issued
-	// before the foreign LoadURL, outside the lock.
+	// only for the current unissued intent with a valid frame. Browsers are
+	// correlated by identifier (never interface equality); foreign calls stay
+	// outside the lock. Mark issued before the foreign LoadURL, outside lock.
+	wv.mu.RLock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		wv.mu.RUnlock()
+		return
+	}
+	currentBrowser := wv.browser
+	wv.mu.RUnlock()
+	if currentBrowser.GetIdentifier() != browser.GetIdentifier() {
+		// Browser was replaced between frame acquisition and claim; retry
+		// the same intent so the new browser is used at execution time.
+		wv.schedulePendingNavigationReplay(attempt + 1)
+		return
+	}
 	wv.mu.Lock()
 	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
 		wv.mu.Unlock()
-		return
-	}
-	if wv.browser != browser {
-		// Browser was replaced between frame acquisition and claim; retry
-		// the same intent so the new browser is used at execution time.
-		wv.mu.Unlock()
-		wv.schedulePendingNavigationReplay(attempt + 1)
 		return
 	}
 	wv.pendingIssued = true

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2076,38 +2076,64 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 		}
 		return
 	}
-	// Re-read the current browser under the state lock and claim submission
-	// only for the current unissued intent with a valid frame. Browsers are
-	// correlated by identifier (never interface equality); foreign calls stay
-	// outside the lock. Mark issued before the foreign LoadURL, outside lock.
-	wv.mu.RLock()
-	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
-		wv.mu.RUnlock()
-		return
-	}
-	currentBrowser := wv.browser
-	wv.mu.RUnlock()
-	if currentBrowser.GetIdentifier() != browser.GetIdentifier() {
+	// Claim submission only for the current unissued intent with a valid
+	// frame; see claimPendingNavigationSubmission. Mark issued before the
+	// foreign LoadURL, outside the lock.
+	submitURI, claim := wv.claimPendingNavigationSubmission(intentID, browser.GetIdentifier())
+	switch claim {
+	case pendingClaimReplaced:
 		// Browser was replaced between frame acquisition and claim; retry
 		// the same intent so the new browser is used at execution time.
 		wv.schedulePendingNavigationReplay(attempt + 1)
-		return
+	case pendingClaimReady:
+		frame.LoadURL(submitURI)
 	}
-	wv.mu.Lock()
-	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
-		wv.mu.Unlock()
-		return
-	}
-	wv.pendingIssued = true
-	wv.markPendingNavigationStartedLocked(uri, time.Now())
-	wv.mu.Unlock()
-	frame.LoadURL(uri)
 	if wv.ctx != nil {
 		logging.FromContext(wv.ctx).Debug().
 			Int("attempt", attempt).
 			Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
 			Msg("cef: replayed pending navigation")
 	}
+}
+
+type pendingClaimResult int
+
+const (
+	// pendingClaimStale means the intent changed, was issued, or was cleared:
+	// the caller must return without submitting.
+	pendingClaimStale pendingClaimResult = iota
+	// pendingClaimReplaced means the browser was replaced between frame
+	// acquisition and claim: the caller must retry the same intent.
+	pendingClaimReplaced
+	// pendingClaimReady means the intent was claimed: the caller submits uri.
+	pendingClaimReady
+)
+
+// claimPendingNavigationSubmission re-reads state and claims submission for
+// intentID only when it is still the current unissued intent. Browsers are
+// correlated by identifier, matching codebase convention; all foreign calls
+// happen outside the state lock. The issued mark is set before the caller
+// performs the foreign LoadURL.
+func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID int32) (string, pendingClaimResult) {
+	wv.mu.RLock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		wv.mu.RUnlock()
+		return "", pendingClaimStale
+	}
+	currentBrowser := wv.browser
+	wv.mu.RUnlock()
+	if currentBrowser.GetIdentifier() != browserID {
+		return "", pendingClaimReplaced
+	}
+	wv.mu.Lock()
+	defer wv.mu.Unlock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		return "", pendingClaimStale
+	}
+	wv.pendingIssued = true
+	uri := wv.pendingURI
+	wv.markPendingNavigationStartedLocked(uri, time.Now())
+	return uri, pendingClaimReady
 }
 
 func pendingURIEquivalent(a, b string) bool {

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -429,3 +429,83 @@ func TestWebViewReplayPendingNavigation_SameURLReloadSubmits(t *testing.T) {
 	defer wv.mu.RUnlock()
 	require.True(t, wv.pendingIssued)
 }
+
+func TestWebViewReplayPendingNavigation_ClearsIssuanceWhenBrowserReplacedAfterClaim(t *testing.T) {
+	const uri = "https://example.com/replaced-after-claim"
+	browserA := cefmocks.NewMockBrowser(t)
+	browserB := cefmocks.NewMockBrowser(t)
+	frameA := cefmocks.NewMockFrame(t)
+	frameB := cefmocks.NewMockFrame(t)
+
+	browserA.EXPECT().GetIdentifier().Return(int32(7)).Twice()
+	browserA.EXPECT().GetMainFrame().Return(frameA).Once()
+	frameA.EXPECT().GetURL().Return("").Once()
+	entered := make(chan struct{})
+	var enterOnce sync.Once
+	proceed := make(chan struct{})
+	frameA.EXPECT().LoadURL(uri).RunAndReturn(func(string) {
+		enterOnce.Do(func() { close(entered) })
+		<-proceed
+	}).Once()
+
+	browserB.EXPECT().GetIdentifier().Return(int32(7)).Twice()
+	browserB.EXPECT().GetMainFrame().Return(frameB).Once()
+	frameB.EXPECT().GetURL().Return("").Once()
+	frameB.EXPECT().LoadURL(uri).Once()
+
+	oldTask := cefNewTask
+	oldDelayed := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldTask
+		cefPostDelayedTask = oldDelayed
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	var scheduled purecef.Task
+	// The post-claim retry schedules with attempt+1, which takes the
+	// delayed-task path; capture it to drive the retry synchronously.
+	cefPostDelayedTask = func(_ purecef.ThreadID, task purecef.Task, _ int64) int32 {
+		scheduled = task
+		return 1
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browserA}
+	wv.setPendingNavigationLocked(uri, time.Now())
+	intentID := wv.pendingIntentID
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wv.replayPendingNavigationForIntent(0, intentID)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("replay did not reach LoadURL")
+	}
+
+	// Replace the attached browser while LoadURL is in flight on the stale
+	// frame: the claim already marked the intent issued.
+	wv.mu.Lock()
+	wv.browser = browserB
+	wv.mu.Unlock()
+	close(proceed)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("replay did not return after LoadURL")
+	}
+
+	wv.mu.RLock()
+	require.False(t, wv.pendingIssued, "post-claim replacement must reopen the issuance for retry")
+	require.Equal(t, intentID, wv.pendingIntentID, "the intent itself must survive the replacement")
+	wv.mu.RUnlock()
+	require.NotNil(t, scheduled, "a retry against the current browser must be scheduled")
+
+	// Driving the retry submits the surviving intent to the new browser.
+	scheduled.Execute()
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.True(t, wv.pendingIssued, "retry must issue the intent on the current browser")
+}

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -16,6 +16,7 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("https://github.com/bnema").Once()
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 
 	wv := &WebView{ctx: context.Background(), browser: browser}
 	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
@@ -104,6 +105,7 @@ func TestWebViewReplayPendingNavigation_UsesCurrentBrowserAtExecutionTime(t *tes
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("https://github.com/bnema").Once()
 	activeBrowser.EXPECT().GetMainFrame().Return(frame).Once()
+	activeBrowser.EXPECT().GetIdentifier().Return(int32(2)).Twice()
 
 	oldTask := cefNewTask
 	oldPost := cefPostTask
@@ -134,6 +136,7 @@ func TestWebViewLoadURI_QueuesPendingNavigationReplayForExistingBrowser(t *testi
 	browser := cefmocks.NewMockBrowser(t)
 	frame := cefmocks.NewMockFrame(t)
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("github.com/bnema").Once()
 
@@ -236,6 +239,7 @@ func TestWebViewReplayPendingNavigation_SubmitsOncePerIntent(t *testing.T) {
 	frame.EXPECT().GetURL().Return("about:blank")
 	frame.EXPECT().LoadURL("https://example.com/target").Once()
 	browser.EXPECT().GetMainFrame().Return(frame)
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 
 	oldTask := cefNewTask
 	oldPost := cefPostTask
@@ -270,6 +274,7 @@ func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T)
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("https://example.com/second").Once()
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 
 	oldTask := cefNewTask
 	oldPost := cefPostTask

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -20,7 +20,7 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 
 	wv := &WebView{ctx: context.Background(), browser: browser}
 	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
-	wv.replayPendingNavigation(0)
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
 
 	wv.mu.RLock()
 	defer wv.mu.RUnlock()
@@ -50,7 +50,7 @@ func TestWebViewReplayPendingNavigation_RetriesWhenMainFrameUnavailable(t *testi
 
 	wv := &WebView{ctx: context.Background(), browser: browser}
 	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
-	wv.replayPendingNavigation(0)
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
 
 	require.True(t, scheduled)
 	wv.mu.RLock()
@@ -298,7 +298,7 @@ func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T)
 	wv.setPendingNavigationLocked("https://example.com/second", time.Now())
 	stale.Execute()
 	// Current intent still unissued; a fresh replay submits it once.
-	wv.replayPendingNavigation(0)
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
 }
 
 // TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost ensures a
@@ -352,4 +352,24 @@ func TestWebViewSetPendingNavigation_RepeatedSameURLInstallsNewIntent(t *testing
 	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
 	require.NotEqual(t, first, wv.pendingIntentID)
 	require.False(t, wv.pendingIssued)
+}
+
+// TestWebViewReplayPendingNavigation_SameURLReloadSubmits verifies an
+// unissued explicit intent for the currently displayed URL proceeds to
+// LoadURL instead of being cleared as already active.
+func TestWebViewReplayPendingNavigation_SameURLReloadSubmits(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().GetURL().Return("https://example.com/page").Once()
+	frame.EXPECT().LoadURL("https://example.com/page").Once()
+	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
+
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.True(t, wv.pendingIssued)
 }

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -2,6 +2,7 @@ package cef
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,61 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 	wv.mu.RLock()
 	defer wv.mu.RUnlock()
 	require.Equal(t, "https://github.com/bnema", wv.pendingURI)
+}
+
+// TestWebViewClaimPendingNavigationSubmission_RejectsInstanceReplacement
+// reproduces a browser swap landing between the identifier check and the
+// final claim: the replacement carries the same identifier, so only the
+// instance-identity guard can catch it. The claim must report replaced
+// without marking the intent issued, leaving the retry path able to submit
+// against the current browser.
+func TestWebViewClaimPendingNavigationSubmission_RejectsInstanceReplacement(t *testing.T) {
+	browserA := cefmocks.NewMockBrowser(t)
+	browserB := cefmocks.NewMockBrowser(t)
+	entered := make(chan struct{})
+	var enterOnce sync.Once
+	proceed := make(chan struct{})
+	browserA.EXPECT().GetIdentifier().RunAndReturn(func() int32 {
+		enterOnce.Do(func() { close(entered) })
+		<-proceed
+		return int32(7)
+	}).Once()
+
+	wv := &WebView{ctx: context.Background(), browser: browserA}
+	wv.setPendingNavigationLocked("https://example.com", time.Now())
+	intentID := wv.pendingIntentID
+	require.NotZero(t, intentID)
+
+	claimed := make(chan pendingClaimResult, 1)
+	go func() {
+		_, result := wv.claimPendingNavigationSubmission(intentID, int32(7))
+		claimed <- result
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("claim did not reach the identifier check")
+	}
+
+	// Swap the attached browser while the claim is past the snapshot: same
+	// identifier, different instance.
+	wv.mu.Lock()
+	wv.browser = browserB
+	wv.mu.Unlock()
+	close(proceed)
+
+	select {
+	case result := <-claimed:
+		require.Equal(t, pendingClaimReplaced, result, "instance replacement must not claim the intent")
+	case <-time.After(10 * time.Second):
+		t.Fatal("claim did not return after the swap")
+	}
+
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.False(t, wv.pendingIssued, "replaced claim must leave the intent unissued for retry")
+	require.Equal(t, intentID, wv.pendingIntentID)
 }
 
 func TestWebViewReplayPendingNavigation_RetriesWhenMainFrameUnavailable(t *testing.T) {

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -245,7 +245,7 @@ func TestWebViewReplayPendingNavigation_SubmitsOncePerIntent(t *testing.T) {
 	}()
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
 	var scheduled []purecef.Task
-	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+	cefPostTask = func(_ purecef.ThreadID, task purecef.Task) int32 {
 		scheduled = append(scheduled, task)
 		return 1
 	}
@@ -279,7 +279,7 @@ func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T)
 	}()
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
 	var scheduled []purecef.Task
-	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+	cefPostTask = func(_ purecef.ThreadID, task purecef.Task) int32 {
 		scheduled = append(scheduled, task)
 		return 1
 	}
@@ -310,11 +310,11 @@ func TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost(t *testing
 		cefScheduleAfter = oldAfter
 	}()
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
-	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+	cefPostTask = func(_ purecef.ThreadID, _ purecef.Task) int32 {
 		return 0
 	}
 	scheduledAfter := false
-	cefScheduleAfter = func(delay time.Duration, fn func()) {
+	cefScheduleAfter = func(delay time.Duration, _ func()) {
 		require.Equal(t, pendingNavigationRetryDelay, delay)
 		scheduledAfter = true
 	}

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -17,7 +17,8 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 	frame.EXPECT().LoadURL("https://github.com/bnema").Once()
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
 
-	wv := &WebView{ctx: context.Background(), browser: browser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.replayPendingNavigation(0)
 
 	wv.mu.RLock()
@@ -46,7 +47,8 @@ func TestWebViewReplayPendingNavigation_RetriesWhenMainFrameUnavailable(t *testi
 		return 1
 	}
 
-	wv := &WebView{ctx: context.Background(), browser: browser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.replayPendingNavigation(0)
 
 	require.True(t, scheduled)
@@ -88,7 +90,8 @@ func TestWebViewSchedulePendingNavigationReplay_RetriesWhenTaskPostFails(t *test
 		return 1
 	}
 
-	wv := &WebView{ctx: context.Background(), browser: browser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.schedulePendingNavigationReplay(0)
 
 	require.True(t, retried)
@@ -116,7 +119,8 @@ func TestWebViewReplayPendingNavigation_UsesCurrentBrowserAtExecutionTime(t *tes
 		return 1
 	}
 
-	wv := &WebView{ctx: context.Background(), browser: staleBrowser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: staleBrowser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.schedulePendingNavigationReplay(0)
 	wv.mu.Lock()
 	wv.browser = activeBrowser
@@ -220,4 +224,127 @@ func TestWebViewUpdateLoadState_KeepsPendingNavigationWhileLoading(t *testing.T)
 	wv.updateLoadState(true, true, false)
 
 	require.Equal(t, pending, wv.pendingNavigationURI())
+}
+
+// TestWebViewReplayPendingNavigation_SubmitsOncePerIntent reproduces the
+// fresh-window race: queue an intent, run OnAfterCreated replay with the
+// frame URL still blank, then deliver blank OnLoadEnd before commit. Exactly
+// one LoadURL must be issued for the intent.
+func TestWebViewReplayPendingNavigation_SubmitsOncePerIntent(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().GetURL().Return("about:blank")
+	frame.EXPECT().LoadURL("https://example.com/target").Once()
+	browser.EXPECT().GetMainFrame().Return(frame)
+
+	oldTask := cefNewTask
+	oldPost := cefPostTask
+	defer func() {
+		cefNewTask = oldTask
+		cefPostTask = oldPost
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	var scheduled []purecef.Task
+	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/target", time.Now())
+	// OnAfterCreated schedules replay...
+	wv.schedulePendingNavigationReplay(0)
+	// ...and blank OnLoadEnd schedules a second replay before commit.
+	wv.schedulePendingNavigationReplay(0)
+	require.Len(t, scheduled, 2)
+	for _, task := range scheduled {
+		task.Execute()
+	}
+}
+
+// TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit verifies a
+// rapid replacement URL invalidates the previously scheduled task.
+func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().GetURL().Return("").Once()
+	frame.EXPECT().LoadURL("https://example.com/second").Once()
+	browser.EXPECT().GetMainFrame().Return(frame).Once()
+
+	oldTask := cefNewTask
+	oldPost := cefPostTask
+	defer func() {
+		cefNewTask = oldTask
+		cefPostTask = oldPost
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	var scheduled []purecef.Task
+	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/first", time.Now())
+	wv.schedulePendingNavigationReplay(0)
+	require.Len(t, scheduled, 1)
+	stale := scheduled[0]
+	// Replacement installs a new intent; the stale task must not submit.
+	wv.setPendingNavigationLocked("https://example.com/second", time.Now())
+	stale.Execute()
+	// Current intent still unissued; a fresh replay submits it once.
+	wv.replayPendingNavigation(0)
+}
+
+// TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost ensures a
+// failed task post retries without consuming or duplicating the intent.
+func TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+
+	oldTask := cefNewTask
+	oldPost := cefPostTask
+	oldAfter := cefScheduleAfter
+	defer func() {
+		cefNewTask = oldTask
+		cefPostTask = oldPost
+		cefScheduleAfter = oldAfter
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+		return 0
+	}
+	scheduledAfter := false
+	cefScheduleAfter = func(delay time.Duration, fn func()) {
+		require.Equal(t, pendingNavigationRetryDelay, delay)
+		scheduledAfter = true
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/target", time.Now())
+	wv.mu.RLock()
+	intent := wv.pendingIntentID
+	wv.mu.RUnlock()
+	wv.schedulePendingNavigationReplay(0)
+	require.True(t, scheduledAfter)
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.Equal(t, intent, wv.pendingIntentID)
+	require.False(t, wv.pendingIssued)
+	require.Equal(t, "https://example.com/target", wv.pendingURI)
+}
+
+// TestWebViewSetPendingNavigation_RepeatedSameURLInstallsNewIntent ensures
+// explicit reloads and repeated navigations still work: each request is a
+// new intent even for an identical URL.
+func TestWebViewSetPendingNavigation_RepeatedSameURLInstallsNewIntent(t *testing.T) {
+	wv := &WebView{ctx: context.Background()}
+	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
+	first := wv.pendingIntentID
+	require.NotZero(t, first)
+	wv.mu.Lock()
+	wv.pendingIssued = true
+	wv.mu.Unlock()
+	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
+	require.NotEqual(t, first, wv.pendingIntentID)
+	require.False(t, wv.pendingIssued)
 }

--- a/internal/infrastructure/desktop/adapter.go
+++ b/internal/infrastructure/desktop/adapter.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/logging"
 )
 
@@ -500,7 +501,10 @@ func launchBrowserURL(
 	}
 
 	cmd := exec.Command(execPath, "browse", uri)
-	cmd.Env = withoutEnvKeys(sanitizedChildEnv(os.Environ()), FreshWindowLaunchEnvVar)
+	// Prepare the child environment with the shared safety merge after
+	// sanitization so application-spawned browser processes start safe.
+	childEnv, _ := process.MergeRuntimeSafety(sanitizedChildEnv(os.Environ()))
+	cmd.Env = withoutEnvKeys(childEnv, FreshWindowLaunchEnvVar)
 	if freshWindow {
 		cmd.Env = append(cmd.Env, FreshWindowLaunchEnvVar+"=1")
 	}
@@ -599,7 +603,8 @@ func (s *SessionSpawner) SpawnWithSession(sessionID entity.SessionID) error {
 	// Start dumber browse with session ID in environment
 	cmd := exec.Command(execPath, "browse")
 
-	sanitizedEnv := withoutEnvKeys(sanitizedChildEnv(os.Environ()), RestoreSessionEnvVar)
+	sanitizedEnv, _ := process.MergeRuntimeSafety(sanitizedChildEnv(os.Environ()))
+	sanitizedEnv = withoutEnvKeys(sanitizedEnv, RestoreSessionEnvVar)
 	overrides := []string{RestoreSessionEnvVar + "=" + string(sessionID)}
 	if s.spawnEnv != nil {
 		sanitizedEnv = withoutEnvKeys(sanitizedEnv, s.spawnEnv.RootCacheEnvVar())

--- a/internal/infrastructure/desktop/adapter_test.go
+++ b/internal/infrastructure/desktop/adapter_test.go
@@ -292,3 +292,24 @@ func requireNoError(t *testing.T, err error) {
 		t.Fatal(err)
 	}
 }
+
+func TestLaunchBrowserBrowseURL_ChildEnvMergesRuntimeSafety(t *testing.T) {
+	t.Setenv("GODEBUG", "gctrace=1")
+
+	err := launchBrowserBrowseURL(
+		"https://example.com",
+		func() (string, error) { return "/usr/bin/dumber", nil },
+		func(cmd *exec.Cmd) error {
+			found := false
+			for _, entry := range cmd.Env {
+				if entry == "GODEBUG=gctrace=1,gcshrinkstackoff=1" {
+					found = true
+				}
+			}
+			assert.True(t, found, "child env must merge safety after sanitization: %#v", cmd.Env)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+}

--- a/internal/infrastructure/process/runtime_safety.go
+++ b/internal/infrastructure/process/runtime_safety.go
@@ -1,0 +1,63 @@
+// Package process provides dependency-leaf process-environment helpers.
+//
+// This file must not import bootstrap, desktop, or any other internal
+// package: both cmd/dumber and internal/infrastructure/desktop import it, and
+// bootstrap already imports desktop. Keep it to the standard library so the
+// merge rule can be shared without an import cycle.
+package process
+
+import "strings"
+
+// RuntimeSafetySetting is the GODEBUG key that must be set before any
+// goroutine or CEF subprocess is created. Go stack shrinking can invalidate
+// frames retained across foreign CEF/GTK stacks.
+const RuntimeSafetySetting = "gcshrinkstackoff"
+
+// EnvironmentValue returns the value for name in an environ slice.
+func EnvironmentValue(environ []string, name string) string {
+	prefix := name + "="
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}
+
+// ReplaceEnvironmentValue returns a copy of environ with name set to value.
+func ReplaceEnvironmentValue(environ []string, name, value string) []string {
+	prefix := name + "="
+	updated := make([]string, 0, len(environ)+1)
+	for _, entry := range environ {
+		if !strings.HasPrefix(entry, prefix) {
+			updated = append(updated, entry)
+		}
+	}
+	return append(updated, prefix+value)
+}
+
+// MergeRuntimeSafety returns a copy of environ with RuntimeSafetySetting=1
+// merged into GODEBUG, preserving all unrelated entries (including other
+// GODEBUG keys). It reports whether a change was applied. Duplicate or
+// conflicting gcshrinkstackoff entries collapse to a single =1 entry.
+func MergeRuntimeSafety(environ []string) ([]string, bool) {
+	updated := append([]string(nil), environ...)
+	parts := strings.Split(EnvironmentValue(updated, "GODEBUG"), ",")
+	kept := make([]string, 0, len(parts)+1)
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, _, _ := strings.Cut(part, "=")
+		if key == RuntimeSafetySetting {
+			continue
+		}
+		kept = append(kept, part)
+	}
+	merged := strings.Join(append(kept, RuntimeSafetySetting+"=1"), ",")
+	if EnvironmentValue(updated, "GODEBUG") == merged {
+		return updated, false
+	}
+	return ReplaceEnvironmentValue(updated, "GODEBUG", merged), true
+}

--- a/internal/infrastructure/process/runtime_safety.go
+++ b/internal/infrastructure/process/runtime_safety.go
@@ -38,12 +38,17 @@ func ReplaceEnvironmentValue(environ []string, name, value string) []string {
 
 // MergeRuntimeSafety returns a copy of environ with RuntimeSafetySetting=1
 // merged into GODEBUG, preserving all unrelated entries (including other
-// GODEBUG keys). It reports whether a change was applied. Duplicate or
-// conflicting gcshrinkstackoff entries collapse to a single =1 entry.
+// GODEBUG keys) and their relative order. It reports whether a change was
+// applied. An already-effective single setting entry is detected
+// independently of its position, so direct invocation never performs an
+// unnecessary self-exec; duplicate or conflicting entries still collapse to
+// one normalized trailing entry.
 func MergeRuntimeSafety(environ []string) ([]string, bool) {
 	updated := append([]string(nil), environ...)
-	parts := strings.Split(EnvironmentValue(updated, "GODEBUG"), ",")
+	current := EnvironmentValue(updated, "GODEBUG")
+	parts := strings.Split(current, ",")
 	kept := make([]string, 0, len(parts)+1)
+	var settingParts []string
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -51,12 +56,21 @@ func MergeRuntimeSafety(environ []string) ([]string, bool) {
 		}
 		key, _, _ := strings.Cut(part, "=")
 		if key == RuntimeSafetySetting {
+			settingParts = append(settingParts, part)
 			continue
 		}
 		kept = append(kept, part)
 	}
+	if len(settingParts) == 1 && settingParts[0] == RuntimeSafetySetting+"=1" {
+		// Exactly one effective entry: already safe in place, independent
+		// of its position among the other keys. Leave the order untouched
+		// so direct invocation performs no self-exec.
+		return updated, false
+	}
+	// Zero, duplicate, conflicting, or valueless entries collapse to one
+	// normalized trailing entry.
 	merged := strings.Join(append(kept, RuntimeSafetySetting+"=1"), ",")
-	if EnvironmentValue(updated, "GODEBUG") == merged {
+	if current == merged {
 		return updated, false
 	}
 	return ReplaceEnvironmentValue(updated, "GODEBUG", merged), true

--- a/internal/infrastructure/process/runtime_safety.go
+++ b/internal/infrastructure/process/runtime_safety.go
@@ -45,7 +45,16 @@ func ReplaceEnvironmentValue(environ []string, name, value string) []string {
 // one normalized trailing entry.
 func MergeRuntimeSafety(environ []string) ([]string, bool) {
 	updated := append([]string(nil), environ...)
-	current := EnvironmentValue(updated, "GODEBUG")
+	// Collect every GODEBUG entry: duplicates are legal in an environ
+	// slice and the first entry alone never describes the effective
+	// setting, so normalization must merge them all before deciding.
+	godebugValues := make([]string, 0, 1)
+	for _, entry := range updated {
+		if strings.HasPrefix(entry, "GODEBUG=") {
+			godebugValues = append(godebugValues, strings.TrimPrefix(entry, "GODEBUG="))
+		}
+	}
+	current := strings.Join(godebugValues, ",")
 	parts := strings.Split(current, ",")
 	kept := make([]string, 0, len(parts)+1)
 	var settingParts []string
@@ -61,10 +70,10 @@ func MergeRuntimeSafety(environ []string) ([]string, bool) {
 		}
 		kept = append(kept, part)
 	}
-	if len(settingParts) == 1 && settingParts[0] == RuntimeSafetySetting+"=1" {
-		// Exactly one effective entry: already safe in place, independent
-		// of its position among the other keys. Leave the order untouched
-		// so direct invocation performs no self-exec.
+	if len(godebugValues) == 1 && len(settingParts) == 1 && settingParts[0] == RuntimeSafetySetting+"=1" {
+		// Exactly one entry with one effective setting: already safe in
+		// place, independent of its position among the other keys. Leave
+		// the order untouched so direct invocation performs no self-exec.
 		return updated, false
 	}
 	// Zero, duplicate, conflicting, or valueless entries collapse to one

--- a/internal/infrastructure/process/runtime_safety_test.go
+++ b/internal/infrastructure/process/runtime_safety_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,12 +22,26 @@ func TestMergeRuntimeSafety(t *testing.T) {
 		{name: "collapses duplicates", environ: []string{"GODEBUG=gcshrinkstackoff=0,gcshrinkstackoff=1"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "bare key without value is unsafe", environ: []string{"GODEBUG=gcshrinkstackoff"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "preserves other debug keys", environ: []string{"GODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0"}, wantGODEBUG: "tracebacklabels=0,x509sslcertoverrideplatform=0,gcshrinkstackoff=1", wantChanged: true},
+		{name: "merges separate duplicate entries", environ: []string{"GODEBUG=gcshrinkstackoff=1", "GODEBUG=gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
+		{name: "safe first entry does not hide second entry keys", environ: []string{"GODEBUG=gcshrinkstackoff=1", "GODEBUG=cpu.all=off"}, wantGODEBUG: "cpu.all=off,gcshrinkstackoff=1", wantChanged: true},
+		{name: "unsafe first entry preserves second entry keys", environ: []string{"GODEBUG=cpu.all=off", "GODEBUG=gcshrinkstackoff=1,foo=bar"}, wantGODEBUG: "cpu.all=off,foo=bar,gcshrinkstackoff=1", wantChanged: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, changed := MergeRuntimeSafety(tt.environ)
 			require.Equal(t, tt.wantChanged, changed)
 			require.Equal(t, tt.wantGODEBUG, EnvironmentValue(got, "GODEBUG"))
+			if changed {
+				// Normalization always collapses to a single trailing
+				// entry; no duplicate GODEBUG may survive a change.
+				count := 0
+				for _, entry := range got {
+					if strings.HasPrefix(entry, "GODEBUG=") {
+						count++
+				}
+				}
+				require.Equal(t, 1, count, "changed environ must hold exactly one GODEBUG entry")
+			}
 		})
 	}
 }

--- a/internal/infrastructure/process/runtime_safety_test.go
+++ b/internal/infrastructure/process/runtime_safety_test.go
@@ -1,0 +1,39 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeRuntimeSafety(t *testing.T) {
+	tests := []struct {
+		name        string
+		environ     []string
+		wantGODEBUG string
+		wantChanged bool
+	}{
+		{name: "missing", environ: []string{"HOME=/tmp"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
+		{name: "preserves settings", environ: []string{"GODEBUG=gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
+		{name: "overrides unsafe value", environ: []string{"GODEBUG=gcshrinkstackoff=0,gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
+		{name: "already safe", environ: []string{"GODEBUG=gctrace=1,gcshrinkstackoff=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: false},
+		{name: "collapses duplicates", environ: []string{"GODEBUG=gcshrinkstackoff=0,gcshrinkstackoff=1"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
+		{name: "bare key without value is unsafe", environ: []string{"GODEBUG=gcshrinkstackoff"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
+		{name: "preserves other debug keys", environ: []string{"GODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0"}, wantGODEBUG: "tracebacklabels=0,x509sslcertoverrideplatform=0,gcshrinkstackoff=1", wantChanged: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := MergeRuntimeSafety(tt.environ)
+			require.Equal(t, tt.wantChanged, changed)
+			require.Equal(t, tt.wantGODEBUG, EnvironmentValue(got, "GODEBUG"))
+		})
+	}
+}
+
+func TestMergeRuntimeSafetyDoesNotMutateInput(t *testing.T) {
+	input := []string{"GODEBUG=gctrace=1"}
+	got, changed := MergeRuntimeSafety(input)
+	require.True(t, changed)
+	require.Equal(t, []string{"GODEBUG=gctrace=1"}, input)
+	require.Equal(t, "gctrace=1,gcshrinkstackoff=1", EnvironmentValue(got, "GODEBUG"))
+}

--- a/internal/infrastructure/process/runtime_safety_test.go
+++ b/internal/infrastructure/process/runtime_safety_test.go
@@ -17,6 +17,7 @@ func TestMergeRuntimeSafety(t *testing.T) {
 		{name: "preserves settings", environ: []string{"GODEBUG=gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
 		{name: "overrides unsafe value", environ: []string{"GODEBUG=gcshrinkstackoff=0,gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
 		{name: "already safe", environ: []string{"GODEBUG=gctrace=1,gcshrinkstackoff=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: false},
+		{name: "safe first keeps position without exec", environ: []string{"GODEBUG=gcshrinkstackoff=1,gctrace=1"}, wantGODEBUG: "gcshrinkstackoff=1,gctrace=1", wantChanged: false},
 		{name: "collapses duplicates", environ: []string{"GODEBUG=gcshrinkstackoff=0,gcshrinkstackoff=1"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "bare key without value is unsafe", environ: []string{"GODEBUG=gcshrinkstackoff"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "preserves other debug keys", environ: []string{"GODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0"}, wantGODEBUG: "tracebacklabels=0,x509sslcertoverrideplatform=0,gcshrinkstackoff=1", wantChanged: true},

--- a/internal/ui/component/logo.go
+++ b/internal/ui/component/logo.go
@@ -2,6 +2,7 @@
 package component
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/bnema/dumber/assets"
@@ -9,26 +10,45 @@ import (
 	"github.com/bnema/puregotk/v4/glib"
 )
 
+var errLogoDecode = errors.New("logo decode failed")
+
 var (
 	logoTexture     *gdk.Texture
 	logoTextureOnce sync.Once
+	// logoAssetBytes supplies the raster logo bytes. Overridden in tests to
+	// count requests without native decoding.
+	logoAssetBytes = func() []byte { return assets.LogoPNG512 }
+	// logoDecodeTexture converts raster bytes to a texture. Overridden in
+	// tests with a fake; production keeps GBytes/texture lifetime by
+	// releasing the temporary byte reference after the native constructor
+	// no longer needs it.
+	logoDecodeTexture = func(data []byte) (*gdk.Texture, error) {
+		bytes := glib.NewBytes(data, uint(len(data)))
+		if bytes == nil {
+			return nil, errLogoDecode
+		}
+		texture, err := gdk.NewTextureFromBytes(bytes)
+		bytes.Unref()
+		if err != nil {
+			return nil, err
+		}
+		return texture, nil
+	}
 )
 
 // GetLogoTexture returns a cached GDK texture of the dumber logo.
 // Safe to call from any goroutine; lazily initializes on first call.
+// Decodes the packaged 512-pixel PNG raster asset; the displayed size and
+// one-texture-per-process lifetime are unchanged.
 // Returns nil if the logo cannot be loaded.
 func GetLogoTexture() *gdk.Texture {
 	logoTextureOnce.Do(func() {
-		data := assets.LogoSVG
+		data := logoAssetBytes()
 		if len(data) == 0 {
 			return
 		}
-		bytes := glib.NewBytes(data, uint(len(data)))
-		if bytes == nil {
-			return
-		}
-		texture, err := gdk.NewTextureFromBytes(bytes)
-		if err != nil {
+		texture, err := logoDecodeTexture(data)
+		if err != nil || texture == nil {
 			return
 		}
 		logoTexture = texture

--- a/internal/ui/component/logo_test.go
+++ b/internal/ui/component/logo_test.go
@@ -1,0 +1,97 @@
+package component
+
+import (
+	"encoding/binary"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bnema/dumber/assets"
+	"github.com/bnema/puregotk/v4/gdk"
+	"github.com/stretchr/testify/require"
+)
+
+func resetLogoForTest() {
+	logoTexture = nil
+	logoTextureOnce = sync.Once{}
+}
+
+func TestLogoPNG512AssetSignatureAndDimensions(t *testing.T) {
+	data := assets.LogoPNG512
+	require.NotEmpty(t, data)
+	require.Equal(t, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, data[:8])
+	require.GreaterOrEqual(t, len(data), 33)
+	require.Equal(t, "IHDR", string(data[12:16]))
+	width := binary.BigEndian.Uint32(data[16:20])
+	height := binary.BigEndian.Uint32(data[20:24])
+	require.Equal(t, uint32(512), width)
+	require.Equal(t, uint32(512), height)
+	require.NotEmpty(t, assets.LogoSVG, "SVG source for desktop icons must remain")
+}
+
+func TestGetLogoTextureRequestsRasterOnce(t *testing.T) {
+	resetLogoForTest()
+	origAsset, origDecode := logoAssetBytes, logoDecodeTexture
+	defer func() {
+		logoAssetBytes, logoDecodeTexture = origAsset, origDecode
+		resetLogoForTest()
+	}()
+	var calls atomic.Int32
+	logoAssetBytes = func() []byte {
+		calls.Add(1)
+		return assets.LogoPNG512
+	}
+	logoDecodeTexture = func(data []byte) (*gdk.Texture, error) {
+		require.Equal(t, assets.LogoPNG512, data)
+		return nil, errors.New("native unavailable in unit test")
+	}
+	require.NotPanics(t, func() {
+		require.Nil(t, GetLogoTexture())
+		require.Nil(t, GetLogoTexture())
+	})
+	require.Equal(t, int32(1), calls.Load(), "raster bytes must be requested once")
+}
+
+func TestGetLogoTextureConcurrentCallersShareResult(t *testing.T) {
+	resetLogoForTest()
+	origAsset, origDecode := logoAssetBytes, logoDecodeTexture
+	defer func() {
+		logoAssetBytes, logoDecodeTexture = origAsset, origDecode
+		resetLogoForTest()
+	}()
+	var calls atomic.Int32
+	logoAssetBytes = func() []byte {
+		calls.Add(1)
+		return assets.LogoPNG512
+	}
+	logoDecodeTexture = func([]byte) (*gdk.Texture, error) {
+		return nil, errors.New("native unavailable in unit test")
+	}
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = GetLogoTexture()
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestGetLogoTextureFailureDoesNotPanic(t *testing.T) {
+	resetLogoForTest()
+	origAsset, origDecode := logoAssetBytes, logoDecodeTexture
+	defer func() {
+		logoAssetBytes, logoDecodeTexture = origAsset, origDecode
+		resetLogoForTest()
+	}()
+	logoAssetBytes = func() []byte { return nil }
+	logoDecodeTexture = func([]byte) (*gdk.Texture, error) {
+		return nil, errors.New("must not be called with empty asset")
+	}
+	require.NotPanics(t, func() {
+		require.Nil(t, GetLogoTexture())
+	})
+}

--- a/scripts/cef_runtime_probe.py
+++ b/scripts/cef_runtime_probe.py
@@ -62,7 +62,12 @@ def main():
 
     try:
         with open(lib_name, "rb") as candidate:
-            library_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+            # Chunked streaming hash: hashlib.file_digest needs 3.11+,
+            # this stays compatible with older 3.x interpreters.
+            digest = hashlib.sha256()
+            for chunk in iter(lambda: candidate.read(65536), b""):
+                digest.update(chunk)
+            library_sha256 = digest.hexdigest()
     except OSError:
         fail("could not hash runtime library")
 

--- a/scripts/cef_runtime_probe.py
+++ b/scripts/cef_runtime_probe.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Report numeric CEF runtime version fields plus library hash.
+
+Opens only the explicitly selected trusted libcef.so using the standard
+library ctypes module and calls the header-verified cef_version_info(int)
+entries from /usr/include/cef/include/cef_version_info.h:
+
+  0 - CEF_VERSION_MAJOR
+  1 - CEF_VERSION_MINOR
+  2 - CEF_VERSION_PATCH
+  3 - CEF_COMMIT_NUMBER
+  4 - CHROME_VERSION_MAJOR
+  5 - CHROME_VERSION_MINOR
+  6 - CHROME_VERSION_BUILD
+  7 - CHROME_VERSION_PATCH
+
+Outputs JSON to stdout with numeric fields and the library SHA-256. Never
+outputs filesystem paths. This probe is not an ABI bypass: the candidate must
+still pass its normal loader ABI/version validation.
+"""
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+import sys
+
+
+ENTRIES = (
+    ("cef_version_major", 0),
+    ("cef_version_minor", 1),
+    ("cef_version_patch", 2),
+    ("cef_commit_number", 3),
+    ("chrome_version_major", 4),
+    ("chrome_version_minor", 5),
+    ("chrome_version_build", 6),
+    ("chrome_version_patch", 7),
+)
+
+
+def fail(message):
+    print("cef-runtime-probe: {}".format(message), file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Probe selected libcef.so version fields.")
+    parser.add_argument("--cef-dir", required=True, help="Selected CEF runtime directory.")
+    args = parser.parse_args()
+
+    cef_dir = args.cef_dir
+    if not cef_dir or not os.path.isabs(cef_dir):
+        fail("cef dir must be an absolute path")
+    lib_name = os.path.join(cef_dir, "libcef.so")
+    try:
+        is_file = os.path.isfile(lib_name) and not os.path.islink(lib_name)
+    except OSError:
+        fail("could not stat runtime library")
+    if not is_file:
+        fail("runtime library not found")
+
+    try:
+        with open(lib_name, "rb") as candidate:
+            library_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+    except OSError:
+        fail("could not hash runtime library")
+
+    try:
+        lib = ctypes.CDLL(lib_name)
+    except OSError:
+        fail("could not open runtime library")
+    try:
+        version_info = lib.cef_version_info
+    except AttributeError:
+        fail("cef_version_info symbol is unavailable")
+    version_info.argtypes = (ctypes.c_int,)
+    version_info.restype = ctypes.c_int
+
+    result = {}
+    for field, entry in ENTRIES:
+        try:
+            value = version_info(entry)
+        except (ctypes.ArgumentError, OSError, ValueError):
+            fail("version query failed")
+        if not isinstance(value, int) or value < 0:
+            fail("version query failed")
+        result[field] = value
+    result["libcef_sha256"] = library_sha256
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_first_presentation.sh
+++ b/scripts/collect_first_presentation.sh
@@ -59,7 +59,12 @@ def fail():
     raise SystemExit("first-presentation: immutable module provenance is unavailable")
 
 with open(binary, "rb") as candidate:
-    binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+    # Chunked streaming hash: hashlib.file_digest needs 3.11+, this stays
+    # compatible with older 3.x interpreters.
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: candidate.read(65536), b""):
+        digest.update(chunk)
+    binary_sha256 = digest.hexdigest()
 
 try:
     buildinfo = subprocess.check_output(["go", "version", "-m", binary], text=True, stderr=subprocess.DEVNULL)

--- a/scripts/collect_first_presentation.sh
+++ b/scripts/collect_first_presentation.sh
@@ -6,13 +6,24 @@ set -euo pipefail
 
 readonly runs=5
 readonly timeout_seconds="${DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS:-45}"
-readonly runtime="${DUMBER_CEF_DIR:-$HOME/.local/share/cef-147-runtime}"
 readonly binary="${DUMBER_FIRST_PRESENTATION_BIN:-$PWD/dist/dumber}"
+readonly manifest="${DUMBER_BUILD_MANIFEST:-${binary}.manifest.json}"
 
 fail_unsafe_output() {
   echo "first-presentation: unsafe output path: $1" >&2
   exit 2
 }
+
+# The measured runtime is always explicit. Never default to a hardcoded path
+# or version: collection fails closed when the caller does not select one.
+if [[ -z "${DUMBER_CEF_DIR:-}" ]]; then
+  echo "first-presentation: DUMBER_CEF_DIR must be set to the selected CEF runtime directory" >&2
+  exit 2
+fi
+readonly runtime="${DUMBER_CEF_DIR}"
+# Never inherit a conflicting CEF_DIR override: the child environment below is
+# built with env -i and receives exactly this selected directory.
+readonly selected_cef_dir="${DUMBER_CEF_DIR}"
 
 if [[ -v DUMBER_FIRST_PRESENTATION_OUTPUT ]]; then
   output="$DUMBER_FIRST_PRESENTATION_OUTPUT"
@@ -31,85 +42,105 @@ else
 fi
 readonly output
 readonly upstream_module="github.com/bnema/purego-cef2gtk"
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly runtime_probe="$script_dir/cef_runtime_probe.py"
 
-# Resolve the version selected by this checkout, then obtain its immutable VCS
-# origin from Go's cached module metadata. Do not infer a revision from a tag,
-# a branch, or a truncated pseudo-version suffix.
-resolve_upstream_provenance() {
-  local selected_metadata selected_version downloaded_metadata
-
-  selected_metadata="$(GOFLAGS=-mod=mod go list -m -json "$upstream_module" 2>/dev/null)" || {
-    echo "first-presentation: immutable module provenance is unavailable" >&2
-    exit 2
-  }
-  selected_version="$(python3 - "$upstream_module" "$selected_metadata" <<'PY'
-import json, sys
-try:
-    metadata = json.loads(sys.argv[2])
-    if metadata.get("Path") != sys.argv[1] or not isinstance(metadata.get("Version"), str):
-        raise ValueError
-    print(metadata["Version"])
-except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
-    raise SystemExit("first-presentation: immutable module provenance is unavailable")
-PY
-)" || exit $?
-  downloaded_metadata="$(go mod download -json "$upstream_module@$selected_version" 2>/dev/null)" || {
-    echo "first-presentation: immutable module provenance is unavailable" >&2
-    exit 2
-  }
-
-  python3 - "$upstream_module" "$selected_metadata" "$downloaded_metadata" <<'PY'
-import json, re, sys
-
-module, selected_raw, downloaded_raw = sys.argv[1:]
+# Resolve provenance from the measured binary, not the collection checkout.
+# Reads embedded build info via `go version -m` and requires a build manifest
+# tied to the candidate SHA-256 when VCS data is absent (including
+# buildvcs=false builds). Never queries the checkout module graph.
+resolve_binary_provenance() {
+  python3 - "$binary" "$manifest" "$upstream_module" <<'PY'
+import hashlib, json, os, re, subprocess, sys
+binary, manifest_path, module = sys.argv[1:]
 
 def fail():
-    # Do not expose Go cache locations or other machine-local values.
+    # Do not expose cache locations or other machine-local values.
     raise SystemExit("first-presentation: immutable module provenance is unavailable")
 
+with open(binary, "rb") as candidate:
+    binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+
 try:
-    selected = json.loads(selected_raw)
-    downloaded = json.loads(downloaded_raw)
-    version = selected["Version"]
-    if selected.get("Path") != module or downloaded.get("Path") != module:
-        fail()
-    if downloaded.get("Version") != version:
-        fail()
-    # A pseudo-version identifies an immutable commit; a released semver tag is
-    # accepted only when Go records that exact tag and its immutable hash.
-    pseudo_match = re.fullmatch(r"(v\d+\.\d+\.\d+)-0\.\d{14}-([0-9a-f]{12})", version)
-    tag_match = re.fullmatch(r"v\d+\.\d+\.\d+", version)
-    if not pseudo_match and not tag_match:
-        fail()
-    info_path = downloaded.get("Info")
-    if not isinstance(info_path, str) or not info_path:
-        fail()
-    with open(info_path, encoding="utf-8") as info_file:
-        info = json.load(info_file)
-    origin = info.get("Origin") or downloaded.get("Origin")
-    if info.get("Version") != version or not isinstance(origin, dict):
-        fail()
-    revision = origin.get("Hash")
-    if origin.get("VCS") != "git" or origin.get("URL") != "https://github.com/bnema/purego-cef2gtk":
-        fail()
-    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40}", revision):
-        fail()
-    if pseudo_match:
-        if not revision.startswith(pseudo_match.group(2)):
-            fail()
-        # A named ref can move. Only the immutable hash itself is acceptable.
-        if origin.get("Ref") not in (None, "", revision):
-            fail()
-        tag = pseudo_match.group(1)
-    else:
-        if origin.get("Ref") != "refs/tags/" + version:
-            fail()
-        tag = version
-except (AttributeError, KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+    buildinfo = subprocess.check_output(["go", "version", "-m", binary], text=True, stderr=subprocess.DEVNULL)
+except (OSError, subprocess.CalledProcessError):
+    raise SystemExit("first-presentation: immutable module provenance is unavailable")
+if "=>" in buildinfo:
+    raise SystemExit("first-presentation: immutable module provenance is unavailable")
+
+mod_version = None
+dep_version = None
+vcs_revision = None
+for line in buildinfo.splitlines():
+    parts = line.split()
+    if len(parts) < 2:
+        continue
+    if parts[0] == "mod" and len(parts) >= 3 and parts[1] == "github.com/bnema/dumber":
+        mod_version = parts[2]
+    if parts[0] == "dep" and len(parts) >= 3 and parts[1] == module:
+        dep_version = parts[2]
+    if parts[0] == "build" and len(parts) >= 2 and parts[1].startswith("vcs.revision="):
+        vcs_revision = parts[1].split("=", 1)[1]
+if dep_version is None:
+    fail()
+pseudo_match = re.fullmatch(r"(v\d+\.\d+\.\d+)-0\.\d{14}-([0-9a-f]{12})", dep_version)
+tag_match = re.fullmatch(r"v\d+\.\d+\.\d+", dep_version)
+if not pseudo_match and not tag_match:
+    fail()
+if vcs_revision is not None and not re.fullmatch(r"[0-9a-f]{40}", vcs_revision):
     fail()
 
-print("\t".join((version, tag, revision)))
+try:
+    with open(manifest_path, encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
+except (OSError, ValueError):
+    manifest = None
+
+if manifest is None:
+    # Without embedded VCS data the binary cannot be attributed; fail closed.
+    if vcs_revision is None:
+        raise SystemExit("first-presentation: build manifest is required for binaries without embedded VCS data")
+    # Embedded VCS revision attributes the binary itself, but the full
+    # upstream revision is not in build info; the manifest must still bind it.
+    raise SystemExit("first-presentation: build manifest is required to bind dependency revisions")
+
+if not isinstance(manifest, dict):
+    raise SystemExit("first-presentation: build manifest is required for binaries without embedded VCS data")
+if manifest.get("binary_sha256") != binary_sha256:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+source_revision = manifest.get("source_revision")
+if not isinstance(source_revision, str) or not re.fullmatch(r"[0-9a-f]{40}", source_revision):
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+if vcs_revision is not None and vcs_revision != source_revision:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+modules = manifest.get("modules")
+if not isinstance(modules, dict) or module not in modules:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+entry = modules[module]
+if not isinstance(entry, dict) or entry.get("version") != dep_version:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+revision = entry.get("revision")
+if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40}", revision):
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+if pseudo_match:
+    if not revision.startswith(pseudo_match.group(2)):
+        raise SystemExit("first-presentation: build manifest does not match the measured binary")
+    tag = pseudo_match.group(1)
+else:
+    tag = dep_version
+
+print("\t".join((binary_sha256, source_revision, dep_version, tag, revision)))
 PY
+}
+
+# Probe the explicitly selected runtime in a separate bounded subprocess.
+# Reports numeric version fields plus library hash, never a path. The
+# candidate must still pass its normal loader ABI/version validation.
+probe_runtime() {
+  timeout --signal=TERM --kill-after=5s 30s python3 "$runtime_probe" --cef-dir "$selected_cef_dir" 2>/dev/null || {
+    echo "first-presentation: CEF runtime probe failed" >&2
+    exit 2
+  }
 }
 
 # The artifact destination is caller-controlled. Never empty or recursively
@@ -141,12 +172,22 @@ prepare_output() {
 
 prepare_output
 
-[[ -x "$binary" ]] || { echo "first-presentation: executable not found: $binary" >&2; exit 2; }
-[[ -d "$runtime" ]] || { echo "first-presentation: CEF runtime not found: $runtime" >&2; exit 2; }
+[[ -x "$binary" ]] || { echo "first-presentation: executable not found" >&2; exit 2; }
+[[ -d "$runtime" ]] || { echo "first-presentation: CEF runtime not found" >&2; exit 2; }
 [[ -n "${WAYLAND_DISPLAY:-}${DISPLAY:-}" ]] || { echo "first-presentation: a current Wayland/X11 display is required" >&2; exit 2; }
-upstream_provenance="$(resolve_upstream_provenance)" || exit $?
-IFS=$'\t' read -r upstream_version upstream_tag upstream_revision <<<"$upstream_provenance"
-readonly upstream_version upstream_tag upstream_revision
+binary_provenance="$(resolve_binary_provenance)" || exit $?
+IFS=$'\t' read -r binary_sha256 measured_source_revision upstream_version upstream_tag upstream_revision <<<"$binary_provenance"
+readonly binary_sha256 measured_source_revision upstream_version upstream_tag upstream_revision
+runtime_probe_json="$(probe_runtime)" || exit $?
+readonly runtime_probe_json
+# Enforce the loader minimum (CHROME_VERSION_MAJOR >= 150) at collection time.
+# This records the observed runtime; it never bypasses the candidate ABI check.
+python3 - "$runtime_probe_json" <<'PY'
+import json, sys
+probe = json.loads(sys.argv[1])
+if not isinstance(probe.get("chrome_version_major"), int) or probe["chrome_version_major"] < 150:
+    raise SystemExit("first-presentation: unsupported CEF runtime")
+PY
 
 # Raw logs and temporary XDG homes may contain machine-local paths. Keep them
 # outside the committed artifact directory and always remove them.
@@ -157,11 +198,10 @@ cleanup_work_root() {
   rm -rf -- "$work_root"
 }
 trap cleanup_work_root EXIT
-python3 - "$output/metadata.json" "$binary" "$timeout_seconds" "$upstream_module" "$upstream_version" "$upstream_tag" "$upstream_revision" <<'PY'
-import hashlib, json, os, platform, subprocess, sys
-path, binary, timeout, upstream_module, upstream_version, upstream_tag, upstream_revision = sys.argv[1:]
-with open(binary, "rb") as candidate:
-  binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+python3 - "$output/metadata.json" "$binary_sha256" "$timeout_seconds" "$upstream_module" "$upstream_version" "$upstream_tag" "$upstream_revision" "$measured_source_revision" "$runtime_probe_json" <<'PY'
+import json, os, platform, sys
+path, binary_sha256, timeout, upstream_module, upstream_version, upstream_tag, upstream_revision, measured_source_revision, probe_raw = sys.argv[1:]
+probe = json.loads(probe_raw)
 
 # These deliberately coarse labels support comparison without exposing a host,
 # device name, driver version, path, or environment dump.
@@ -175,10 +215,10 @@ if gpu_profile not in allowed_gpu_profiles:
 
 json.dump({
   "runs": 5,
-  "runtime": {"label": "cef", "version": "147"},
+  "runtime": {"label": "cef", "chrome_major": probe["chrome_version_major"], "cef_version_major": probe["cef_version_major"], "libcef_sha256": probe["libcef_sha256"]},
   "binary": {"label": "dumber", "sha256": binary_sha256},
   "timeout_seconds": int(timeout),
-  "measured_source_revision": subprocess.check_output(["git", "-c", f"safe.directory={os.getcwd()}", "rev-parse", "HEAD"], text=True).strip(),
+  "measured_source_revision": measured_source_revision,
   "upstream": {"module": upstream_module, "version": upstream_version, "tag": upstream_tag, "revision": upstream_revision},
   "comparison": {"os": os_label, "architecture": architecture, "display_protocol": display_protocol, "machine_gpu_profile": gpu_profile},
   "render_configuration": {"backend": "gdk-dmabuf", "buffer_sharing": "dmabuf", "renderer": "vulkan"}
@@ -197,16 +237,19 @@ format = "json"
 enable_file_log = false
 
 [engine.cef]
-cef_dir = "$runtime"
+cef_dir = "$selected_cef_dir"
 EOF
   # Every directory below is newly created for this one launch. Do not inherit
   # a profile, shader cache, CEF root cache, or mutable app configuration.
+  # CEF_DIR is set to exactly the selected runtime, never a conflicting
+  # inherited override.
   set +e
   env -i \
     HOME="$HOME" PATH="$PATH" LANG="${LANG:-C.UTF-8}" \
     WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-}" DISPLAY="${DISPLAY:-}" XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-}" \
     DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}" XAUTHORITY="${XAUTHORITY:-}" \
     XDG_CONFIG_HOME="$root/config" XDG_DATA_HOME="$root/data" XDG_STATE_HOME="$root/state" XDG_CACHE_HOME="$root/cache" \
+    CEF_DIR="$selected_cef_dir" DUMBER_CEF_DIR="$selected_cef_dir" \
     DUMBER_CEF_ROOT_CACHE_PATH="$root/cef-root-cache" DUMBER_RENDER_STACK="vulkan-dmabuf" \
     PUREGO_CEF2GTK_BACKEND="gdk-dmabuf" PUREGO_CEF2GTK_ANGLE_BACKEND="vulkan" GSK_RENDERER="vulkan" \
     timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" "$binary" browse about:blank >"$root/process.log" 2>&1

--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Generate the build manifest required by scripts/collect_first_presentation.sh.
+
+The collector binds the measured binary to its source and dependency
+revisions via `go version -m` plus this manifest, and fails closed when
+attribution is missing or mismatched. Generate the manifest at build time
+from the same tree that produced the binary:
+
+    python3 scripts/generate_build_manifest.py --binary dist/dumber
+    DUMBER_CEF_DIR=/path/to/cef-runtime scripts/collect_first_presentation.sh
+
+Manifest schema (JSON, sorted keys):
+    {
+      "binary_sha256": "<hex sha256 of the measured binary>",
+      "source_revision": "<40-hex git revision of the built source>",
+      "modules": {
+        "<module path>": {"version": "<exact version>", "revision": "<40-hex>"},
+        ...
+      }
+    }
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+UPSTREAM_MODULE = "github.com/bnema/purego-cef2gtk"
+VERSION_RE = r"(v\d+\.\d+\.\d+)-0\.\d{14}-([0-9a-f]{12})"
+TAG_RE = r"v\d+\.\d+\.\d+"
+
+
+def run(args, **kwargs):
+    return subprocess.check_output(args, text=True, **kwargs).strip()
+
+
+def fail(message):
+    print("generate-build-manifest: {}".format(message), file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a collector build manifest.")
+    parser.add_argument("--binary", required=True, help="Measured binary to attribute.")
+    parser.add_argument("--output", default=None, help="Manifest path (default: <binary>.manifest.json).")
+    parser.add_argument("--source-revision", default=None,
+                        help="40-hex source revision (default: git rev-parse HEAD).")
+    parser.add_argument("--module", default=UPSTREAM_MODULE, help="Dependency module to bind.")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.binary):
+        fail("binary not found")
+    output = args.output or (args.binary + ".manifest.json")
+
+    with open(args.binary, "rb") as candidate:
+        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+
+    try:
+        buildinfo = run(["go", "version", "-m", args.binary], stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        fail("could not read embedded build info")
+    if "=>" in buildinfo:
+        fail("binary was built with a replacement; refusing to attribute it")
+    dep_version = None
+    for line in buildinfo.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0] == "dep" and parts[1] == args.module:
+            dep_version = parts[2]
+    if dep_version is None:
+        fail("dependency {} not found in build info".format(args.module))
+    pseudo = re.fullmatch(VERSION_RE, dep_version)
+    tag = re.fullmatch(TAG_RE, dep_version)
+    if not pseudo and not tag:
+        fail("dependency version is not an immutable tag or pseudo-version")
+
+    try:
+        downloaded = json.loads(run(["go", "mod", "download", "-json", "{}@{}".format(args.module, dep_version)],
+                                    stderr=subprocess.DEVNULL))
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        fail("could not resolve dependency origin")
+    origin = downloaded.get("Origin") or {}
+    revision = origin.get("Hash", "")
+    if origin.get("VCS") != "git" or not re.fullmatch(r"[0-9a-f]{40}", revision):
+        fail("dependency origin is not an immutable git hash")
+    if pseudo and not revision.startswith(pseudo.group(2)):
+        fail("dependency revision does not match its pseudo-version")
+
+    source_revision = args.source_revision
+    if source_revision is None:
+        try:
+            source_revision = run(["git", "rev-parse", "HEAD"])
+        except (OSError, subprocess.CalledProcessError):
+            fail("could not determine source revision; pass --source-revision")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision or ""):
+        fail("source revision must be a 40-hex git revision")
+
+    manifest = {
+        "binary_sha256": binary_sha256,
+        "source_revision": source_revision,
+        "modules": {
+            args.module: {"version": dep_version, "revision": revision},
+        },
+    }
+    with open(output, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print("manifest: {}".format(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -56,7 +56,12 @@ def main():
     output = args.output or (args.binary + ".manifest.json")
 
     with open(args.binary, "rb") as candidate:
-        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+        # Chunked streaming hash: hashlib.file_digest needs 3.11+, this
+        # stays compatible with older 3.x interpreters.
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: candidate.read(65536), b""):
+            digest.update(chunk)
+        binary_sha256 = digest.hexdigest()
 
     try:
         buildinfo = run(["go", "version", "-m", args.binary], stderr=subprocess.DEVNULL)
@@ -65,10 +70,29 @@ def main():
     if "=>" in buildinfo:
         fail("binary was built with a replacement; refusing to attribute it")
     dep_version = None
+    vcs_revision = None
+    vcs_modified = None
     for line in buildinfo.splitlines():
         parts = line.split()
         if len(parts) >= 3 and parts[0] == "dep" and parts[1] == args.module:
             dep_version = parts[2]
+        # `go version -m` reports stamping as "build vcs.revision=<hex>"
+        # (two tab-separated fields, key=value form).
+        elif len(parts) >= 2 and parts[0] == "build" and parts[1].startswith("vcs."):
+            key, _, value = parts[1].partition("=")
+            if key == "vcs.revision":
+                vcs_revision = value
+            elif key == "vcs.modified":
+                vcs_modified = value
+    # The measured binary, not the ambient checkout, is the provenance
+    # source: build-manifest builds with VCS stamping enabled, so the
+    # embedded revision describes the exact built tree. Binaries without
+    # stamping (for example -buildvcs=false quick builds) or built from a
+    # dirty tree are rejected instead of inheriting the checkout HEAD.
+    if vcs_revision is None or not re.fullmatch(r"[0-9a-f]{40}", vcs_revision):
+        fail("binary lacks embedded VCS revision; rebuild with VCS stamping enabled")
+    if vcs_modified != "false":
+        fail("binary was built from a dirty checkout; refusing to attribute it")
     if dep_version is None:
         fail("dependency {} not found in build info".format(args.module))
     pseudo = re.fullmatch(VERSION_RE, dep_version)
@@ -88,14 +112,11 @@ def main():
     if pseudo and not revision.startswith(pseudo.group(2)):
         fail("dependency revision does not match its pseudo-version")
 
-    source_revision = args.source_revision
-    if source_revision is None:
-        try:
-            source_revision = run(["git", "rev-parse", "HEAD"])
-        except (OSError, subprocess.CalledProcessError):
-            fail("could not determine source revision; pass --source-revision")
+    source_revision = args.source_revision or vcs_revision
     if not re.fullmatch(r"[0-9a-f]{40}", source_revision or ""):
         fail("source revision must be a 40-hex git revision")
+    if source_revision != vcs_revision:
+        fail("source revision does not match the revision embedded in the binary")
 
     manifest = {
         "binary_sha256": binary_sha256,

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Local CEF startup harness with synthetic fixtures (stdlib only).
+
+Scenarios:
+  process-warm   new process, isolated previously initialized profile
+  profile-fresh  new process, new profile each sample
+  relay-window   existing browser owns relay; launch browse with
+                 DUMBER_BROWSER_FRESH_WINDOW=1 and the same isolated profile
+
+Fixtures (loopback only): static, delayed, redirect, cache.
+
+Protocol: the fixture pages embed a buffered PerformanceObserver that prints
+single-line JSON records with opaque run/navigation tokens and numeric fields
+only. The harness parses child stdout for those records plus the existing
+startup_trace milestones. External spawn-to-summary is recorded as an
+explicitly named observation duration, including output-delivery overhead; it
+is never presented as an exact child event timestamp.
+
+Clock domains are kept separate: child t_ms values are never subtracted from
+the harness wall clock. GTK after-paint is labeled GTK paint, never compositor
+presentation. Missing target FCP remains incomplete; the harness never stops
+on a blank GTK summary.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import secrets
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+TOKEN_RE = re.compile(r"^[0-9a-f]{16}$")
+NAV_RE = re.compile(r"^[0-9a-f]{16}$")
+POST_NAV_CUTOFF_SECONDS = 5.0
+
+
+class FixtureState:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.document_requests = []
+        self.subresource_requests = []
+
+
+def build_fixture_html(kind, run_token, nav_token):
+    observer = (
+        "<script>(function(){"
+        "var buf=[];"
+        "function emit(e){console.log(JSON.stringify(e));}"
+        "try{"
+        "var po=new PerformanceObserver(function(list){"
+        "list.getEntries().forEach(function(en){"
+        "if(en.name==='first-contentful-paint'||en.entryType==='largest-contentful-paint'){"
+        "buf.push({message:'cef-startup-fixture',event:en.name,"
+        "run_token:'%s',nav_token:'%s',value_ms:Math.round(en.startTime)});"
+        "}});"
+        "po.observe({type:'paint',buffered:true});"
+        "po.observe({type:'largest-contentful-paint',buffered:true});"
+        "}catch(e){}"
+        "window.addEventListener('load',function(){"
+        "setTimeout(function(){buf.forEach(emit);"
+        "emit({message:'cef-startup-fixture',event:'fixture-load',"
+        "run_token:'%s',nav_token:'%s',value_ms:0});},100);});"
+        "})();</script>" % (run_token, nav_token, run_token, nav_token)
+    )
+    if kind == "static":
+        return (
+            "<!doctype html><html><head><title>static</title>"
+            '<link rel="stylesheet" href="/app.css">'
+            "</head><body><h1>static</h1>"
+            '<img src="/pixel.png">'
+            + observer
+            + "</body></html>"
+        )
+    if kind == "delayed":
+        return (
+            "<!doctype html><html><head><title>delayed</title></head>"
+            "<body><h1>delayed</h1>" + observer + "</body></html>"
+        )
+    if kind == "redirect":
+        return (
+            "<!doctype html><html><head><title>target</title></head>"
+            "<body><h1>target</h1>" + observer + "</body></html>"
+        )
+    if kind == "cache":
+        return (
+            "<!doctype html><html><head><title>cache</title>"
+            '<script src="/cacheable.js"></script>'
+            "</head><body><h1>cache</h1>"
+            '<img src="/cacheable.png">'
+            + observer
+            + "</body></html>"
+        )
+    raise ValueError("unknown fixture: " + kind)
+
+
+class Handler(BaseHTTPRequestHandler):
+    state = None
+    fixture = "static"
+    run_token = ""
+    nav_token = ""
+    delay_seconds = 0.3
+
+    def log_message(self, *args):
+        pass
+
+    def _record(self, document):
+        with self.state.lock:
+            entry = {"path": self.path, "time": time.time()}
+            if document:
+                self.state.document_requests.append(entry)
+            else:
+                self.state.subresource_requests.append(entry)
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        if path in ("/", "/index.html", "/target"):
+            self._record(True)
+            if self.fixture == "delayed" and path == "/":
+                time.sleep(self.delay_seconds)
+            body = build_fixture_html(
+                "static" if self.fixture == "redirect" and path == "/" else self.fixture,
+                self.run_token,
+                self.nav_token,
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/redirect":
+            self._record(True)
+            target = "/target?run=%s&nav=%s" % (self.run_token, self.nav_token)
+            self.send_response(302)
+            self.send_header("Location", target)
+            self.end_headers()
+            return
+        if path in ("/app.css", "/pixel.png", "/cacheable.js", "/cacheable.png"):
+            self._record(False)
+            body = b"/* fixture */" if path.endswith((".css", ".js")) else bytes(64)
+            self.send_response(200)
+            if path.endswith(".css"):
+                self.send_header("Content-Type", "text/css")
+            elif path.endswith(".js"):
+                self.send_header("Content-Type", "application/javascript")
+            else:
+                self.send_header("Content-Type", "image/png")
+            if self.fixture == "cache":
+                self.send_header("Cache-Control", "private, max-age=3600")
+            else:
+                self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self._record(False)
+        self.send_response(404)
+        self.end_headers()
+
+
+def parse_child_output(lines, run_token):
+    milestones = []
+    fixture_events = []
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("message") == "cef-startup-fixture":
+            if (
+                isinstance(event.get("run_token"), str)
+                and TOKEN_RE.fullmatch(event["run_token"])
+                and isinstance(event.get("nav_token"), str)
+                and NAV_RE.fullmatch(event["nav_token"])
+                and event["run_token"] == run_token
+                and isinstance(event.get("value_ms"), int)
+                and event.get("event") in ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
+            ):
+                fixture_events.append(event)
+            continue
+        if event.get("message") == "startup_trace: milestone":
+            milestones.append(event)
+    return milestones, fixture_events
+
+
+def validate_tokens_unique(records):
+    seen = set()
+    for record in records:
+        key = (record.get("run_token"), record.get("nav_token"))
+        if key in seen:
+            return False
+        seen.add(key)
+    return True
+
+
+def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profile_dir, extra_env):
+    run_token = secrets.token_hex(8)
+    nav_token = secrets.token_hex(8)
+    state = FixtureState()
+    Handler.state = state
+    Handler.fixture = fixture
+    Handler.run_token = run_token
+    Handler.nav_token = nav_token
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05})
+    thread.daemon = True
+    thread.start()
+    try:
+        if fixture == "redirect":
+            url = "http://127.0.0.1:%d/redirect?run=%s&nav=%s" % (port, run_token, nav_token)
+        else:
+            url = "http://127.0.0.1:%d/?run=%s&nav=%s" % (port, run_token, nav_token)
+        run_dir = tempfile.mkdtemp(prefix="cef-startup-run-%02d-" % run_index)
+        config_dir = os.path.join(run_dir, "config")
+        os.makedirs(os.path.join(config_dir, "dumber"))
+        with open(os.path.join(config_dir, "dumber", "config.toml"), "w") as config:
+            config.write(
+                '[logging]\nlevel = "debug"\nformat = "json"\nenable_file_log = false\n\n'
+                '[engine.cef]\ncef_dir = "%s"\n' % cef_dir
+            )
+        env = {
+            "HOME": os.environ.get("HOME", ""),
+            "PATH": os.environ.get("PATH", ""),
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+            "DISPLAY": os.environ.get("DISPLAY", ""),
+            "WAYLAND_DISPLAY": os.environ.get("WAYLAND_DISPLAY", ""),
+            "XDG_CONFIG_HOME": config_dir,
+            "XDG_DATA_HOME": os.path.join(run_dir, "data"),
+            "XDG_STATE_HOME": os.path.join(run_dir, "state"),
+            "XDG_CACHE_HOME": os.path.join(run_dir, "cache"),
+            "CEF_DIR": cef_dir,
+            "DUMBER_CEF_DIR": cef_dir,
+            "DUMBER_CEF_ROOT_CACHE_PATH": os.path.join(run_dir, "cef-root-cache"),
+        }
+        if scenario == "relay-window":
+            env["DUMBER_BROWSER_FRESH_WINDOW"] = "1"
+        env.update(extra_env)
+        for key in ("XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"):
+            os.makedirs(env[key], exist_ok=True)
+        if scenario == "process-warm" and profile_dir is not None:
+            env["DUMBER_PROFILE_DIR"] = profile_dir
+        start = time.monotonic()
+        if scenario == "relay-window" and relay_proc is not None:
+            proc = subprocess.Popen(
+                [binary, "browse", url],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            relayed = relay_proc.poll() is None
+        else:
+            proc = subprocess.Popen(
+                [binary, "browse", url],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            relayed = False
+        try:
+            stdout, _ = proc.communicate(timeout=POST_NAV_CUTOFF_SECONDS + 10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, _ = proc.communicate()
+        observation_ms = int((time.monotonic() - start) * 1000)
+        lines = stdout.splitlines()
+        milestones, fixture_events = parse_child_output(lines, run_token)
+        fcp = [e for e in fixture_events if e["event"] == "first-contentful-paint"]
+        lcp = [e for e in fixture_events if e["event"] == "largest-contentful-paint"]
+        with state.lock:
+            document_count = len(state.document_requests)
+            subresource_count = len(state.subresource_requests)
+        if fixture == "redirect":
+            complete = document_count >= 1 and len(fcp) > 0
+        else:
+            complete = document_count == 1 and len(fcp) > 0
+        result = {
+            "run": run_index,
+            "scenario": scenario,
+            "fixture": fixture,
+            "run_token": run_token,
+            "nav_token": nav_token,
+            "observation_spawn_to_summary_ms": observation_ms,
+            "document_requests": document_count,
+            "subresource_requests": subresource_count,
+            "target_fcp_ms": fcp[0]["value_ms"] if fcp else None,
+            "target_lcp_through_cutoff_ms": lcp[-1]["value_ms"] if lcp else None,
+            "complete": complete,
+            "relayed": relayed,
+            "fallback_spawn": scenario == "relay-window" and not relayed,
+        }
+        return result
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Measure CEF startup against synthetic fixtures.")
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--cef-dir", required=True)
+    parser.add_argument(
+        "--scenario",
+        required=True,
+        choices=("process-warm", "profile-fresh", "relay-window"),
+    )
+    parser.add_argument(
+        "--fixture",
+        required=True,
+        choices=("static", "delayed", "redirect", "cache"),
+    )
+    parser.add_argument("--runs", type=int, default=30)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    if args.runs < 1 or args.runs > 100:
+        print("measure: --runs must be 1..100", file=sys.stderr)
+        raise SystemExit(2)
+    if not os.path.isabs(args.output) or os.path.exists(args.output) or os.path.islink(args.output):
+        print("measure: --output must be a fresh absolute directory", file=sys.stderr)
+        raise SystemExit(2)
+    parent = os.path.dirname(args.output)
+    if not os.path.isdir(parent) or os.path.islink(parent):
+        print("measure: --output parent must be an existing directory", file=sys.stderr)
+        raise SystemExit(2)
+    if not (os.path.isfile(args.binary) and os.access(args.binary, os.X_OK)):
+        print("measure: --binary must be executable", file=sys.stderr)
+        raise SystemExit(2)
+    if not os.path.isdir(args.cef_dir):
+        print("measure: --cef-dir must be a directory", file=sys.stderr)
+        raise SystemExit(2)
+    with open(args.binary, "rb") as candidate:
+        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+
+    os.makedirs(args.output)
+    profile_dir = None
+    if args.scenario == "process-warm":
+        profile_dir = os.path.join(args.output, "warm-profile")
+        os.makedirs(profile_dir)
+    relay_proc = None
+    if args.scenario == "relay-window":
+        relay_proc = subprocess.Popen(
+            [args.binary, "--relay-owner"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(0.5)
+        if relay_proc.poll() is not None:
+            relay_proc = None
+
+    results = []
+    try:
+        for index in range(1, args.runs + 1):
+            result = run_sample(
+                args.binary, args.cef_dir, args.scenario, args.fixture, index, relay_proc, profile_dir, {}
+            )
+            results.append(result)
+            with open(os.path.join(args.output, "run-%02d.json" % index), "w") as handle:
+                json.dump(result, handle, indent=2, sort_keys=True)
+    finally:
+        if relay_proc is not None and relay_proc.poll() is None:
+            relay_proc.terminate()
+            try:
+                relay_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                relay_proc.kill()
+
+    summary = {
+        "binary_sha256": binary_sha256,
+        "scenario": args.scenario,
+        "fixture": args.fixture,
+        "runs": len(results),
+        "complete_runs": sum(1 for r in results if r["complete"]),
+        "incomplete_runs": sum(1 for r in results if not r["complete"]),
+        "duplicate_document_runs": sum(
+            1 for r in results if r["document_requests"] != (1 if args.fixture != "redirect" else r["document_requests"])
+        ),
+    }
+    with open(os.path.join(args.output, "summary.json"), "w") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+    print("measure artifacts: %s" % args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -2,19 +2,21 @@
 """Local CEF startup harness with synthetic fixtures (stdlib only).
 
 Scenarios:
-  process-warm   new process, isolated previously initialized profile
+  process-warm   one unrecorded warm-up, then new processes sharing an
+                 isolated previously initialized CEF root-cache profile
   profile-fresh  new process, new profile each sample
-  relay-window   existing browser owns relay; launch browse with
-                 DUMBER_BROWSER_FRESH_WINDOW=1 and the same isolated profile
+  relay-window   a real long-lived owner browser holds the relay; samples
+                 launch browse with DUMBER_BROWSER_FRESH_WINDOW=1 in that
+                 same isolated profile
 
 Fixtures (loopback only): static, delayed, redirect, cache.
 
-Protocol: the fixture pages embed a buffered PerformanceObserver that prints
-single-line JSON records with opaque run/navigation tokens and numeric fields
-only. The harness parses child stdout for those records plus the existing
-startup_trace milestones. External spawn-to-summary is recorded as an
-explicitly named observation duration, including output-delivery overhead; it
-is never presented as an exact child event timestamp.
+Protocol: fixture pages report PerformanceObserver results through a
+token-authenticated loopback beacon (/__beacon with run/nav/event/value
+parameters) served by the harness HTTP server. Beacon arrivals carry the
+harness monotonic timestamp. External spawn-to-arrival is recorded as an
+explicitly named observation duration, including output-delivery overhead;
+it is never presented as an exact child event timestamp.
 
 Clock domains are kept separate: child t_ms values are never subtracted from
 the harness wall clock. GTK after-paint is labeled GTK paint, never compositor
@@ -28,17 +30,28 @@ import json
 import os
 import re
 import secrets
+import shutil
+import socket
 import subprocess
 import sys
 import tempfile
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 TOKEN_RE = re.compile(r"^[0-9a-f]{16}$")
 NAV_RE = re.compile(r"^[0-9a-f]{16}$")
-POST_NAV_CUTOFF_SECONDS = 5.0
+BEACON_EVENTS = ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
+DEFAULT_POST_NAV_CUTOFF_SECONDS = 5.0
+
+
+def post_nav_cutoff_seconds():
+    try:
+        value = float(os.environ.get("DUMBER_MEASURE_CUTOFF_SECONDS", DEFAULT_POST_NAV_CUTOFF_SECONDS))
+    except ValueError:
+        return DEFAULT_POST_NAV_CUTOFF_SECONDS
+    return min(30.0, max(0.1, value))
 
 
 class FixtureState:
@@ -46,28 +59,29 @@ class FixtureState:
         self.lock = threading.Lock()
         self.document_requests = []
         self.subresource_requests = []
+        self.beacons = []
+        self.first_document_monotonic = None
 
 
 def build_fixture_html(kind, run_token, nav_token):
     observer = (
         "<script>(function(){"
-        "var buf=[];"
-        "function emit(e){console.log(JSON.stringify(e));}"
+        "function beacon(event, value){"
+        "fetch('/__beacon?run=%s&nav=%s&event='+event+'&value='+value,"
+        "{cache:'no-store'}).catch(function(){});"
+        "}"
         "try{"
         "var po=new PerformanceObserver(function(list){"
         "list.getEntries().forEach(function(en){"
-        "if(en.name==='first-contentful-paint'||en.entryType==='largest-contentful-paint'){"
-        "buf.push({message:'cef-startup-fixture',event:en.name,"
-        "run_token:'%s',nav_token:'%s',value_ms:Math.round(en.startTime)});"
+        "if(en.name==='first-contentful-paint'){beacon('first-contentful-paint',Math.round(en.startTime));}"
+        "else if(en.entryType==='largest-contentful-paint'){beacon('largest-contentful-paint',Math.round(en.startTime));}"
         "}});"
         "po.observe({type:'paint',buffered:true});"
         "po.observe({type:'largest-contentful-paint',buffered:true});"
         "}catch(e){}"
         "window.addEventListener('load',function(){"
-        "setTimeout(function(){buf.forEach(emit);"
-        "emit({message:'cef-startup-fixture',event:'fixture-load',"
-        "run_token:'%s',nav_token:'%s',value_ms:0});},100);});"
-        "})();</script>" % (run_token, nav_token, run_token, nav_token)
+        "setTimeout(function(){beacon('fixture-load',0);},100);});"
+        "})();</script>" % (run_token, nav_token)
     )
     if kind == "static":
         return (
@@ -112,15 +126,20 @@ class Handler(BaseHTTPRequestHandler):
 
     def _record(self, document):
         with self.state.lock:
-            entry = {"path": self.path, "time": time.time()}
+            entry = {"path": self.path, "time": time.monotonic()}
             if document:
                 self.state.document_requests.append(entry)
+                if self.state.first_document_monotonic is None:
+                    self.state.first_document_monotonic = entry["time"]
             else:
                 self.state.subresource_requests.append(entry)
 
     def do_GET(self):
         parsed = urlparse(self.path)
         path = parsed.path
+        if path == "/__beacon":
+            self._handle_beacon(parsed)
+            return
         if path in ("/", "/index.html", "/target"):
             self._record(True)
             if self.fixture == "delayed" and path == "/":
@@ -165,47 +184,139 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(404)
         self.end_headers()
 
+    def _handle_beacon(self, parsed):
+        query = parse_qs(parsed.query)
+        run = query.get("run", [None])[0]
+        nav = query.get("nav", [None])[0]
+        event = query.get("event", [None])[0]
+        value_raw = query.get("value", [None])[0]
+        valid = (
+            isinstance(run, str) and TOKEN_RE.fullmatch(run) and run == self.run_token
+            and isinstance(nav, str) and NAV_RE.fullmatch(nav) and nav == self.nav_token
+            and event in BEACON_EVENTS
+        )
+        try:
+            value = int(value_raw) if valid else None
+            valid = valid and value is not None and value >= 0
+        except (TypeError, ValueError):
+            valid = False
+        if not valid:
+            self.send_response(400)
+            self.end_headers()
+            return
+        with self.state.lock:
+            self.state.beacons.append({
+                "event": event,
+                "value_ms": value,
+                "arrival_monotonic": time.monotonic(),
+            })
+        self.send_response(204)
+        self.end_headers()
 
-def parse_child_output(lines, run_token):
+
+def parse_child_output(lines):
     milestones = []
-    fixture_events = []
     for line in lines:
         try:
             event = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
-        if not isinstance(event, dict):
-            continue
-        if event.get("message") == "cef-startup-fixture":
-            if (
-                isinstance(event.get("run_token"), str)
-                and TOKEN_RE.fullmatch(event["run_token"])
-                and isinstance(event.get("nav_token"), str)
-                and NAV_RE.fullmatch(event["nav_token"])
-                and event["run_token"] == run_token
-                and isinstance(event.get("value_ms"), int)
-                and event.get("event") in ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
-            ):
-                fixture_events.append(event)
-            continue
-        if event.get("message") == "startup_trace: milestone":
+        if isinstance(event, dict) and event.get("message") == "startup_trace: milestone":
             milestones.append(event)
-    return milestones, fixture_events
+    return milestones
 
 
-def validate_tokens_unique(records):
-    seen = set()
-    for record in records:
-        key = (record.get("run_token"), record.get("nav_token"))
-        if key in seen:
-            return False
-        seen.add(key)
-    return True
+def scenario_env(cef_dir, dirs, extra=None):
+    env = {
+        "HOME": os.environ.get("HOME", ""),
+        "PATH": os.environ.get("PATH", ""),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "DISPLAY": os.environ.get("DISPLAY", ""),
+        "WAYLAND_DISPLAY": os.environ.get("WAYLAND_DISPLAY", ""),
+        "XDG_CONFIG_HOME": dirs["config"],
+        "XDG_DATA_HOME": dirs["data"],
+        "XDG_STATE_HOME": dirs["state"],
+        "XDG_CACHE_HOME": dirs["cache"],
+        "XDG_RUNTIME_DIR": dirs["runtime"],
+        "CEF_DIR": cef_dir,
+        "DUMBER_CEF_DIR": cef_dir,
+        "DUMBER_CEF_ROOT_CACHE_PATH": dirs["root_cache"],
+    }
+    if extra:
+        env.update(extra)
+    for key in ("config", "data", "state", "cache", "runtime"):
+        os.makedirs(dirs[key], exist_ok=True)
+    os.makedirs(dirs["root_cache"], exist_ok=True)
+    return env
 
 
-def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profile_dir, extra_env):
+def wait_for_relay_socket(runtime_dir, timeout_seconds=30.0):
+    end = time.monotonic() + timeout_seconds
+    while time.monotonic() < end:
+        for root, _, files in os.walk(runtime_dir):
+            if "browser-launch.sock" in files:
+                path = os.path.join(root, "browser-launch.sock")
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.settimeout(2.0)
+                try:
+                    sock.connect(path)
+                    return path
+                except OSError:
+                    pass
+                finally:
+                    sock.close()
+        time.sleep(0.2)
+    return None
+
+
+def start_relay_owner(binary, cef_dir, scenario_dir):
+    dirs = {
+        "config": os.path.join(scenario_dir, "owner-config"),
+        "data": os.path.join(scenario_dir, "owner-data"),
+        "state": os.path.join(scenario_dir, "owner-state"),
+        "cache": os.path.join(scenario_dir, "owner-cache"),
+        "runtime": os.path.join(scenario_dir, "owner-runtime"),
+        "root_cache": os.path.join(scenario_dir, "shared-profile"),
+    }
+    env = scenario_env(cef_dir, dirs)
+    try:
+        proc = subprocess.Popen(
+            [binary, "browse", "about:blank"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+    except OSError:
+        return None, None
+    time.sleep(0.5)
+    if proc.poll() is not None:
+        return None, None
+    if wait_for_relay_socket(dirs["runtime"]) is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        return None, None
+    return proc, dirs
+
+
+def stop_proc(proc):
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_dirs=None,
+               shared_root_cache=None):
     run_token = secrets.token_hex(8)
     nav_token = secrets.token_hex(8)
+    cutoff = post_nav_cutoff_seconds()
     state = FixtureState()
     Handler.state = state
     Handler.fixture = fixture
@@ -216,77 +327,103 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profil
     thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05})
     thread.daemon = True
     thread.start()
+    run_dir = tempfile.mkdtemp(prefix="cef-startup-run-%02d-" % run_index)
     try:
         if fixture == "redirect":
             url = "http://127.0.0.1:%d/redirect?run=%s&nav=%s" % (port, run_token, nav_token)
         else:
             url = "http://127.0.0.1:%d/?run=%s&nav=%s" % (port, run_token, nav_token)
-        run_dir = tempfile.mkdtemp(prefix="cef-startup-run-%02d-" % run_index)
-        config_dir = os.path.join(run_dir, "config")
-        os.makedirs(os.path.join(config_dir, "dumber"))
-        with open(os.path.join(config_dir, "dumber", "config.toml"), "w") as config:
-            config.write(
-                '[logging]\nlevel = "debug"\nformat = "json"\nenable_file_log = false\n\n'
-                '[engine.cef]\ncef_dir = "%s"\n' % cef_dir
-            )
-        env = {
-            "HOME": os.environ.get("HOME", ""),
-            "PATH": os.environ.get("PATH", ""),
-            "LANG": os.environ.get("LANG", "C.UTF-8"),
-            "DISPLAY": os.environ.get("DISPLAY", ""),
-            "WAYLAND_DISPLAY": os.environ.get("WAYLAND_DISPLAY", ""),
-            "XDG_CONFIG_HOME": config_dir,
-            "XDG_DATA_HOME": os.path.join(run_dir, "data"),
-            "XDG_STATE_HOME": os.path.join(run_dir, "state"),
-            "XDG_CACHE_HOME": os.path.join(run_dir, "cache"),
-            "CEF_DIR": cef_dir,
-            "DUMBER_CEF_DIR": cef_dir,
-            "DUMBER_CEF_ROOT_CACHE_PATH": os.path.join(run_dir, "cef-root-cache"),
-        }
-        if scenario == "relay-window":
-            env["DUMBER_BROWSER_FRESH_WINDOW"] = "1"
-        env.update(extra_env)
-        for key in ("XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"):
-            os.makedirs(env[key], exist_ok=True)
-        if scenario == "process-warm" and profile_dir is not None:
-            env["DUMBER_PROFILE_DIR"] = profile_dir
-        start = time.monotonic()
-        if scenario == "relay-window" and relay_proc is not None:
-            proc = subprocess.Popen(
-                [binary, "browse", url],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
-            relayed = relay_proc.poll() is None
+        if scenario == "relay-window" and owner_dirs is not None:
+            dirs = dict(owner_dirs)
+            extra = {"DUMBER_BROWSER_FRESH_WINDOW": "1"}
         else:
-            proc = subprocess.Popen(
-                [binary, "browse", url],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
-            relayed = False
+            dirs = {
+                "config": os.path.join(run_dir, "config"),
+                "data": os.path.join(run_dir, "data"),
+                "state": os.path.join(run_dir, "state"),
+                "cache": os.path.join(run_dir, "cache"),
+                "runtime": os.path.join(run_dir, "runtime"),
+                "root_cache": shared_root_cache or os.path.join(run_dir, "cef-root-cache"),
+            }
+            extra = {}
+        env = scenario_env(cef_dir, dirs, extra)
+        owner_alive_at_start = owner is not None and owner.poll() is None
+        spawn_ts = time.monotonic()
+        proc = subprocess.Popen(
+            [binary, "browse", url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+        arrivals = []
+
+        def pump():
+            try:
+                for line in proc.stdout:
+                    arrivals.append((time.monotonic(), line))
+            except ValueError:
+                pass
+
+        pump_thread = threading.Thread(target=pump)
+        pump_thread.daemon = True
+        pump_thread.start()
+        hard_end = spawn_ts + cutoff + 25.0
+        while True:
+            now = time.monotonic()
+            with state.lock:
+                navigated_at = state.first_document_monotonic
+                fixture_done = any(
+                    b["event"] == "fixture-load" for b in state.beacons
+                )
+            exited = proc.poll() is not None
+            if navigated_at is not None:
+                if fixture_done and now >= navigated_at + cutoff:
+                    break
+                if now >= navigated_at + cutoff + 5.0:
+                    break
+            elif now >= spawn_ts + cutoff + 5.0 or exited:
+                break
+            if now >= hard_end:
+                break
+            time.sleep(0.05)
+        self_exited = proc.poll() is not None
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        pump_thread.join(timeout=5)
         try:
-            stdout, _ = proc.communicate(timeout=POST_NAV_CUTOFF_SECONDS + 10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            stdout, _ = proc.communicate()
-        observation_ms = int((time.monotonic() - start) * 1000)
-        lines = stdout.splitlines()
-        milestones, fixture_events = parse_child_output(lines, run_token)
-        fcp = [e for e in fixture_events if e["event"] == "first-contentful-paint"]
-        lcp = [e for e in fixture_events if e["event"] == "largest-contentful-paint"]
+            proc.stdout.close()
+        except (AttributeError, ValueError):
+            pass
+        decision_ts = time.monotonic()
+        milestones = parse_child_output([line for _, line in arrivals])
         with state.lock:
+            beacons = list(state.beacons)
             document_count = len(state.document_requests)
             subresource_count = len(state.subresource_requests)
+        fcp = [b for b in beacons if b["event"] == "first-contentful-paint"]
+        lcp = [b for b in beacons if b["event"] == "largest-contentful-paint"]
+        if fcp:
+            observation_ms = int((fcp[0]["arrival_monotonic"] - spawn_ts) * 1000)
+        elif beacons:
+            observation_ms = int((beacons[-1]["arrival_monotonic"] - spawn_ts) * 1000)
+        else:
+            observation_ms = int((decision_ts - spawn_ts) * 1000)
         if fixture == "redirect":
             complete = document_count >= 1 and len(fcp) > 0
         else:
             complete = document_count == 1 and len(fcp) > 0
-        result = {
+        if scenario == "relay-window":
+            relayed = bool(owner_alive_at_start and self_exited)
+        else:
+            relayed = False
+        return {
             "run": run_index,
             "scenario": scenario,
             "fixture": fixture,
@@ -297,15 +434,16 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profil
             "subresource_requests": subresource_count,
             "target_fcp_ms": fcp[0]["value_ms"] if fcp else None,
             "target_lcp_through_cutoff_ms": lcp[-1]["value_ms"] if lcp else None,
+            "startup_milestones": len(milestones),
             "complete": complete,
             "relayed": relayed,
             "fallback_spawn": scenario == "relay-window" and not relayed,
         }
-        return result
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
+        shutil.rmtree(run_dir, ignore_errors=True)
 
 
 def main():
@@ -346,37 +484,36 @@ def main():
         binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
 
     os.makedirs(args.output)
-    profile_dir = None
+    owner = None
+    owner_dirs = None
+    shared_root_cache = None
+    warmup_discarded = False
     if args.scenario == "process-warm":
-        profile_dir = os.path.join(args.output, "warm-profile")
-        os.makedirs(profile_dir)
-    relay_proc = None
+        shared_root_cache = os.path.join(args.output, "warm-profile", "cef-root-cache")
+        os.makedirs(shared_root_cache)
     if args.scenario == "relay-window":
-        relay_proc = subprocess.Popen(
-            [args.binary, "--relay-owner"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        time.sleep(0.5)
-        if relay_proc.poll() is not None:
-            relay_proc = None
+        scenario_dir = os.path.join(args.output, "relay-scenario")
+        os.makedirs(scenario_dir)
+        owner, owner_dirs = start_relay_owner(args.binary, args.cef_dir, scenario_dir)
 
     results = []
     try:
+        if args.scenario == "process-warm":
+            # One unrecorded warm-up initializes the shared profile; only the
+            # recorded samples below count toward the report.
+            run_sample(args.binary, args.cef_dir, args.scenario, args.fixture,
+                       0, shared_root_cache=shared_root_cache)
+            warmup_discarded = True
         for index in range(1, args.runs + 1):
             result = run_sample(
-                args.binary, args.cef_dir, args.scenario, args.fixture, index, relay_proc, profile_dir, {}
+                args.binary, args.cef_dir, args.scenario, args.fixture, index,
+                owner=owner, owner_dirs=owner_dirs, shared_root_cache=shared_root_cache,
             )
             results.append(result)
             with open(os.path.join(args.output, "run-%02d.json" % index), "w") as handle:
                 json.dump(result, handle, indent=2, sort_keys=True)
     finally:
-        if relay_proc is not None and relay_proc.poll() is None:
-            relay_proc.terminate()
-            try:
-                relay_proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                relay_proc.kill()
+        stop_proc(owner)
 
     summary = {
         "binary_sha256": binary_sha256,
@@ -386,8 +523,10 @@ def main():
         "complete_runs": sum(1 for r in results if r["complete"]),
         "incomplete_runs": sum(1 for r in results if not r["complete"]),
         "duplicate_document_runs": sum(
-            1 for r in results if r["document_requests"] != (1 if args.fixture != "redirect" else r["document_requests"])
+            1 for r in results if args.fixture != "redirect" and r["document_requests"] != 1
         ),
+        "warmup_discarded": warmup_discarded,
+        "relay_owner_ready": owner is not None,
     }
     with open(os.path.join(args.output, "summary.json"), "w") as handle:
         json.dump(summary, handle, indent=2, sort_keys=True)

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -45,6 +45,15 @@ NAV_RE = re.compile(r"^[0-9a-f]{16}$")
 BEACON_EVENTS = ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
 DEFAULT_POST_NAV_CUTOFF_SECONDS = 5.0
 
+# Deterministic 1x1 RGBA PNG so image endpoints exercise a successful decode
+# and paint instead of the decode-failure path.
+FIXTURE_PNG = bytes.fromhex(
+    "89504e470d0a1a0a"
+    "0000000d49484452000000010000000108060000001f15c489"
+    "0000000b4944415478da6360000300000700012122db13"
+    "0000000049454e44ae426082"
+)
+
 
 def post_nav_cutoff_seconds():
     try:
@@ -164,7 +173,10 @@ class Handler(BaseHTTPRequestHandler):
             return
         if path in ("/app.css", "/pixel.png", "/cacheable.js", "/cacheable.png"):
             self._record(False)
-            body = b"/* fixture */" if path.endswith((".css", ".js")) else bytes(64)
+            if path.endswith(".png"):
+                body = FIXTURE_PNG
+            else:
+                body = b"/* fixture */"
             self.send_response(200)
             if path.endswith(".css"):
                 self.send_header("Content-Type", "text/css")

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -427,10 +427,8 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             observation_ms = int((beacons[-1]["arrival_monotonic"] - spawn_ts) * 1000)
         else:
             observation_ms = int((decision_ts - spawn_ts) * 1000)
-        if fixture == "redirect":
-            complete = document_count >= 1 and len(fcp) > 0
-        else:
-            complete = document_count == 1 and len(fcp) > 0
+        expected_document_requests = 2 if fixture == "redirect" else 1
+        complete = document_count == expected_document_requests and len(fcp) > 0
         if scenario == "relay-window":
             relayed = bool(owner_alive_at_start and self_exited)
         else:
@@ -493,7 +491,12 @@ def main():
         print("measure: --cef-dir must be a directory", file=sys.stderr)
         raise SystemExit(2)
     with open(args.binary, "rb") as candidate:
-        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+        # Chunked streaming hash: hashlib.file_digest needs 3.11+, this
+        # stays compatible with older 3.x interpreters.
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: candidate.read(65536), b""):
+            digest.update(chunk)
+        binary_sha256 = digest.hexdigest()
 
     os.makedirs(args.output)
     owner = None
@@ -512,9 +515,14 @@ def main():
     try:
         if args.scenario == "process-warm":
             # One unrecorded warm-up initializes the shared profile; only the
-            # recorded samples below count toward the report.
-            run_sample(args.binary, args.cef_dir, args.scenario, args.fixture,
+            # recorded samples below count toward the report. A failed
+            # warm-up aborts the scenario: later runs must never use an
+            # uninitialized profile.
+            warmup = run_sample(args.binary, args.cef_dir, args.scenario, args.fixture,
                        0, shared_root_cache=shared_root_cache)
+            if not warmup["complete"]:
+                print("measure: process-warm warm-up was incomplete", file=sys.stderr)
+                raise SystemExit(1)
             warmup_discarded = True
         for index in range(1, args.runs + 1):
             result = run_sample(
@@ -535,7 +543,9 @@ def main():
         "complete_runs": sum(1 for r in results if r["complete"]),
         "incomplete_runs": sum(1 for r in results if not r["complete"]),
         "duplicate_document_runs": sum(
-            1 for r in results if args.fixture != "redirect" and r["document_requests"] != 1
+            1
+            for r in results
+            if r["document_requests"] != (2 if args.fixture == "redirect" else 1)
         ),
         "warmup_discarded": warmup_discarded,
         "relay_owner_ready": owner is not None,

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Unit tests for measure_cef_startup.py (stdlib only)."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import measure_cef_startup as harness
+
+
+class ParseTest(unittest.TestCase):
+    def test_accepts_valid_fixture_event(self):
+        token = "a" * 16
+        nav = "b" * 16
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": token, "nav_token": nav, "value_ms": 12}),
+        ]
+        _, events = harness.parse_child_output(lines, token)
+        self.assertEqual(len(events), 1)
+
+    def test_rejects_wrong_token(self):
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": "c" * 16, "nav_token": "d" * 16, "value_ms": 12}),
+        ]
+        _, events = harness.parse_child_output(lines, "a" * 16)
+        self.assertEqual(events, [])
+
+    def test_rejects_non_numeric_value(self):
+        token = "a" * 16
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": token, "nav_token": "b" * 16, "value_ms": "12"}),
+        ]
+        _, events = harness.parse_child_output(lines, token)
+        self.assertEqual(events, [])
+
+    def test_rejects_malformed_token(self):
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": "short", "nav_token": "b" * 16, "value_ms": 12}),
+        ]
+        _, events = harness.parse_child_output(lines, "short")
+        self.assertEqual(events, [])
+
+
+class CliValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "measure_cef_startup.py")
+        self.temp = tempfile.mkdtemp()
+        self.binary = os.path.join(self.temp, "fakebin")
+        with open(self.binary, "w") as handle:
+            handle.write("#!/bin/sh\nexit 0\n")
+        os.chmod(self.binary, 0o755)
+        self.cef_dir = os.path.join(self.temp, "cef")
+        os.makedirs(self.cef_dir)
+
+    def run_harness(self, *extra):
+        cmd = [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+               "--scenario", "profile-fresh", "--fixture", "static", "--runs", "1"] + list(extra)
+        return subprocess.run(cmd, capture_output=True, text=True)
+
+    def test_rejects_existing_output(self):
+        existing = os.path.join(self.temp, "exists")
+        os.makedirs(existing)
+        result = self.run_harness("--output", existing)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("fresh absolute directory", result.stderr)
+
+    def test_rejects_relative_output(self):
+        result = self.run_harness("--output", "relative/path")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_missing_binary(self):
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", os.path.join(self.temp, "missing"),
+             "--cef-dir", self.cef_dir, "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "1", "--output", os.path.join(self.temp, "out")],
+            capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_bad_runs(self):
+        result = self.run_harness("--output", os.path.join(self.temp, "out"), "--runs", "0")
+        # argparse passes --runs twice; last wins; use explicit override instead
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+             "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "0", "--output", os.path.join(self.temp, "out2")],
+            capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+
+
+class FakeBinaryLifetimeTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkdtemp()
+        self.cef_dir = os.path.join(self.temp, "cef")
+        os.makedirs(self.cef_dir)
+
+    def make_binary(self, body):
+        path = os.path.join(self.temp, "fake-%d" % len(os.listdir(self.temp)))
+        with open(path, "w") as handle:
+            handle.write("#!/bin/sh\n" + body + "\n")
+        os.chmod(path, 0o755)
+        return path
+
+    def test_duplicate_documents_marked(self):
+        binary = self.make_binary("exit 0")
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        # No fixture events and no document requests through the real binary:
+        # the sample must report incomplete, never synthesized success.
+        self.assertFalse(result["complete"])
+        self.assertIsNone(result["target_fcp_ms"])
+
+    def test_absent_fcp_is_incomplete(self):
+        binary = self.make_binary("echo '{\"message\":\"startup_trace: milestone\"}'; exit 0")
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        self.assertFalse(result["complete"])
+
+    def test_relay_fallback_recorded(self):
+        binary = self.make_binary("exit 0")
+        result = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 1, None, None, {})
+        self.assertTrue(result["fallback_spawn"])
+        self.assertFalse(result["relayed"])
+
+    def test_second_window_uses_observation_not_process_summary(self):
+        binary = self.make_binary("exit 0")
+        first = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        second = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 2, None, None, {})
+        self.assertIn("observation_spawn_to_summary_ms", first)
+        self.assertIn("observation_spawn_to_summary_ms", second)
+        self.assertNotIn("total_ms", second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -1,53 +1,81 @@
 #!/usr/bin/env python3
-"""Unit tests for measure_cef_startup.py (stdlib only)."""
+"""Unit tests for measure_cef_startup.py (stdlib only).
 
-import json
+Run headless: python3 -m unittest discover -s scripts -p 'test_measure_cef_startup.py'
+Set DUMBER_MEASURE_CUTOFF_SECONDS=0.2 for fast streaming tests (default 5.0).
+"""
+
 import os
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import measure_cef_startup as harness
 
 
-class ParseTest(unittest.TestCase):
-    def test_accepts_valid_fixture_event(self):
-        token = "a" * 16
-        nav = "b" * 16
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": token, "nav_token": nav, "value_ms": 12}),
-        ]
-        _, events = harness.parse_child_output(lines, token)
-        self.assertEqual(len(events), 1)
+class BeaconTest(unittest.TestCase):
+    def setUp(self):
+        self.state = harness.FixtureState()
+        harness.Handler.state = self.state
+        harness.Handler.fixture = "static"
+        harness.Handler.run_token = "a" * 16
+        harness.Handler.nav_token = "b" * 16
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), harness.Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, kwargs={"poll_interval": 0.05})
+        self.thread.daemon = True
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    def get(self, query):
+        url = "http://127.0.0.1:%d/__beacon?%s" % (self.port, query)
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                return response.status
+        except urllib.error.HTTPError as exc:
+            exc.read()
+            return exc.code
+
+    def test_accepts_valid_beacon(self):
+        status = self.get("run=%s&nav=%s&event=%s&value=12" % ("a" * 16, "b" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 204)
+        self.assertEqual(len(self.state.beacons), 1)
+        self.assertEqual(self.state.beacons[0]["value_ms"], 12)
 
     def test_rejects_wrong_token(self):
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": "c" * 16, "nav_token": "d" * 16, "value_ms": 12}),
-        ]
-        _, events = harness.parse_child_output(lines, "a" * 16)
-        self.assertEqual(events, [])
-
-    def test_rejects_non_numeric_value(self):
-        token = "a" * 16
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": token, "nav_token": "b" * 16, "value_ms": "12"}),
-        ]
-        _, events = harness.parse_child_output(lines, token)
-        self.assertEqual(events, [])
+        status = self.get("run=%s&nav=%s&event=%s&value=12" % ("c" * 16, "d" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
 
     def test_rejects_malformed_token(self):
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": "short", "nav_token": "b" * 16, "value_ms": 12}),
-        ]
-        _, events = harness.parse_child_output(lines, "short")
-        self.assertEqual(events, [])
+        status = self.get("run=short&nav=%s&event=%s&value=12" % ("b" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
+
+    def test_rejects_non_numeric_value(self):
+        status = self.get("run=%s&nav=%s&event=%s&value=abc" % ("a" * 16, "b" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
+
+    def test_rejects_unknown_event(self):
+        status = self.get("run=%s&nav=%s&event=%s&value=1" % ("a" * 16, "b" * 16, "bogus"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
+
+    def test_milestones_still_parsed(self):
+        lines = ['{"message":"startup_trace: milestone","milestone":"process_entry"}', "not json"]
+        self.assertEqual(len(harness.parse_child_output(lines)), 1)
 
 
 class CliValidationTest(unittest.TestCase):
@@ -61,20 +89,23 @@ class CliValidationTest(unittest.TestCase):
         self.cef_dir = os.path.join(self.temp, "cef")
         os.makedirs(self.cef_dir)
 
-    def run_harness(self, *extra):
-        cmd = [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
-               "--scenario", "profile-fresh", "--fixture", "static", "--runs", "1"] + list(extra)
-        return subprocess.run(cmd, capture_output=True, text=True)
-
     def test_rejects_existing_output(self):
         existing = os.path.join(self.temp, "exists")
         os.makedirs(existing)
-        result = self.run_harness("--output", existing)
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+             "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "1", "--output", existing],
+            capture_output=True, text=True)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("fresh absolute directory", result.stderr)
 
     def test_rejects_relative_output(self):
-        result = self.run_harness("--output", "relative/path")
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+             "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "1", "--output", "relative/path"],
+            capture_output=True, text=True)
         self.assertNotEqual(result.returncode, 0)
 
     def test_rejects_missing_binary(self):
@@ -86,8 +117,6 @@ class CliValidationTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
 
     def test_rejects_bad_runs(self):
-        result = self.run_harness("--output", os.path.join(self.temp, "out"), "--runs", "0")
-        # argparse passes --runs twice; last wins; use explicit override instead
         result = subprocess.run(
             [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
              "--scenario", "profile-fresh", "--fixture", "static",
@@ -101,40 +130,69 @@ class FakeBinaryLifetimeTest(unittest.TestCase):
         self.temp = tempfile.mkdtemp()
         self.cef_dir = os.path.join(self.temp, "cef")
         os.makedirs(self.cef_dir)
+        self.counter = 0
 
     def make_binary(self, body):
-        path = os.path.join(self.temp, "fake-%d" % len(os.listdir(self.temp)))
+        self.counter += 1
+        path = os.path.join(self.temp, "fake-%d" % self.counter)
         with open(path, "w") as handle:
             handle.write("#!/bin/sh\n" + body + "\n")
         os.chmod(path, 0o755)
         return path
 
-    def test_duplicate_documents_marked(self):
+    def make_fetch_binary(self):
+        # Fetches the fixture URL passed as argv[2] (argv: browse <url>),
+        # then exits: exercises document counting without a real browser.
+        path = os.path.join(self.temp, "fetch-%d" % self.counter)
+        self.counter += 1
+        with open(path, "w") as handle:
+            handle.write("#!/usr/bin/env python3\nimport sys, urllib.request\n"
+                         "urllib.request.urlopen(sys.argv[2], timeout=10).read()\n")
+        os.chmod(path, 0o755)
+        return path
+
+    def test_duplicate_documents_marked_incomplete(self):
         binary = self.make_binary("exit 0")
-        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
-        # No fixture events and no document requests through the real binary:
-        # the sample must report incomplete, never synthesized success.
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
         self.assertFalse(result["complete"])
         self.assertIsNone(result["target_fcp_ms"])
 
     def test_absent_fcp_is_incomplete(self):
-        binary = self.make_binary("echo '{\"message\":\"startup_trace: milestone\"}'; exit 0")
-        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        binary = self.make_fetch_binary()
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        self.assertEqual(result["document_requests"], 1)
+        self.assertIsNone(result["target_fcp_ms"])
         self.assertFalse(result["complete"])
 
-    def test_relay_fallback_recorded(self):
+    def test_relay_fallback_recorded_without_owner(self):
         binary = self.make_binary("exit 0")
-        result = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 1, None, None, {})
+        result = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 1)
         self.assertTrue(result["fallback_spawn"])
         self.assertFalse(result["relayed"])
 
     def test_second_window_uses_observation_not_process_summary(self):
         binary = self.make_binary("exit 0")
-        first = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
-        second = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 2, None, None, {})
+        first = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        second = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 2)
         self.assertIn("observation_spawn_to_summary_ms", first)
         self.assertIn("observation_spawn_to_summary_ms", second)
         self.assertNotIn("total_ms", second)
+
+    def test_run_dir_cleaned_up(self):
+        before = set(os.listdir(tempfile.gettempdir()))
+        binary = self.make_binary("exit 0")
+        harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        after = set(os.listdir(tempfile.gettempdir()))
+        leaked = [name for name in (after - before) if name.startswith("cef-startup-run-")]
+        self.assertEqual(leaked, [])
+
+    def test_streaming_returns_without_process_exit(self):
+        # A hanging GUI must not pin the harness: with a short cutoff the
+        # sample decides from streamed output, then terminates the child.
+        binary = self.make_binary("exec sleep 30")
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        self.assertFalse(result["complete"])
+        self.assertLess(result["observation_spawn_to_summary_ms"], 15000)
 
 
 if __name__ == "__main__":

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -77,6 +77,22 @@ class BeaconTest(unittest.TestCase):
         lines = ['{"message":"startup_trace: milestone","milestone":"process_entry"}', "not json"]
         self.assertEqual(len(harness.parse_child_output(lines)), 1)
 
+    def test_image_endpoint_serves_decodable_png(self):
+        import struct
+        import zlib
+        url = "http://127.0.0.1:%d/pixel.png" % self.port
+        with urllib.request.urlopen(url, timeout=5) as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.headers.get_content_type(), "image/png")
+            body = response.read()
+        self.assertEqual(body[:8], bytes.fromhex("89504e470d0a1a0a"))
+        width, height = struct.unpack(">II", body[16:24])
+        self.assertEqual((width, height), (1, 1))
+        idat_len = struct.unpack(">I", body[33:37])[0]
+        self.assertEqual(body[37:41], b"IDAT")
+        zlib.decompress(body[41:41 + idat_len])
+        self.assertEqual(body[-8:-4], b"IEND")
+
 
 class CliValidationTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Implements Plan 01 (cold-start critical path) from the CEF startup roadmap: issues #391, #392, #393, #394, #407.

## What changed
- **Measurement (P1):** collector fixtures isolated with fake Go/Git provenance; provenance now bound to the measured binary (`go version -m` + SHA-256-tied build manifest, no checkout `go list`, no hardcoded CEF 147); explicit `DUMBER_CEF_DIR` with child `CEF_DIR` pinned; new `scripts/cef_runtime_probe.py` (header-verified `cef_version_info(0..7)` via ctypes, hash only, never paths); new stdlib-only `scripts/measure_cef_startup.py` harness (process-warm/profile-fresh/relay-window x static/delayed/redirect/cache) with unit tests.
- **Logo (P3):** loading placeholder decodes packaged 512px PNG instead of SVG; SVG kept for desktop icons; one-texture-per-process lifetime preserved.
- **Navigation (P4):** one `LoadURL` per navigation intent (monotonic IDs incl. same-URL repeats, issued-claim under lock, browser correlation by identifier, stale-task suppression). Acknowledgement paths unchanged.
- **Launch env (P5):** safety merge shared from new leaf `internal/infrastructure/process` (no import cycle); browser/session child envs merged after sanitization; single combined omnibox re-exec for safety+preload; CEF helpers excluded from preload.

## Deferred with record
- **P2 (WebKit lazy init)** stops at the publication gate: needs authorization before any puregotk/purego-cef2gtk publish+pin.
- **P6 A/B samples** need a display/GPU host; collector contract documented in `docs/first-presentation.md`.

## Gates
- `git diff --check` clean, `make lint` clean, focused suites green (cef, coordinator/content, cmd/dumber, desktop, process, component, assets, bootstrap).
- Full `make test`/`make check`: everything passes except `internal/ui/input`, which segfaults identically on clean main (headless native GTK, pre-existing, unrelated).
- No `replace` directives. Go-reviewer go-ahead on the intent guard (narrowed scope).

## Test build
Binary + manifest published alongside (see PR comments). Requires `DUMBER_CEF_DIR` pointing at a CEF 150+ runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added verified build-manifest generation.
  - Added CEF runtime validation and startup measurement tools.
  - Added explicit CEF runtime selection and provenance recording.
  - Improved loading-screen logo rendering with a packaged raster asset.

- **Bug Fixes**
  - Improved omnibox startup reliability and runtime safety.
  - Prevented duplicate or outdated navigation requests.
  - Improved child-process environment handling.

- **Documentation**
  - Updated first-presentation performance collection and provenance requirements.

- **Tests**
  - Expanded coverage for startup, navigation, runtime validation, logo loading, and performance measurement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->