### PR TITLE
feat(cef): resident runtime with bounded prewarming gates (Plan 02)

### DIFF
--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -333,6 +333,11 @@ func runGUI(cfg *config.Config, timing startupTiming) int {
 		log.Error().Err(err).Msg("failed to create application")
 		return 1
 	}
+	// Latch the bounded-residency timeout once at startup. Only CEF uses
+	// it, and only when nonzero; later config changes are restart-required.
+	if cfg.Engine.ResolveEngineType() == config.EngineTypeCEF {
+		app.SetResidencyTimeout(ui.ResidencyTimeoutFromMillis(cfg.Engine.CEF.IdleRuntimeTimeoutMs))
+	}
 	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
 		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
 			if err := app.OpenExternalURL(ctx, url); err != nil {

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -266,6 +266,16 @@ func main() {
 	cmd.Execute()
 }
 
+func setAlreadyRunningRelaunchHandler(engine port.Engine, app *ui.App, ctx context.Context, log *zerolog.Logger) {
+	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
+		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
+			if err := app.OpenExternalURL(ctx, url); err != nil {
+				log.Warn().Err(err).Str("url", url).Msg("failed to open relaunch external URL")
+			}
+		})
+	}
+}
+
 func runGUI(cfg *config.Config, timing startupTiming) int {
 	bootstrap.ApplyGTKIMModuleFallbackDefault(os.Stderr)
 
@@ -333,18 +343,9 @@ func runGUI(cfg *config.Config, timing startupTiming) int {
 		log.Error().Err(err).Msg("failed to create application")
 		return 1
 	}
-	// Latch the bounded-residency timeout once at startup. Only CEF uses
-	// it, and only when nonzero; later config changes are restart-required.
-	if cfg.Engine.ResolveEngineType() == config.EngineTypeCEF {
-		app.SetResidencyTimeout(ui.ResidencyTimeoutFromMillis(cfg.Engine.CEF.IdleRuntimeTimeoutMs))
-	}
-	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
-		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
-			if err := app.OpenExternalURL(ctx, url); err != nil {
-				log.Warn().Err(err).Str("url", url).Msg("failed to open relaunch external URL")
-			}
-		})
-	}
+	// Latch the bounded-residency timeout once at startup (CEF only).
+	ui.LatchResidencyTimeoutForApp(app, cfg.Engine.CEF.IdleRuntimeTimeoutMs, cfg.Engine.ResolveEngineType() == config.EngineTypeCEF)
+	setAlreadyRunningRelaunchHandler(engine, app, ctx, log)
 	timer.Mark("ui_deps")
 	timer.Log(ctx)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -66,6 +66,7 @@
 | `engine.cef.adaptive_windowless_frame_rate` | bool | `true` | |
 | `engine.cef.windowless_frame_rate` | int32 | `0` | >= 0 |
 | `engine.cef.windowless_frame_rate_max` | int32 | `240` | >= 0 |
+| `engine.cef.idle_runtime_timeout_ms` | int | `0` | 0..300000, restart-required |
 | `engine.cef.input.scroll_wheel_multiplier` | float | `1.0` | > 0 |
 | `engine.cef.input.scroll_precise_multiplier` | float | `2.5` | > 0 |
 | `engine.cef.input.scroll_horizontal_multiplier` | float | `1.0` | > 0 |

--- a/internal/application/port/runtime_activity.go
+++ b/internal/application/port/runtime_activity.go
@@ -1,0 +1,44 @@
+package port
+
+import "context"
+
+// RuntimeActivitySnapshot is an engine-neutral view of outstanding native
+// runtime work that must settle before the process may idle out. Counts only:
+// generations and acknowledgement correlation live with the implementation.
+type RuntimeActivitySnapshot struct {
+	// PendingCreations counts accepted browser creations not yet resolved
+	// through OnAfterCreated or a definitive failure.
+	PendingCreations int
+	// ActiveViews counts registered live views, including views whose
+	// native close has started but whose GTK teardown is outstanding.
+	ActiveViews int
+	// PendingCleanup counts native-closed views whose queued GTK
+	// bridge/popup cleanup has not completed.
+	PendingCleanup int
+	// ActiveDownloads counts downloads with a terminal event outstanding.
+	ActiveDownloads int
+}
+
+// Quiescent reports whether no native work is outstanding.
+func (s RuntimeActivitySnapshot) Quiescent() bool {
+	return s.PendingCreations == 0 && s.ActiveViews == 0 && s.PendingCleanup == 0 && s.ActiveDownloads == 0
+}
+
+// RuntimeActivity is the application-port boundary for native runtime
+// quiescence. The initial snapshot and subscription are race-safe and
+// sequenced: Subscribe delivers the current snapshot synchronously, then all
+// later transitions in order. Unsubscribe at shutdown.
+type RuntimeActivity interface {
+	Snapshot() RuntimeActivitySnapshot
+	Subscribe(func(RuntimeActivitySnapshot)) (unsubscribe func())
+}
+
+// PersistenceDrain is the narrow activity/drain boundary for persistence
+// owners whose saves cross the GTK/database boundary. Active covers pending
+// debounce, in-flight capture/execution, and unsettled terminal failure.
+// WaitSettled blocks until settled or ctx ends; it must never be called on
+// the GTK thread when capture dispatches there.
+type PersistenceDrain interface {
+	Active() bool
+	WaitSettled(ctx context.Context) error
+}

--- a/internal/application/port/runtime_activity.go
+++ b/internal/application/port/runtime_activity.go
@@ -42,3 +42,29 @@ type PersistenceDrain interface {
 	Active() bool
 	WaitSettled(ctx context.Context) error
 }
+
+// AdmissionBoundary is the admission/work-lease contract shared by the relay
+// listener and the shutdown/residency policy. Infrastructure provides the
+// implementation; application code depends only on this boundary.
+type AdmissionBoundary interface {
+	// Acquire takes one work lease, reporting false when admission is
+	// closed. Callers send the existing error response instead of
+	// acknowledging.
+	Acquire() bool
+	// Release returns one work lease on dispatch settlement.
+	Release()
+	// Close atomically stops admission; in-flight leases drain.
+	Close()
+	// Reopen resumes admission after an invalidated seal.
+	Reopen()
+	// Closed reports whether admission is stopped.
+	Closed() bool
+	// Active reports the number of held leases.
+	Active() int
+	// OnDrained registers a callback for every transition to zero leases.
+	// Callbacks run without the gate lock and must not reenter it.
+	OnDrained(func())
+	// WaitDrained blocks until no leases are held or ctx ends, reporting
+	// false on expiry so shutdown never waits forever.
+	WaitDrained(ctx context.Context) bool
+}

--- a/internal/application/usecase/runtime_residency.go
+++ b/internal/application/usecase/runtime_residency.go
@@ -105,6 +105,11 @@ func (r *RuntimeResidency) ShutdownRequested() ResidencyDecision {
 	return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
 }
 
+// IdleArmed reports whether an idle deadline is currently armed.
+func (r *RuntimeResidency) IdleArmed() bool {
+	return r.armed
+}
+
 // HandleExpiry processes a fired idle timer. Stale generations (superseded by
 // a later arm/cancel) are ignored. Expiry quits only when still quiescent;
 // otherwise it stands down and lets the next event re-arm.

--- a/internal/application/usecase/runtime_residency.go
+++ b/internal/application/usecase/runtime_residency.go
@@ -80,7 +80,7 @@ func (r *RuntimeResidency) OpenFailed(now time.Time) ResidencyDecision {
 }
 
 // WorkStarted records newly accepted native work. An armed deadline is
-// cancelled: expiry must never fire while required work is outstanding.
+// canceled: expiry must never fire while required work is outstanding.
 func (r *RuntimeResidency) WorkStarted(_ time.Time) ResidencyDecision {
 	r.activeWork++
 	if r.armed {

--- a/internal/application/usecase/runtime_residency.go
+++ b/internal/application/usecase/runtime_residency.go
@@ -1,0 +1,161 @@
+package usecase
+
+import "time"
+
+// ResidencyAction is the single decision a RuntimeResidency event produces.
+// The UI boundary maps it to scheduler operations: clock and timer handles
+// stay outside this controller, which never sleeps.
+type ResidencyAction int
+
+const (
+	// ResidencyNone requires no scheduler change.
+	ResidencyNone ResidencyAction = iota
+	// ResidencyArm starts (or restarts) the idle deadline.
+	ResidencyArm
+	// ResidencyCancel drops a previously armed idle deadline.
+	ResidencyCancel
+	// ResidencyQuit ends the process through the orderly shutdown path.
+	ResidencyQuit
+)
+
+// ResidencyDecision is the outcome of one residency event.
+type ResidencyDecision struct {
+	Action     ResidencyAction
+	Deadline   time.Time
+	Generation uint64
+}
+
+// RuntimeResidency is a testable bounded-residency policy: after the last
+// user window closes it arms a deadline instead of quitting immediately, so
+// a fast reopen can reuse the retained runtime. It tracks only engine-neutral
+// counts; native GTK holds, timers, and quiescence signals live in UI
+// adapters. The zero timeout preserves the existing last-window exit.
+type RuntimeResidency struct {
+	timeout    time.Duration
+	windows    int
+	activeWork int
+	shutdown   bool
+	armed      bool
+	deadline   time.Time
+	generation uint64
+}
+
+// NewRuntimeResidency returns a policy with the given idle timeout. Negative
+// values clamp to zero (disabled). The accepted configuration range is
+// 0..300000ms; enforcement of that range belongs to config validation.
+func NewRuntimeResidency(timeout time.Duration) *RuntimeResidency {
+	if timeout < 0 {
+		timeout = 0
+	}
+	return &RuntimeResidency{timeout: timeout}
+}
+
+// WindowOpened records a user window (including native browser/auth popups
+// that still belong to the application) and cancels any armed deadline.
+func (r *RuntimeResidency) WindowOpened(_ time.Time) ResidencyDecision {
+	r.windows++
+	if r.armed {
+		return r.cancel()
+	}
+	return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+}
+
+// WindowClosed records a user-window close. Duplicate closes are idempotent
+// and never drive the count negative.
+func (r *RuntimeResidency) WindowClosed(now time.Time) ResidencyDecision {
+	if r.windows > 0 {
+		r.windows--
+	}
+	return r.evaluateIdle(now)
+}
+
+// OpenFailed records a failed reopen attempt. Idle eligibility is restored
+// rather than stranding the policy: a failed open can never leak the
+// application hold indefinitely.
+func (r *RuntimeResidency) OpenFailed(now time.Time) ResidencyDecision {
+	if r.windows > 0 {
+		r.windows--
+	}
+	return r.evaluateIdle(now)
+}
+
+// WorkStarted records newly accepted native work. An armed deadline is
+// cancelled: expiry must never fire while required work is outstanding.
+func (r *RuntimeResidency) WorkStarted(_ time.Time) ResidencyDecision {
+	r.activeWork++
+	if r.armed {
+		return r.cancel()
+	}
+	return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+}
+
+// WorkFinished records settled work and re-evaluates idle eligibility.
+func (r *RuntimeResidency) WorkFinished(now time.Time) ResidencyDecision {
+	if r.activeWork > 0 {
+		r.activeWork--
+	}
+	return r.evaluateIdle(now)
+}
+
+// ShutdownRequested records an explicit quit or signal. It always decides
+// Quit immediately and never waits for the idle deadline.
+func (r *RuntimeResidency) ShutdownRequested() ResidencyDecision {
+	r.shutdown = true
+	r.armed = false
+	return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+}
+
+// HandleExpiry processes a fired idle timer. Stale generations (superseded by
+// a later arm/cancel) are ignored. Expiry quits only when still quiescent;
+// otherwise it stands down and lets the next event re-arm.
+func (r *RuntimeResidency) HandleExpiry(_ time.Time, generation uint64) ResidencyDecision {
+	if !r.armed || generation != r.generation {
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	if r.windows > 0 || r.activeWork > 0 || r.shutdown {
+		r.armed = false
+		if r.shutdown {
+			return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+		}
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	r.armed = false
+	return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+}
+
+// Armed reports whether an idle deadline is currently armed. The UI boundary
+// uses it only for diagnostics; scheduling follows decisions.
+func (r *RuntimeResidency) Armed() bool { return r.armed }
+
+// Generation returns the current timer generation for expiry correlation.
+func (r *RuntimeResidency) Generation() uint64 { return r.generation }
+
+func (r *RuntimeResidency) cancel() ResidencyDecision {
+	r.armed = false
+	r.generation++
+	return ResidencyDecision{Action: ResidencyCancel, Generation: r.generation}
+}
+
+func (r *RuntimeResidency) evaluateIdle(now time.Time) ResidencyDecision {
+	if r.shutdown {
+		r.armed = false
+		return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+	}
+	if r.windows > 0 {
+		if r.armed {
+			return r.cancel()
+		}
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	if r.timeout <= 0 {
+		r.armed = false
+		return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+	}
+	if r.activeWork > 0 {
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	r.armed = true
+	r.deadline = now.Add(r.timeout)
+	r.generation++
+	return ResidencyDecision{Action: ResidencyArm, Deadline: r.deadline, Generation: r.generation}
+}

--- a/internal/application/usecase/runtime_residency_test.go
+++ b/internal/application/usecase/runtime_residency_test.go
@@ -1,0 +1,133 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeResidencyDisabledQuitsOnLastWindow(t *testing.T) {
+	r := NewRuntimeResidency(0)
+	r.WindowOpened(time.Now())
+	decision := r.WindowClosed(time.Now())
+	require.Equal(t, ResidencyQuit, decision.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyNegativeTimeoutDisables(t *testing.T) {
+	r := NewRuntimeResidency(-time.Second)
+	r.WindowOpened(time.Now())
+	require.Equal(t, ResidencyQuit, r.WindowClosed(time.Now()).Action)
+}
+
+func TestRuntimeResidencyFirstIdleArmsDeadline(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	decision := r.WindowClosed(now)
+	require.Equal(t, ResidencyArm, decision.Action)
+	require.Equal(t, now.Add(time.Minute), decision.Deadline)
+	require.True(t, r.Armed())
+	gen := decision.Generation
+
+	expiry := r.HandleExpiry(now.Add(2*time.Minute), gen)
+	require.Equal(t, ResidencyQuit, expiry.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyReopenCancelsDeadline(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	arm := r.WindowClosed(now)
+	require.Equal(t, ResidencyArm, arm.Action)
+
+	cancel := r.WindowOpened(now)
+	require.Equal(t, ResidencyCancel, cancel.Action)
+	require.False(t, r.Armed())
+
+	stale := r.HandleExpiry(now.Add(2*time.Minute), arm.Generation)
+	require.Equal(t, ResidencyNone, stale.Action)
+}
+
+func TestRuntimeResidencyFailedReopenRestoresIdle(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	require.Equal(t, ResidencyArm, r.WindowClosed(now).Action)
+
+	// Optimistic open followed by failure: the hold must not leak, idle
+	// eligibility returns.
+	r.WindowOpened(now)
+	decision := r.OpenFailed(now)
+	require.Equal(t, ResidencyArm, decision.Action)
+	require.True(t, r.Armed())
+}
+
+func TestRuntimeResidencyPopupRemainingPreventsIdle(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	r.WindowOpened(now)
+	decision := r.WindowClosed(now)
+	require.Equal(t, ResidencyNone, decision.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyDuplicateCloseIsIdempotent(t *testing.T) {
+	r := NewRuntimeResidency(0)
+	decision := r.WindowClosed(time.Now())
+	require.Equal(t, ResidencyQuit, decision.Action)
+	again := r.WindowClosed(time.Now())
+	require.Equal(t, ResidencyQuit, again.Action)
+}
+
+func TestRuntimeResidencyStaleExpiryIgnored(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	first := r.WindowClosed(now)
+	r.WindowOpened(now)
+	second := r.WindowClosed(now)
+	require.NotEqual(t, first.Generation, second.Generation)
+
+	require.Equal(t, ResidencyNone, r.HandleExpiry(now, first.Generation).Action)
+	require.True(t, r.Armed())
+	require.Equal(t, ResidencyQuit, r.HandleExpiry(now, second.Generation).Action)
+}
+
+func TestRuntimeResidencyExplicitQuitNeverWaits(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	require.Equal(t, ResidencyArm, r.WindowClosed(now).Action)
+	require.True(t, r.Armed())
+
+	decision := r.ShutdownRequested()
+	require.Equal(t, ResidencyQuit, decision.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyWorkBlocksIdleUntilDrained(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	r.WorkStarted(now)
+	decision := r.WindowClosed(now)
+	require.Equal(t, ResidencyNone, decision.Action)
+	require.False(t, r.Armed())
+
+	drained := r.WorkFinished(now)
+	require.Equal(t, ResidencyArm, drained.Action)
+	require.True(t, r.Armed())
+}
+
+func TestRuntimeResidencyWorkCancelsArmedDeadline(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	require.Equal(t, ResidencyArm, r.WindowClosed(now).Action)
+	require.Equal(t, ResidencyCancel, r.WorkStarted(now).Action)
+	require.False(t, r.Armed())
+}

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -24,6 +24,9 @@ type downloadHandler struct {
 	mu       sync.Mutex
 	active   map[uint32]cefDownloadState
 	finished map[uint32]struct{} // IDs that already emitted a terminal event
+	// activity tracks download starts against their terminal events for
+	// the quiescence boundary. Nil-safe: unset in unit-test literals.
+	activity *RuntimeActivityTracker
 }
 
 type cefDownloadState struct {
@@ -102,11 +105,13 @@ func newDownloadHandler(
 	downloadPath string,
 	eventHandler port.DownloadEventHandler,
 	preparer port.DownloadPreparer,
+	activity *RuntimeActivityTracker,
 ) *downloadHandler {
 	return &downloadHandler{
 		runtime:  downloadruntime.New(downloadPath, eventHandler, preparer),
 		active:   make(map[uint32]cefDownloadState),
 		finished: make(map[uint32]struct{}),
+		activity: activity,
 	}
 }
 
@@ -116,7 +121,7 @@ func (h *downloadHandler) canDownload(_ purecef.Browser, _, _ string) bool {
 
 func (h *downloadHandler) onBeforeDownload(
 	ctx context.Context,
-	_ purecef.Browser,
+	browser purecef.Browser,
 	downloadItem purecef.DownloadItem,
 	suggestedName string,
 	callback purecef.BeforeDownloadCallback,
@@ -124,6 +129,14 @@ func (h *downloadHandler) onBeforeDownload(
 	if downloadItem == nil || callback == nil {
 		return false
 	}
+	// Retain browser ownership the previous code discarded: activity is
+	// keyed by (browser identity, CEF download ID), never by filename or
+	// destination, which can collide or change mid-download.
+	var browserID int32
+	if browser != nil {
+		browserID = browser.GetIdentifier()
+	}
+	h.activity.NoteDownloadStarted(browserID, downloadItem.GetID())
 
 	log := logging.FromContext(ctx)
 	output, err := h.runtime.ResolveDestination(ctx, suggestedName, &cefDownloadResponseAdapter{item: downloadItem})
@@ -175,11 +188,13 @@ func (h *downloadHandler) onDownloadUpdated(
 		if !h.markFinished(id) {
 			return
 		}
+		h.activity.NoteDownloadTerminal(id)
 		h.runtime.EmitFinished(ctx, state.filename, state.destination)
 	case downloadItem.IsCanceled() || downloadItem.IsInterrupted():
 		if !h.markFinished(id) {
 			return
 		}
+		h.activity.NoteDownloadTerminal(id)
 		var err error
 		if downloadItem.IsInterrupted() {
 			err = cefDownloadInterruptError{

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -162,12 +162,17 @@ func (h *downloadHandler) onBeforeDownload(
 
 func (h *downloadHandler) onDownloadUpdated(
 	ctx context.Context,
+	browser purecef.Browser,
 	downloadItem purecef.DownloadItem,
 	callback purecef.DownloadItemCallback,
 ) {
 	_ = callback
 	if downloadItem == nil {
 		return
+	}
+	var browserID int32
+	if browser != nil {
+		browserID = browser.GetIdentifier()
 	}
 
 	id := downloadItem.GetID()
@@ -188,13 +193,13 @@ func (h *downloadHandler) onDownloadUpdated(
 		if !h.markFinished(id) {
 			return
 		}
-		h.activity.NoteDownloadTerminal(id)
+		h.activity.NoteDownloadTerminal(browserID, id)
 		h.runtime.EmitFinished(ctx, state.filename, state.destination)
 	case downloadItem.IsCanceled() || downloadItem.IsInterrupted():
 		if !h.markFinished(id) {
 			return
 		}
-		h.activity.NoteDownloadTerminal(id)
+		h.activity.NoteDownloadTerminal(browserID, id)
 		var err error
 		if downloadItem.IsInterrupted() {
 			err = cefDownloadInterruptError{

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -94,9 +94,9 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 
 	item.complete = true
 	item.fullPath = callback.path
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 	// Repeated completion updates should not emit duplicate finished events.
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	require.Len(t, events.events, 2)
 	require.Equal(t, port.DownloadEventFinished, events.events[1].Type)
@@ -166,12 +166,12 @@ func TestCEFDownloadHandlerEmitsProgressOncePerPercent(t *testing.T) {
 	item.percentComplete = 12
 	item.receivedBytes = 12
 	item.totalBytes = 100
-	handler.onDownloadUpdated(ctx, item, nil)
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	item.percentComplete = 13
 	item.receivedBytes = 13
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	require.Len(t, events.events, 3)
 	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
@@ -200,7 +200,7 @@ func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
 	item.fullPath = callback.path
 	item.interrupted = true
 	item.reason = purecef.DownloadInterruptReasonServerBadContent
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	require.Len(t, events.events, 2)
 	require.Error(t, events.events[1].Error)
@@ -230,7 +230,7 @@ func TestDownloadHandlerTracksOwnersByBrowserAndID(t *testing.T) {
 	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
 
 	// Terminal for one ID leaves the other owner outstanding.
-	handler.onDownloadUpdated(ctx, stubDownloadItem{id: 11, complete: true, fullPath: "/tmp/a.bin"}, nil)
+	handler.onDownloadUpdated(ctx, first, stubDownloadItem{id: 11, complete: true, fullPath: "/tmp/a.bin"}, nil)
 	require.Equal(t, 1, tracker.Snapshot().ActiveDownloads)
 
 	// Lost owners reconcile through the native lifecycle, never removal.

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	purecef "github.com/bnema/purego-cef/cef"
+	cefmocks "github.com/bnema/purego-cef/cef/mocks"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bnema/dumber/internal/application/port"
@@ -74,7 +75,7 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
 	events := &captureDownloadEvents{}
 	downloadDir := t.TempDir()
-	handler := newDownloadHandler(downloadDir, events, preparer)
+	handler := newDownloadHandler(downloadDir, events, preparer, nil)
 	callback := &stubBeforeDownloadCallback{}
 
 	item := stubDownloadItem{
@@ -112,7 +113,7 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 
 func TestCanDownload_AllowsAllMethods(t *testing.T) {
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
-	handler := newDownloadHandler("/tmp/downloads", nil, preparer)
+	handler := newDownloadHandler("/tmp/downloads", nil, preparer, nil)
 
 	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", "GET"))
 	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", "POST"))
@@ -122,7 +123,7 @@ func TestCanDownload_AllowsAllMethods(t *testing.T) {
 
 func TestMarkFinished_SuppressesDuplicatesAfterCleanup(t *testing.T) {
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
-	handler := newDownloadHandler("/tmp/downloads", nil, preparer)
+	handler := newDownloadHandler("/tmp/downloads", nil, preparer, nil)
 
 	// Simulate a download that was tracked through onBeforeDownload.
 	handler.mu.Lock()
@@ -149,7 +150,7 @@ func TestCEFDownloadHandlerEmitsProgressOncePerPercent(t *testing.T) {
 	ctx := context.Background()
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
 	events := &captureDownloadEvents{}
-	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	handler := newDownloadHandler("/tmp/downloads", events, preparer, nil)
 	callback := &stubBeforeDownloadCallback{}
 
 	item := stubDownloadItem{
@@ -184,7 +185,7 @@ func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
 	ctx := context.Background()
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
 	events := &captureDownloadEvents{}
-	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	handler := newDownloadHandler("/tmp/downloads", events, preparer, nil)
 	callback := &stubBeforeDownloadCallback{}
 
 	item := stubDownloadItem{
@@ -206,4 +207,33 @@ func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
 	expectedCode := fmt.Sprintf("code=%d", purecef.DownloadInterruptReasonServerBadContent)
 	require.ErrorContains(t, events.events[1].Error, expectedCode)
 	require.ErrorContains(t, events.events[1].Error, "reason=server_bad_content")
+}
+
+func TestDownloadHandlerTracksOwnersByBrowserAndID(t *testing.T) {
+	ctx := context.Background()
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+	events := &captureDownloadEvents{}
+	tracker := NewRuntimeActivityTracker()
+	handler := newDownloadHandler(t.TempDir(), events, preparer, tracker)
+	callback := &stubBeforeDownloadCallback{}
+
+	first := cefmocks.NewMockBrowser(t)
+	first.EXPECT().GetIdentifier().Return(int32(7))
+	second := cefmocks.NewMockBrowser(t)
+	second.EXPECT().GetIdentifier().Return(int32(9))
+
+	// Same filename from two owners are distinct activity entries.
+	require.True(t, handler.onBeforeDownload(ctx, first,
+		stubDownloadItem{id: 11, url: "https://example.com/a.bin", suggested: "a.bin"}, "a.bin", callback))
+	require.True(t, handler.onBeforeDownload(ctx, second,
+		stubDownloadItem{id: 12, url: "https://other.example/a.bin", suggested: "a.bin"}, "a.bin", callback))
+	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
+
+	// Terminal for one ID leaves the other owner outstanding.
+	handler.onDownloadUpdated(ctx, stubDownloadItem{id: 11, complete: true, fullPath: "/tmp/a.bin"}, nil)
+	require.Equal(t, 1, tracker.Snapshot().ActiveDownloads)
+
+	// Lost owners reconcile through the native lifecycle, never removal.
+	tracker.DropBrowser(9)
+	require.True(t, tracker.Snapshot().Quiescent())
 }

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -62,6 +62,11 @@ type Engine struct {
 	browserWebViews sync.Map // map[int32]*WebView
 	activeCount     atomic.Int32
 
+	// activity tracks outstanding native runtime work for the residency
+	// quiescence boundary. Initialized by NewEngine; nil in unit-test
+	// literals, where tracker methods are safe no-ops.
+	activity *RuntimeActivityTracker
+
 	// shutdownNotify is signaled when the active webview count reaches 0
 	// during shutdown, replacing the busy-wait poll in closeActiveWebViews.
 	shutdownNotify chan struct{}
@@ -85,6 +90,16 @@ type Engine struct {
 	browserCreateLastWidth  atomic.Int32
 	browserCreateLastHeight atomic.Int32
 	browserCreateComplete   atomic.Bool
+}
+
+// RuntimeActivity exposes the engine's outstanding-work tracker through
+// the application port. UI subscribes at startup and unsubscribes at
+// shutdown; the initial snapshot is race-safe and sequenced.
+func (e *Engine) RuntimeActivity() port.RuntimeActivity {
+	if e == nil || e.activity == nil {
+		return NewRuntimeActivityTracker()
+	}
+	return e.activity
 }
 
 func (e *Engine) Factory() port.WebViewFactory {
@@ -162,6 +177,7 @@ func (e *Engine) recordGPURelaunch() {
 func (e *Engine) registerWebView(wv *WebView) {
 	e.activeWebViews.Store(wv.id, wv)
 	e.activeCount.Add(1)
+	e.activity.NoteViewRegistered()
 }
 
 func (e *Engine) lookupWebView(id port.WebViewID) *WebView {
@@ -204,6 +220,7 @@ func (e *Engine) unbindBrowserWebView(browserID int32, wv *WebView) {
 func (e *Engine) unregisterWebView(wv *WebView, browserID int32) {
 	e.activeWebViews.Delete(wv.id)
 	e.unbindBrowserWebView(browserID, wv)
+	e.activity.DropBrowser(browserID)
 	if e.activeCount.Add(-1) == 0 && e.shutdownNotify != nil {
 		select {
 		case e.shutdownNotify <- struct{}{}:
@@ -305,6 +322,7 @@ func (e *Engine) destroyClosedWebViewBridges(webViews []*WebView) {
 	for _, wv := range webViews {
 		if wv != nil && wv.destroyed.Load() {
 			wv.destroyViewBridgeOnGTKSync()
+			e.activity.NoteCleanupCompleted()
 		}
 	}
 }
@@ -340,7 +358,7 @@ func (e *Engine) ConfigureDownloads(
 		return fmt.Errorf("cef: download preparer is required")
 	}
 	e.downloadMu.Lock()
-	e.downloadHandler = newDownloadHandler(downloadPath, eventHandler, preparer)
+	e.downloadHandler = newDownloadHandler(downloadPath, eventHandler, preparer, e.activity)
 	e.downloadMu.Unlock()
 	return nil
 }
@@ -503,18 +521,21 @@ func (e *Engine) recordBrowserCreateRequest(width, height, result int32) {
 		Int32("height", height).
 		Int32("result", result).
 		Msg("cef: BrowserHostCreateBrowser returned")
-	if result != 1 {
-		logging.FromContext(e.ctx).Warn().
-			Uint64("request_count", count).
-			Int32("width", width).
-			Int32("height", height).
-			Int32("result", result).
-			Msg("cef: BrowserHostCreateBrowser returned non-success")
+	if result == 1 {
+		e.activity.NoteCreationAccepted()
+		return
 	}
+	logging.FromContext(e.ctx).Warn().
+		Uint64("request_count", count).
+		Int32("width", width).
+		Int32("height", height).
+		Int32("result", result).
+		Msg("cef: BrowserHostCreateBrowser returned non-success")
 }
 
 func (e *Engine) recordBrowserAfterCreated(browser purecef.Browser) {
 	count := e.browserAfterCreated.Add(1)
+	e.activity.NoteCreationResolved()
 	if count >= e.browserCreateRequests.Load() {
 		e.browserCreateComplete.Store(true)
 	}

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -321,8 +321,8 @@ func (e *Engine) closeActiveWebViews() {
 func (e *Engine) destroyClosedWebViewBridges(webViews []*WebView) {
 	for _, wv := range webViews {
 		if wv != nil && wv.destroyed.Load() {
+			// Completion accounting lands in destroyViewBridgeOnGTKThread.
 			wv.destroyViewBridgeOnGTKSync()
-			e.activity.NoteCleanupCompleted()
 		}
 	}
 }

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -84,7 +84,7 @@ func NewEngine(
 		ctxMenuRenderer:        deps.ContextMenuRenderer,
 		clipboard:              deps.Clipboard,
 		resolver:               deps.ImageDataResolver,
-		activity:              NewRuntimeActivityTracker(),
+		activity:               NewRuntimeActivityTracker(),
 	}
 
 	logger.Info().

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -84,6 +84,7 @@ func NewEngine(
 		ctxMenuRenderer:        deps.ContextMenuRenderer,
 		clipboard:              deps.Clipboard,
 		resolver:               deps.ImageDataResolver,
+		activity:              NewRuntimeActivityTracker(),
 	}
 
 	logger.Info().

--- a/internal/infrastructure/cef/pool.go
+++ b/internal/infrastructure/cef/pool.go
@@ -110,6 +110,19 @@ func (p *WebViewPool) Size() int {
 	return len(p.pool)
 }
 
+// pooledViewBrowserReady reports whether a pooled reserve holds a live
+// browser. Wrapper-only reserves (allocated struct, no OnAfterCreated yet)
+// are never reported browser-ready. Viewport validity and first blank frame
+// require native validation and stay outside this predicate.
+func pooledViewBrowserReady(wv *WebView) bool {
+	if wv == nil || wv.destroyed.Load() {
+		return false
+	}
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	return wv.browser != nil
+}
+
 // Close shuts down the pool and destroys all pooled WebViews.
 func (p *WebViewPool) Close() {
 	p.mu.Lock()

--- a/internal/infrastructure/cef/pool_test.go
+++ b/internal/infrastructure/cef/pool_test.go
@@ -1,0 +1,39 @@
+package cef
+
+import (
+	"context"
+	"testing"
+
+	cefmocks "github.com/bnema/purego-cef/cef/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolZeroCountCreatesNothing(t *testing.T) {
+	pool := &WebViewPool{}
+	pool.Prewarm(0)
+	pool.Prewarm(-3)
+	pool.PrewarmAsync(context.Background(), 0)
+	require.Equal(t, 0, pool.Size())
+}
+
+func TestPoolReserveReadinessRequiresBrowser(t *testing.T) {
+	// A wrapper-only reserve (no browser yet) is never browser-ready.
+	require.False(t, pooledViewBrowserReady(nil))
+	require.False(t, pooledViewBrowserReady(&WebView{}))
+
+	browser := cefmocks.NewMockBrowser(t)
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	require.True(t, pooledViewBrowserReady(wv))
+
+	wv.Destroy()
+	require.False(t, pooledViewBrowserReady(wv), "destroyed views leave the ready set")
+}
+
+func TestPoolReleaseDestroysAndIgnoresNil(t *testing.T) {
+	pool := &WebViewPool{}
+	require.NotPanics(t, func() { pool.Release(nil) })
+
+	wv := &WebView{ctx: context.Background()}
+	pool.Release(wv)
+	require.True(t, wv.destroyed.Load(), "Release destroys user-loaded views")
+}

--- a/internal/infrastructure/cef/runtime_activity.go
+++ b/internal/infrastructure/cef/runtime_activity.go
@@ -151,19 +151,16 @@ func (t *RuntimeActivityTracker) NoteDownloadStarted(browserID int32, downloadID
 func (t *RuntimeActivityTracker) NoteDownloadProgress(_ int32, _ uint32) {}
 
 // NoteDownloadTerminal records one terminal download event (complete,
-// cancel, or failure). Duplicate terminals are idempotent; terminals for
-// unknown IDs resolve no owner and change nothing.
-func (t *RuntimeActivityTracker) NoteDownloadTerminal(downloadID uint32) {
+// cancel, or failure) for the exact owning browser. Duplicate terminals are
+// idempotent; terminals for unknown owners change nothing, so one browser
+// completing a download ID never clears another browser's same ID.
+func (t *RuntimeActivityTracker) NoteDownloadTerminal(browserID int32, downloadID uint32) {
 	if t == nil {
 		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for owner := range t.downloads {
-		if owner.downloadID == downloadID {
-			delete(t.downloads, owner)
-		}
-	}
+	delete(t.downloads, downloadOwner{browserID: browserID, downloadID: downloadID})
 	t.notifyLocked()
 }
 

--- a/internal/infrastructure/cef/runtime_activity.go
+++ b/internal/infrastructure/cef/runtime_activity.go
@@ -1,0 +1,232 @@
+package cef
+
+import (
+	"sync"
+
+	"github.com/bnema/dumber/internal/application/port"
+)
+
+// downloadOwner identifies one download by its owning browser and the CEF
+// download ID. Filename and destination are never identity: they can collide
+// or change mid-download.
+type downloadOwner struct {
+	browserID  int32
+	downloadID uint32
+}
+
+// RuntimeActivityTracker implements port.RuntimeActivity for the CEF engine.
+// It counts accepted creations through OnAfterCreated/failure, registered
+// live views, outstanding GTK cleanup, and unterminated downloads. All
+// methods are safe for concurrent use from CEF callbacks; subscriber
+// delivery is sequenced under the tracker lock snapshot.
+type RuntimeActivityTracker struct {
+	mu          sync.Mutex
+	pending     int
+	active      int
+	cleanup     int
+	downloads   map[downloadOwner]struct{}
+	subscribers map[uint64]func(port.RuntimeActivitySnapshot)
+	nextSub     uint64
+}
+
+// NewRuntimeActivityTracker returns an idle tracker.
+func NewRuntimeActivityTracker() *RuntimeActivityTracker {
+	return &RuntimeActivityTracker{
+		downloads:   make(map[downloadOwner]struct{}),
+		subscribers: make(map[uint64]func(port.RuntimeActivitySnapshot)),
+	}
+}
+
+// Snapshot returns the current outstanding-work counts.
+func (t *RuntimeActivityTracker) Snapshot() port.RuntimeActivitySnapshot {
+	if t == nil {
+		return port.RuntimeActivitySnapshot{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.snapshotLocked()
+}
+
+// Subscribe delivers the current snapshot synchronously, then every later
+// transition in subscription order. The returned function unsubscribes.
+func (t *RuntimeActivityTracker) Subscribe(fn func(port.RuntimeActivitySnapshot)) (unsubscribe func()) {
+	if fn == nil {
+		return func() {}
+	}
+	if t == nil {
+		return func() {}
+	}
+	t.mu.Lock()
+	id := t.nextSub
+	t.nextSub++
+	t.subscribers[id] = fn
+	snapshot := t.snapshotLocked()
+	t.mu.Unlock()
+	fn(snapshot)
+	return func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		delete(t.subscribers, id)
+	}
+}
+
+// NoteCreationAccepted records one accepted browser creation.
+func (t *RuntimeActivityTracker) NoteCreationAccepted() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.pending++
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteCreationResolved records one creation resolved through OnAfterCreated
+// (registered) or a definitive failure. Over-resolution is clamped at zero.
+func (t *RuntimeActivityTracker) NoteCreationResolved() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.pending > 0 {
+		t.pending--
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteViewRegistered records one live view registration.
+func (t *RuntimeActivityTracker) NoteViewRegistered() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.active++
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteViewCloseStarted records one native close: the view leaves the active
+// set and enters GTK-teardown outstanding.
+func (t *RuntimeActivityTracker) NoteViewCloseStarted() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.active > 0 {
+		t.active--
+	}
+	t.cleanup++
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteCleanupCompleted records one finished GTK bridge/popup cleanup.
+func (t *RuntimeActivityTracker) NoteCleanupCompleted() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.cleanup > 0 {
+		t.cleanup--
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteDownloadStarted records one download start keyed by owning browser and
+// CEF download ID.
+func (t *RuntimeActivityTracker) NoteDownloadStarted(browserID int32, downloadID uint32) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.downloads[downloadOwner{browserID: browserID, downloadID: downloadID}] = struct{}{}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteDownloadProgress is observed without effect: only start and terminal
+// events change activity. Progress without a start never creates work.
+func (t *RuntimeActivityTracker) NoteDownloadProgress(_ int32, _ uint32) {}
+
+// NoteDownloadTerminal records one terminal download event (complete,
+// cancel, or failure). Duplicate terminals are idempotent; terminals for
+// unknown IDs resolve no owner and change nothing.
+func (t *RuntimeActivityTracker) NoteDownloadTerminal(downloadID uint32) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	for owner := range t.downloads {
+		if owner.downloadID == downloadID {
+			delete(t.downloads, owner)
+		}
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// DropBrowser reconciles owner destruction through the native lifecycle:
+// entries owned by a destroyed browser can never receive terminal events.
+// It is never driven by window removal alone.
+func (t *RuntimeActivityTracker) DropBrowser(browserID int32) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	changed := false
+	for owner := range t.downloads {
+		if owner.browserID == browserID {
+			delete(t.downloads, owner)
+			changed = true
+		}
+	}
+	if !changed {
+		t.mu.Unlock()
+		return
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+func (t *RuntimeActivityTracker) snapshotLocked() port.RuntimeActivitySnapshot {
+	return port.RuntimeActivitySnapshot{
+		PendingCreations: t.pending,
+		ActiveViews:      t.active,
+		PendingCleanup:   t.cleanup,
+		ActiveDownloads:  len(t.downloads),
+	}
+}
+
+func (t *RuntimeActivityTracker) subscribersLocked() []func(port.RuntimeActivitySnapshot) {
+	subs := make([]func(port.RuntimeActivitySnapshot), 0, len(t.subscribers))
+	for id := uint64(0); id < t.nextSub; id++ {
+		if fn, ok := t.subscribers[id]; ok {
+			subs = append(subs, fn)
+		}
+	}
+	return subs
+}
+
+func notifyRuntimeActivitySubscribers(subs []func(port.RuntimeActivitySnapshot), snapshot port.RuntimeActivitySnapshot) {
+	for _, fn := range subs {
+		fn(snapshot)
+	}
+}

--- a/internal/infrastructure/cef/runtime_activity.go
+++ b/internal/infrastructure/cef/runtime_activity.go
@@ -17,8 +17,10 @@ type downloadOwner struct {
 // RuntimeActivityTracker implements port.RuntimeActivity for the CEF engine.
 // It counts accepted creations through OnAfterCreated/failure, registered
 // live views, outstanding GTK cleanup, and unterminated downloads. All
-// methods are safe for concurrent use from CEF callbacks; subscriber
-// delivery is sequenced under the tracker lock snapshot.
+// methods are safe for concurrent use from CEF callbacks. Delivery is
+// serialized under the state lock, so the initial snapshot and every later
+// transition arrive in order; subscribers must not reenter the tracker.
+// A nil tracker is a safe no-op sink.
 type RuntimeActivityTracker struct {
 	mu          sync.Mutex
 	pending     int
@@ -48,21 +50,19 @@ func (t *RuntimeActivityTracker) Snapshot() port.RuntimeActivitySnapshot {
 }
 
 // Subscribe delivers the current snapshot synchronously, then every later
-// transition in subscription order. The returned function unsubscribes.
+// transition in subscription order. Delivery holds the state lock, so
+// callbacks must not call back into the tracker. The returned function
+// unsubscribes.
 func (t *RuntimeActivityTracker) Subscribe(fn func(port.RuntimeActivitySnapshot)) (unsubscribe func()) {
-	if fn == nil {
-		return func() {}
-	}
-	if t == nil {
+	if t == nil || fn == nil {
 		return func() {}
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	id := t.nextSub
 	t.nextSub++
 	t.subscribers[id] = fn
-	snapshot := t.snapshotLocked()
-	t.mu.Unlock()
-	fn(snapshot)
+	fn(t.snapshotLocked())
 	return func() {
 		t.mu.Lock()
 		defer t.mu.Unlock()
@@ -76,11 +76,9 @@ func (t *RuntimeActivityTracker) NoteCreationAccepted() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.pending++
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteCreationResolved records one creation resolved through OnAfterCreated
@@ -90,13 +88,11 @@ func (t *RuntimeActivityTracker) NoteCreationResolved() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.pending > 0 {
 		t.pending--
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteViewRegistered records one live view registration.
@@ -105,11 +101,9 @@ func (t *RuntimeActivityTracker) NoteViewRegistered() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.active++
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteViewCloseStarted records one native close: the view leaves the active
@@ -119,14 +113,12 @@ func (t *RuntimeActivityTracker) NoteViewCloseStarted() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.active > 0 {
 		t.active--
 	}
 	t.cleanup++
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteCleanupCompleted records one finished GTK bridge/popup cleanup.
@@ -135,13 +127,11 @@ func (t *RuntimeActivityTracker) NoteCleanupCompleted() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.cleanup > 0 {
 		t.cleanup--
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteDownloadStarted records one download start keyed by owning browser and
@@ -151,11 +141,9 @@ func (t *RuntimeActivityTracker) NoteDownloadStarted(browserID int32, downloadID
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.downloads[downloadOwner{browserID: browserID, downloadID: downloadID}] = struct{}{}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteDownloadProgress is observed without effect: only start and terminal
@@ -170,15 +158,13 @@ func (t *RuntimeActivityTracker) NoteDownloadTerminal(downloadID uint32) {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	for owner := range t.downloads {
 		if owner.downloadID == downloadID {
 			delete(t.downloads, owner)
 		}
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // DropBrowser reconciles owner destruction through the native lifecycle:
@@ -189,6 +175,7 @@ func (t *RuntimeActivityTracker) DropBrowser(browserID int32) {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	changed := false
 	for owner := range t.downloads {
 		if owner.browserID == browserID {
@@ -196,14 +183,9 @@ func (t *RuntimeActivityTracker) DropBrowser(browserID int32) {
 			changed = true
 		}
 	}
-	if !changed {
-		t.mu.Unlock()
-		return
+	if changed {
+		t.notifyLocked()
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
 }
 
 func (t *RuntimeActivityTracker) snapshotLocked() port.RuntimeActivitySnapshot {
@@ -215,18 +197,14 @@ func (t *RuntimeActivityTracker) snapshotLocked() port.RuntimeActivitySnapshot {
 	}
 }
 
-func (t *RuntimeActivityTracker) subscribersLocked() []func(port.RuntimeActivitySnapshot) {
-	subs := make([]func(port.RuntimeActivitySnapshot), 0, len(t.subscribers))
+// notifyLocked delivers the current snapshot to subscribers in subscription
+// order. The caller must hold t.mu and must not reenter the tracker from a
+// callback.
+func (t *RuntimeActivityTracker) notifyLocked() {
+	snapshot := t.snapshotLocked()
 	for id := uint64(0); id < t.nextSub; id++ {
 		if fn, ok := t.subscribers[id]; ok {
-			subs = append(subs, fn)
+			fn(snapshot)
 		}
-	}
-	return subs
-}
-
-func notifyRuntimeActivitySubscribers(subs []func(port.RuntimeActivitySnapshot), snapshot port.RuntimeActivitySnapshot) {
-	for _, fn := range subs {
-		fn(snapshot)
 	}
 }

--- a/internal/infrastructure/cef/runtime_activity_test.go
+++ b/internal/infrastructure/cef/runtime_activity_test.go
@@ -1,0 +1,111 @@
+package cef
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeActivityTrackerStartsQuiescent(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerCreationLifecycle(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	tracker.NoteCreationAccepted()
+	require.Equal(t, 1, tracker.Snapshot().PendingCreations)
+	require.False(t, tracker.Snapshot().Quiescent())
+
+	tracker.NoteCreationResolved()
+	require.True(t, tracker.Snapshot().Quiescent())
+
+	// Over-resolution clamps instead of going negative.
+	tracker.NoteCreationResolved()
+	require.Equal(t, 0, tracker.Snapshot().PendingCreations)
+}
+
+func TestRuntimeActivityTrackerViewLifecycle(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	tracker.NoteViewRegistered()
+	tracker.NoteViewRegistered()
+	require.Equal(t, 2, tracker.Snapshot().ActiveViews)
+
+	tracker.NoteViewCloseStarted()
+	snapshot := tracker.Snapshot()
+	require.Equal(t, 1, snapshot.ActiveViews)
+	require.Equal(t, 1, snapshot.PendingCleanup)
+	require.False(t, snapshot.Quiescent())
+
+	tracker.NoteCleanupCompleted()
+	tracker.NoteViewCloseStarted()
+	tracker.NoteCleanupCompleted()
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerDownloads(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+
+	// Same filename on two browsers are distinct owners.
+	tracker.NoteDownloadStarted(7, 100)
+	tracker.NoteDownloadStarted(9, 100)
+	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
+
+	// Progress without a start never creates work.
+	tracker.NoteDownloadProgress(7, 999)
+	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
+
+	// Terminal resolves every owner sharing the CEF download ID.
+	tracker.NoteDownloadTerminal(100)
+	require.Equal(t, 0, tracker.Snapshot().ActiveDownloads)
+
+	// Duplicate terminals are idempotent; unknown IDs change nothing.
+	tracker.NoteDownloadTerminal(100)
+	tracker.NoteDownloadTerminal(424242)
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerDropBrowser(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	tracker.NoteDownloadStarted(7, 100)
+	tracker.NoteDownloadStarted(9, 200)
+	tracker.DropBrowser(7)
+	snapshot := tracker.Snapshot()
+	require.Equal(t, 1, snapshot.ActiveDownloads)
+
+	tracker.NoteDownloadTerminal(200)
+	require.True(t, tracker.Snapshot().Quiescent())
+
+	// Dropping an unknown browser notifies nobody and changes nothing.
+	tracker.DropBrowser(12345)
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerSubscribeSequenced(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	var mu sync.Mutex
+	var seen []port.RuntimeActivitySnapshot
+	unsubscribe := tracker.Subscribe(func(snapshot port.RuntimeActivitySnapshot) {
+		mu.Lock()
+		seen = append(seen, snapshot)
+		mu.Unlock()
+	})
+	// Initial delivery is synchronous and quiescent.
+	mu.Lock()
+	require.Len(t, seen, 1)
+	require.True(t, seen[0].Quiescent())
+	mu.Unlock()
+
+	tracker.NoteCreationAccepted()
+	tracker.NoteCreationResolved()
+	unsubscribe()
+	tracker.NoteViewRegistered()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seen, 3, "unsubscribe stops delivery")
+	require.Equal(t, 1, seen[1].PendingCreations)
+	require.True(t, seen[2].Quiescent())
+}

--- a/internal/infrastructure/cef/runtime_activity_test.go
+++ b/internal/infrastructure/cef/runtime_activity_test.go
@@ -57,13 +57,16 @@ func TestRuntimeActivityTrackerDownloads(t *testing.T) {
 	tracker.NoteDownloadProgress(7, 999)
 	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
 
-	// Terminal resolves every owner sharing the CEF download ID.
-	tracker.NoteDownloadTerminal(100)
+	// Terminal resolves only the exact owner sharing the CEF download ID.
+	tracker.NoteDownloadTerminal(7, 100)
+	require.Equal(t, 1, tracker.Snapshot().ActiveDownloads)
+
+	tracker.NoteDownloadTerminal(9, 100)
 	require.Equal(t, 0, tracker.Snapshot().ActiveDownloads)
 
-	// Duplicate terminals are idempotent; unknown IDs change nothing.
-	tracker.NoteDownloadTerminal(100)
-	tracker.NoteDownloadTerminal(424242)
+	// Duplicate terminals are idempotent; unknown owners change nothing.
+	tracker.NoteDownloadTerminal(9, 100)
+	tracker.NoteDownloadTerminal(7, 424242)
 	require.True(t, tracker.Snapshot().Quiescent())
 }
 
@@ -75,7 +78,7 @@ func TestRuntimeActivityTrackerDropBrowser(t *testing.T) {
 	snapshot := tracker.Snapshot()
 	require.Equal(t, 1, snapshot.ActiveDownloads)
 
-	tracker.NoteDownloadTerminal(200)
+	tracker.NoteDownloadTerminal(9, 200)
 	require.True(t, tracker.Snapshot().Quiescent())
 
 	// Dropping an unknown browser notifies nobody and changes nothing.

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -1264,6 +1264,11 @@ func (wv *WebView) Destroy() {
 	if !wv.destroyed.CompareAndSwap(false, true) {
 		return
 	}
+	// Native close begins here: the view leaves the active set and enters
+	// GTK-teardown outstanding for the quiescence boundary.
+	if wv.engine != nil {
+		wv.engine.activity.NoteViewCloseStarted()
+	}
 	// Retire scroll motion the moment destruction begins, regardless of
 	// calling thread; GTK-only cleanup follows through the owning
 	// dispatcher without waiting for the deferred native browser close.

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -278,12 +278,12 @@ type WebView struct {
 	loadDiagLastLoadStateAt time.Time
 
 	// Atomic state.
-	destroyed                     atomic.Bool
-	fullscreen                    atomic.Bool
+	destroyed  atomic.Bool
+	fullscreen atomic.Bool
 	// bridgeTeardownNoted gates quiescence accounting exactly once per
 	// view: every bridge teardown is scheduled through the Sync/Async
 	// wrappers below and completes in destroyViewBridgeOnGTKThread.
-	bridgeTeardownNoted         atomic.Bool
+	bridgeTeardownNoted           atomic.Bool
 	generation                    atomic.Uint64
 	audioPlaying                  atomic.Bool
 	zoomFactor                    atomic.Value // float64, initialized to 1.0

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -280,6 +280,10 @@ type WebView struct {
 	// Atomic state.
 	destroyed                     atomic.Bool
 	fullscreen                    atomic.Bool
+	// bridgeTeardownNoted gates quiescence accounting exactly once per
+	// view: every bridge teardown is scheduled through the Sync/Async
+	// wrappers below and completes in destroyViewBridgeOnGTKThread.
+	bridgeTeardownNoted         atomic.Bool
 	generation                    atomic.Uint64
 	audioPlaying                  atomic.Bool
 	zoomFactor                    atomic.Value // float64, initialized to 1.0
@@ -1264,11 +1268,6 @@ func (wv *WebView) Destroy() {
 	if !wv.destroyed.CompareAndSwap(false, true) {
 		return
 	}
-	// Native close begins here: the view leaves the active set and enters
-	// GTK-teardown outstanding for the quiescence boundary.
-	if wv.engine != nil {
-		wv.engine.activity.NoteViewCloseStarted()
-	}
 	// Retire scroll motion the moment destruction begins, regardless of
 	// calling thread; GTK-only cleanup follows through the owning
 	// dispatcher without waiting for the deferred native browser close.
@@ -1323,6 +1322,7 @@ func (wv *WebView) destroyViewBridgeOnGTKSync() {
 	if wv == nil || wv.viewBridge == nil {
 		return
 	}
+	wv.noteBridgeTeardownScheduled()
 	wv.runOnGTKSyncLabelAllowLateStart("cef.destroy_view_bridge", true, func() {
 		wv.destroyViewBridgeOnGTKThread()
 	})
@@ -1332,9 +1332,27 @@ func (wv *WebView) destroyViewBridgeOnGTKAsync() {
 	if wv == nil || wv.viewBridge == nil {
 		return
 	}
+	wv.noteBridgeTeardownScheduled()
 	wv.runOnGTK(func() {
 		wv.destroyViewBridgeOnGTKThread()
 	})
+}
+
+// noteBridgeTeardownScheduled records one outstanding GTK teardown for the
+// quiescence boundary. Exactly one caller wins per view however often the
+// Sync/Async wrappers race; the matching completion lands in
+// destroyViewBridgeOnGTKThread, which runs exactly once per view because it
+// nils the bridge on completion.
+func (wv *WebView) noteBridgeTeardownScheduled() {
+	if wv == nil {
+		return
+	}
+	if !wv.bridgeTeardownNoted.CompareAndSwap(false, true) {
+		return
+	}
+	if wv.engine != nil {
+		wv.engine.activity.NoteViewCloseStarted()
+	}
 }
 
 func (wv *WebView) destroyViewBridgeOnGTKThread() {
@@ -1355,6 +1373,11 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 	_ = wv.viewBridge.Destroy()
 	wv.viewBridge = nil
 	wv.nativeWidget = nil
+	// The bridge actually tore down here (second arrivals return early on
+	// the nil guard above), completing the outstanding teardown exactly once.
+	if wv.engine != nil {
+		wv.engine.activity.NoteCleanupCompleted()
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -841,6 +841,11 @@ func (h *handlerSet) OnAfterCreated(browser purecef.Browser) {
 	host := browser.GetHost()
 	if host == nil {
 		log.Warn().Msg("cef: OnAfterCreated returned nil host")
+		if h.wv.engine != nil {
+			// No view will ever attach to this browser: resolve the
+			// pending count so quiescence cannot strand on it.
+			h.wv.engine.activity.NoteCreationResolved()
+		}
 		return
 	}
 
@@ -1091,7 +1096,7 @@ func (h *handlerSet) OnBeforeDownload(
 }
 
 func (h *handlerSet) OnDownloadUpdated(
-	_ purecef.Browser,
+	browser purecef.Browser,
 	downloadItem purecef.DownloadItem,
 	callback purecef.DownloadItemCallback,
 ) {
@@ -1099,7 +1104,7 @@ func (h *handlerSet) OnDownloadUpdated(
 	if handler == nil {
 		return
 	}
-	handler.onDownloadUpdated(h.currentContext(), downloadItem, callback)
+	handler.onDownloadUpdated(h.currentContext(), browser, downloadItem, callback)
 }
 
 func (h *handlerSet) downloadHandler() *downloadHandler {

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -828,6 +828,11 @@ func (h *handlerSet) OnAfterCreated(browser purecef.Browser) {
 	log := logging.FromContext(h.wv.ctx)
 	if browser == nil {
 		log.Warn().Msg("cef: OnAfterCreated called with nil browser")
+		if h.wv.engine != nil {
+			// No browser will ever complete this creation: resolve the
+			// pending count so quiescence cannot strand on it.
+			h.wv.engine.activity.NoteCreationResolved()
+		}
 		return
 	}
 	browserID := browser.GetIdentifier()
@@ -845,6 +850,9 @@ func (h *handlerSet) OnAfterCreated(browser purecef.Browser) {
 			Int32("browser_id", browserID).
 			Int32("existing_browser_id", state.duplicateBrowserID).
 			Msg("cef: duplicate popup browser attached after shell already had a browser; closing duplicate")
+		if h.wv.engine != nil {
+			h.wv.engine.activity.NoteCreationResolved()
+		}
 		host.CloseBrowser(1)
 		return
 	}

--- a/internal/infrastructure/config/engine.go
+++ b/internal/infrastructure/config/engine.go
@@ -112,6 +112,11 @@ type CEFEngineConfig struct {
 	WindowlessFrameRateMax int32 `mapstructure:"windowless_frame_rate_max" toml:"windowless_frame_rate_max" yaml:"windowless_frame_rate_max"` //nolint:lll // struct tags exceed lll limit
 	// Input controls GTK input translation before events are forwarded to CEF.
 	Input CEFInputConfig `mapstructure:"input" toml:"input" yaml:"input"`
+	// IdleRuntimeTimeoutMs bounds opt-in CEF runtime residency after the last
+	// user window closes. Integer milliseconds, default 0 (disabled),
+	// accepted range 0..300000. Read once at process startup; changes require
+	// a restart and are never partially hot-applied.
+	IdleRuntimeTimeoutMs int `mapstructure:"idle_runtime_timeout_ms" toml:"idle_runtime_timeout_ms" yaml:"idle_runtime_timeout_ms"`
 	// EnableAudioHandler opts into the experimental CEF AudioHandler bridge.
 	EnableAudioHandler bool `mapstructure:"enable_audio_handler" toml:"enable_audio_handler" yaml:"enable_audio_handler"`
 	// TraceHandlers enables purego-cef handler/refcount tracing for diagnostics.

--- a/internal/infrastructure/config/idle_runtime_timeout_test.go
+++ b/internal/infrastructure/config/idle_runtime_timeout_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleRuntimeTimeoutDefaultsToDisabled(t *testing.T) {
+	require.Equal(t, 0, DefaultConfig().Engine.CEF.IdleRuntimeTimeoutMs)
+}
+
+func TestIdleRuntimeTimeoutFileOverride(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\nidle_runtime_timeout_ms = 60000\n"), 0o600))
+
+	m := &Manager{viper: viper.New()}
+	m.viper.SetConfigFile(configPath)
+	m.viper.SetConfigType("toml")
+	m.configureAutomaticEnv()
+	m.setDefaults()
+	require.NoError(t, m.viper.ReadInConfig())
+
+	require.Equal(t, 60000, m.viper.GetInt("engine.cef.idle_runtime_timeout_ms"))
+}
+
+func TestIdleRuntimeTimeoutEnvMapping(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\n"), 0o600))
+	t.Setenv("DUMBER_ENGINE_CEF_IDLE_RUNTIME_TIMEOUT_MS", "45000")
+
+	m := &Manager{viper: viper.New()}
+	m.viper.SetConfigFile(configPath)
+	m.viper.SetConfigType("toml")
+	m.configureAutomaticEnv()
+	m.setDefaults()
+	require.NoError(t, m.viper.ReadInConfig())
+
+	require.Equal(t, 45000, m.viper.GetInt("engine.cef.idle_runtime_timeout_ms"))
+}
+
+func TestIdleRuntimeTimeoutStableAcrossUnrelatedReload(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\nidle_runtime_timeout_ms = 60000\n"), 0o600))
+
+	load := func() int {
+		m := &Manager{viper: viper.New()}
+		m.viper.SetConfigFile(configPath)
+		m.viper.SetConfigType("toml")
+		m.configureAutomaticEnv()
+		m.setDefaults()
+		require.NoError(t, m.viper.ReadInConfig())
+		return m.viper.GetInt("engine.cef.idle_runtime_timeout_ms")
+	}
+	require.Equal(t, 60000, load())
+
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\nidle_runtime_timeout_ms = 60000\nlog_severity = 3\n"), 0o600))
+	require.Equal(t, 60000, load(), "unrelated reload must not change the effective timeout")
+}

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -808,6 +808,7 @@ func (m *Manager) setEngineDefaults(defaults *Config) {
 	m.viper.SetDefault("engine.cef.windowless_frame_rate_max", ce.CEFWindowlessFrameRateMax())
 	m.viper.SetDefault("engine.cef.enable_audio_handler", ce.EnableAudioHandler)
 	m.viper.SetDefault("engine.cef.trace_handlers", ce.TraceHandlers)
+	m.viper.SetDefault("engine.cef.idle_runtime_timeout_ms", ce.IdleRuntimeTimeoutMs)
 	m.setCEFInputDefaults(ce.Input)
 
 	wk := e.WebKit

--- a/internal/infrastructure/config/schema_provider.go
+++ b/internal/infrastructure/config/schema_provider.go
@@ -1118,6 +1118,14 @@ func (*SchemaProvider) getPerformanceKeys(defaults *Config) []entity.ConfigKeyIn
 			Section:     SectionPerformance,
 		},
 		{
+			Key:         "engine.cef.idle_runtime_timeout_ms",
+			Type:        "int",
+			Default:     fmt.Sprintf("%d", defaults.Engine.CEF.IdleRuntimeTimeoutMs),
+			Description: "Bounded opt-in CEF runtime residency in milliseconds after the last window closes; 0 disables, changes require restart",
+			Range:       "0..300000",
+			Section:     SectionPerformance,
+		},
+		{
 			Key:         "engine.cef.input.scroll_wheel_multiplier",
 			Type:        "float64",
 			Default:     fmt.Sprintf("%.2f", defaults.Engine.CEF.Input.ScrollWheelMultiplier),

--- a/internal/infrastructure/config/validation.go
+++ b/internal/infrastructure/config/validation.go
@@ -501,6 +501,9 @@ func validateCEF(config *Config) []string {
 	if config.Engine.CEF.WindowlessFrameRateMax < 0 {
 		validationErrors = append(validationErrors, "engine.cef.windowless_frame_rate_max must be >= 0")
 	}
+	if config.Engine.CEF.IdleRuntimeTimeoutMs < 0 || config.Engine.CEF.IdleRuntimeTimeoutMs > 300000 {
+		validationErrors = append(validationErrors, "engine.cef.idle_runtime_timeout_ms must be within 0..300000")
+	}
 
 	input := config.Engine.CEF.Input
 	if invalidPositiveFloat(input.ScrollWheelMultiplier) {

--- a/internal/infrastructure/config/validation_test.go
+++ b/internal/infrastructure/config/validation_test.go
@@ -198,6 +198,36 @@ func TestValidateConfig_CEFConfig(t *testing.T) {
 			wantText: "engine.cef.windowless_frame_rate",
 		},
 		{
+			name: "zero idle residency timeout disables",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = 0
+			},
+			wantErr: false,
+		},
+		{
+			name: "maximum idle residency timeout accepted",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = 300000
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative idle residency timeout",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = -1
+			},
+			wantErr:  true,
+			wantText: "engine.cef.idle_runtime_timeout_ms",
+		},
+		{
+			name: "oversized idle residency timeout",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = 300001
+			},
+			wantErr:  true,
+			wantText: "engine.cef.idle_runtime_timeout_ms",
+		},
+		{
 			name: "zero wheel multiplier",
 			mutate: func(cfg *Config) {
 				cfg.Engine.CEF.Input.ScrollWheelMultiplier = 0

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/bnema/dumber/internal/logging"
+	"github.com/rs/zerolog"
 )
 
 const browserLaunchSocketName = "browser-launch.sock"
@@ -55,7 +56,25 @@ type browserLaunchAction string
 const (
 	browserLaunchActionOpenExternalURL browserLaunchAction = "open-external-url"
 	browserLaunchActionOpenFreshWindow browserLaunchAction = "open-fresh-window"
+	// browserLaunchActionCloseAllWindows is a diagnostic-only action for the
+	// residency harness: it closes every user window through the standard
+	// removal path. It is honored only when the OWNING process sets
+	// DUMBER_DIAGNOSTIC_WINDOW_CLOSE=1; otherwise it is rejected before
+	// acknowledgement. It is never a general unauthenticated shutdown
+	// command: the relay socket itself remains owner-only (0700, uid).
+	browserLaunchActionCloseAllWindows browserLaunchAction = "close-all-windows"
 )
+
+// diagnosticWindowCloseEnvVar gates the diagnostic close action on the
+// owning (server) process environment.
+const diagnosticWindowCloseEnvVar = "DUMBER_DIAGNOSTIC_WINDOW_CLOSE"
+
+// windowCloseOpener is implemented by openers that support the diagnostic
+// close action. It is matched structurally so the port interface is
+// unchanged.
+type windowCloseOpener interface {
+	CloseAllWindows(ctx context.Context) error
+}
 
 type browserLaunchResponse struct {
 	RequestID string `json:"request_id,omitempty"`
@@ -343,6 +362,47 @@ func (l *browserLaunchRelayListener) serve(ctx context.Context, opener port.Brow
 	}
 }
 
+// admitRelayConnection acquires one admission lease for the decoded request
+// and enforces pre-acknowledgement eligibility. It returns nil after sending
+// an error response (closed admission or unauthorized diagnostic action);
+// the caller must return without acknowledging. An admitted lease is released
+// by the caller on early failure and by dispatch completion otherwise.
+func admitRelayConnection(
+	conn *net.UnixConn,
+	configured *process.AdmissionGate,
+	request browserLaunchRequest,
+	requestID string,
+	log *zerolog.Logger,
+) *process.AdmissionGate {
+	gate := configured
+	if gate == nil {
+		gate = process.NewAdmissionGate()
+	}
+	refuse := func(errorBody string) *process.AdmissionGate {
+		if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
+			return nil
+		}
+		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Error: errorBody})
+		return nil
+	}
+	if !gate.Acquire() {
+		log.Debug().
+			Str("request_id", requestID).
+			Msg("browser launch relay refused request after admission closed")
+		return refuse("shutting down")
+	}
+	// The diagnostic close action is rejected before acknowledgement
+	// unless the owning process explicitly enables it.
+	if request.Action == browserLaunchActionCloseAllWindows && os.Getenv(diagnosticWindowCloseEnvVar) != "1" {
+		gate.Release()
+		log.Warn().
+			Str("request_id", requestID).
+			Msg("browser launch relay rejected diagnostic close without owner opt-in")
+		return refuse("diagnostic close not enabled")
+	}
+	return gate
+}
+
 func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn *net.UnixConn, opener port.BrowserWindowOpener) {
 	defer func() { _ = conn.Close() }()
 	log := logging.FromContext(ctx)
@@ -367,18 +427,8 @@ func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn 
 	// error response here, never an acknowledgement for work that will not
 	// run. Acknowledgement still precedes expensive UI dispatch below, and
 	// unconfirmed delivery keeps its no-duplicate-fallback semantics.
-	gate := l.admission
+	gate := admitRelayConnection(conn, l.admission, request, requestID, log)
 	if gate == nil {
-		gate = process.NewAdmissionGate()
-	}
-	if !gate.Acquire() {
-		if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
-			return
-		}
-		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Error: "shutting down"})
-		log.Debug().
-			Str("request_id", requestID).
-			Msg("browser launch relay refused request after admission closed")
 		return
 	}
 
@@ -423,6 +473,12 @@ func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn 
 			err = opener.OpenExternalURL(ctx, request.URL)
 		case browserLaunchActionOpenFreshWindow:
 			err = opener.OpenFreshWindow(ctx, request.URL)
+		case browserLaunchActionCloseAllWindows:
+			if closer, ok := opener.(windowCloseOpener); ok {
+				err = closer.CloseAllWindows(ctx)
+			} else {
+				err = errors.New("browser launch relay opener does not support diagnostic close")
+			}
 		default:
 			log.Warn().
 				Str("request_id", requestID).

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/bnema/dumber/internal/logging"
 )
@@ -36,6 +37,11 @@ var ErrBrowserLaunchRelayUnconfirmed = errors.New("browser launch relay did not 
 
 type browserLaunchRelay struct {
 	ipc runtimeprofile.IPCPaths
+	// admission is the shared admission/work-lease boundary: a lease is
+	// acquired before sending Accepted and released when dispatch settles.
+	// Shutdown closes it so losing requests get an error response instead
+	// of an acknowledgement. Initialized eagerly; never nil.
+	admission *process.AdmissionGate
 }
 
 type browserLaunchRequest struct {
@@ -60,6 +66,7 @@ type browserLaunchResponse struct {
 type browserLaunchRelayListener struct {
 	listener   *net.UnixListener
 	socketPath string
+	admission  *process.AdmissionGate
 	once       sync.Once
 	err        error
 }
@@ -73,7 +80,21 @@ var newBrowserLaunchRequestID = func() string {
 }
 
 func NewBrowserLaunchRelay(ipc runtimeprofile.IPCPaths) port.BrowserLaunchRelay {
-	return &browserLaunchRelay{ipc: ipc}
+	return &browserLaunchRelay{ipc: ipc, admission: process.NewAdmissionGate()}
+}
+
+// AdmissionGateProvider exposes the relay's shared admission boundary
+// without extending the port interface or regenerating mocks.
+type AdmissionGateProvider interface {
+	AdmissionGate() *process.AdmissionGate
+}
+
+// AdmissionGate returns the shared admission/work-lease boundary.
+func (r *browserLaunchRelay) AdmissionGate() *process.AdmissionGate {
+	if r == nil || r.admission == nil {
+		return process.NewAdmissionGate()
+	}
+	return r.admission
 }
 
 func (r *browserLaunchRelay) DeliverOpenExternalURL(ctx context.Context, url string) (bool, error) {
@@ -269,7 +290,7 @@ func (r *browserLaunchRelay) Listen(ctx context.Context, opener port.BrowserWind
 		}
 	}
 
-	relayListener := &browserLaunchRelayListener{listener: listener, socketPath: socketPath}
+	relayListener := &browserLaunchRelayListener{listener: listener, socketPath: socketPath, admission: r.AdmissionGate()}
 	go relayListener.serve(ctx, opener)
 
 	return relayListener, nil
@@ -322,7 +343,7 @@ func (l *browserLaunchRelayListener) serve(ctx context.Context, opener port.Brow
 	}
 }
 
-func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *net.UnixConn, opener port.BrowserWindowOpener) {
+func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn *net.UnixConn, opener port.BrowserWindowOpener) {
 	defer func() { _ = conn.Close() }()
 	log := logging.FromContext(ctx)
 	if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
@@ -342,7 +363,27 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 		Str("url_host", safeURLHost(request.URL)).
 		Msg("browser launch relay request received")
 
+	// Admit before acknowledgement: losing requests receive the existing
+	// error response here, never an acknowledgement for work that will not
+	// run. Acknowledgement still precedes expensive UI dispatch below, and
+	// unconfirmed delivery keeps its no-duplicate-fallback semantics.
+	gate := l.admission
+	if gate == nil {
+		gate = process.NewAdmissionGate()
+	}
+	if !gate.Acquire() {
+		if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
+			return
+		}
+		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Error: "shutting down"})
+		log.Debug().
+			Str("request_id", requestID).
+			Msg("browser launch relay refused request after admission closed")
+		return
+	}
+
 	if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
+		gate.Release()
 		return
 	}
 	if err := json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Accepted: true}); err != nil {
@@ -350,6 +391,7 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
 			Msg("failed to encode browser launch response")
+		gate.Release()
 		return
 	}
 	log.Debug().
@@ -358,6 +400,11 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 		Msg("browser launch relay request accepted")
 
 	go func() {
+		// The lease spans acknowledgement through dispatch completion or
+		// definitive factory/dispatch failure. Factory/dispatch failure
+		// retains the documented existing failure semantics and never
+		// triggers duplicate fallback.
+		defer gate.Release()
 		if opener == nil {
 			log.Warn().
 				Str("request_id", requestID).

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -108,6 +108,9 @@ type AdmissionGateProvider interface {
 	AdmissionGate() *process.AdmissionGate
 }
 
+// Compile-time check: the shared gate implements the application boundary.
+var _ port.AdmissionBoundary = (*process.AdmissionGate)(nil)
+
 // AdmissionGate returns the shared admission/work-lease boundary.
 func (r *browserLaunchRelay) AdmissionGate() *process.AdmissionGate {
 	if r == nil || r.admission == nil {

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/stretchr/testify/assert"
@@ -651,7 +652,7 @@ func TestBrowserLaunchRelay_SilentClientDoesNotStallListener(t *testing.T) {
 }
 
 type blockingRelayOpener struct {
-	release chan struct{}
+	release  chan struct{}
 	received chan string
 }
 
@@ -665,7 +666,7 @@ func (o *blockingRelayOpener) OpenFreshWindow(_ context.Context, url string) err
 	return o.OpenExternalURL(context.Background(), url)
 }
 
-func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) *browserLaunchRelay {
+func startLeaseTestListener(t *testing.T, opener port.BrowserWindowOpener) *browserLaunchRelay {
 	t.Helper()
 	ipc := testIPC(shortTempDir(t))
 	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
@@ -757,4 +758,50 @@ func TestBrowserLaunchRelay_ClosedAdmissionSendsErrorResponse(t *testing.T) {
 	case <-time.After(300 * time.Millisecond):
 	}
 	_ = delivered
+}
+
+type closeTrackingOpener struct {
+	*blockingRelayOpener
+	closed chan struct{}
+}
+
+func (o *closeTrackingOpener) CloseAllWindows(_ context.Context) error {
+	close(o.closed)
+	return nil
+}
+
+func sendRelayAction(t *testing.T, socketPath, action string) browserLaunchResponse {
+	t.Helper()
+	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: socketPath, Net: "unix"})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, conn.SetDeadline(time.Now().Add(3*time.Second)))
+	require.NoError(t, json.NewEncoder(conn).Encode(browserLaunchRequest{RequestID: "diag-1", Action: browserLaunchAction(action)}))
+	var response browserLaunchResponse
+	require.NoError(t, json.NewDecoder(conn).Decode(&response))
+	return response
+}
+
+func TestBrowserLaunchRelay_DiagnosticCloseRejectedWithoutOptIn(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
+	close(opener.release)
+	relay := startLeaseTestListener(t, opener)
+	response := sendRelayAction(t, relay.ipc.BrowserLaunchSocket, "close-all-windows")
+	require.False(t, response.Accepted, "rejected close must not acknowledge")
+	require.Contains(t, response.Error, "diagnostic close not enabled")
+}
+
+func TestBrowserLaunchRelay_DiagnosticCloseDispatchedWithOptIn(t *testing.T) {
+	t.Setenv(diagnosticWindowCloseEnvVar, "1")
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
+	close(opener.release)
+	tracker := &closeTrackingOpener{blockingRelayOpener: opener, closed: make(chan struct{})}
+	relay := startLeaseTestListener(t, tracker)
+	response := sendRelayAction(t, relay.ipc.BrowserLaunchSocket, "close-all-windows")
+	require.True(t, response.Accepted)
+	select {
+	case <-tracker.closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("diagnostic close never reached the opener")
+	}
 }

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -666,7 +665,7 @@ func (o *blockingRelayOpener) OpenFreshWindow(_ context.Context, url string) err
 	return o.OpenExternalURL(context.Background(), url)
 }
 
-func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) (*browserLaunchRelay, io.Closer) {
+func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) *browserLaunchRelay {
 	t.Helper()
 	ipc := testIPC(shortTempDir(t))
 	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
@@ -676,7 +675,7 @@ func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) (*browser
 	closer, err := relay.Listen(ctx, opener)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
-	return relay, closer
+	return relay
 }
 
 func waitForLeaseCount(t *testing.T, gate *process.AdmissionGate, want int) {
@@ -693,7 +692,7 @@ func waitForLeaseCount(t *testing.T, gate *process.AdmissionGate, want int) {
 
 func TestBrowserLaunchRelay_HoldsLeaseThroughDispatch(t *testing.T) {
 	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 2)}
-	relay, _ := startLeaseTestListener(t, opener)
+	relay := startLeaseTestListener(t, opener)
 	gate := relay.AdmissionGate()
 
 	delivered := make(chan error, 1)
@@ -721,7 +720,7 @@ func TestBrowserLaunchRelay_HoldsLeaseThroughDispatch(t *testing.T) {
 
 func TestBrowserLaunchRelay_SimultaneousOpensHoldLeases(t *testing.T) {
 	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 4)}
-	relay, _ := startLeaseTestListener(t, opener)
+	relay := startLeaseTestListener(t, opener)
 	gate := relay.AdmissionGate()
 
 	for range 2 {
@@ -743,7 +742,7 @@ func TestBrowserLaunchRelay_SimultaneousOpensHoldLeases(t *testing.T) {
 
 func TestBrowserLaunchRelay_ClosedAdmissionSendsErrorResponse(t *testing.T) {
 	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
-	relay, _ := startLeaseTestListener(t, opener)
+	relay := startLeaseTestListener(t, opener)
 	gate := relay.AdmissionGate()
 	close(opener.release)
 

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -647,4 +649,113 @@ func TestBrowserLaunchRelay_SilentClientDoesNotStallListener(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected opener to receive the URL")
 	}
+}
+
+type blockingRelayOpener struct {
+	release chan struct{}
+	received chan string
+}
+
+func (o *blockingRelayOpener) OpenExternalURL(_ context.Context, url string) error {
+	o.received <- url
+	<-o.release
+	return nil
+}
+
+func (o *blockingRelayOpener) OpenFreshWindow(_ context.Context, url string) error {
+	return o.OpenExternalURL(context.Background(), url)
+}
+
+func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) (*browserLaunchRelay, io.Closer) {
+	t.Helper()
+	ipc := testIPC(shortTempDir(t))
+	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
+	relay := NewBrowserLaunchRelay(ipc).(*browserLaunchRelay)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	closer, err := relay.Listen(ctx, opener)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+	return relay, closer
+}
+
+func waitForLeaseCount(t *testing.T, gate *process.AdmissionGate, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if gate.Active() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("lease count = %d, want %d", gate.Active(), want)
+}
+
+func TestBrowserLaunchRelay_HoldsLeaseThroughDispatch(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 2)}
+	relay, _ := startLeaseTestListener(t, opener)
+	gate := relay.AdmissionGate()
+
+	delivered := make(chan error, 1)
+	go func() {
+		_, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/lease")
+		delivered <- err
+	}()
+	select {
+	case url := <-opener.received:
+		require.Equal(t, "https://example.com/lease", url)
+	case <-time.After(3 * time.Second):
+		t.Fatal("opener never received the request")
+	}
+	// Acknowledged and dispatched: the lease is held until dispatch settles.
+	waitForLeaseCount(t, gate, 1)
+	select {
+	case err := <-delivered:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("client never received acknowledgement")
+	}
+	close(opener.release)
+	waitForLeaseCount(t, gate, 0)
+}
+
+func TestBrowserLaunchRelay_SimultaneousOpensHoldLeases(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 4)}
+	relay, _ := startLeaseTestListener(t, opener)
+	gate := relay.AdmissionGate()
+
+	for range 2 {
+		go func() {
+			_, _ = relay.DeliverOpenExternalURL(context.Background(), "https://example.com/parallel")
+		}()
+	}
+	for range 2 {
+		select {
+		case <-opener.received:
+		case <-time.After(3 * time.Second):
+			t.Fatal("opener never received a parallel request")
+		}
+	}
+	waitForLeaseCount(t, gate, 2)
+	close(opener.release)
+	waitForLeaseCount(t, gate, 0)
+}
+
+func TestBrowserLaunchRelay_ClosedAdmissionSendsErrorResponse(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
+	relay, _ := startLeaseTestListener(t, opener)
+	gate := relay.AdmissionGate()
+	close(opener.release)
+
+	gate.Close()
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/late")
+	require.Error(t, err, "losing request must receive the error response")
+	require.Contains(t, err.Error(), "shutting down")
+	require.Equal(t, 0, gate.Active(), "refused requests hold no lease")
+	select {
+	case url := <-opener.received:
+		t.Fatalf("refused request reached the opener: %s", url)
+	case <-time.After(300 * time.Millisecond):
+	}
+	_ = delivered
 }

--- a/internal/infrastructure/process/admission_gate.go
+++ b/internal/infrastructure/process/admission_gate.go
@@ -61,6 +61,15 @@ func (g *AdmissionGate) Close() {
 	g.closed = true
 }
 
+// Reopen resumes admission after a seal that no longer applies: an
+// invalidated deferred quit (e.g. a reopened window) must not leave the
+// surviving process permanently deaf to relay requests.
+func (g *AdmissionGate) Reopen() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.closed = false
+}
+
 // Closed reports whether admission is stopped.
 func (g *AdmissionGate) Closed() bool {
 	g.mu.Lock()

--- a/internal/infrastructure/process/admission_gate.go
+++ b/internal/infrastructure/process/admission_gate.go
@@ -1,0 +1,115 @@
+package process
+
+import (
+	"context"
+	"sync"
+)
+
+// AdmissionGate is a narrow thread-safe admission/work-lease boundary shared
+// by the relay listener and the shutdown/residency policy. A lease must be
+// acquired before sending an acknowledgement; shutdown atomically stops
+// admission while admitted work drains. It never blocks the holder: waiting
+// uses WaitDrained with a caller-provided bounded context.
+type AdmissionGate struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	closed   bool
+	active   int
+	onDrained []func()
+}
+
+// NewAdmissionGate returns an open gate with no active leases.
+func NewAdmissionGate() *AdmissionGate {
+	gate := &AdmissionGate{}
+	gate.cond = sync.NewCond(&gate.mu)
+	return gate
+}
+
+// Acquire takes one work lease. It reports false when admission is closed;
+// the caller must then send the existing error response before any
+// acknowledgement and must not dispatch.
+func (g *AdmissionGate) Acquire() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closed {
+		return false
+	}
+	g.active++
+	return true
+}
+
+// Release returns one work lease. The final release wakes drain waiters and
+// notifies drain subscribers.
+func (g *AdmissionGate) Release() {
+	g.mu.Lock()
+	var notify []func()
+	if g.active > 0 {
+		g.active--
+	}
+	if g.active == 0 {
+		g.cond.Broadcast()
+		notify = append([]func(){}, g.onDrained...)
+	}
+	g.mu.Unlock()
+	for _, fn := range notify {
+		fn()
+	}
+}
+
+// Close atomically stops admission. In-flight leases are unaffected; they
+// drain through Release.
+func (g *AdmissionGate) Close() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.closed = true
+}
+
+// Closed reports whether admission is stopped.
+func (g *AdmissionGate) Closed() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.closed
+}
+
+// Active reports the number of held leases.
+func (g *AdmissionGate) Active() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.active
+}
+
+// OnDrained registers a callback invoked (without holding the gate lock)
+// every time the active count reaches zero. Registration is not idempotent:
+// each call appends. There is no unsubscribe; gates are process-lifetime
+// owners. Callbacks must not call back into the gate.
+func (g *AdmissionGate) OnDrained(fn func()) {
+	if fn == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.onDrained = append(g.onDrained, fn)
+}
+
+// WaitDrained blocks until no leases are held or ctx ends. It reports false
+// on context expiry so shutdown never waits forever.
+func (g *AdmissionGate) WaitDrained(ctx context.Context) bool {
+	done := make(chan struct{})
+	go func() {
+		g.mu.Lock()
+		for g.active > 0 {
+			g.cond.Wait()
+		}
+		g.mu.Unlock()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-ctx.Done():
+		g.mu.Lock()
+		g.cond.Broadcast()
+		g.mu.Unlock()
+		return false
+	}
+}

--- a/internal/infrastructure/process/admission_gate.go
+++ b/internal/infrastructure/process/admission_gate.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // AdmissionGate is a narrow thread-safe admission/work-lease boundary shared
@@ -11,18 +12,15 @@ import (
 // admission while admitted work drains. It never blocks the holder: waiting
 // uses WaitDrained with a caller-provided bounded context.
 type AdmissionGate struct {
-	mu       sync.Mutex
-	cond     *sync.Cond
-	closed   bool
-	active   int
+	mu        sync.Mutex
+	closed    bool
+	active    int
 	onDrained []func()
 }
 
 // NewAdmissionGate returns an open gate with no active leases.
 func NewAdmissionGate() *AdmissionGate {
-	gate := &AdmissionGate{}
-	gate.cond = sync.NewCond(&gate.mu)
-	return gate
+	return &AdmissionGate{}
 }
 
 // Acquire takes one work lease. It reports false when admission is closed;
@@ -38,8 +36,8 @@ func (g *AdmissionGate) Acquire() bool {
 	return true
 }
 
-// Release returns one work lease. The final release wakes drain waiters and
-// notifies drain subscribers.
+// Release returns one work lease. The final release notifies drain
+// subscribers.
 func (g *AdmissionGate) Release() {
 	g.mu.Lock()
 	var notify []func()
@@ -47,7 +45,6 @@ func (g *AdmissionGate) Release() {
 		g.active--
 	}
 	if g.active == 0 {
-		g.cond.Broadcast()
 		notify = append([]func(){}, g.onDrained...)
 	}
 	g.mu.Unlock()
@@ -92,24 +89,22 @@ func (g *AdmissionGate) OnDrained(fn func()) {
 }
 
 // WaitDrained blocks until no leases are held or ctx ends. It reports false
-// on context expiry so shutdown never waits forever.
+// on context expiry so shutdown never waits forever. The short poll runs
+// only on shutdown/drain paths, never on any frame or event loop.
 func (g *AdmissionGate) WaitDrained(ctx context.Context) bool {
-	done := make(chan struct{})
-	go func() {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
 		g.mu.Lock()
-		for g.active > 0 {
-			g.cond.Wait()
+		drained := g.active == 0
+		g.mu.Unlock()
+		if drained {
+			return true
 		}
-		g.mu.Unlock()
-		close(done)
-	}()
-	select {
-	case <-done:
-		return true
-	case <-ctx.Done():
-		g.mu.Lock()
-		g.cond.Broadcast()
-		g.mu.Unlock()
-		return false
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
 	}
 }

--- a/internal/infrastructure/process/admission_gate_test.go
+++ b/internal/infrastructure/process/admission_gate_test.go
@@ -1,0 +1,96 @@
+package process
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdmissionGateAcquireRelease(t *testing.T) {
+	gate := NewAdmissionGate()
+	require.True(t, gate.Acquire())
+	require.True(t, gate.Acquire())
+	require.Equal(t, 2, gate.Active())
+	gate.Release()
+	require.Equal(t, 1, gate.Active())
+	gate.Release()
+	require.Equal(t, 0, gate.Active())
+}
+
+func TestAdmissionGateCloseStopsAdmission(t *testing.T) {
+	gate := NewAdmissionGate()
+	require.True(t, gate.Acquire())
+	gate.Close()
+	require.True(t, gate.Closed())
+	require.False(t, gate.Acquire(), "closed gate must refuse new leases")
+	require.Equal(t, 1, gate.Active(), "in-flight lease survives close")
+	gate.Release()
+	require.Equal(t, 0, gate.Active())
+}
+
+func TestAdmissionGateWaitDrained(t *testing.T) {
+	gate := NewAdmissionGate()
+	gate.Acquire()
+	done := make(chan bool, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		done <- gate.WaitDrained(ctx)
+	}()
+	select {
+	case <-done:
+		t.Fatal("drain must not complete while a lease is held")
+	case <-time.After(50 * time.Millisecond):
+	}
+	gate.Release()
+	select {
+	case drained := <-done:
+		require.True(t, drained)
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain must complete after release")
+	}
+}
+
+func TestAdmissionGateWaitDrainedExpiry(t *testing.T) {
+	gate := NewAdmissionGate()
+	gate.Acquire()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.False(t, gate.WaitDrained(ctx), "expiry must not hang shutdown")
+	gate.Release()
+}
+
+func TestAdmissionGateOnDrained(t *testing.T) {
+	gate := NewAdmissionGate()
+	var mu sync.Mutex
+	calls := 0
+	gate.OnDrained(func() {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	})
+	gate.Acquire()
+	gate.Release()
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, calls)
+}
+
+func TestAdmissionGateConcurrent(t *testing.T) {
+	gate := NewAdmissionGate()
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if gate.Acquire() {
+				gate.Release()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 0, gate.Active())
+}

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -35,13 +35,15 @@ type Service struct {
 	retries    int
 	retryDelay time.Duration
 
-	mu     sync.Mutex
-	timer  *time.Timer
+	mu       sync.Mutex
+	timer    *time.Timer
 	timerGen uint64
-	dirty  bool
-	ready  bool // true when session is persisted to DB and snapshots can be saved
-	ctx    context.Context
-	cancel context.CancelFunc
+	// stopped latches Stop: no new debounce work schedules afterwards.
+	stopped bool
+	dirty   bool
+	ready   bool // true when session is persisted to DB and snapshots can be saved
+	ctx     context.Context
+	cancel  context.CancelFunc
 
 	// Drain boundary for the residency quiescence contract. inflight
 	// counts an executing capture/database save; lastErr records the
@@ -108,6 +110,8 @@ func (s *Service) SetReady() {
 // Stop stops the service and saves final state, then joins an
 // already-running save within a bounded wait so shutdown observes the
 // drain barrier instead of racing it. The wait never blocks forever.
+// Latching stopped also prevents any later debounce from scheduling work
+// on the dead service.
 func (s *Service) Stop(ctx context.Context) error {
 	s.mu.Lock()
 	if s.cancel != nil {
@@ -117,6 +121,7 @@ func (s *Service) Stop(ctx context.Context) error {
 		s.timer.Stop()
 		s.timer = nil
 	}
+	s.stopped = true
 	s.mu.Unlock()
 
 	// Final save on shutdown
@@ -130,11 +135,14 @@ func (s *Service) Stop(ctx context.Context) error {
 }
 
 // MarkDirty signals that state has changed.
-// Debounces saves to avoid excessive DB writes.
+// Debounces saves to avoid excessive DB writes. It is a no-op after Stop
+// so shutdown never resurrects debounce work on the dead service.
 func (s *Service) MarkDirty() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
+	if s.stopped {
+		return
+	}
 	s.dirty = true
 
 	// Reset or create timer
@@ -148,10 +156,17 @@ func (s *Service) MarkDirty() {
 		// Retire the owning timer as it fires: a non-nil timer means
 		// debounce work is outstanding, so leaving it set would strand
 		// the drain after the save settles. The generation check keeps
-		// a superseded timer from clearing its replacement.
-		if s.timerGen == gen {
-			s.timer = nil
+		// a superseded timer from clearing its replacement, and a
+		// superseded or stopped timer saves nothing: the replacement
+		// timer or Stop's own final save owns that work.
+		if s.timerGen != gen || s.stopped {
+			if s.timerGen == gen {
+				s.timer = nil
+			}
+			s.mu.Unlock()
+			return
 		}
+		s.timer = nil
 		ctx := s.ctx
 		s.mu.Unlock()
 
@@ -190,6 +205,13 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 		s.mu.Unlock()
 		return nil
 	}
+	// Claim the dirty work atomically: concurrent timer and SaveNow paths
+	// serialize here, so exactly one save runs and shutdown joins rather
+	// than duplicates the active save.
+	if !s.dirty {
+		s.mu.Unlock()
+		return nil
+	}
 	// Only clear dirty when we're actually going to save
 	s.dirty = false
 	s.lastErr = nil
@@ -204,7 +226,7 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	sessionID := s.provider.GetSessionID()
 
 	if sessionID == "" {
-		s.markDirty()
+		s.MarkDirty()
 		return nil
 	}
 
@@ -212,7 +234,7 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	// A nil window list with no active index means the snapshot is truly unavailable,
 	// not merely empty. Keep the session dirty so a later capture can retry.
 	if windows == nil && activeWindowIndex < 0 {
-		s.markDirty()
+		s.MarkDirty()
 		logging.FromContext(ctx).Warn().Msg("window snapshot unavailable; keeping session snapshot dirty")
 		return nil
 	}
@@ -246,11 +268,11 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 // later retry while lastErr records it, so the drain always terminates and
 // never loops forever merely because dirty remains set.
 func (s *Service) Active() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.inflight.Load() > 0 {
 		return true
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.timer != nil {
 		return true
 	}

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -37,6 +37,7 @@ type Service struct {
 
 	mu     sync.Mutex
 	timer  *time.Timer
+	timerGen uint64
 	dirty  bool
 	ready  bool // true when session is persisted to DB and snapshots can be saved
 	ctx    context.Context
@@ -104,7 +105,9 @@ func (s *Service) SetReady() {
 	}()
 }
 
-// Stop stops the service and saves final state.
+// Stop stops the service and saves final state, then joins an
+// already-running save within a bounded wait so shutdown observes the
+// drain barrier instead of racing it. The wait never blocks forever.
 func (s *Service) Stop(ctx context.Context) error {
 	s.mu.Lock()
 	if s.cancel != nil {
@@ -117,7 +120,13 @@ func (s *Service) Stop(ctx context.Context) error {
 	s.mu.Unlock()
 
 	// Final save on shutdown
-	return s.SaveNow(ctx)
+	err := s.SaveNow(ctx)
+	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	if waitErr := s.WaitSettled(drainCtx); waitErr != nil {
+		logging.FromContext(ctx).Warn().Err(waitErr).Msg("snapshot drain did not settle before shutdown")
+	}
+	return err
 }
 
 // MarkDirty signals that state has changed.
@@ -132,9 +141,17 @@ func (s *Service) MarkDirty() {
 	if s.timer != nil {
 		s.timer.Stop()
 	}
-
+	s.timerGen++
+	gen := s.timerGen
 	s.timer = time.AfterFunc(s.interval, func() {
 		s.mu.Lock()
+		// Retire the owning timer as it fires: a non-nil timer means
+		// debounce work is outstanding, so leaving it set would strand
+		// the drain after the save settles. The generation check keeps
+		// a superseded timer from clearing its replacement.
+		if s.timerGen == gen {
+			s.timer = nil
+		}
 		ctx := s.ctx
 		s.mu.Unlock()
 

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
@@ -23,6 +24,9 @@ const (
 // Compile-time interface check.
 var _ port.SnapshotService = (*Service)(nil)
 
+// Compile-time drain boundary check.
+var _ port.PersistenceDrain = (*Service)(nil)
+
 // Service handles debounced session state snapshots.
 type Service struct {
 	snapshotUC *usecase.SnapshotSessionUseCase
@@ -37,6 +41,15 @@ type Service struct {
 	ready  bool // true when session is persisted to DB and snapshots can be saved
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// Drain boundary for the residency quiescence contract. inflight
+	// counts an executing capture/database save; lastErr records the
+	// terminal failure of the most recent save while dirty is preserved
+	// for reporting and later retry. Failed writes are settled-but-failed:
+	// the drain terminates instead of looping forever on dirty.
+	inflight  atomic.Int32
+	lastErr   error
+	onSettled []func()
 }
 
 // NewService creates a new snapshot service.
@@ -162,7 +175,14 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	}
 	// Only clear dirty when we're actually going to save
 	s.dirty = false
+	s.lastErr = nil
+	s.inflight.Add(1)
 	s.mu.Unlock()
+
+	defer func() {
+		s.inflight.Add(-1)
+		s.notifyIfSettled()
+	}()
 
 	sessionID := s.provider.GetSessionID()
 
@@ -196,10 +216,88 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 
 	if err := s.executeWithRetry(ctx, input); err != nil {
 		s.markDirty()
+		s.setTerminalError(err)
 		return err
 	}
 
 	return nil
+}
+
+// Active reports whether snapshot work is outstanding: pending debounce,
+// an armed timer, or an in-flight capture/database save. A terminally
+// failed save is settled-but-failed: dirty is preserved for reporting and
+// later retry while lastErr records it, so the drain always terminates and
+// never loops forever merely because dirty remains set.
+func (s *Service) Active() bool {
+	if s.inflight.Load() > 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.timer != nil {
+		return true
+	}
+	if !s.dirty {
+		return false
+	}
+	return s.lastErr == nil
+}
+
+// LastError returns the terminal error of the most recent save, or nil.
+// Dirty is preserved alongside it for reporting and later retry.
+func (s *Service) LastError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastErr
+}
+
+// OnSettled registers a callback invoked when the service reaches a
+// settled state after a save completes. Callbacks run on the completing
+// goroutine and must be non-blocking; the UI wraps them with GTK dispatch.
+// There is no unsubscribe; services are process-lifetime owners.
+func (s *Service) OnSettled(fn func()) {
+	if fn == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onSettled = append(s.onSettled, fn)
+}
+
+// WaitSettled blocks until no snapshot work is outstanding or ctx ends.
+// It reports ctx.Err() on expiry so shutdown never waits forever. It must
+// never be called on the GTK thread when capture dispatches there.
+func (s *Service) WaitSettled(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if !s.Active() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Service) setTerminalError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastErr = err
+}
+
+func (s *Service) notifyIfSettled() {
+	if s.Active() {
+		return
+	}
+	s.mu.Lock()
+	callbacks := append([]func(){}, s.onSettled...)
+	s.mu.Unlock()
+	for _, fn := range callbacks {
+		fn()
+	}
 }
 
 func (s *Service) executeWithRetry(ctx context.Context, input usecase.SnapshotInput) error {

--- a/internal/infrastructure/snapshot/service_test.go
+++ b/internal/infrastructure/snapshot/service_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -324,4 +325,63 @@ func TestService_SaveNowPreservesLegacySingleEmptyWindowSentinel(t *testing.T) {
 	err := svc.saveSnapshot(context.Background())
 	require.NoError(t, err)
 	assert.False(t, svc.dirty)
+}
+
+func TestService_DebounceTimerClearsOnFire(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		Return(nil).Once()
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_fire", nil, 0), 1)
+	svc.ready = true
+	svc.ctx = context.Background()
+	svc.MarkDirty()
+	require.True(t, svc.Active())
+	// The fired timer retires itself; the save settles the drain.
+	require.Eventually(t, func() bool { return !svc.Active() }, 5*time.Second, 5*time.Millisecond)
+}
+
+func TestService_StopJoinsInFlightSave(t *testing.T) {
+	released := make(chan struct{})
+	var calls atomic.Int32
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		RunAndReturn(func(_ context.Context, _ *entity.SessionState) error {
+			calls.Add(1)
+			<-released
+			return nil
+		})
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_join", nil, 0), 1)
+	svc.ready = true
+	svc.dirty = true
+	saveDone := make(chan error, 1)
+	go func() { saveDone <- svc.saveSnapshot(context.Background()) }()
+	// The in-flight save reached the database: dirty is cleared and the
+	// provider was consumed exactly once, so Stop cannot start a second.
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, 5*time.Second, 5*time.Millisecond)
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- svc.Stop(context.Background()) }()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned while a save was still in flight: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(released)
+	select {
+	case err := <-saveDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight save never completed")
+	}
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("Stop did not join the in-flight save")
+	}
+	require.False(t, svc.Active())
+	require.Equal(t, int32(1), calls.Load(), "Stop must join, not duplicate, the save")
 }

--- a/internal/infrastructure/snapshot/service_test.go
+++ b/internal/infrastructure/snapshot/service_test.go
@@ -27,6 +27,80 @@ func newWindowStateProvider(
 	return provider
 }
 
+func TestService_DrainSettlesAfterDebounceAndSave(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		Return(nil).Once()
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_drain", nil, 0), 60000)
+	svc.ready = true
+	require.False(t, svc.Active())
+
+	svc.MarkDirty()
+	require.True(t, svc.Active(), "pending debounce is outstanding work")
+
+	require.NoError(t, svc.SaveNow(context.Background()))
+	require.False(t, svc.Active())
+	require.NoError(t, svc.LastError())
+}
+
+func TestService_FailedSaveIsSettledButFailed(t *testing.T) {
+	closedErr := errors.New("database is closed")
+	repo := repomocks.NewMockSessionStateRepository(t)
+	calls := 0
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		RunAndReturn(func(_ context.Context, _ *entity.SessionState) error {
+			calls++
+			return closedErr
+		})
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_closed", nil, 0), 60000)
+	svc.ready = true
+	svc.dirty = true
+
+	err := svc.SaveNow(context.Background())
+	require.ErrorIs(t, err, closedErr)
+	require.Equal(t, 1, calls, "no write retries after terminal database failure")
+	require.True(t, svc.dirty, "dirty preserved for reporting and later retry")
+	require.ErrorIs(t, svc.LastError(), closedErr)
+	require.False(t, svc.Active(), "terminal failure settles the drain")
+	require.NoError(t, svc.WaitSettled(context.Background()))
+}
+
+func TestService_WaitSettledExpiry(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, mocks.NewMockWindowStateProvider(t), 60000)
+	svc.MarkDirty()
+	require.True(t, svc.Active())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.Error(t, svc.WaitSettled(ctx), "drain must expire instead of looping forever")
+}
+
+func TestService_OnSettledFiresAfterSave(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		Return(nil).Once()
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_settled", nil, 0), 60000)
+	svc.ready = true
+	svc.dirty = true
+	settled := make(chan struct{}, 1)
+	svc.OnSettled(func() { settled <- struct{}{} })
+
+	require.NoError(t, svc.SaveNow(context.Background()))
+	select {
+	case <-settled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("settled callback must fire after save completes")
+	}
+}
+
 func TestService_SaveSnapshot_RetriesTransientFKAndSucceeds(t *testing.T) {
 	repo := repomocks.NewMockSessionStateRepository(t)
 	calls := 0

--- a/internal/infrastructure/snapshot/service_test.go
+++ b/internal/infrastructure/snapshot/service_test.go
@@ -385,3 +385,36 @@ func TestService_StopJoinsInFlightSave(t *testing.T) {
 	require.False(t, svc.Active())
 	require.Equal(t, int32(1), calls.Load(), "Stop must join, not duplicate, the save")
 }
+
+func TestService_MarkDirtyNoOpAfterStop(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, mocks.NewMockWindowStateProvider(t), 1)
+	require.NoError(t, svc.Stop(context.Background()))
+	svc.MarkDirty()
+	require.False(t, svc.Active(), "stopped service schedules nothing")
+	time.Sleep(20 * time.Millisecond)
+	require.False(t, svc.Active())
+}
+
+func TestService_SupersededTimerSavesNothing(t *testing.T) {
+	var calls atomic.Int32
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		RunAndReturn(func(_ context.Context, _ *entity.SessionState) error {
+			calls.Add(1)
+			return nil
+		})
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_superseded", nil, 0), 1)
+	svc.ready = true
+	svc.MarkDirty()
+	// Stop consumes the pending work in its own final save and retires
+	// the debounce timer; the stopped timer callback must save nothing.
+	require.NoError(t, svc.Stop(context.Background()))
+	require.Equal(t, int32(1), calls.Load())
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), calls.Load(), "stopped timer must not save")
+	require.False(t, svc.Active())
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -367,6 +367,16 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	})
 	a.residency.SetQuiescentFunc(a.residencyQuiescent)
 	a.residency.SetSealFunc(a.closeRelayAdmission)
+	a.residency.SetUnsealFunc(func() {
+		if a.deps == nil {
+			return
+		}
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil {
+				gate.Reopen()
+			}
+		}
+	})
 	a.residency.AcquireHold(a.gtkApp)
 	defer a.residency.ReleaseHold(a.gtkApp)
 
@@ -3103,9 +3113,10 @@ func (a *App) onShutdown(ctx context.Context) {
 
 	// Stop relay admission before snapshot/update teardown so no new work
 	// starts while persistence drains. Admitted leases keep their sockets
-	// until dispatch settles; shutdown never waits on them unboundedly.
+	// until dispatch settles; off-thread quits already drained beforehand
+	// (see Quit), and on the GTK thread itself a drain wait is impossible,
+	// so teardown relies on close-then-teardown ordering here.
 	a.closeRelayAdmission()
-	a.waitRelayAdmissionDrained(ctx)
 	a.unsubscribeResidencyQuiescence()
 
 	// Persistence drain barriers, in teardown order. The snapshot service
@@ -3837,6 +3848,14 @@ func (a *App) Quit() {
 		}
 	}
 	glibCtx := glib.MainContextDefault()
+	if glibCtx == nil || !glibCtx.IsOwner() {
+		// Off-thread quits (signals, relay threads) drain admission and
+		// persistence BEFORE entering GTK shutdown, while the loop can
+		// still service admitted work. On the GTK thread itself this wait
+		// is impossible, so shutdown relies on close-then-teardown
+		// ordering instead; the dispatched closure below never blocks.
+		a.drainForShutdownOffThread()
+	}
 	if glibCtx != nil && glibCtx.IsOwner() {
 		quit()
 		return

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -144,6 +144,9 @@ type App struct {
 	// wholesale, so this field is never re-read from them; a changed value
 	// is reported as restart-required instead of partially hot-applied.
 	residencyTimeout time.Duration
+	// residency owns the opt-in idle hold and deadline. Always non-nil
+	// after Run starts; nil beforehand (e.g. in tests without Run).
+	residency *ResidencyController
 
 	// Web content (managed by content.Coordinator)
 	faviconAdapter *adapter.FaviconAdapter
@@ -347,6 +350,15 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	defer a.gtkApp.Unref()
 	a.dispatchOnMainThread = a.runOnMainThread
 
+	// Bounded opt-in residency owns exactly one application hold, taken
+	// only when enabled and released once on every Run exit (including
+	// activation failure before the shutdown signal).
+	a.residency = NewResidencyController(a.residencyTimeout, time.Now, nil, nil, a.Quit)
+	a.residency.schedule = a.residency.scheduleGLibTimeout
+	a.residency.cancel = a.residency.cancelGLibTimeout
+	a.residency.AcquireHold(a.gtkApp)
+	defer a.residency.ReleaseHold(a.gtkApp)
+
 	// Connect activate signal
 	activateCb := func(_ gio.Application) {
 		a.onActivate(ctx)
@@ -378,6 +390,12 @@ func (a *App) onActivate(ctx context.Context) {
 
 	if err := a.openInitialBrowserWindowShell(ctx, a.initialWindowURL()); err != nil {
 		log.Error().Err(err).Msg("failed to create main window")
+		// Reach bounded idle or orderly shutdown instead of lingering on
+		// the residency hold with no windows: disabled residency quits here
+		// exactly as before (GTK auto-exits holderless), enabled arms.
+		if a.residencyShouldQuitAfterLastWindow() {
+			a.Quit()
+		}
 		return
 	}
 
@@ -3246,9 +3264,13 @@ func (a *App) initTabCoordinator(ctx context.Context) {
 				bw.mainWindow.Destroy()
 			}
 		}
-		// Quit the app only when all browser windows are gone.
+		// Quit through residency when enabled rather than unconditionally:
+		// the last window close arms the bounded idle deadline instead.
+		// Disabled residency preserves the pre-existing unconditional Quit.
 		if len(a.browserWindows) == 0 {
-			a.Quit()
+			if a.residencyShouldQuitAfterLastWindow() {
+				a.Quit()
+			}
 		}
 	})
 	// Wire popup tab WebView attachment
@@ -3783,6 +3805,11 @@ func (a *App) MainWindow() *window.MainWindow {
 func (a *App) Quit() {
 	if a == nil || a.gtkApp == nil {
 		return
+	}
+	// Explicit quits and signals never wait for the idle deadline and must
+	// not bypass orderly cleanup: cancel any armed deadline first.
+	if a.residency != nil {
+		a.residency.NoteExplicitQuit()
 	}
 	quit := func() {
 		if a.gtkApp != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3286,14 +3286,8 @@ func (a *App) initTabCoordinator(ctx context.Context) {
 				bw.mainWindow.Destroy()
 			}
 		}
-		// Quit through residency when enabled rather than unconditionally:
-		// the last window close arms the bounded idle deadline instead.
-		// Disabled residency preserves the pre-existing unconditional Quit.
-		if len(a.browserWindows) == 0 {
-			if a.residencyShouldQuitAfterLastWindow() {
-				a.Quit()
-			}
-		}
+		// Quitting is decided inside removeBrowserWindow through residency;
+		// nothing further to do here.
 	})
 	// Wire popup tab WebView attachment
 	a.tabCoord.SetOnAttachPopupToTab(a.attachPopupToTab)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -139,6 +139,12 @@ type App struct {
 	// Engine
 	engine port.Engine
 
+	// residencyTimeout is the effective bounded-residency idle timeout
+	// latched once at process startup. Live config snapshots are replaced
+	// wholesale, so this field is never re-read from them; a changed value
+	// is reported as restart-required instead of partially hot-applied.
+	residencyTimeout time.Duration
+
 	// Web content (managed by content.Coordinator)
 	faviconAdapter *adapter.FaviconAdapter
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -147,6 +147,8 @@ type App struct {
 	// residency owns the opt-in idle hold and deadline. Always non-nil
 	// after Run starts; nil beforehand (e.g. in tests without Run).
 	residency *ResidencyController
+	// residencyUnsubscribe drops native quiescence subscriptions at shutdown.
+	residencyUnsubscribe []func()
 
 	// Web content (managed by content.Coordinator)
 	faviconAdapter *adapter.FaviconAdapter
@@ -356,6 +358,14 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	a.residency = NewResidencyController(a.residencyTimeout, time.Now, nil, nil, a.Quit)
 	a.residency.schedule = a.residency.scheduleGLibTimeout
 	a.residency.cancel = a.residency.cancelGLibTimeout
+	a.residency.SetDispatchToGTK(func(f func()) {
+		callback := glib.SourceFunc(func(_ uintptr) bool {
+			f()
+			return false
+		})
+		glib.IdleAdd(&callback, 0)
+	})
+	a.residency.SetQuiescentFunc(a.residencyQuiescent)
 	a.residency.AcquireHold(a.gtkApp)
 	defer a.residency.ReleaseHold(a.gtkApp)
 
@@ -412,6 +422,7 @@ func (a *App) onActivate(ctx context.Context) {
 	a.wireSessionManagerShortcut()
 	a.initSnapshotService(ctx)
 	a.initUpdateCoordinator(ctx)
+	a.subscribeResidencyQuiescence()
 	a.createInitialTab(ctx)
 	a.finalizeActivation(ctx)
 }
@@ -3089,6 +3100,17 @@ func (a *App) onShutdown(ctx context.Context) {
 	log := logging.FromContext(ctx)
 	log.Debug().Msg("GTK application shutting down")
 
+	// Stop relay admission before snapshot/update teardown so no new work
+	// starts while persistence drains. Admitted leases keep their sockets
+	// until dispatch settles; shutdown never waits on them unboundedly.
+	a.closeRelayAdmission()
+	a.unsubscribeResidencyQuiescence()
+
+	// Persistence drain barriers, in teardown order. The snapshot service
+	// owns debounced session writes (Stop performs the final synchronous
+	// save); the history recorder flushes synchronously on Close. All
+	// other persistence owners are synchronous use-case calls with no
+	// background work, so no additional drain exists.
 	// Save final session state before shutdown
 	if a.snapshotService != nil {
 		if err := a.snapshotService.Stop(ctx); err != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -366,6 +366,7 @@ func (a *App) Run(ctx context.Context, args []string) int {
 		glib.IdleAdd(&callback, 0)
 	})
 	a.residency.SetQuiescentFunc(a.residencyQuiescent)
+	a.residency.SetSealFunc(a.closeRelayAdmission)
 	a.residency.AcquireHold(a.gtkApp)
 	defer a.residency.ReleaseHold(a.gtkApp)
 
@@ -3104,6 +3105,7 @@ func (a *App) onShutdown(ctx context.Context) {
 	// starts while persistence drains. Admitted leases keep their sockets
 	// until dispatch settles; shutdown never waits on them unboundedly.
 	a.closeRelayAdmission()
+	a.waitRelayAdmissionDrained(ctx)
 	a.unsubscribeResidencyQuiescence()
 
 	// Persistence drain barriers, in teardown order. The snapshot service
@@ -3822,12 +3824,14 @@ func (a *App) Quit() {
 	if a == nil || a.gtkApp == nil {
 		return
 	}
-	// Explicit quits and signals never wait for the idle deadline and must
-	// not bypass orderly cleanup: cancel any armed deadline first.
-	if a.residency != nil {
-		a.residency.NoteExplicitQuit()
-	}
 	quit := func() {
+		// The whole residency/GTK quit transition runs on the GTK thread:
+		// canceling the idle timer touches GLib sources, which is only
+		// safe on its owner thread. Explicit quits and signals never wait
+		// for the idle deadline and must not bypass orderly cleanup.
+		if a.residency != nil {
+			a.residency.NoteExplicitQuit()
+		}
 		if a.gtkApp != nil {
 			a.gtkApp.Quit()
 		}

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -393,6 +393,7 @@ func (a *App) removeBrowserWindow(id string) {
 	if wasMainWindow {
 		a.clearMainBrowserWindowAfterRemoval(fallback)
 	}
+	a.residencyAfterWindowRemoved()
 }
 
 func (a *App) releaseNativePopupsForBrowserWindow(windowID string) {

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -343,6 +343,7 @@ func (a *App) registerBrowserWindow(bw *browserWindow) {
 		return
 	}
 	a.browserWindowOrder = append(a.browserWindowOrder, bw.id)
+	a.residencyNoteWindowsChanged()
 }
 
 func (a *App) releaseTabWorkspace(ctx context.Context, tab *entity.Tab) {

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -1,0 +1,46 @@
+package ui
+
+import "time"
+
+// ResidencyTimeoutFromMillis resolves the effective bounded-residency idle
+// timeout for CEF from the startup configuration value in milliseconds.
+// Values outside 0..300000 are rejected by config validation; this resolver
+// additionally clamps defensively so an unvalidated caller can never arm an
+// unbounded or negative deadline.
+func ResidencyTimeoutFromMillis(timeoutMs int) time.Duration {
+	if timeoutMs <= 0 {
+		return 0
+	}
+	if timeoutMs > 300000 {
+		timeoutMs = 300000
+	}
+	return time.Duration(timeoutMs) * time.Millisecond
+}
+
+// SetResidencyTimeout latches the effective idle timeout once at process
+// startup. Call it before App.Run; later config reloads must use
+// ResidencyTimeoutRestartRequired instead of calling this again.
+func (a *App) SetResidencyTimeout(timeout time.Duration) {
+	if a == nil {
+		return
+	}
+	a.residencyTimeout = timeout
+}
+
+// LatchedResidencyTimeout returns the startup-latched idle timeout.
+func (a *App) LatchedResidencyTimeout() time.Duration {
+	if a == nil {
+		return 0
+	}
+	return a.residencyTimeout
+}
+
+// ResidencyTimeoutRestartRequired reports whether a reloaded configuration
+// value differs from the startup latch. A true result means the process must
+// restart to apply it; residency is never partially hot-applied.
+func (a *App) ResidencyTimeoutRestartRequired(timeoutMs int) bool {
+	if a == nil {
+		return false
+	}
+	return ResidencyTimeoutFromMillis(timeoutMs) != a.residencyTimeout
+}

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/bnema/dumber/internal/infrastructure/process"
+	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/glib"
 )
 
@@ -89,6 +90,9 @@ type ResidencyController struct {
 	pendingQuit   bool
 	quiescent     func() bool
 	dispatchToGTK func(func())
+	// seal stops new admissions before a quit commits, closing the race
+	// between the quiescence recheck and admitted work starting.
+	seal func()
 
 	timerCallback *glib.SourceFunc
 	timerTag      uint
@@ -157,6 +161,8 @@ func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecisio
 	for c.lastWindows < count {
 		c.lastWindows++
 		events = true
+		// A reopened window invalidates any deferred quit.
+		c.pendingQuit = false
 		decision = c.apply(c.policy.WindowOpened(now))
 	}
 	for c.lastWindows > count {
@@ -168,6 +174,10 @@ func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecisio
 		// No windows were ever reported (e.g. activation failure):
 		// evaluate once so the process reaches bounded idle or orderly
 		// shutdown instead of idling forever on the residency hold.
+		// An already-armed idle state stays put instead of re-arming.
+		if c.policy.IdleArmed() {
+			return usecase.ResidencyDecision{Action: usecase.ResidencyNone, Generation: c.policy.Generation()}
+		}
 		decision = c.apply(c.policy.WindowClosed(now))
 	}
 	return decision
@@ -231,7 +241,17 @@ func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.
 // Otherwise it defers: the next settling source rechecks via MaybeQuit.
 // Disabled residency quits unconditionally, preserving pre-existing behavior.
 func (c *ResidencyController) requestQuit() {
-	if c.enabled && c.quiescent != nil && !c.quiescent() {
+	if !c.enabled {
+		c.pendingQuit = false
+		c.doQuit()
+		return
+	}
+	// Seal admission first so no new work starts between the recheck and
+	// the quit. Draining leases then settle through MaybeQuit.
+	if c.seal != nil {
+		c.seal()
+	}
+	if c.quiescent != nil && !c.quiescent() {
 		c.pendingQuit = true
 		return
 	}
@@ -241,8 +261,14 @@ func (c *ResidencyController) requestQuit() {
 
 // MaybeQuit rechecks a deferred quit after sources settle. It is invoked
 // from settle callbacks (already dispatched to GTK) and busy transitions.
+// A reopened window invalidates the deferral: quitting then would bypass
+// the fresh idle interval.
 func (c *ResidencyController) MaybeQuit() {
 	if c == nil || !c.pendingQuit || c.quitting {
+		return
+	}
+	if c.lastWindows > 0 {
+		c.pendingQuit = false
 		return
 	}
 	if c.quiescent != nil && !c.quiescent() {
@@ -269,6 +295,16 @@ func (c *ResidencyController) SetDispatchToGTK(fn func(func())) {
 		return
 	}
 	c.dispatchToGTK = fn
+}
+
+// SetSealFunc installs the admission seal invoked before an enabled quit
+// commits, so no new relay work starts between the quiescence recheck and
+// the quit.
+func (c *ResidencyController) SetSealFunc(fn func()) {
+	if c == nil {
+		return
+	}
+	c.seal = fn
 }
 
 // DispatchToGTK runs fn on the GTK thread through the installed dispatch,
@@ -331,7 +367,12 @@ func (c *ResidencyController) scheduleGLibTimeout(d time.Duration, generation ui
 		ms = 1
 	}
 	callback := glib.SourceFunc(func(_ uintptr) bool {
+		// GLib retires this source on return; drop our tag on entry so a
+		// later cancel can never remove an expired or reused source ID.
+		// The callback stays retained through return.
+		c.timerTag = 0
 		c.OnTimerFired(generation)
+		c.timerCallback = nil
 		return false
 	})
 	c.timerCallback = &callback
@@ -500,5 +541,28 @@ func (a *App) closeRelayAdmission() {
 		if gate := provider.AdmissionGate(); gate != nil {
 			gate.Close()
 		}
+	}
+}
+
+// waitRelayAdmissionDrained settles admitted relay work before persistence
+// teardown within a short bound. Admitted dispatch may need the GTK loop,
+// so the wait never blocks shutdown forever; expiry only logs and the
+// sockets settle through their own completion paths.
+func (a *App) waitRelayAdmissionDrained(ctx context.Context) {
+	if a == nil || a.deps == nil {
+		return
+	}
+	provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider)
+	if !ok || provider == nil {
+		return
+	}
+	gate := provider.AdmissionGate()
+	if gate == nil || gate.Active() == 0 {
+		return
+	}
+	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+	if !gate.WaitDrained(drainCtx) {
+		logging.FromContext(ctx).Warn().Int("admitted", gate.Active()).Msg("relay admission did not drain before teardown")
 	}
 }

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
@@ -364,6 +365,43 @@ func (a *App) residencyShouldQuitAfterLastWindow() bool {
 		return true
 	}
 	return a.residency.SetWindowCount(len(a.browserWindows)).Action == usecase.ResidencyQuit
+}
+
+// residencyAfterWindowRemoved converges residency accounting after every
+// removal path (close-request, tab-empty, eject, failures) and quits when
+// the policy decides the empty state must exit. Disabled or missing
+// residency preserves unconditional Quit.
+func (a *App) residencyAfterWindowRemoved() {
+	if a == nil {
+		return
+	}
+	decision := a.residencyNoteWindowsChanged()
+	if len(a.browserWindows) == 0 && decision.Action == usecase.ResidencyQuit {
+		a.Quit()
+	}
+}
+
+// CloseAllWindows closes every user window through the standard removal
+// path, converging residency exactly like interactive closes. It runs on
+// the main thread via the window-URL dispatch.
+func (a *App) CloseAllWindows(ctx context.Context) error {
+	return a.dispatchWindowURLWork(ctx, "ui.close_all_windows", "", func(context.Context) error {
+		ids := make([]string, 0, len(a.browserWindows))
+		for id := range a.browserWindows {
+			ids = append(ids, id)
+		}
+		for _, id := range ids {
+			bw, ok := a.browserWindows[id]
+			if !ok || bw == nil {
+				continue
+			}
+			a.removeBrowserWindow(bw.id)
+			if bw.mainWindow != nil {
+				bw.mainWindow.Destroy()
+			}
+		}
+		return nil
+	})
 }
 
 // residencyNoteWindowsChanged converges residency accounting to the current

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -3,9 +3,14 @@ package ui
 import (
 	"time"
 
+	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/puregotk/v4/glib"
 )
+
+// ResidencyTimeoutMaxMs bounds the startup-only idle timeout in milliseconds.
+const ResidencyTimeoutMaxMs = 300000
 
 // ResidencyTimeoutFromMillis resolves the effective bounded-residency idle
 // timeout for CEF from the startup configuration value in milliseconds.
@@ -16,8 +21,8 @@ func ResidencyTimeoutFromMillis(timeoutMs int) time.Duration {
 	if timeoutMs <= 0 {
 		return 0
 	}
-	if timeoutMs > 300000 {
-		timeoutMs = 300000
+	if timeoutMs > ResidencyTimeoutMaxMs {
+		timeoutMs = ResidencyTimeoutMaxMs
 	}
 	return time.Duration(timeoutMs) * time.Millisecond
 }
@@ -75,6 +80,15 @@ type ResidencyController struct {
 	quitting    bool
 	held        bool
 
+	// Native quiescence inputs. Sources report busy/clear transitions;
+	// expiry commits to quit only after admitted work drains and every
+	// source settles. All methods must run on the GTK thread; cross-thread
+	// settle callbacks arrive through dispatchToGTK.
+	nativeBusy    map[string]bool
+	pendingQuit   bool
+	quiescent     func() bool
+	dispatchToGTK func(func())
+
 	timerCallback *glib.SourceFunc
 	timerTag      uint
 }
@@ -82,7 +96,12 @@ type ResidencyController struct {
 // NewResidencyController builds the UI-side residency owner. A zero timeout
 // keeps the controller disabled: decisions then always resolve to the
 // pre-existing last-window exit behavior.
-func NewResidencyController(timeout time.Duration, clock func() time.Time, schedule func(time.Duration, uint64), cancel func(), quit func()) *ResidencyController {
+func NewResidencyController(
+	timeout time.Duration,
+	clock func() time.Time,
+	schedule func(time.Duration, uint64),
+	cancel, quit func(),
+) *ResidencyController {
 	if clock == nil {
 		clock = time.Now
 	}
@@ -163,7 +182,7 @@ func (c *ResidencyController) Evaluate() usecase.ResidencyDecision {
 }
 
 // NoteExplicitQuit records an explicit quit or signal: the timer is
-// cancelled, the policy resolves Quit immediately, and the deadline is never
+// canceled, the policy resolves Quit immediately, and the deadline is never
 // waited on. It never invokes the quit function itself.
 func (c *ResidencyController) NoteExplicitQuit() {
 	if c == nil {
@@ -202,7 +221,88 @@ func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.
 			c.cancel()
 		}
 	case usecase.ResidencyQuit:
-		c.doQuit()
+		c.requestQuit()
+	}
+	return decision
+}
+
+// requestQuit commits to quit only when every native source has settled.
+// Otherwise it defers: the next settling source rechecks via MaybeQuit.
+// Disabled residency quits unconditionally, preserving pre-existing behavior.
+func (c *ResidencyController) requestQuit() {
+	if c.enabled && c.quiescent != nil && !c.quiescent() {
+		c.pendingQuit = true
+		return
+	}
+	c.pendingQuit = false
+	c.doQuit()
+}
+
+// MaybeQuit rechecks a deferred quit after sources settle. It is invoked
+// from settle callbacks (already dispatched to GTK) and busy transitions.
+func (c *ResidencyController) MaybeQuit() {
+	if c == nil || !c.pendingQuit || c.quitting {
+		return
+	}
+	if c.quiescent != nil && !c.quiescent() {
+		return
+	}
+	c.pendingQuit = false
+	c.doQuit()
+}
+
+// SetQuiescentFunc installs the composed quiescence predicate consulted
+// before an expiry commits to quit. A nil predicate means always settled.
+func (c *ResidencyController) SetQuiescentFunc(fn func() bool) {
+	if c == nil {
+		return
+	}
+	c.quiescent = fn
+}
+
+// SetDispatchToGTK installs the cross-thread dispatch used by settle
+// callbacks from CEF, relay, and persistence threads. A nil dispatch
+// invokes callbacks directly (tests only).
+func (c *ResidencyController) SetDispatchToGTK(fn func(func())) {
+	if c == nil {
+		return
+	}
+	c.dispatchToGTK = fn
+}
+
+// DispatchToGTK runs fn on the GTK thread through the installed dispatch,
+// or directly when none is installed. Settle callbacks must use this.
+func (c *ResidencyController) DispatchToGTK(fn func()) {
+	if c == nil || fn == nil {
+		return
+	}
+	if c.dispatchToGTK != nil {
+		c.dispatchToGTK(fn)
+		return
+	}
+	fn()
+}
+
+// SetNativeBusy records one native source busy (true) or settled (false).
+// Transitions drive policy work events so expiry never fires while required
+// work is outstanding; settling also rechecks a deferred quit.
+func (c *ResidencyController) SetNativeBusy(source string, busy bool) usecase.ResidencyDecision {
+	if c == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyNone}
+	}
+	if c.nativeBusy == nil {
+		c.nativeBusy = make(map[string]bool)
+	}
+	if c.nativeBusy[source] == busy {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyNone}
+	}
+	c.nativeBusy[source] = busy
+	var decision usecase.ResidencyDecision
+	if busy {
+		decision = c.apply(c.policy.WorkStarted(c.clock()))
+	} else {
+		decision = c.apply(c.policy.WorkFinished(c.clock()))
+		c.MaybeQuit()
 	}
 	return decision
 }
@@ -222,7 +322,7 @@ func (c *ResidencyController) doQuit() {
 
 // scheduleGLibTimeout arms a one-shot GLib timeout for the idle deadline.
 // The callback is retained on the controller until it fires or is
-// cancelled, and stale generations are rejected by the policy on fire.
+// canceled, and stale generations are rejected by the policy on fire.
 func (c *ResidencyController) scheduleGLibTimeout(d time.Duration, generation uint64) {
 	c.cancelGLibTimeout()
 	ms := uint(d.Milliseconds())
@@ -246,6 +346,16 @@ func (c *ResidencyController) cancelGLibTimeout() {
 	c.timerCallback = nil
 }
 
+// LatchResidencyTimeoutForApp latches the bounded-residency timeout once at
+// startup. Only CEF uses it, and only when nonzero; later config changes
+// are restart-required instead of partially hot-applied.
+func LatchResidencyTimeoutForApp(app *App, timeoutMs int, isCEF bool) {
+	if app == nil || !isCEF {
+		return
+	}
+	app.SetResidencyTimeout(ResidencyTimeoutFromMillis(timeoutMs))
+}
+
 // residencyShouldQuitAfterLastWindow reports whether the app must quit now
 // that no user windows remain. A nil controller (before Run) preserves
 // unconditional Quit.
@@ -263,4 +373,94 @@ func (a *App) residencyNoteWindowsChanged() usecase.ResidencyDecision {
 		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
 	}
 	return a.residency.SetWindowCount(len(a.browserWindows))
+}
+
+// relayAdmissionProvider exposes a relay admission boundary without
+// extending the port interface. It matches desktop's provider structurally.
+type relayAdmissionProvider interface {
+	AdmissionGate() *process.AdmissionGate
+}
+
+// residencyQuiescent composes every native quiescence input: CEF runtime
+// activity, snapshot persistence drain, and relay admission leases.
+func (a *App) residencyQuiescent() bool {
+	if a == nil {
+		return true
+	}
+	if eng, ok := a.engine.(interface{ RuntimeActivity() port.RuntimeActivity }); ok && eng != nil {
+		if act := eng.RuntimeActivity(); act != nil && !act.Snapshot().Quiescent() {
+			return false
+		}
+	}
+	if drain, ok := a.snapshotService.(port.PersistenceDrain); ok && drain != nil && drain.Active() {
+		return false
+	}
+	if a.deps != nil {
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil && gate.Active() > 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// subscribeResidencyQuiescence wires native settle callbacks into the
+// residency controller. CEF activity transitions drive policy work events;
+// persistence and relay settle paths recheck a deferred quit. Every
+// callback crosses into GTK through the controller dispatch: no GTK work
+// runs on CEF callbacks and no per-frame polling observes quiescence.
+func (a *App) subscribeResidencyQuiescence() {
+	r := a.residency
+	if a == nil || r == nil || !r.Enabled() {
+		return
+	}
+	dispatch := func(fn func()) { r.DispatchToGTK(fn) }
+	if eng, ok := a.engine.(interface{ RuntimeActivity() port.RuntimeActivity }); ok && eng != nil {
+		if act := eng.RuntimeActivity(); act != nil {
+			unsubscribe := act.Subscribe(func(snapshot port.RuntimeActivitySnapshot) {
+				busy := !snapshot.Quiescent()
+				dispatch(func() { r.SetNativeBusy("cef-activity", busy) })
+			})
+			a.residencyUnsubscribe = append(a.residencyUnsubscribe, unsubscribe)
+		}
+	}
+	if drain, ok := a.snapshotService.(port.PersistenceDrain); ok && drain != nil {
+		if notifier, ok := drain.(interface{ OnSettled(func()) }); ok {
+			notifier.OnSettled(func() { dispatch(func() { r.MaybeQuit() }) })
+		}
+	}
+	if a.deps != nil {
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil {
+				gate.OnDrained(func() { dispatch(func() { r.MaybeQuit() }) })
+			}
+		}
+	}
+}
+
+// unsubscribeResidencyQuiescence drops native subscriptions at shutdown.
+func (a *App) unsubscribeResidencyQuiescence() {
+	if a == nil {
+		return
+	}
+	for _, unsubscribe := range a.residencyUnsubscribe {
+		if unsubscribe != nil {
+			unsubscribe()
+		}
+	}
+	a.residencyUnsubscribe = nil
+}
+
+// closeRelayAdmission stops relay admission before snapshot/update
+// teardown so no new work starts while persistence drains.
+func (a *App) closeRelayAdmission() {
+	if a == nil || a.deps == nil {
+		return
+	}
+	if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+		if gate := provider.AdmissionGate(); gate != nil {
+			gate.Close()
+		}
+	}
 }

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -1,6 +1,11 @@
 package ui
 
-import "time"
+import (
+	"time"
+
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/puregotk/v4/glib"
+)
 
 // ResidencyTimeoutFromMillis resolves the effective bounded-residency idle
 // timeout for CEF from the startup configuration value in milliseconds.
@@ -43,4 +48,219 @@ func (a *App) ResidencyTimeoutRestartRequired(timeoutMs int) bool {
 		return false
 	}
 	return ResidencyTimeoutFromMillis(timeoutMs) != a.residencyTimeout
+}
+
+// residencyApplication is the application-lifetime subset used for bounded
+// residency: one hold while opt-in residency is enabled, released exactly
+// once on every Run exit. *gtk.Application satisfies it through embedding.
+type residencyApplication interface {
+	Hold()
+	Release()
+	Quit()
+}
+
+// ResidencyController owns one application hold and the idle timer for
+// bounded opt-in residency. It maps engine-neutral policy decisions to
+// scheduler operations; the clock and timer handles are injected so tests
+// use fakes while production uses the GLib main context. It never sleeps.
+type ResidencyController struct {
+	policy   *usecase.RuntimeResidency
+	clock    func() time.Time
+	schedule func(d time.Duration, generation uint64)
+	cancel   func()
+	quit     func()
+
+	enabled     bool
+	lastWindows int
+	quitting    bool
+	held        bool
+
+	timerCallback *glib.SourceFunc
+	timerTag      uint
+}
+
+// NewResidencyController builds the UI-side residency owner. A zero timeout
+// keeps the controller disabled: decisions then always resolve to the
+// pre-existing last-window exit behavior.
+func NewResidencyController(timeout time.Duration, clock func() time.Time, schedule func(time.Duration, uint64), cancel func(), quit func()) *ResidencyController {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &ResidencyController{
+		policy:   usecase.NewRuntimeResidency(timeout),
+		enabled:  timeout > 0,
+		clock:    clock,
+		schedule: schedule,
+		cancel:   cancel,
+		quit:     quit,
+	}
+}
+
+// Enabled reports whether opt-in residency is active (nonzero latch).
+// A disabled controller resolves every empty state to the pre-existing
+// last-window exit behavior.
+func (c *ResidencyController) Enabled() bool {
+	return c != nil && c.enabled
+}
+
+// AcquireHold takes exactly one application hold for enabled residency.
+// It is a no-op when disabled, already held, or given a nil application.
+// Pair every acquisition with ReleaseHold, typically via defer in Run so
+// all exits (including activation failure) match it exactly once.
+func (c *ResidencyController) AcquireHold(app residencyApplication) {
+	if c == nil || !c.enabled || c.held || app == nil {
+		return
+	}
+	app.Hold()
+	c.held = true
+}
+
+// ReleaseHold releases a previously acquired hold exactly once.
+func (c *ResidencyController) ReleaseHold(app residencyApplication) {
+	if c == nil || !c.held || app == nil {
+		return
+	}
+	c.held = false
+	app.Release()
+}
+
+// SetWindowCount converges the policy to the current user-window count.
+// Opens and closes funnel through here so duplicate or reordered events
+// cannot strand the count. It returns the final decision for this update.
+func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecision {
+	if c == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
+	}
+	now := c.clock()
+	var decision usecase.ResidencyDecision
+	events := false
+	for c.lastWindows < count {
+		c.lastWindows++
+		events = true
+		decision = c.apply(c.policy.WindowOpened(now))
+	}
+	for c.lastWindows > count {
+		c.lastWindows--
+		events = true
+		decision = c.apply(c.policy.WindowClosed(now))
+	}
+	if count == 0 && !events {
+		// No windows were ever reported (e.g. activation failure):
+		// evaluate once so the process reaches bounded idle or orderly
+		// shutdown instead of idling forever on the residency hold.
+		decision = c.apply(c.policy.WindowClosed(now))
+	}
+	return decision
+}
+
+// Evaluate forces one idle evaluation for paths that never report windows
+// (e.g. initial-shell failure). It returns the resulting decision.
+func (c *ResidencyController) Evaluate() usecase.ResidencyDecision {
+	if c == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
+	}
+	return c.apply(c.policy.WindowClosed(c.clock()))
+}
+
+// NoteExplicitQuit records an explicit quit or signal: the timer is
+// cancelled, the policy resolves Quit immediately, and the deadline is never
+// waited on. It never invokes the quit function itself.
+func (c *ResidencyController) NoteExplicitQuit() {
+	if c == nil {
+		return
+	}
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.policy.ShutdownRequested()
+}
+
+// OnTimerFired processes a fired idle timer for the given generation.
+// Stale generations are ignored by the policy.
+func (c *ResidencyController) OnTimerFired(generation uint64) {
+	if c == nil {
+		return
+	}
+	c.apply(c.policy.HandleExpiry(c.clock(), generation))
+}
+
+func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.ResidencyDecision {
+	switch decision.Action {
+	case usecase.ResidencyArm:
+		if c.cancel != nil {
+			c.cancel()
+		}
+		if c.schedule != nil {
+			delay := time.Until(decision.Deadline)
+			if delay < 0 {
+				delay = 0
+			}
+			c.schedule(delay, decision.Generation)
+		}
+	case usecase.ResidencyCancel:
+		if c.cancel != nil {
+			c.cancel()
+		}
+	case usecase.ResidencyQuit:
+		c.doQuit()
+	}
+	return decision
+}
+
+func (c *ResidencyController) doQuit() {
+	if c.quitting {
+		return
+	}
+	c.quitting = true
+	if c.cancel != nil {
+		c.cancel()
+	}
+	if c.quit != nil {
+		c.quit()
+	}
+}
+
+// scheduleGLibTimeout arms a one-shot GLib timeout for the idle deadline.
+// The callback is retained on the controller until it fires or is
+// cancelled, and stale generations are rejected by the policy on fire.
+func (c *ResidencyController) scheduleGLibTimeout(d time.Duration, generation uint64) {
+	c.cancelGLibTimeout()
+	ms := uint(d.Milliseconds())
+	if ms == 0 {
+		ms = 1
+	}
+	callback := glib.SourceFunc(func(_ uintptr) bool {
+		c.OnTimerFired(generation)
+		return false
+	})
+	c.timerCallback = &callback
+	c.timerTag = glib.TimeoutAdd(ms, &callback, 0)
+}
+
+// cancelGLibTimeout drops a pending idle timer and releases its callback.
+func (c *ResidencyController) cancelGLibTimeout() {
+	if c.timerTag != 0 {
+		glib.SourceRemove(c.timerTag)
+		c.timerTag = 0
+	}
+	c.timerCallback = nil
+}
+
+// residencyShouldQuitAfterLastWindow reports whether the app must quit now
+// that no user windows remain. A nil controller (before Run) preserves
+// unconditional Quit.
+func (a *App) residencyShouldQuitAfterLastWindow() bool {
+	if a == nil || a.residency == nil {
+		return true
+	}
+	return a.residency.SetWindowCount(len(a.browserWindows)).Action == usecase.ResidencyQuit
+}
+
+// residencyNoteWindowsChanged converges residency accounting to the current
+// window count after opens, closes, and activation outcomes.
+func (a *App) residencyNoteWindowsChanged() usecase.ResidencyDecision {
+	if a == nil || a.residency == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
+	}
+	return a.residency.SetWindowCount(len(a.browserWindows))
 }

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
-	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/glib"
 )
@@ -93,6 +92,10 @@ type ResidencyController struct {
 	// seal stops new admissions before a quit commits, closing the race
 	// between the quiescence recheck and admitted work starting.
 	seal func()
+	// unseal reopens admission when a deferred quit is invalidated (e.g.
+	// a reopened window); without it the surviving process would stay
+	// permanently deaf to relay requests.
+	unseal func()
 
 	timerCallback *glib.SourceFunc
 	timerTag      uint
@@ -161,8 +164,14 @@ func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecisio
 	for c.lastWindows < count {
 		c.lastWindows++
 		events = true
-		// A reopened window invalidates any deferred quit.
-		c.pendingQuit = false
+		// A reopened window invalidates any deferred quit, and with it
+		// the admission seal: the surviving process keeps serving relay.
+		if c.pendingQuit {
+			c.pendingQuit = false
+			if c.unseal != nil {
+				c.unseal()
+			}
+		}
 		decision = c.apply(c.policy.WindowOpened(now))
 	}
 	for c.lastWindows > count {
@@ -221,7 +230,9 @@ func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.
 			c.cancel()
 		}
 		if c.schedule != nil {
-			delay := time.Until(decision.Deadline)
+			// Delay derives from the injected clock, never wall time, so
+			// fake clocks in tests observe the policy deadline exactly.
+			delay := decision.Deadline.Sub(c.clock())
 			if delay < 0 {
 				delay = 0
 			}
@@ -262,13 +273,16 @@ func (c *ResidencyController) requestQuit() {
 // MaybeQuit rechecks a deferred quit after sources settle. It is invoked
 // from settle callbacks (already dispatched to GTK) and busy transitions.
 // A reopened window invalidates the deferral: quitting then would bypass
-// the fresh idle interval.
+// the fresh idle interval, so admission reopens with it.
 func (c *ResidencyController) MaybeQuit() {
 	if c == nil || !c.pendingQuit || c.quitting {
 		return
 	}
 	if c.lastWindows > 0 {
 		c.pendingQuit = false
+		if c.unseal != nil {
+			c.unseal()
+		}
 		return
 	}
 	if c.quiescent != nil && !c.quiescent() {
@@ -305,6 +319,15 @@ func (c *ResidencyController) SetSealFunc(fn func()) {
 		return
 	}
 	c.seal = fn
+}
+
+// SetUnsealFunc installs the admission reopen invoked when a deferred quit
+// is invalidated by a reopened window.
+func (c *ResidencyController) SetUnsealFunc(fn func()) {
+	if c == nil {
+		return
+	}
+	c.unseal = fn
 }
 
 // DispatchToGTK runs fn on the GTK thread through the installed dispatch,
@@ -456,8 +479,9 @@ func (a *App) residencyNoteWindowsChanged() usecase.ResidencyDecision {
 
 // relayAdmissionProvider exposes a relay admission boundary without
 // extending the port interface. It matches desktop's provider structurally.
+// The boundary type keeps application code off the concrete gate.
 type relayAdmissionProvider interface {
-	AdmissionGate() *process.AdmissionGate
+	AdmissionGate() port.AdmissionBoundary
 }
 
 // residencyQuiescent composes every native quiescence input: CEF runtime
@@ -544,25 +568,31 @@ func (a *App) closeRelayAdmission() {
 	}
 }
 
-// waitRelayAdmissionDrained settles admitted relay work before persistence
-// teardown within a short bound. Admitted dispatch may need the GTK loop,
-// so the wait never blocks shutdown forever; expiry only logs and the
-// sockets settle through their own completion paths.
-func (a *App) waitRelayAdmissionDrained(ctx context.Context) {
-	if a == nil || a.deps == nil {
+// drainForShutdownOffThread settles admission leases and persistence
+// before GTK shutdown, while the loop can still service admitted work.
+// It runs only off the GTK thread (see Quit); every wait is bounded and
+// expiry only logs.
+func (a *App) drainForShutdownOffThread() {
+	if a == nil {
 		return
 	}
-	provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider)
-	if !ok || provider == nil {
-		return
+	a.closeRelayAdmission()
+	if a.deps != nil {
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil && gate.Active() > 0 {
+				drainCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				if !gate.WaitDrained(drainCtx) {
+					logging.FromContext(context.Background()).Warn().Int("admitted", gate.Active()).Msg("relay admission did not drain before shutdown")
+				}
+				cancel()
+			}
+		}
 	}
-	gate := provider.AdmissionGate()
-	if gate == nil || gate.Active() == 0 {
-		return
-	}
-	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
-	defer cancel()
-	if !gate.WaitDrained(drainCtx) {
-		logging.FromContext(ctx).Warn().Int("admitted", gate.Active()).Msg("relay admission did not drain before teardown")
+	if drain, ok := a.snapshotService.(port.PersistenceDrain); ok && drain != nil {
+		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := drain.WaitSettled(drainCtx); err != nil {
+			logging.FromContext(context.Background()).Warn().Err(err).Msg("persistence did not settle before shutdown")
+		}
+		cancel()
 	}
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -203,7 +203,9 @@ func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
 func TestResidencyControllerSealsBeforeCommit(t *testing.T) {
 	ctl, _, sched, quits := newResidencyTestController(time.Minute)
 	sealed := 0
+	unsealed := 0
 	ctl.SetSealFunc(func() { sealed++ })
+	ctl.SetUnsealFunc(func() { unsealed++ })
 	ctl.SetQuiescentFunc(func() bool { return true })
 	ctl.SetWindowCount(1)
 	ctl.SetWindowCount(0)
@@ -211,12 +213,15 @@ func TestResidencyControllerSealsBeforeCommit(t *testing.T) {
 	// Quiescent expiry seals admission, then commits the quit.
 	ctl.OnTimerFired(armed)
 	require.Equal(t, 1, sealed)
+	require.Equal(t, 0, unsealed)
 	require.Equal(t, 1, *quits)
 }
 
 func TestResidencyControllerReopenInvalidatesDeferredQuit(t *testing.T) {
 	ctl, _, sched, quits := newResidencyTestController(time.Minute)
 	quiescent := true
+	unsealed := 0
+	ctl.SetUnsealFunc(func() { unsealed++ })
 	ctl.SetQuiescentFunc(func() bool { return quiescent })
 	ctl.SetWindowCount(1)
 	ctl.SetWindowCount(0)
@@ -229,6 +234,7 @@ func TestResidencyControllerReopenInvalidatesDeferredQuit(t *testing.T) {
 	quiescent = true
 	ctl.MaybeQuit()
 	require.Equal(t, 0, *quits, "obsolete quit must not run after reopen")
+	require.Equal(t, 1, unsealed, "invalidation reopens admission")
 }
 
 func TestResidencyControllerDuplicateEmptyStaysArmed(t *testing.T) {

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -136,4 +136,64 @@ func TestResidencyControllerNilSafe(t *testing.T) {
 	ctl.OnTimerFired(7)
 	ctl.AcquireHold(nil)
 	ctl.ReleaseHold(nil)
+	ctl.SetQuiescentFunc(nil)
+	ctl.SetDispatchToGTK(nil)
+	ctl.DispatchToGTK(nil)
+	ctl.MaybeQuit()
+	require.Equal(t, usecase.ResidencyNone, ctl.SetNativeBusy("x", true).Action)
+}
+
+func TestResidencyControllerDefersQuitUntilSettled(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	quiescent := true
+	ctl.SetQuiescentFunc(func() bool { return quiescent })
+	ctl.SetWindowCount(1)
+	decision := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyArm, decision.Action)
+	armed := sched.generations[len(sched.generations)-1]
+
+	quiescent = false
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 0, *quits, "expiry defers while native work is outstanding")
+
+	quiescent = true
+	ctl.MaybeQuit()
+	require.Equal(t, 1, *quits, "settle recheck commits the deferred quit")
+	ctl.MaybeQuit()
+	require.Equal(t, 1, *quits, "quit commits exactly once")
+}
+
+func TestResidencyControllerNativeBusyDrivesPolicy(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+
+	decision := ctl.SetNativeBusy("cef-activity", true)
+	require.Equal(t, usecase.ResidencyNone, decision.Action)
+	decision = ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyNone, decision.Action, "close with native work outstanding arms nothing")
+	require.Empty(t, sched.scheduled)
+
+	decision = ctl.SetNativeBusy("cef-activity", false)
+	require.Equal(t, usecase.ResidencyArm, decision.Action, "settle re-arms idle")
+	require.NotEmpty(t, sched.scheduled)
+	require.Equal(t, 0, *quits)
+}
+
+func TestResidencyControllerDuplicateBusyIsSilent(t *testing.T) {
+	ctl, _, sched, _ := newResidencyTestController(time.Minute)
+	ctl.SetNativeBusy("downloads", true)
+	decision := ctl.SetNativeBusy("downloads", true)
+	require.Equal(t, usecase.ResidencyNone, decision.Action)
+	require.Empty(t, sched.scheduled)
+}
+
+func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
+	ctl, _, _, _ := newResidencyTestController(time.Minute)
+	var routed []string
+	ctl.SetDispatchToGTK(func(fn func()) {
+		routed = append(routed, "gtk")
+		fn()
+	})
+	ctl.DispatchToGTK(func() { routed = append(routed, "cb") })
+	require.Equal(t, []string{"gtk", "cb"}, routed)
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -82,7 +82,7 @@ func TestResidencyControllerDisabledPreservesQuit(t *testing.T) {
 }
 
 func TestResidencyControllerHoldMatchesReleaseOnce(t *testing.T) {
-	ctl, app, _, _ := newResidencyTestController(time.Minute)
+	ctl, app, _, quits := newResidencyTestController(time.Minute)
 	require.True(t, ctl.Enabled())
 	ctl.AcquireHold(app)
 	ctl.AcquireHold(app)
@@ -90,6 +90,7 @@ func TestResidencyControllerHoldMatchesReleaseOnce(t *testing.T) {
 	ctl.ReleaseHold(app)
 	ctl.ReleaseHold(app)
 	require.Equal(t, 1, app.releases, "exactly one release")
+	require.Equal(t, 0, *quits, "hold cycling never quits")
 }
 
 func TestResidencyControllerLastWindowArmsAndExpiryQuits(t *testing.T) {
@@ -188,7 +189,7 @@ func TestResidencyControllerDuplicateBusyIsSilent(t *testing.T) {
 }
 
 func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
-	ctl, _, _, _ := newResidencyTestController(time.Minute)
+	ctl, _, _, quits := newResidencyTestController(time.Minute)
 	var routed []string
 	ctl.SetDispatchToGTK(func(fn func()) {
 		routed = append(routed, "gtk")
@@ -196,4 +197,5 @@ func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
 	})
 	ctl.DispatchToGTK(func() { routed = append(routed, "cb") })
 	require.Equal(t, []string{"gtk", "cb"}, routed)
+	require.Equal(t, 0, *quits)
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,4 +31,109 @@ func TestResidencyTimeoutLatchAndRestartRequired(t *testing.T) {
 	nilApp.SetResidencyTimeout(time.Minute)
 	require.Equal(t, time.Duration(0), nilApp.LatchedResidencyTimeout())
 	require.False(t, nilApp.ResidencyTimeoutRestartRequired(60000))
+}
+
+type residencyFakeApp struct {
+	holds    int
+	releases int
+	quits    int
+}
+
+func (f *residencyFakeApp) Hold()    { f.holds++ }
+func (f *residencyFakeApp) Release() { f.releases++ }
+func (f *residencyFakeApp) Quit()    { f.quits++ }
+
+type residencyFakeScheduler struct {
+	scheduled   []time.Duration
+	generations []uint64
+	cancels     int
+}
+
+func (f *residencyFakeScheduler) schedule(d time.Duration, generation uint64) {
+	f.scheduled = append(f.scheduled, d)
+	f.generations = append(f.generations, generation)
+}
+
+func (f *residencyFakeScheduler) cancel() { f.cancels++ }
+
+func newResidencyTestController(timeout time.Duration) (*ResidencyController, *residencyFakeApp, *residencyFakeScheduler, *int) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	app := &residencyFakeApp{}
+	sched := &residencyFakeScheduler{}
+	quits := 0
+	ctl := NewResidencyController(timeout, clock, sched.schedule, sched.cancel, func() { quits++ })
+	return ctl, app, sched, &quits
+}
+
+func TestResidencyControllerDisabledPreservesQuit(t *testing.T) {
+	ctl, app, sched, quits := newResidencyTestController(0)
+	require.False(t, ctl.Enabled())
+	ctl.AcquireHold(app)
+	require.Equal(t, 0, app.holds, "disabled residency takes no hold")
+	ctl.ReleaseHold(app)
+	require.Equal(t, 0, app.releases)
+
+	ctl.SetWindowCount(1)
+	decision := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyQuit, decision.Action)
+	require.Equal(t, 1, *quits)
+	require.Empty(t, sched.scheduled)
+}
+
+func TestResidencyControllerHoldMatchesReleaseOnce(t *testing.T) {
+	ctl, app, _, _ := newResidencyTestController(time.Minute)
+	require.True(t, ctl.Enabled())
+	ctl.AcquireHold(app)
+	ctl.AcquireHold(app)
+	require.Equal(t, 1, app.holds, "exactly one hold")
+	ctl.ReleaseHold(app)
+	ctl.ReleaseHold(app)
+	require.Equal(t, 1, app.releases, "exactly one release")
+}
+
+func TestResidencyControllerLastWindowArmsAndExpiryQuits(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	decision := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyArm, decision.Action)
+	require.NotEmpty(t, sched.scheduled)
+	armed := sched.generations[len(sched.generations)-1]
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 1, *quits)
+}
+
+func TestResidencyControllerReopenCancelsTimer(t *testing.T) {
+	ctl, _, sched, _ := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	require.NotEmpty(t, sched.scheduled)
+	armed := sched.generations[len(sched.generations)-1]
+	cancels := sched.cancels
+	ctl.SetWindowCount(1)
+	require.Greater(t, sched.cancels, cancels, "reopen cancels the armed deadline")
+	ctl.OnTimerFired(armed)
+}
+
+func TestResidencyControllerExplicitQuitBypassesDeadline(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	require.NotEmpty(t, sched.scheduled)
+	armed := sched.generations[len(sched.generations)-1]
+	ctl.NoteExplicitQuit()
+	require.Equal(t, 0, *quits, "noting quit never invokes quit itself")
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 0, *quits, "deadline never fires after explicit quit")
+}
+
+func TestResidencyControllerNilSafe(t *testing.T) {
+	var ctl *ResidencyController
+	require.False(t, ctl.Enabled())
+	require.Equal(t, usecase.ResidencyQuit, ctl.SetWindowCount(0).Action)
+	require.Equal(t, usecase.ResidencyQuit, ctl.Evaluate().Action)
+	ctl.NoteExplicitQuit()
+	ctl.OnTimerFired(7)
+	ctl.AcquireHold(nil)
+	ctl.ReleaseHold(nil)
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResidencyTimeoutFromMillis(t *testing.T) {
+	require.Equal(t, time.Duration(0), ResidencyTimeoutFromMillis(0))
+	require.Equal(t, time.Duration(0), ResidencyTimeoutFromMillis(-5))
+	require.Equal(t, 60*time.Second, ResidencyTimeoutFromMillis(60000))
+	require.Equal(t, 300000*time.Millisecond, ResidencyTimeoutFromMillis(300000))
+	require.Equal(t, 300000*time.Millisecond, ResidencyTimeoutFromMillis(999999))
+}
+
+func TestResidencyTimeoutLatchAndRestartRequired(t *testing.T) {
+	app := &App{}
+	require.Equal(t, time.Duration(0), app.LatchedResidencyTimeout())
+
+	app.SetResidencyTimeout(60 * time.Second)
+	require.Equal(t, 60*time.Second, app.LatchedResidencyTimeout())
+	require.False(t, app.ResidencyTimeoutRestartRequired(60000))
+	require.True(t, app.ResidencyTimeoutRestartRequired(0))
+	require.True(t, app.ResidencyTimeoutRestartRequired(120000))
+
+	// A nil app never panics and reports no change.
+	var nilApp *App
+	nilApp.SetResidencyTimeout(time.Minute)
+	require.Equal(t, time.Duration(0), nilApp.LatchedResidencyTimeout())
+	require.False(t, nilApp.ResidencyTimeoutRestartRequired(60000))
+}

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -199,3 +199,48 @@ func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
 	require.Equal(t, []string{"gtk", "cb"}, routed)
 	require.Equal(t, 0, *quits)
 }
+
+func TestResidencyControllerSealsBeforeCommit(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	sealed := 0
+	ctl.SetSealFunc(func() { sealed++ })
+	ctl.SetQuiescentFunc(func() bool { return true })
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	armed := sched.generations[len(sched.generations)-1]
+	// Quiescent expiry seals admission, then commits the quit.
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 1, sealed)
+	require.Equal(t, 1, *quits)
+}
+
+func TestResidencyControllerReopenInvalidatesDeferredQuit(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	quiescent := true
+	ctl.SetQuiescentFunc(func() bool { return quiescent })
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	armed := sched.generations[len(sched.generations)-1]
+	quiescent = false
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 0, *quits, "quit defers while unsettled")
+	// A reopened window invalidates the deferral.
+	ctl.SetWindowCount(1)
+	quiescent = true
+	ctl.MaybeQuit()
+	require.Equal(t, 0, *quits, "obsolete quit must not run after reopen")
+}
+
+func TestResidencyControllerDuplicateEmptyStaysArmed(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	first := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyArm, first.Action)
+	require.Len(t, sched.scheduled, 1)
+	// A repeated empty update (e.g. tab-empty after window removal)
+	// stays on the armed deadline instead of re-arming.
+	again := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyNone, again.Action)
+	require.Len(t, sched.scheduled, 1, "no duplicate timer")
+	require.Equal(t, 0, *quits)
+}

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -382,6 +382,37 @@ def child_pids(root_pid):
     return children
 
 
+def proc_starttime(pid):
+    """Process start time (jiffies since boot) via /proc, or None.
+    Combined with the pid it forms an independently observed identity that
+    survives Popen-handle reuse and detects pid recycling."""
+    try:
+        with open("/proc/%d/stat" % pid) as handle:
+            parts = handle.read().rsplit(")", 1)[1].split()
+            return int(parts[19])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def wait_for_child_quiescence(owner_pid, settle_seconds=2.0, timeout_seconds=15.0):
+    """Wait until the owner's child count is stable across settle_seconds.
+    Window close is asynchronous: the relay acknowledgement only means the
+    request was accepted, so reopening must wait for an observable steady
+    state instead of a fixed sleep. Returns the stable child count."""
+    end = time.monotonic() + timeout_seconds
+    last_change = time.monotonic()
+    last_count = len(child_pids(owner_pid))
+    while time.monotonic() < end:
+        time.sleep(0.5)
+        count = len(child_pids(owner_pid))
+        if count != last_count:
+            last_count = count
+            last_change = time.monotonic()
+        elif time.monotonic() - last_change >= settle_seconds:
+            return count
+    return len(child_pids(owner_pid))
+
+
 def proc_rss_kb(pid):
     """Resident memory of pid in KiB via /proc, or None."""
     try:
@@ -433,14 +464,19 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
         reopen = None
         if scenario == "reopen-window" and owner is not None and owner_socket:
             owner_pid = owner.pid
+            owner_start = proc_starttime(owner_pid)
             children_before = child_pids(owner_pid)
             rss_before = proc_rss_kb(owner_pid)
             acknowledged = send_diagnostic_close(owner_socket)
-            time.sleep(0.5)
+            # The acknowledgement only means accepted: wait for an
+            # observable steady state before measuring the reopen.
+            quiescent_children = wait_for_child_quiescence(owner_pid)
             reopen = {
                 "owner_pid": owner_pid,
+                "owner_starttime": owner_start,
                 "close_acknowledged": acknowledged,
                 "browser_child_count_before": len(children_before),
+                "browser_child_count_quiescent": quiescent_children,
                 "owner_rss_kb_before": rss_before,
             }
         spawn_ts = time.monotonic()
@@ -533,9 +569,18 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             "fallback_spawn": scenario in ("relay-window", "reopen-window") and not relayed,
         }
         if reopen is not None:
+            # Owner identity is verified independently of the Popen handle:
+            # the same pid with a different start time is a recycled pid,
+            # not the same process. Unverifiable identity counts as different.
+            start_now = proc_starttime(reopen["owner_pid"]) if owner is not None else None
             owner_alive = owner is not None and owner.poll() is None
+            same = bool(
+                owner_alive
+                and reopen["owner_starttime"] is not None
+                and start_now == reopen["owner_starttime"]
+            )
             reopen["owner_alive_after"] = owner_alive
-            reopen["same_process"] = bool(owner_alive and reopen["owner_pid"] == owner.pid)
+            reopen["same_process"] = same
             reopen["browser_child_count_after"] = len(child_pids(owner.pid)) if owner_alive else 0
             reopen["owner_rss_kb_after"] = proc_rss_kb(owner.pid) if owner_alive else None
             result["reopen"] = reopen

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -8,6 +8,10 @@ Scenarios:
   relay-window   a real long-lived owner browser holds the relay; samples
                  launch browse with DUMBER_BROWSER_FRESH_WINDOW=1 in that
                  same isolated profile
+  reopen-window  like relay-window, but each sample first closes all owner
+                 windows through the diagnostic relay action, then reopens
+                 through the relay; verifies the same owner process serves
+                 the reopen without a second CEF initialization
 
 Fixtures (loopback only): static, delayed, redirect, cache.
 
@@ -281,7 +285,7 @@ def wait_for_relay_socket(runtime_dir, timeout_seconds=30.0):
     return None
 
 
-def start_relay_owner(binary, cef_dir, scenario_dir):
+def start_relay_owner(binary, cef_dir, scenario_dir, diagnostic_close=False):
     dirs = {
         "config": os.path.join(scenario_dir, "owner-config"),
         "data": os.path.join(scenario_dir, "owner-data"),
@@ -291,6 +295,12 @@ def start_relay_owner(binary, cef_dir, scenario_dir):
         "root_cache": os.path.join(scenario_dir, "shared-profile"),
     }
     env = scenario_env(cef_dir, dirs)
+    if diagnostic_close:
+        # Owned window-close mechanism for the reopen scenario only: the
+        # relay honors it solely in processes carrying this variable. It is
+        # never a general unauthenticated shutdown command.
+        env = dict(env)
+        env["DUMBER_DIAGNOSTIC_WINDOW_CLOSE"] = "1"
     try:
         proc = subprocess.Popen(
             [binary, "browse", "about:blank"],
@@ -299,18 +309,19 @@ def start_relay_owner(binary, cef_dir, scenario_dir):
             env=env,
         )
     except OSError:
-        return None, None
+        return None, None, None
     time.sleep(0.5)
     if proc.poll() is not None:
-        return None, None
-    if wait_for_relay_socket(dirs["runtime"]) is None:
+        return None, None, None
+    socket_path = wait_for_relay_socket(dirs["runtime"])
+    if socket_path is None:
         proc.terminate()
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
-        return None, None
-    return proc, dirs
+        return None, None, None
+    return proc, dirs, socket_path
 
 
 def stop_proc(proc):
@@ -324,8 +335,67 @@ def stop_proc(proc):
         proc.wait(timeout=5)
 
 
+def send_diagnostic_close(socket_path, timeout_seconds=10.0):
+    """Ask the relay owner to close all windows. Returns True only on an
+    explicit acknowledgement. Never a general shutdown command: owners
+    honor it solely with DUMBER_DIAGNOSTIC_WINDOW_CLOSE=1."""
+    request = json.dumps({"request_id": secrets.token_hex(8), "action": "close-all-windows"}) + "\n"
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout_seconds)
+    try:
+        sock.connect(socket_path)
+        sock.sendall(request.encode())
+        received = b""
+        while b"\n" not in received:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            received += chunk
+        try:
+            response = json.loads(received.decode())
+        except ValueError:
+            return False
+        return bool(response.get("accepted")) and not response.get("error")
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def child_pids(root_pid):
+    """Direct child pids of root_pid via /proc (stdlib only)."""
+    children = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return children
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        try:
+            with open("/proc/%s/stat" % entry) as handle:
+                parts = handle.read().rsplit(")", 1)[1].split()
+                if int(parts[1]) == root_pid:
+                    children.append(int(entry))
+        except (OSError, ValueError, IndexError):
+            continue
+    return children
+
+
+def proc_rss_kb(pid):
+    """Resident memory of pid in KiB via /proc, or None."""
+    try:
+        with open("/proc/%d/status" % pid) as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
 def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_dirs=None,
-               shared_root_cache=None):
+               shared_root_cache=None, owner_socket=None):
     run_token = secrets.token_hex(8)
     nav_token = secrets.token_hex(8)
     cutoff = post_nav_cutoff_seconds()
@@ -345,7 +415,7 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             url = "http://127.0.0.1:%d/redirect?run=%s&nav=%s" % (port, run_token, nav_token)
         else:
             url = "http://127.0.0.1:%d/?run=%s&nav=%s" % (port, run_token, nav_token)
-        if scenario == "relay-window" and owner_dirs is not None:
+        if scenario in ("relay-window", "reopen-window") and owner_dirs is not None:
             dirs = dict(owner_dirs)
             extra = {"DUMBER_BROWSER_FRESH_WINDOW": "1"}
         else:
@@ -360,6 +430,19 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             extra = {}
         env = scenario_env(cef_dir, dirs, extra)
         owner_alive_at_start = owner is not None and owner.poll() is None
+        reopen = None
+        if scenario == "reopen-window" and owner is not None and owner_socket:
+            owner_pid = owner.pid
+            children_before = child_pids(owner_pid)
+            rss_before = proc_rss_kb(owner_pid)
+            acknowledged = send_diagnostic_close(owner_socket)
+            time.sleep(0.5)
+            reopen = {
+                "owner_pid": owner_pid,
+                "close_acknowledged": acknowledged,
+                "browser_child_count_before": len(children_before),
+                "owner_rss_kb_before": rss_before,
+            }
         spawn_ts = time.monotonic()
         proc = subprocess.Popen(
             [binary, "browse", url],
@@ -429,11 +512,11 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             observation_ms = int((decision_ts - spawn_ts) * 1000)
         expected_document_requests = 2 if fixture == "redirect" else 1
         complete = document_count == expected_document_requests and len(fcp) > 0
-        if scenario == "relay-window":
+        if scenario in ("relay-window", "reopen-window"):
             relayed = bool(owner_alive_at_start and self_exited)
         else:
             relayed = False
-        return {
+        result = {
             "run": run_index,
             "scenario": scenario,
             "fixture": fixture,
@@ -447,8 +530,16 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             "startup_milestones": len(milestones),
             "complete": complete,
             "relayed": relayed,
-            "fallback_spawn": scenario == "relay-window" and not relayed,
+            "fallback_spawn": scenario in ("relay-window", "reopen-window") and not relayed,
         }
+        if reopen is not None:
+            owner_alive = owner is not None and owner.poll() is None
+            reopen["owner_alive_after"] = owner_alive
+            reopen["same_process"] = bool(owner_alive and reopen["owner_pid"] == owner.pid)
+            reopen["browser_child_count_after"] = len(child_pids(owner.pid)) if owner_alive else 0
+            reopen["owner_rss_kb_after"] = proc_rss_kb(owner.pid) if owner_alive else None
+            result["reopen"] = reopen
+        return result
     finally:
         server.shutdown()
         server.server_close()
@@ -463,7 +554,7 @@ def main():
     parser.add_argument(
         "--scenario",
         required=True,
-        choices=("process-warm", "profile-fresh", "relay-window"),
+        choices=("process-warm", "profile-fresh", "relay-window", "reopen-window"),
     )
     parser.add_argument(
         "--fixture",
@@ -501,6 +592,7 @@ def main():
     os.makedirs(args.output)
     owner = None
     owner_dirs = None
+    owner_socket = None
     shared_root_cache = None
     warmup_discarded = False
     if args.scenario == "process-warm":
@@ -509,7 +601,12 @@ def main():
     if args.scenario == "relay-window":
         scenario_dir = os.path.join(args.output, "relay-scenario")
         os.makedirs(scenario_dir)
-        owner, owner_dirs = start_relay_owner(args.binary, args.cef_dir, scenario_dir)
+        owner, owner_dirs, owner_socket = start_relay_owner(args.binary, args.cef_dir, scenario_dir)
+    if args.scenario == "reopen-window":
+        scenario_dir = os.path.join(args.output, "reopen-scenario")
+        os.makedirs(scenario_dir)
+        owner, owner_dirs, owner_socket = start_relay_owner(
+            args.binary, args.cef_dir, scenario_dir, diagnostic_close=True)
 
     results = []
     try:
@@ -528,6 +625,7 @@ def main():
             result = run_sample(
                 args.binary, args.cef_dir, args.scenario, args.fixture, index,
                 owner=owner, owner_dirs=owner_dirs, shared_root_cache=shared_root_cache,
+                owner_socket=owner_socket,
             )
             results.append(result)
             with open(os.path.join(args.output, "run-%02d.json" % index), "w") as handle:

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -211,5 +211,66 @@ class FakeBinaryLifetimeTest(unittest.TestCase):
         self.assertLess(result["observation_spawn_to_summary_ms"], 15000)
 
 
+class ReopenWindowTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkdtemp()
+        self.cef_dir = os.path.join(self.temp, "cef")
+        os.makedirs(self.cef_dir)
+
+    def test_diagnostic_close_acknowledged(self):
+        import json
+        import socket
+        socket_path = os.path.join(self.temp, "test.sock")
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(socket_path)
+        listener.listen(1)
+        listener.settimeout(5)
+
+        def serve_once():
+            conn, _ = listener.accept()
+            with conn:
+                conn.settimeout(5)
+                data = b""
+                while b"\n" not in data:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+                request = json.loads(data.decode())
+                assert request["action"] == "close-all-windows"
+                conn.sendall(json.dumps({"request_id": request["request_id"],
+                                         "accepted": True}).encode() + b"\n")
+
+        thread = threading.Thread(target=serve_once)
+        thread.daemon = True
+        thread.start()
+        try:
+            self.assertTrue(harness.send_diagnostic_close(socket_path))
+        finally:
+            thread.join(timeout=5)
+            listener.close()
+
+    def test_diagnostic_close_refused_without_server(self):
+        self.assertFalse(harness.send_diagnostic_close(os.path.join(self.temp, "missing.sock"), 1.0))
+
+    def test_proc_helpers_observe_current_process(self):
+        self.assertIsInstance(harness.child_pids(os.getpid()), list)
+        rss = harness.proc_rss_kb(os.getpid())
+        self.assertIsNotNone(rss)
+        self.assertGreater(rss, 0)
+        self.assertIsNone(harness.proc_rss_kb(2 ** 30))
+
+    def test_reopen_without_owner_falls_back(self):
+        binary = os.path.join(self.temp, "fakebin")
+        with open(binary, "w") as handle:
+            handle.write("#!/bin/sh\nexit 0\n")
+        os.chmod(binary, 0o755)
+        result = harness.run_sample(binary, self.cef_dir, "reopen-window", "static", 1,
+                                    owner=None, owner_dirs=None, owner_socket=None)
+        self.assertTrue(result["fallback_spawn"])
+        self.assertFalse(result["relayed"])
+        self.assertNotIn("reopen", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -260,6 +260,18 @@ class ReopenWindowTest(unittest.TestCase):
         self.assertGreater(rss, 0)
         self.assertIsNone(harness.proc_rss_kb(2 ** 30))
 
+    def test_proc_starttime_identifies_current_process(self):
+        first = harness.proc_starttime(os.getpid())
+        self.assertIsNotNone(first)
+        self.assertGreaterEqual(first, 0)
+        self.assertEqual(first, harness.proc_starttime(os.getpid()))
+        self.assertIsNone(harness.proc_starttime(2 ** 30))
+
+    def test_child_quiescence_returns_stable_count(self):
+        count = harness.wait_for_child_quiescence(os.getpid(), settle_seconds=0.2, timeout_seconds=5.0)
+        self.assertIsInstance(count, int)
+        self.assertGreaterEqual(count, 0)
+
     def test_reopen_without_owner_falls_back(self):
         binary = os.path.join(self.temp, "fakebin")
         with open(binary, "w") as handle:


### PR DESCRIPTION
Stacked on #410. Implements Plan 02 (resident CEF runtime and bounded prewarming): issues #390, #395. Default stays disabled (`engine.cef.idle_runtime_timeout_ms: 0`).

## What changed
- **P1 policy+config:** engine-neutral residency controller (arm/cancel/quit with timer generations; failed opens restore idle; explicit quit never waits); startup-only `engine.cef.idle_runtime_timeout_ms` (0..300000, validated, env-mapped, documented, restart-required latch on App).
- **P2 lifecycle:** single GTK hold owned by the controller (all Run exits incl. activation failure); all close paths converge accounting in `removeBrowserWindow`; CEF quiescence boundary (creation/view/cleanup/download tracking with (browser, downloadID) identity); admission lease before relay ack with error responses on refusal; snapshot drain boundary (settled-but-failed, bounded waits, Stop joins); onShutdown closes admission then drains before snapshot/update teardown; expiry commits only after seal + quiescence recheck.
- **P3/P4 gates:** reopen-window harness scenario (diagnostic relay close, owner-identity verification); pool readiness predicate (wrapper-only never ready); production prewarm stays off.

## Review disposition
Senior-engineer review returned NO-GO with 6 blockers + 3 concerns; all addressed in cce5e093 (exact-once teardown pairing, timer retirement, GTK-thread quit, tag retirement, close-then-drain with bounds, serialized subscription, reopen invalidation, armed dedup, leak-free waits) with regression tests.

## Gates
- `git diff --check` clean, `make lint` clean, 11 headless suites green (incl. -race on process/usecase/snapshot/tracker).
- Display/native validation outstanding: enabled-config smoke, reopen/expiry A/B, idle cost, spare-view experiment.