### PR TITLE
perf(cef): GUI initialization and first-frame scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,11 @@ scripts/*
 !scripts/verify_purego_only.sh
 !scripts/stress_omnibox_callbacks.go
 !scripts/cef-gpu-diagnostics.sh
+!scripts/collect_first_presentation.sh
+!scripts/cef_runtime_probe.py
+!scripts/measure_cef_startup.py
+!scripts/test_measure_cef_startup.py
+!scripts/test_systemview_startup.py
 specs/
 templates/
 .serena/

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ scripts/*
 !scripts/cef_runtime_probe.py
 !scripts/measure_cef_startup.py
 !scripts/test_measure_cef_startup.py
+!scripts/generate_build_manifest.py
 !scripts/test_systemview_startup.py
 specs/
 templates/

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X m
 # package boundaries. Both are required — -l alone is insufficient.
 GCFLAGS=-gcflags 'all=-N -l'
 
+# VCS stamping for measured binaries. build-quick stays unstamped for fast
+# iteration; build-manifest forces stamping so the manifest binds the exact
+# built tree instead of the ambient checkout HEAD.
+BUILDVCS?=false
+
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -72,11 +77,12 @@ build-systemviews: generate-systemviews ## Build the WASM systemviews runtime
 build-quick: ## Build quickly for backend development
 	@echo "Building $(BINARY_NAME) $(VERSION) (quick)..."
 	@mkdir -p $(DIST_DIR)
-	GOFLAGS="$(NATIVE_GOFLAGS)" CGO_ENABLED=0 go build -buildvcs=false -p $(NPROCS) $(GCFLAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) $(MAIN_PATH)
+	GOFLAGS="$(NATIVE_GOFLAGS)" CGO_ENABLED=0 go build -buildvcs=$(BUILDVCS) -p $(NPROCS) $(GCFLAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) $(MAIN_PATH)
 	@rm -f $(DIST_DIR)/cef-helper
 	@echo "Build successful! Binary: $(DIST_DIR)/$(BINARY_NAME)"
 
-build-manifest: build-quick ## Generate the collector build manifest for dist/dumber
+build-manifest: ## Generate the collector build manifest for dist/dumber (VCS-stamped build)
+	@$(MAKE) build-quick BUILDVCS=true
 	@echo "Generating build manifest..."
 	python3 scripts/generate_build_manifest.py --binary $(DIST_DIR)/$(BINARY_NAME)
 	@echo "Manifest: $(DIST_DIR)/$(BINARY_NAME).manifest.json"

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,11 @@ build-quick: ## Build quickly for backend development
 	@rm -f $(DIST_DIR)/cef-helper
 	@echo "Build successful! Binary: $(DIST_DIR)/$(BINARY_NAME)"
 
+build-manifest: build-quick ## Generate the collector build manifest for dist/dumber
+	@echo "Generating build manifest..."
+	python3 scripts/generate_build_manifest.py --binary $(DIST_DIR)/$(BINARY_NAME)
+	@echo "Manifest: $(DIST_DIR)/$(BINARY_NAME).manifest.json"
+
 install-local: build-quick ## Install dumber to ~/.local/bin atomically
 	@echo "Installing $(BINARY_NAME) to $(LOCAL_BIN_DIR)..."
 	@mkdir -p $(LOCAL_BIN_DIR)

--- a/assets/webui_embed.go
+++ b/assets/webui_embed.go
@@ -21,3 +21,11 @@ var LogoSVG []byte
 //
 //go:embed logo-32.png
 var LogoPNG32 []byte
+
+// LogoPNG512 contains the dumber logo as 512x512 PNG for the loading
+// placeholder. The initial pane decodes this raster asset instead of SVG to
+// avoid XML parsing and rasterization on the critical path. LogoSVG remains
+// the source for desktop icon installation.
+//
+//go:embed logo-512.png
+var LogoPNG512 []byte

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -333,6 +333,11 @@ func runGUI(cfg *config.Config, timing startupTiming) int {
 		log.Error().Err(err).Msg("failed to create application")
 		return 1
 	}
+	// Latch the bounded-residency timeout once at startup. Only CEF uses
+	// it, and only when nonzero; later config changes are restart-required.
+	if cfg.Engine.ResolveEngineType() == config.EngineTypeCEF {
+		app.SetResidencyTimeout(ui.ResidencyTimeoutFromMillis(cfg.Engine.CEF.IdleRuntimeTimeoutMs))
+	}
 	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
 		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
 			if err := app.OpenExternalURL(ctx, url); err != nil {

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -667,6 +667,20 @@ func initStackAndRepos(
 	}
 
 	log := logging.FromContext(ctx)
+
+	// Non-restore browser startup uses the same lazy provider throughout:
+	// create it before engine initialization and warm it in an owned
+	// background task so slow database initialization overlaps CEF startup
+	// instead of blocking the GTK main context on first access. The detached
+	// warmup context preserves values without letting shutdown cancellation
+	// poison the cached initialization result; Close waits for the warmup to
+	// settle before releasing the connection.
+	lazyDB, err := bootstrap.CreateLazyDatabase()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	lazyDB.Warmup(context.WithoutCancel(ctx))
+
 	engine, err := bootstrap.BuildEngine(bootstrap.EngineInput{
 		Ctx:                 ctx,
 		Config:              cfg,
@@ -677,14 +691,12 @@ func initStackAndRepos(
 		Logger:              *log,
 	})
 	if err != nil {
+		_ = lazyDB.Close()
 		return nil, nil, nil, err
 	}
 
-	repos, dbCleanup, err := initStandaloneOmniboxRepos()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return engine, repos, dbCleanup, nil
+	dbCleanup := func() { _ = lazyDB.Close() }
+	return engine, createLazyRepositories(lazyDB), dbCleanup, nil
 }
 
 func initStandaloneOmniboxRepos() (*repositories, func(), error) {

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -266,6 +266,16 @@ func main() {
 	cmd.Execute()
 }
 
+func setAlreadyRunningRelaunchHandler(engine port.Engine, app *ui.App, ctx context.Context, log *zerolog.Logger) {
+	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
+		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
+			if err := app.OpenExternalURL(ctx, url); err != nil {
+				log.Warn().Err(err).Str("url", url).Msg("failed to open relaunch external URL")
+			}
+		})
+	}
+}
+
 func runGUI(cfg *config.Config, timing startupTiming) int {
 	bootstrap.ApplyGTKIMModuleFallbackDefault(os.Stderr)
 
@@ -333,18 +343,9 @@ func runGUI(cfg *config.Config, timing startupTiming) int {
 		log.Error().Err(err).Msg("failed to create application")
 		return 1
 	}
-	// Latch the bounded-residency timeout once at startup. Only CEF uses
-	// it, and only when nonzero; later config changes are restart-required.
-	if cfg.Engine.ResolveEngineType() == config.EngineTypeCEF {
-		app.SetResidencyTimeout(ui.ResidencyTimeoutFromMillis(cfg.Engine.CEF.IdleRuntimeTimeoutMs))
-	}
-	if relaunchSetter, ok := engine.(port.AlreadyRunningAppRelaunchHandlerSetter); ok {
-		relaunchSetter.SetAlreadyRunningAppRelaunchHandler(func(url string) {
-			if err := app.OpenExternalURL(ctx, url); err != nil {
-				log.Warn().Err(err).Str("url", url).Msg("failed to open relaunch external URL")
-			}
-		})
-	}
+	// Latch the bounded-residency timeout once at startup (CEF only).
+	ui.LatchResidencyTimeoutForApp(app, cfg.Engine.CEF.IdleRuntimeTimeoutMs, cfg.Engine.ResolveEngineType() == config.EngineTypeCEF)
+	setAlreadyRunningRelaunchHandler(engine, app, ctx, log)
 	timer.Mark("ui_deps")
 	timer.Log(ctx)
 

--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bnema/dumber/internal/infrastructure/filesystem"
 	"github.com/bnema/dumber/internal/infrastructure/idle"
 	"github.com/bnema/dumber/internal/infrastructure/persistence/sqlite"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/bnema/dumber/internal/infrastructure/snapshot"
 	"github.com/bnema/dumber/internal/infrastructure/textinput"
@@ -173,7 +174,14 @@ func main() {
 	// invalidate frames retained across those boundaries and make the GC abort
 	// with "traceback did not unwind completely". Re-exec once so the runtime
 	// sees the safety setting before it creates any goroutine or CEF subprocess.
-	if err := ensureRuntimeSafety(); err != nil {
+	// The standalone omnibox may additionally need a layer-shell preload; both
+	// changes are computed together there so they cost at most one re-exec.
+	if omniboxCombinedLaunchEnvironment(os.Args) {
+		if err := ensureOmniboxLaunchEnvironment(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "dumber: %v\n", err)
+			os.Exit(1)
+		}
+	} else if err := ensureRuntimeSafety(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "dumber: %v\n", err)
 		os.Exit(1)
 	}
@@ -430,7 +438,84 @@ func preInitializeAdwaitaForCEF(cfg *config.Config, initResult *bootstrap.Parall
 	}
 }
 
+// omniboxCombinedLaunchEnvironment reports whether argv selects the
+// standalone omnibox outside a classified CEF helper subprocess. CEF helpers
+// keep safety-only handling and the early helper routing below; they are
+// excluded from omnibox preload handling.
+func omniboxCombinedLaunchEnvironment(args []string) bool {
+	if isCEFSubprocess(args) {
+		return false
+	}
+	mode, _ := launchModeFromArgs(args)
+	return mode == launchModeStandaloneOmnibox
+}
+
+// ensureOmniboxLaunchEnvironment computes safety (GODEBUG) and layer-shell
+// preload (LD_PRELOAD) changes together and applies at most one self-exec.
+// A safety-required exec failure is fatal; a preload-only exec failure keeps
+// the existing best-effort behavior and continues without preload.
+func ensureOmniboxLaunchEnvironment() error {
+	if isCEFSubprocess(os.Args) {
+		return ensureRuntimeSafety()
+	}
+	environ, safetyChange := process.MergeRuntimeSafety(os.Environ())
+	envMap := environSliceToMap(environ)
+	preloadChange := false
+	if bootstrap.ShouldPreloadLayerShell(envMap) {
+		if libraryPath := bootstrap.LayerShellLibraryPath(); libraryPath != "" {
+			envMap = bootstrap.LayerShellPreloadEnv(envMap, libraryPath)
+			environ = environMapToSlice(envMap)
+			preloadChange = true
+		}
+	}
+	if !safetyChange && !preloadChange {
+		return nil
+	}
+	execPath, err := resolveCurrentExecutable(os.Executable)
+	if err != nil {
+		if safetyChange {
+			return fmt.Errorf("resolve executable for launch environment re-exec: %w", err)
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to resolve standalone omnibox executable path: %v\n", err)
+		return nil
+	}
+	// #nosec G702 -- execPath comes from os.Executable(), not user input.
+	if err := syscall.Exec(execPath, os.Args, environ); err != nil {
+		if safetyChange {
+			return fmt.Errorf("launch environment re-exec: %w", err)
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to re-exec standalone omnibox with layer-shell preload: %v\n", err)
+		return nil
+	}
+	return nil
+}
+
+func environSliceToMap(environ []string) map[string]string {
+	env := make(map[string]string, len(environ))
+	for _, entry := range environ {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		env[key] = value
+	}
+	return env
+}
+
+func environMapToSlice(env map[string]string) []string {
+	envSlice := make([]string, 0, len(env))
+	for key, value := range env {
+		envSlice = append(envSlice, key+"="+value)
+	}
+	return envSlice
+}
+
 func maybeReexecStandaloneOmniboxWithLayerShell() {
+	// Classified CEF helpers never take the omnibox preload path; early
+	// helper routing in main owns those processes.
+	if isCEFSubprocess(os.Args) {
+		return
+	}
 	env := bootstrap.CurrentEnvMap()
 	if !bootstrap.ShouldPreloadLayerShell(env) {
 		return

--- a/cmd/dumber/main_test.go
+++ b/cmd/dumber/main_test.go
@@ -334,3 +334,25 @@ func TestTryForwardBrowseURLToRunningInstance_PropagatesError(t *testing.T) {
 		t.Fatal("expected forwarded to be false on error")
 	}
 }
+
+func TestOmniboxCombinedLaunchEnvironment(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "omnibox", args: []string{"dumber", "omnibox"}, want: true},
+		{name: "browse", args: []string{"dumber", "browse", "https://example.com"}, want: false},
+		{name: "cli", args: []string{"dumber"}, want: false},
+		{name: "cli with flags", args: []string{"dumber", "browse", "--help"}, want: false},
+		{name: "helper excluded", args: []string{"dumber", "--type=renderer"}, want: false},
+		{name: "helper with omnibox-like tail excluded", args: []string{"dumber", "--type", "renderer", "omnibox"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := omniboxCombinedLaunchEnvironment(tt.args); got != tt.want {
+				t.Fatalf("omniboxCombinedLaunchEnvironment(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/dumber/runtime_safety.go
+++ b/cmd/dumber/runtime_safety.go
@@ -3,55 +3,21 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 	"syscall"
+
+	"github.com/bnema/dumber/internal/infrastructure/process"
 )
 
 func environmentValue(environ []string, name string) string {
-	prefix := name + "="
-	for _, entry := range environ {
-		if strings.HasPrefix(entry, prefix) {
-			return strings.TrimPrefix(entry, prefix)
-		}
-	}
-	return ""
+	return process.EnvironmentValue(environ, name)
 }
 
 func replaceEnvironmentValue(environ []string, name, value string) []string {
-	prefix := name + "="
-	updated := make([]string, 0, len(environ)+1)
-	for _, entry := range environ {
-		if !strings.HasPrefix(entry, prefix) {
-			updated = append(updated, entry)
-		}
-	}
-	return append(updated, prefix+value)
+	return process.ReplaceEnvironmentValue(environ, name, value)
 }
 
 func runtimeSafetyEnvironment(environ []string) ([]string, bool) {
-	updated := append([]string(nil), environ...)
-	const setting = "gcshrinkstackoff"
-	parts := strings.Split(environmentValue(updated, "GODEBUG"), ",")
-	kept := make([]string, 0, len(parts)+1)
-	alreadySafe := false
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		key, value, found := strings.Cut(part, "=")
-		if key == setting {
-			alreadySafe = found && value == "1"
-			continue
-		}
-		kept = append(kept, part)
-	}
-	if alreadySafe {
-		return updated, false
-	}
-	kept = append(kept, setting+"=1")
-	updated = replaceEnvironmentValue(updated, "GODEBUG", strings.Join(kept, ","))
-	return updated, true
+	return process.MergeRuntimeSafety(environ)
 }
 
 func ensureRuntimeSafety() error {

--- a/cmd/dumber/runtime_safety.go
+++ b/cmd/dumber/runtime_safety.go
@@ -12,10 +12,6 @@ func environmentValue(environ []string, name string) string {
 	return process.EnvironmentValue(environ, name)
 }
 
-func replaceEnvironmentValue(environ []string, name, value string) []string {
-	return process.ReplaceEnvironmentValue(environ, name, value)
-}
-
 func runtimeSafetyEnvironment(environ []string) ([]string, bool) {
 	return process.MergeRuntimeSafety(environ)
 }

--- a/docs/first-presentation.md
+++ b/docs/first-presentation.md
@@ -82,6 +82,6 @@ the selected `github.com/bnema/purego-cef2gtk` version, tag, and full revision
 from that same binary-bound evidence; it never derives provenance from the
 collection checkout. The child processes receive exactly the selected runtime
 via `CEF_DIR`, never a conflicting inherited override. Branch selectors,
-replacement contamination, missing manifests, or missing origin metadata
+replacement contamination, version/manifest mismatches, or a missing manifest
 fail collection. A missing or incomplete timeline, non-DMABUF backend, or invalid
 run also fails collection.

--- a/docs/first-presentation.md
+++ b/docs/first-presentation.md
@@ -36,13 +36,21 @@ contract rather than this CEF trace.
 
 ## Reproducible collection
 
-Build the candidate, then run:
+Build the candidate and its build manifest, then run:
 
 ```bash
+DUMBER_CEF_DIR=/path/to/selected-cef-runtime \
 DUMBER_FIRST_PRESENTATION_BIN="$PWD/dist/dumber" \
+DUMBER_BUILD_MANIFEST="$PWD/dist/dumber.manifest.json" \
 DUMBER_MACHINE_GPU_PROFILE=integrated-gpu \
   scripts/collect_first_presentation.sh
 ```
+
+The manifest records the measured binary SHA-256, the 40-character source
+revision, and the selected `github.com/bnema/purego-cef2gtk` version plus its
+full 40-character revision. Generate it at build time; collection verifies the
+manifest against `go version -m` output for the measured binary and fails
+closed on missing or mismatched attribution.
 
 The collector is for the accelerated CEF/DMABUF/GTK contract above. By default
 each collection is a fresh directory below
@@ -52,8 +60,14 @@ not in the repository. `DUMBER_FIRST_PRESENTATION_OUTPUT` may override it only
 with a new absolute directory below an existing non-symlink parent. The
 collector never clears or reuses a caller-supplied path.
 
-The script requires the current display and the CEF 147 runtime at
-`~/.local/share/cef-147-runtime` (override with `DUMBER_CEF_DIR`). It performs
+The script requires the current display and an explicit `DUMBER_CEF_DIR`
+selecting the measured runtime; there is no default path or version.
+`scripts/cef_runtime_probe.py` runs in a separate bounded subprocess, opens
+only the selected `libcef.so` with standard-library ctypes, calls the
+header-verified `cef_version_info(int)` entries (0-7), and reports numeric
+version fields plus the library hash, never its path. The candidate must still
+pass its normal loader ABI/version validation; the probe never bypasses it.
+Runtimes below Chrome major 150 fail collection. It performs
 exactly five bounded launches with fresh XDG homes and CEF root cache, fixes the
 DMABUF/Vulkan renderer, and writes exactly `metadata.json`, `run-01.json`
 through `run-05.json`, and `baseline.json`. Metadata includes only coarse,
@@ -62,8 +76,12 @@ labels. Set `DUMBER_MACHINE_GPU_PROFILE` to one of `generic-gpu`,
 `integrated-gpu`, `discrete-gpu`, `hybrid-gpu`, `virtual-gpu`, or `unknown-gpu`;
 do not use a device model or other identifier. Publish only the seven reviewed
 JSON files to an external Gist. Raw logs and temporary XDG homes are removed and
-must not be published. `metadata.json` derives the selected
-`github.com/bnema/purego-cef2gtk` pseudo-version and its full immutable Git
-origin hash from Go module metadata; branch selectors or missing origin metadata
+must not be published. `metadata.json` binds the measured binary SHA-256 to
+its source revision via `go version -m` plus the build manifest, and records
+the selected `github.com/bnema/purego-cef2gtk` version, tag, and full revision
+from that same binary-bound evidence; it never derives provenance from the
+collection checkout. The child processes receive exactly the selected runtime
+via `CEF_DIR`, never a conflicting inherited override. Branch selectors,
+replacement contamination, missing manifests, or missing origin metadata
 fail collection. A missing or incomplete timeline, non-DMABUF backend, or invalid
 run also fails collection.

--- a/docs/first-presentation.md
+++ b/docs/first-presentation.md
@@ -48,9 +48,36 @@ DUMBER_MACHINE_GPU_PROFILE=integrated-gpu \
 
 The manifest records the measured binary SHA-256, the 40-character source
 revision, and the selected `github.com/bnema/purego-cef2gtk` version plus its
-full 40-character revision. Generate it at build time; collection verifies the
-manifest against `go version -m` output for the measured binary and fails
-closed on missing or mismatched attribution.
+full 40-character revision. Generate it at build time from the same tree
+that produced the binary; collection verifies the manifest against
+`go version -m` output for the measured binary and fails closed on missing
+or mismatched attribution.
+
+```bash
+make build-manifest
+# or, equivalently:
+python3 scripts/generate_build_manifest.py --binary dist/dumber
+```
+
+Manifest schema (JSON, sorted keys):
+
+```json
+{
+  "binary_sha256": "<hex sha256 of the measured binary>",
+  "source_revision": "<40-hex git revision of the built source>",
+  "modules": {
+    "github.com/bnema/purego-cef2gtk": {
+      "version": "<exact version from go version -m>",
+      "revision": "<40-hex git hash from go mod download origin>"
+    }
+  }
+}
+```
+
+The generator refuses binaries built with a `replace` directive, non-tag
+dependency versions, and missing source revisions. The default manifest
+path is `<binary>.manifest.json`, which is also the collector default
+(`DUMBER_BUILD_MANIFEST` overrides it).
 
 The collector is for the accelerated CEF/DMABUF/GTK contract above. By default
 each collection is a fresh directory below

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -66,6 +66,7 @@
 | `engine.cef.adaptive_windowless_frame_rate` | bool | `true` | |
 | `engine.cef.windowless_frame_rate` | int32 | `0` | >= 0 |
 | `engine.cef.windowless_frame_rate_max` | int32 | `240` | >= 0 |
+| `engine.cef.idle_runtime_timeout_ms` | int | `0` | 0..300000, restart-required |
 | `engine.cef.input.scroll_wheel_multiplier` | float | `1.0` | > 0 |
 | `engine.cef.input.scroll_precise_multiplier` | float | `2.5` | > 0 |
 | `engine.cef.input.scroll_horizontal_multiplier` | float | `1.0` | > 0 |

--- a/internal/application/port/runtime_activity.go
+++ b/internal/application/port/runtime_activity.go
@@ -1,0 +1,44 @@
+package port
+
+import "context"
+
+// RuntimeActivitySnapshot is an engine-neutral view of outstanding native
+// runtime work that must settle before the process may idle out. Counts only:
+// generations and acknowledgement correlation live with the implementation.
+type RuntimeActivitySnapshot struct {
+	// PendingCreations counts accepted browser creations not yet resolved
+	// through OnAfterCreated or a definitive failure.
+	PendingCreations int
+	// ActiveViews counts registered live views, including views whose
+	// native close has started but whose GTK teardown is outstanding.
+	ActiveViews int
+	// PendingCleanup counts native-closed views whose queued GTK
+	// bridge/popup cleanup has not completed.
+	PendingCleanup int
+	// ActiveDownloads counts downloads with a terminal event outstanding.
+	ActiveDownloads int
+}
+
+// Quiescent reports whether no native work is outstanding.
+func (s RuntimeActivitySnapshot) Quiescent() bool {
+	return s.PendingCreations == 0 && s.ActiveViews == 0 && s.PendingCleanup == 0 && s.ActiveDownloads == 0
+}
+
+// RuntimeActivity is the application-port boundary for native runtime
+// quiescence. The initial snapshot and subscription are race-safe and
+// sequenced: Subscribe delivers the current snapshot synchronously, then all
+// later transitions in order. Unsubscribe at shutdown.
+type RuntimeActivity interface {
+	Snapshot() RuntimeActivitySnapshot
+	Subscribe(func(RuntimeActivitySnapshot)) (unsubscribe func())
+}
+
+// PersistenceDrain is the narrow activity/drain boundary for persistence
+// owners whose saves cross the GTK/database boundary. Active covers pending
+// debounce, in-flight capture/execution, and unsettled terminal failure.
+// WaitSettled blocks until settled or ctx ends; it must never be called on
+// the GTK thread when capture dispatches there.
+type PersistenceDrain interface {
+	Active() bool
+	WaitSettled(ctx context.Context) error
+}

--- a/internal/application/port/runtime_activity.go
+++ b/internal/application/port/runtime_activity.go
@@ -42,3 +42,29 @@ type PersistenceDrain interface {
 	Active() bool
 	WaitSettled(ctx context.Context) error
 }
+
+// AdmissionBoundary is the admission/work-lease contract shared by the relay
+// listener and the shutdown/residency policy. Infrastructure provides the
+// implementation; application code depends only on this boundary.
+type AdmissionBoundary interface {
+	// Acquire takes one work lease, reporting false when admission is
+	// closed. Callers send the existing error response instead of
+	// acknowledging.
+	Acquire() bool
+	// Release returns one work lease on dispatch settlement.
+	Release()
+	// Close atomically stops admission; in-flight leases drain.
+	Close()
+	// Reopen resumes admission after an invalidated seal.
+	Reopen()
+	// Closed reports whether admission is stopped.
+	Closed() bool
+	// Active reports the number of held leases.
+	Active() int
+	// OnDrained registers a callback for every transition to zero leases.
+	// Callbacks run without the gate lock and must not reenter it.
+	OnDrained(func())
+	// WaitDrained blocks until no leases are held or ctx ends, reporting
+	// false on expiry so shutdown never waits forever.
+	WaitDrained(ctx context.Context) bool
+}

--- a/internal/application/usecase/runtime_residency.go
+++ b/internal/application/usecase/runtime_residency.go
@@ -105,6 +105,11 @@ func (r *RuntimeResidency) ShutdownRequested() ResidencyDecision {
 	return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
 }
 
+// IdleArmed reports whether an idle deadline is currently armed.
+func (r *RuntimeResidency) IdleArmed() bool {
+	return r.armed
+}
+
 // HandleExpiry processes a fired idle timer. Stale generations (superseded by
 // a later arm/cancel) are ignored. Expiry quits only when still quiescent;
 // otherwise it stands down and lets the next event re-arm.

--- a/internal/application/usecase/runtime_residency.go
+++ b/internal/application/usecase/runtime_residency.go
@@ -80,7 +80,7 @@ func (r *RuntimeResidency) OpenFailed(now time.Time) ResidencyDecision {
 }
 
 // WorkStarted records newly accepted native work. An armed deadline is
-// cancelled: expiry must never fire while required work is outstanding.
+// canceled: expiry must never fire while required work is outstanding.
 func (r *RuntimeResidency) WorkStarted(_ time.Time) ResidencyDecision {
 	r.activeWork++
 	if r.armed {

--- a/internal/application/usecase/runtime_residency.go
+++ b/internal/application/usecase/runtime_residency.go
@@ -1,0 +1,161 @@
+package usecase
+
+import "time"
+
+// ResidencyAction is the single decision a RuntimeResidency event produces.
+// The UI boundary maps it to scheduler operations: clock and timer handles
+// stay outside this controller, which never sleeps.
+type ResidencyAction int
+
+const (
+	// ResidencyNone requires no scheduler change.
+	ResidencyNone ResidencyAction = iota
+	// ResidencyArm starts (or restarts) the idle deadline.
+	ResidencyArm
+	// ResidencyCancel drops a previously armed idle deadline.
+	ResidencyCancel
+	// ResidencyQuit ends the process through the orderly shutdown path.
+	ResidencyQuit
+)
+
+// ResidencyDecision is the outcome of one residency event.
+type ResidencyDecision struct {
+	Action     ResidencyAction
+	Deadline   time.Time
+	Generation uint64
+}
+
+// RuntimeResidency is a testable bounded-residency policy: after the last
+// user window closes it arms a deadline instead of quitting immediately, so
+// a fast reopen can reuse the retained runtime. It tracks only engine-neutral
+// counts; native GTK holds, timers, and quiescence signals live in UI
+// adapters. The zero timeout preserves the existing last-window exit.
+type RuntimeResidency struct {
+	timeout    time.Duration
+	windows    int
+	activeWork int
+	shutdown   bool
+	armed      bool
+	deadline   time.Time
+	generation uint64
+}
+
+// NewRuntimeResidency returns a policy with the given idle timeout. Negative
+// values clamp to zero (disabled). The accepted configuration range is
+// 0..300000ms; enforcement of that range belongs to config validation.
+func NewRuntimeResidency(timeout time.Duration) *RuntimeResidency {
+	if timeout < 0 {
+		timeout = 0
+	}
+	return &RuntimeResidency{timeout: timeout}
+}
+
+// WindowOpened records a user window (including native browser/auth popups
+// that still belong to the application) and cancels any armed deadline.
+func (r *RuntimeResidency) WindowOpened(_ time.Time) ResidencyDecision {
+	r.windows++
+	if r.armed {
+		return r.cancel()
+	}
+	return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+}
+
+// WindowClosed records a user-window close. Duplicate closes are idempotent
+// and never drive the count negative.
+func (r *RuntimeResidency) WindowClosed(now time.Time) ResidencyDecision {
+	if r.windows > 0 {
+		r.windows--
+	}
+	return r.evaluateIdle(now)
+}
+
+// OpenFailed records a failed reopen attempt. Idle eligibility is restored
+// rather than stranding the policy: a failed open can never leak the
+// application hold indefinitely.
+func (r *RuntimeResidency) OpenFailed(now time.Time) ResidencyDecision {
+	if r.windows > 0 {
+		r.windows--
+	}
+	return r.evaluateIdle(now)
+}
+
+// WorkStarted records newly accepted native work. An armed deadline is
+// cancelled: expiry must never fire while required work is outstanding.
+func (r *RuntimeResidency) WorkStarted(_ time.Time) ResidencyDecision {
+	r.activeWork++
+	if r.armed {
+		return r.cancel()
+	}
+	return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+}
+
+// WorkFinished records settled work and re-evaluates idle eligibility.
+func (r *RuntimeResidency) WorkFinished(now time.Time) ResidencyDecision {
+	if r.activeWork > 0 {
+		r.activeWork--
+	}
+	return r.evaluateIdle(now)
+}
+
+// ShutdownRequested records an explicit quit or signal. It always decides
+// Quit immediately and never waits for the idle deadline.
+func (r *RuntimeResidency) ShutdownRequested() ResidencyDecision {
+	r.shutdown = true
+	r.armed = false
+	return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+}
+
+// HandleExpiry processes a fired idle timer. Stale generations (superseded by
+// a later arm/cancel) are ignored. Expiry quits only when still quiescent;
+// otherwise it stands down and lets the next event re-arm.
+func (r *RuntimeResidency) HandleExpiry(_ time.Time, generation uint64) ResidencyDecision {
+	if !r.armed || generation != r.generation {
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	if r.windows > 0 || r.activeWork > 0 || r.shutdown {
+		r.armed = false
+		if r.shutdown {
+			return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+		}
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	r.armed = false
+	return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+}
+
+// Armed reports whether an idle deadline is currently armed. The UI boundary
+// uses it only for diagnostics; scheduling follows decisions.
+func (r *RuntimeResidency) Armed() bool { return r.armed }
+
+// Generation returns the current timer generation for expiry correlation.
+func (r *RuntimeResidency) Generation() uint64 { return r.generation }
+
+func (r *RuntimeResidency) cancel() ResidencyDecision {
+	r.armed = false
+	r.generation++
+	return ResidencyDecision{Action: ResidencyCancel, Generation: r.generation}
+}
+
+func (r *RuntimeResidency) evaluateIdle(now time.Time) ResidencyDecision {
+	if r.shutdown {
+		r.armed = false
+		return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+	}
+	if r.windows > 0 {
+		if r.armed {
+			return r.cancel()
+		}
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	if r.timeout <= 0 {
+		r.armed = false
+		return ResidencyDecision{Action: ResidencyQuit, Generation: r.generation}
+	}
+	if r.activeWork > 0 {
+		return ResidencyDecision{Action: ResidencyNone, Generation: r.generation}
+	}
+	r.armed = true
+	r.deadline = now.Add(r.timeout)
+	r.generation++
+	return ResidencyDecision{Action: ResidencyArm, Deadline: r.deadline, Generation: r.generation}
+}

--- a/internal/application/usecase/runtime_residency_test.go
+++ b/internal/application/usecase/runtime_residency_test.go
@@ -1,0 +1,133 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeResidencyDisabledQuitsOnLastWindow(t *testing.T) {
+	r := NewRuntimeResidency(0)
+	r.WindowOpened(time.Now())
+	decision := r.WindowClosed(time.Now())
+	require.Equal(t, ResidencyQuit, decision.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyNegativeTimeoutDisables(t *testing.T) {
+	r := NewRuntimeResidency(-time.Second)
+	r.WindowOpened(time.Now())
+	require.Equal(t, ResidencyQuit, r.WindowClosed(time.Now()).Action)
+}
+
+func TestRuntimeResidencyFirstIdleArmsDeadline(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	decision := r.WindowClosed(now)
+	require.Equal(t, ResidencyArm, decision.Action)
+	require.Equal(t, now.Add(time.Minute), decision.Deadline)
+	require.True(t, r.Armed())
+	gen := decision.Generation
+
+	expiry := r.HandleExpiry(now.Add(2*time.Minute), gen)
+	require.Equal(t, ResidencyQuit, expiry.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyReopenCancelsDeadline(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	arm := r.WindowClosed(now)
+	require.Equal(t, ResidencyArm, arm.Action)
+
+	cancel := r.WindowOpened(now)
+	require.Equal(t, ResidencyCancel, cancel.Action)
+	require.False(t, r.Armed())
+
+	stale := r.HandleExpiry(now.Add(2*time.Minute), arm.Generation)
+	require.Equal(t, ResidencyNone, stale.Action)
+}
+
+func TestRuntimeResidencyFailedReopenRestoresIdle(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	require.Equal(t, ResidencyArm, r.WindowClosed(now).Action)
+
+	// Optimistic open followed by failure: the hold must not leak, idle
+	// eligibility returns.
+	r.WindowOpened(now)
+	decision := r.OpenFailed(now)
+	require.Equal(t, ResidencyArm, decision.Action)
+	require.True(t, r.Armed())
+}
+
+func TestRuntimeResidencyPopupRemainingPreventsIdle(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	r.WindowOpened(now)
+	decision := r.WindowClosed(now)
+	require.Equal(t, ResidencyNone, decision.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyDuplicateCloseIsIdempotent(t *testing.T) {
+	r := NewRuntimeResidency(0)
+	decision := r.WindowClosed(time.Now())
+	require.Equal(t, ResidencyQuit, decision.Action)
+	again := r.WindowClosed(time.Now())
+	require.Equal(t, ResidencyQuit, again.Action)
+}
+
+func TestRuntimeResidencyStaleExpiryIgnored(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	first := r.WindowClosed(now)
+	r.WindowOpened(now)
+	second := r.WindowClosed(now)
+	require.NotEqual(t, first.Generation, second.Generation)
+
+	require.Equal(t, ResidencyNone, r.HandleExpiry(now, first.Generation).Action)
+	require.True(t, r.Armed())
+	require.Equal(t, ResidencyQuit, r.HandleExpiry(now, second.Generation).Action)
+}
+
+func TestRuntimeResidencyExplicitQuitNeverWaits(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	require.Equal(t, ResidencyArm, r.WindowClosed(now).Action)
+	require.True(t, r.Armed())
+
+	decision := r.ShutdownRequested()
+	require.Equal(t, ResidencyQuit, decision.Action)
+	require.False(t, r.Armed())
+}
+
+func TestRuntimeResidencyWorkBlocksIdleUntilDrained(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	r.WorkStarted(now)
+	decision := r.WindowClosed(now)
+	require.Equal(t, ResidencyNone, decision.Action)
+	require.False(t, r.Armed())
+
+	drained := r.WorkFinished(now)
+	require.Equal(t, ResidencyArm, drained.Action)
+	require.True(t, r.Armed())
+}
+
+func TestRuntimeResidencyWorkCancelsArmedDeadline(t *testing.T) {
+	now := time.Now()
+	r := NewRuntimeResidency(time.Minute)
+	r.WindowOpened(now)
+	require.Equal(t, ResidencyArm, r.WindowClosed(now).Action)
+	require.Equal(t, ResidencyCancel, r.WorkStarted(now).Action)
+	require.False(t, r.Armed())
+}

--- a/internal/bootstrap/deferred_init_test.go
+++ b/internal/bootstrap/deferred_init_test.go
@@ -1,0 +1,41 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bnema/dumber/internal/infrastructure/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunDeferredInit_CEFExecutesNoWebKitDiagnostics verifies that automatic
+// CEF startup runs no unrelated WebKit pkg-config or GStreamer media
+// diagnostics. Explicit diagnostic commands invoke the Check* functions
+// directly and are unaffected.
+func TestRunDeferredInit_CEFExecutesNoWebKitDiagnostics(t *testing.T) {
+	t.Setenv("DUMBER_ENGINE", config.EngineTypeCEF)
+	cfg := config.DefaultConfig()
+	cfg.Engine.Type = config.EngineTypeCEF
+
+	result := RunDeferredInit(DeferredInitInput{Ctx: context.Background(), Config: cfg})
+
+	assert.NoError(t, result.RuntimeErr, "CEF startup must not run WebKit runtime diagnostics")
+	assert.NoError(t, result.MediaErr, "CEF startup must not run GStreamer media diagnostics")
+}
+
+// TestCheckFunctions_RemainAvailableForExplicitCommands verifies the
+// underlying checks stay callable for explicit diagnostic commands after
+// RunDeferredInit stops invoking them automatically for CEF.
+func TestCheckFunctions_RemainAvailableForExplicitCommands(t *testing.T) {
+	t.Setenv("DUMBER_ENGINE", config.EngineTypeCEF)
+	cfg := config.DefaultConfig()
+	cfg.Engine.Type = config.EngineTypeCEF
+
+	// The functions must exist and be invocable regardless of engine; their
+	// results depend on host tooling, so only invocation (not success) is
+	// asserted here.
+	_ = CheckRuntimeRequirements(context.Background(), cfg)
+	_ = CheckMediaRequirements(context.Background(), cfg)
+	require.NotNil(t, cfg)
+}

--- a/internal/bootstrap/deferred_init_test.go
+++ b/internal/bootstrap/deferred_init_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/bnema/dumber/internal/infrastructure/config"
@@ -18,10 +19,23 @@ func TestRunDeferredInit_CEFExecutesNoWebKitDiagnostics(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Engine.Type = config.EngineTypeCEF
 
+	// The probe fires inside each check goroutine, so a zero count proves
+	// engine selection skipped the checks without invoking them. Not
+	// parallel-safe with other probe users by design; restored via defer.
+	var mu sync.Mutex
+	var invoked []string
+	deferredInitProbeForTest = func(kind string) {
+		mu.Lock()
+		defer mu.Unlock()
+		invoked = append(invoked, kind)
+	}
+	defer func() { deferredInitProbeForTest = nil }()
+
 	result := RunDeferredInit(DeferredInitInput{Ctx: context.Background(), Config: cfg})
 
 	assert.NoError(t, result.RuntimeErr, "CEF startup must not run WebKit runtime diagnostics")
 	assert.NoError(t, result.MediaErr, "CEF startup must not run GStreamer media diagnostics")
+	assert.Empty(t, invoked, "CEF startup must not invoke WebKit runtime/media diagnostics at all")
 }
 
 // TestCheckFunctions_RemainAvailableForExplicitCommands verifies the

--- a/internal/bootstrap/gui.go
+++ b/internal/bootstrap/gui.go
@@ -196,6 +196,11 @@ func LogResolvedTheme(ctx context.Context, resolved entity.ResolvedTheme) {
 	event.Msg("theme resolved")
 }
 
+// deferredInitProbeForTest, when non-nil, observes each deferred check
+// before it runs. Tests use it to prove engine selection skips checks
+// without invoking them. It must remain nil in production.
+var deferredInitProbeForTest func(kind string)
+
 // RunDeferredInit runs deferred initialization checks off the critical path.
 // Applicable checks are selected by engine: WebKit runs the pkg-config
 // runtime and GStreamer media diagnostics, while CEF skips both (they cover
@@ -219,11 +224,17 @@ func RunDeferredInit(input DeferredInitInput) DeferredInitResult {
 
 	go func() {
 		defer wg.Done()
+		if deferredInitProbeForTest != nil {
+			deferredInitProbeForTest("runtime")
+		}
 		runtimeErr = CheckRuntimeRequirements(input.Ctx, input.Config)
 	}()
 
 	go func() {
 		defer wg.Done()
+		if deferredInitProbeForTest != nil {
+			deferredInitProbeForTest("media")
+		}
 		mediaErr = CheckMediaRequirements(input.Ctx, input.Config)
 	}()
 

--- a/internal/bootstrap/gui.go
+++ b/internal/bootstrap/gui.go
@@ -197,15 +197,24 @@ func LogResolvedTheme(ctx context.Context, resolved entity.ResolvedTheme) {
 }
 
 // RunDeferredInit runs deferred initialization checks off the critical path.
-// This includes runtime requirements and media checks.
+// Applicable checks are selected by engine: WebKit runs the pkg-config
+// runtime and GStreamer media diagnostics, while CEF skips both (they cover
+// the WebKit stack only) and reports no error. Explicit diagnostic commands
+// (doctor, media checks) invoke the Check* functions directly and are
+// unaffected by this selection.
 func RunDeferredInit(input DeferredInitInput) DeferredInitResult {
+	start := time.Now()
+	if input.Config != nil && input.Config.Engine.ResolveEngineType() == config.EngineTypeCEF {
+		logging.FromContext(input.Ctx).Debug().Msg("skipping WebKit runtime/media diagnostics for CEF engine")
+		return DeferredInitResult{Duration: time.Since(start)}
+	}
+
 	var (
 		runtimeErr error
 		mediaErr   error
 		wg         sync.WaitGroup
 	)
 
-	start := time.Now()
 	wg.Add(2)
 
 	go func() {

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -24,6 +24,9 @@ type downloadHandler struct {
 	mu       sync.Mutex
 	active   map[uint32]cefDownloadState
 	finished map[uint32]struct{} // IDs that already emitted a terminal event
+	// activity tracks download starts against their terminal events for
+	// the quiescence boundary. Nil-safe: unset in unit-test literals.
+	activity *RuntimeActivityTracker
 }
 
 type cefDownloadState struct {
@@ -102,11 +105,13 @@ func newDownloadHandler(
 	downloadPath string,
 	eventHandler port.DownloadEventHandler,
 	preparer port.DownloadPreparer,
+	activity *RuntimeActivityTracker,
 ) *downloadHandler {
 	return &downloadHandler{
 		runtime:  downloadruntime.New(downloadPath, eventHandler, preparer),
 		active:   make(map[uint32]cefDownloadState),
 		finished: make(map[uint32]struct{}),
+		activity: activity,
 	}
 }
 
@@ -116,7 +121,7 @@ func (h *downloadHandler) canDownload(_ purecef.Browser, _, _ string) bool {
 
 func (h *downloadHandler) onBeforeDownload(
 	ctx context.Context,
-	_ purecef.Browser,
+	browser purecef.Browser,
 	downloadItem purecef.DownloadItem,
 	suggestedName string,
 	callback purecef.BeforeDownloadCallback,
@@ -124,6 +129,14 @@ func (h *downloadHandler) onBeforeDownload(
 	if downloadItem == nil || callback == nil {
 		return false
 	}
+	// Retain browser ownership the previous code discarded: activity is
+	// keyed by (browser identity, CEF download ID), never by filename or
+	// destination, which can collide or change mid-download.
+	var browserID int32
+	if browser != nil {
+		browserID = browser.GetIdentifier()
+	}
+	h.activity.NoteDownloadStarted(browserID, downloadItem.GetID())
 
 	log := logging.FromContext(ctx)
 	output, err := h.runtime.ResolveDestination(ctx, suggestedName, &cefDownloadResponseAdapter{item: downloadItem})
@@ -175,11 +188,13 @@ func (h *downloadHandler) onDownloadUpdated(
 		if !h.markFinished(id) {
 			return
 		}
+		h.activity.NoteDownloadTerminal(id)
 		h.runtime.EmitFinished(ctx, state.filename, state.destination)
 	case downloadItem.IsCanceled() || downloadItem.IsInterrupted():
 		if !h.markFinished(id) {
 			return
 		}
+		h.activity.NoteDownloadTerminal(id)
 		var err error
 		if downloadItem.IsInterrupted() {
 			err = cefDownloadInterruptError{

--- a/internal/infrastructure/cef/download_handler.go
+++ b/internal/infrastructure/cef/download_handler.go
@@ -162,12 +162,17 @@ func (h *downloadHandler) onBeforeDownload(
 
 func (h *downloadHandler) onDownloadUpdated(
 	ctx context.Context,
+	browser purecef.Browser,
 	downloadItem purecef.DownloadItem,
 	callback purecef.DownloadItemCallback,
 ) {
 	_ = callback
 	if downloadItem == nil {
 		return
+	}
+	var browserID int32
+	if browser != nil {
+		browserID = browser.GetIdentifier()
 	}
 
 	id := downloadItem.GetID()
@@ -188,13 +193,13 @@ func (h *downloadHandler) onDownloadUpdated(
 		if !h.markFinished(id) {
 			return
 		}
-		h.activity.NoteDownloadTerminal(id)
+		h.activity.NoteDownloadTerminal(browserID, id)
 		h.runtime.EmitFinished(ctx, state.filename, state.destination)
 	case downloadItem.IsCanceled() || downloadItem.IsInterrupted():
 		if !h.markFinished(id) {
 			return
 		}
-		h.activity.NoteDownloadTerminal(id)
+		h.activity.NoteDownloadTerminal(browserID, id)
 		var err error
 		if downloadItem.IsInterrupted() {
 			err = cefDownloadInterruptError{

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -94,9 +94,9 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 
 	item.complete = true
 	item.fullPath = callback.path
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 	// Repeated completion updates should not emit duplicate finished events.
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	require.Len(t, events.events, 2)
 	require.Equal(t, port.DownloadEventFinished, events.events[1].Type)
@@ -166,12 +166,12 @@ func TestCEFDownloadHandlerEmitsProgressOncePerPercent(t *testing.T) {
 	item.percentComplete = 12
 	item.receivedBytes = 12
 	item.totalBytes = 100
-	handler.onDownloadUpdated(ctx, item, nil)
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	item.percentComplete = 13
 	item.receivedBytes = 13
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	require.Len(t, events.events, 3)
 	require.Equal(t, port.DownloadEventStarted, events.events[0].Type)
@@ -200,7 +200,7 @@ func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
 	item.fullPath = callback.path
 	item.interrupted = true
 	item.reason = purecef.DownloadInterruptReasonServerBadContent
-	handler.onDownloadUpdated(ctx, item, nil)
+	handler.onDownloadUpdated(ctx, nil, item, nil)
 
 	require.Len(t, events.events, 2)
 	require.Error(t, events.events[1].Error)
@@ -230,7 +230,7 @@ func TestDownloadHandlerTracksOwnersByBrowserAndID(t *testing.T) {
 	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
 
 	// Terminal for one ID leaves the other owner outstanding.
-	handler.onDownloadUpdated(ctx, stubDownloadItem{id: 11, complete: true, fullPath: "/tmp/a.bin"}, nil)
+	handler.onDownloadUpdated(ctx, first, stubDownloadItem{id: 11, complete: true, fullPath: "/tmp/a.bin"}, nil)
 	require.Equal(t, 1, tracker.Snapshot().ActiveDownloads)
 
 	// Lost owners reconcile through the native lifecycle, never removal.

--- a/internal/infrastructure/cef/download_handler_test.go
+++ b/internal/infrastructure/cef/download_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	purecef "github.com/bnema/purego-cef/cef"
+	cefmocks "github.com/bnema/purego-cef/cef/mocks"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bnema/dumber/internal/application/port"
@@ -74,7 +75,7 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
 	events := &captureDownloadEvents{}
 	downloadDir := t.TempDir()
-	handler := newDownloadHandler(downloadDir, events, preparer)
+	handler := newDownloadHandler(downloadDir, events, preparer, nil)
 	callback := &stubBeforeDownloadCallback{}
 
 	item := stubDownloadItem{
@@ -112,7 +113,7 @@ func TestCEFDownloadHandlerLifecycle(t *testing.T) {
 
 func TestCanDownload_AllowsAllMethods(t *testing.T) {
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
-	handler := newDownloadHandler("/tmp/downloads", nil, preparer)
+	handler := newDownloadHandler("/tmp/downloads", nil, preparer, nil)
 
 	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", "GET"))
 	require.True(t, handler.canDownload(nil, "https://example.com/file.zip", "POST"))
@@ -122,7 +123,7 @@ func TestCanDownload_AllowsAllMethods(t *testing.T) {
 
 func TestMarkFinished_SuppressesDuplicatesAfterCleanup(t *testing.T) {
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
-	handler := newDownloadHandler("/tmp/downloads", nil, preparer)
+	handler := newDownloadHandler("/tmp/downloads", nil, preparer, nil)
 
 	// Simulate a download that was tracked through onBeforeDownload.
 	handler.mu.Lock()
@@ -149,7 +150,7 @@ func TestCEFDownloadHandlerEmitsProgressOncePerPercent(t *testing.T) {
 	ctx := context.Background()
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
 	events := &captureDownloadEvents{}
-	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	handler := newDownloadHandler("/tmp/downloads", events, preparer, nil)
 	callback := &stubBeforeDownloadCallback{}
 
 	item := stubDownloadItem{
@@ -184,7 +185,7 @@ func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
 	ctx := context.Background()
 	preparer := usecase.NewPrepareDownloadUseCase(nil)
 	events := &captureDownloadEvents{}
-	handler := newDownloadHandler("/tmp/downloads", events, preparer)
+	handler := newDownloadHandler("/tmp/downloads", events, preparer, nil)
 	callback := &stubBeforeDownloadCallback{}
 
 	item := stubDownloadItem{
@@ -206,4 +207,33 @@ func TestCEFDownloadInterruptedErrorIncludesCodeAndReason(t *testing.T) {
 	expectedCode := fmt.Sprintf("code=%d", purecef.DownloadInterruptReasonServerBadContent)
 	require.ErrorContains(t, events.events[1].Error, expectedCode)
 	require.ErrorContains(t, events.events[1].Error, "reason=server_bad_content")
+}
+
+func TestDownloadHandlerTracksOwnersByBrowserAndID(t *testing.T) {
+	ctx := context.Background()
+	preparer := usecase.NewPrepareDownloadUseCase(nil)
+	events := &captureDownloadEvents{}
+	tracker := NewRuntimeActivityTracker()
+	handler := newDownloadHandler(t.TempDir(), events, preparer, tracker)
+	callback := &stubBeforeDownloadCallback{}
+
+	first := cefmocks.NewMockBrowser(t)
+	first.EXPECT().GetIdentifier().Return(int32(7))
+	second := cefmocks.NewMockBrowser(t)
+	second.EXPECT().GetIdentifier().Return(int32(9))
+
+	// Same filename from two owners are distinct activity entries.
+	require.True(t, handler.onBeforeDownload(ctx, first,
+		stubDownloadItem{id: 11, url: "https://example.com/a.bin", suggested: "a.bin"}, "a.bin", callback))
+	require.True(t, handler.onBeforeDownload(ctx, second,
+		stubDownloadItem{id: 12, url: "https://other.example/a.bin", suggested: "a.bin"}, "a.bin", callback))
+	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
+
+	// Terminal for one ID leaves the other owner outstanding.
+	handler.onDownloadUpdated(ctx, stubDownloadItem{id: 11, complete: true, fullPath: "/tmp/a.bin"}, nil)
+	require.Equal(t, 1, tracker.Snapshot().ActiveDownloads)
+
+	// Lost owners reconcile through the native lifecycle, never removal.
+	tracker.DropBrowser(9)
+	require.True(t, tracker.Snapshot().Quiescent())
 }

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -62,6 +62,11 @@ type Engine struct {
 	browserWebViews sync.Map // map[int32]*WebView
 	activeCount     atomic.Int32
 
+	// activity tracks outstanding native runtime work for the residency
+	// quiescence boundary. Initialized by NewEngine; nil in unit-test
+	// literals, where tracker methods are safe no-ops.
+	activity *RuntimeActivityTracker
+
 	// shutdownNotify is signaled when the active webview count reaches 0
 	// during shutdown, replacing the busy-wait poll in closeActiveWebViews.
 	shutdownNotify chan struct{}
@@ -85,6 +90,16 @@ type Engine struct {
 	browserCreateLastWidth  atomic.Int32
 	browserCreateLastHeight atomic.Int32
 	browserCreateComplete   atomic.Bool
+}
+
+// RuntimeActivity exposes the engine's outstanding-work tracker through
+// the application port. UI subscribes at startup and unsubscribes at
+// shutdown; the initial snapshot is race-safe and sequenced.
+func (e *Engine) RuntimeActivity() port.RuntimeActivity {
+	if e == nil || e.activity == nil {
+		return NewRuntimeActivityTracker()
+	}
+	return e.activity
 }
 
 func (e *Engine) Factory() port.WebViewFactory {
@@ -162,6 +177,7 @@ func (e *Engine) recordGPURelaunch() {
 func (e *Engine) registerWebView(wv *WebView) {
 	e.activeWebViews.Store(wv.id, wv)
 	e.activeCount.Add(1)
+	e.activity.NoteViewRegistered()
 }
 
 func (e *Engine) lookupWebView(id port.WebViewID) *WebView {
@@ -204,6 +220,7 @@ func (e *Engine) unbindBrowserWebView(browserID int32, wv *WebView) {
 func (e *Engine) unregisterWebView(wv *WebView, browserID int32) {
 	e.activeWebViews.Delete(wv.id)
 	e.unbindBrowserWebView(browserID, wv)
+	e.activity.DropBrowser(browserID)
 	if e.activeCount.Add(-1) == 0 && e.shutdownNotify != nil {
 		select {
 		case e.shutdownNotify <- struct{}{}:
@@ -305,6 +322,7 @@ func (e *Engine) destroyClosedWebViewBridges(webViews []*WebView) {
 	for _, wv := range webViews {
 		if wv != nil && wv.destroyed.Load() {
 			wv.destroyViewBridgeOnGTKSync()
+			e.activity.NoteCleanupCompleted()
 		}
 	}
 }
@@ -340,7 +358,7 @@ func (e *Engine) ConfigureDownloads(
 		return fmt.Errorf("cef: download preparer is required")
 	}
 	e.downloadMu.Lock()
-	e.downloadHandler = newDownloadHandler(downloadPath, eventHandler, preparer)
+	e.downloadHandler = newDownloadHandler(downloadPath, eventHandler, preparer, e.activity)
 	e.downloadMu.Unlock()
 	return nil
 }
@@ -503,18 +521,21 @@ func (e *Engine) recordBrowserCreateRequest(width, height, result int32) {
 		Int32("height", height).
 		Int32("result", result).
 		Msg("cef: BrowserHostCreateBrowser returned")
-	if result != 1 {
-		logging.FromContext(e.ctx).Warn().
-			Uint64("request_count", count).
-			Int32("width", width).
-			Int32("height", height).
-			Int32("result", result).
-			Msg("cef: BrowserHostCreateBrowser returned non-success")
+	if result == 1 {
+		e.activity.NoteCreationAccepted()
+		return
 	}
+	logging.FromContext(e.ctx).Warn().
+		Uint64("request_count", count).
+		Int32("width", width).
+		Int32("height", height).
+		Int32("result", result).
+		Msg("cef: BrowserHostCreateBrowser returned non-success")
 }
 
 func (e *Engine) recordBrowserAfterCreated(browser purecef.Browser) {
 	count := e.browserAfterCreated.Add(1)
+	e.activity.NoteCreationResolved()
 	if count >= e.browserCreateRequests.Load() {
 		e.browserCreateComplete.Store(true)
 	}

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -321,8 +321,8 @@ func (e *Engine) closeActiveWebViews() {
 func (e *Engine) destroyClosedWebViewBridges(webViews []*WebView) {
 	for _, wv := range webViews {
 		if wv != nil && wv.destroyed.Load() {
+			// Completion accounting lands in destroyViewBridgeOnGTKThread.
 			wv.destroyViewBridgeOnGTKSync()
-			e.activity.NoteCleanupCompleted()
 		}
 	}
 }

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -84,7 +84,7 @@ func NewEngine(
 		ctxMenuRenderer:        deps.ContextMenuRenderer,
 		clipboard:              deps.Clipboard,
 		resolver:               deps.ImageDataResolver,
-		activity:              NewRuntimeActivityTracker(),
+		activity:               NewRuntimeActivityTracker(),
 	}
 
 	logger.Info().

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -84,6 +84,7 @@ func NewEngine(
 		ctxMenuRenderer:        deps.ContextMenuRenderer,
 		clipboard:              deps.Clipboard,
 		resolver:               deps.ImageDataResolver,
+		activity:              NewRuntimeActivityTracker(),
 	}
 
 	logger.Info().

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -1,6 +1,8 @@
 package cef
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -22,6 +24,12 @@ const validFirstPresentationLog = `{"message":"startup_trace: milestone","milest
 {"message":"startup_trace: milestone","milestone":"first_gtk_presentation","t_ms":7,"delta_ms":1}
 {"message":"startup_trace: first presentation","backend":"gdk-dmabuf","incomplete_reason":"","total_ms":7,"host":"alice"}`
 
+const (
+	testUpstreamVersion  = "v0.8.5-0.20300102030405-bbd397409ebe"
+	testUpstreamRevision = "bbd397409ebed75a5979c1e4566a2ef319f6a484"
+	testSourceRevision   = "0123456789abcdef0123456789abcdef01234567"
+)
+
 func TestFirstPresentationCollectorNeverRecursivelyDeletesCallerOutput(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
@@ -31,12 +39,26 @@ func TestFirstPresentationCollectorNeverRecursivelyDeletesCallerOutput(t *testin
 	require.NotContains(t, string(script), "rm -rf -- \"$output\"")
 }
 
+func TestFirstPresentationCollectorHasNoHardcodedRuntimeDefaults(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	script, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	require.NoError(t, err)
+	require.NotContains(t, string(script), "cef-147")
+	require.NotContains(t, string(script), `"version": "147"`)
+	require.NotContains(t, string(script), "go list -m")
+	require.NotContains(t, string(script), "go mod download")
+	require.NotContains(t, string(script), "-mod=mod")
+	require.Contains(t, string(script), "DUMBER_CEF_DIR must be set")
+	require.Contains(t, string(script), "cef_runtime_probe.py")
+	require.Contains(t, string(script), `CEF_DIR="$selected_cef_dir"`)
+}
+
 func TestFirstPresentationCollectorRejectsUnsafeOutputPaths(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 	home := filepath.Join(temp, "home")
@@ -112,15 +134,12 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
-
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-	const upstreamVersion = "v0.8.5-0.20300102030405-bbd397409ebe"
-	const upstreamRevision = "bbd397409ebed75a5979c1e4566a2ef319f6a484"
-	goBin := collectorProvenanceGo(t, temp, upstreamVersion, upstreamRevision, "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 	output := filepath.Join(temp, "artifacts")
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -129,6 +148,7 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 		"WAYLAND_DISPLAY=",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"DUMBER_MACHINE_GPU_PROFILE=integrated-gpu",
@@ -143,14 +163,16 @@ func TestFirstPresentationCollectorSanitizesMachineLocalValues(t *testing.T) {
 		require.NoError(t, readErr)
 		artifacts.Write(artifactContents)
 	}
-	for _, forbidden := range []string{"/home/", temp, "alice", "machine_path", `"time"`} {
+	for _, forbidden := range []string{"/home/", temp, "alice", "machine_path", `"time"`, runtime, "libcef.so"} {
 		require.NotContainsf(t, artifacts.String(), forbidden, "committed artifact leaked %q", forbidden)
 	}
 	for _, required := range []string{
 		`"measured_source_revision"`,
-		`"version": "` + upstreamVersion + `"`,
+		`"version": "` + testUpstreamVersion + `"`,
 		`"tag": "v0.8.5"`,
-		`"revision": "` + upstreamRevision + `"`,
+		`"revision": "` + testUpstreamRevision + `"`,
+		`"chrome_major": 150`,
+		`"libcef_sha256"`,
 	} {
 		require.Contains(t, artifacts.String(), required)
 	}
@@ -176,16 +198,12 @@ func TestFirstPresentationCollectorDerivesSelectedImmutableModuleProvenance(t *t
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-	// This exact pseudo-version is deliberately newer than the former v0.8.4
-	// hardcode; the collector must report what the selected module says.
-	const version = "v0.8.5-0.20300102030405-bbd397409ebe"
-	const revision = "bbd397409ebed75a5979c1e4566a2ef319f6a484"
-	goBin := collectorProvenanceGo(t, temp, version, revision, "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 	output := filepath.Join(temp, "artifacts")
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -193,6 +211,7 @@ func TestFirstPresentationCollectorDerivesSelectedImmutableModuleProvenance(t *t
 		"DISPLAY=:test",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
@@ -207,14 +226,16 @@ func TestFirstPresentationCollectorDerivesSelectedImmutableModuleProvenance(t *t
 			Tag      string `json:"tag"`
 			Revision string `json:"revision"`
 		} `json:"upstream"`
+		MeasuredSourceRevision string `json:"measured_source_revision"`
 	}
 	contents, err := os.ReadFile(filepath.Join(output, "metadata.json"))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(contents, &metadata))
 	require.Equal(t, "github.com/bnema/purego-cef2gtk", metadata.Upstream.Module)
-	require.Equal(t, version, metadata.Upstream.Version)
+	require.Equal(t, testUpstreamVersion, metadata.Upstream.Version)
 	require.Equal(t, "v0.8.5", metadata.Upstream.Tag)
-	require.Equal(t, revision, metadata.Upstream.Revision)
+	require.Equal(t, testUpstreamRevision, metadata.Upstream.Revision)
+	require.Equal(t, testSourceRevision, metadata.MeasuredSourceRevision)
 
 	script, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	require.NoError(t, err)
@@ -226,20 +247,20 @@ func TestFirstPresentationCollectorRejectsNonImmutableModuleProvenanceWithoutLea
 	require.NoError(t, err)
 
 	for _, test := range []struct {
-		name, version, revision, ref string
+		name, version string
 	}{
-		{name: "branch selector", version: "main", ref: "main"},
-		{name: "missing origin", version: "v0.8.5-0.20300102030405-bbd397409ebe"},
-		{name: "named origin ref", version: "v0.8.5-0.20300102030405-bbd397409ebe", revision: "bbd397409ebed75a5979c1e4566a2ef319f6a484", ref: "main"},
+		{name: "branch selector", version: "main"},
+		{name: "devel version", version: "(devel)"},
+		{name: "missing patch", version: "v0.8"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			temp := t.TempDir()
-			runtime := filepath.Join(temp, "cef-147-runtime")
-			require.NoError(t, os.Mkdir(runtime, 0o755))
+			runtime := collectorFakeCEFRuntime(t, 150)
 			binary := filepath.Join(temp, "dumber")
 			require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-			goBin := collectorProvenanceGo(t, temp, test.version, test.revision, test.ref)
+			goBin := collectorFakeGo(t, temp, test.version, testSourceRevision, false)
+			manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 			output := filepath.Join(temp, "artifacts")
 			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 			cmd.Dir = repoRoot
@@ -247,6 +268,7 @@ func TestFirstPresentationCollectorRejectsNonImmutableModuleProvenanceWithoutLea
 				"DISPLAY=:test",
 				"DUMBER_CEF_DIR="+runtime,
 				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+				"DUMBER_BUILD_MANIFEST="+manifest,
 				"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 			)
@@ -262,55 +284,296 @@ func TestFirstPresentationCollectorRejectsNonImmutableModuleProvenanceWithoutLea
 	}
 }
 
-func collectorProvenanceGo(t *testing.T, temp, version, revision, ref string) string {
-	t.Helper()
-	infoPath := filepath.Join(temp, "module.info")
-	info := map[string]any{"Version": version}
-	if revision != "" {
-		info["Origin"] = map[string]string{
-			"VCS": "git", "URL": "https://github.com/bnema/purego-cef2gtk", "Hash": revision, "Ref": ref,
-		}
-	}
-	infoJSON, err := json.Marshal(info)
+func TestFirstPresentationCollectorRequiresExplicitRuntimeDir(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(infoPath, infoJSON, 0o600))
+	temp := t.TempDir()
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 
-	selectedJSON, err := json.Marshal(map[string]string{
-		"Path": "github.com/bnema/purego-cef2gtk", "Version": version,
-	})
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	env := envWithout("DUMBER_CEF_DIR")
+	env = append(env,
+		"DISPLAY=:test",
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+	)
+	cmd.Env = env
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted missing runtime dir: %s", result)
+	require.Contains(t, string(result), "DUMBER_CEF_DIR must be set")
+}
+
+func TestFirstPresentationCollectorIgnoresConflictingParentCEFDir(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
-	downloadedJSON, err := json.Marshal(map[string]string{
-		"Path": "github.com/bnema/purego-cef2gtk", "Version": version, "Info": infoPath,
-	})
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 150)
+	bogus := filepath.Join(temp, "bogus-runtime")
+	require.NoError(t, os.Mkdir(bogus, 0o755))
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	output := filepath.Join(temp, "artifacts")
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"CEF_DIR="+bogus,
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
+		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "collector failed with conflicting parent CEF_DIR: %s", result)
+	require.FileExists(t, filepath.Join(output, "metadata.json"))
+}
+
+func TestFirstPresentationCollectorRejectsProbeFailure(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
-	binDir := filepath.Join(temp, "bin")
-	require.NoError(t, os.Mkdir(binDir, 0o755))
+	temp := t.TempDir()
+	runtime := filepath.Join(temp, "empty-runtime")
+	require.NoError(t, os.Mkdir(runtime, 0o755))
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted missing runtime library: %s", result)
+	require.Contains(t, string(result), "CEF runtime probe failed")
+}
+
+func TestFirstPresentationCollectorRejectsUnsupportedRuntime(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 140)
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted unsupported runtime: %s", result)
+	require.Contains(t, string(result), "unsupported CEF runtime")
+}
+
+func TestFirstPresentationCollectorRequiresManifestWithoutEmbeddedVCS(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 150)
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, "", false)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+filepath.Join(temp, "missing-manifest.json"),
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted binary without VCS or manifest: %s", result)
+	require.Contains(t, string(result), "build manifest is required")
+}
+
+func TestFirstPresentationCollectorRejectsManifestMismatch(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name           string
+		sourceRevision string
+		depVersion     string
+		depRevision    string
+		mutateBinary   bool
+	}{
+		{name: "binary checkout mismatch", sourceRevision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", depVersion: testUpstreamVersion, depRevision: testUpstreamRevision},
+		{name: "dependency version mismatch", sourceRevision: testSourceRevision, depVersion: "v0.9.3", depRevision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+		{name: "dependency revision mismatch", sourceRevision: testSourceRevision, depVersion: testUpstreamVersion, depRevision: "cccccccccccccccccccccccccccccccccccccccc"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			temp := t.TempDir()
+			runtime := collectorFakeCEFRuntime(t, 150)
+			binary := filepath.Join(temp, "dumber")
+			require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+			goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+			manifest := collectorManifest(t, temp, binary, test.sourceRevision, test.depVersion, test.depRevision)
+			if test.mutateBinary {
+				require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog+"extra"), 0o755))
+			}
+			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+			cmd.Dir = repoRoot
+			cmd.Env = append(os.Environ(),
+				"DISPLAY=:test",
+				"DUMBER_CEF_DIR="+runtime,
+				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+				"DUMBER_BUILD_MANIFEST="+manifest,
+				"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+			)
+			result, err := cmd.CombinedOutput()
+			require.Errorf(t, err, "collector accepted mismatched manifest: %s", result)
+			require.Contains(t, string(result), "build manifest does not match")
+		})
+	}
+}
+
+func TestFirstPresentationCollectorRejectsReplacementContamination(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	temp := t.TempDir()
+	runtime := collectorFakeCEFRuntime(t, 150)
+	binary := filepath.Join(temp, "dumber")
+	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
+
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, true)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"DISPLAY=:test",
+		"DUMBER_CEF_DIR="+runtime,
+		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
+		"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
+	)
+	result, err := cmd.CombinedOutput()
+	require.Errorf(t, err, "collector accepted replacement contamination: %s", result)
+	require.Contains(t, string(result), "immutable module provenance is unavailable")
+}
+
+// collectorFakeGo fakes `go version -m <binary>` for the measured binary.
+// It never consults the current checkout module graph.
+func collectorFakeGo(t *testing.T, temp, depVersion, vcsRevision string, replacement bool) string {
+	t.Helper()
+	binDir := filepath.Join(temp, "gobin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	goBin := filepath.Join(binDir, "go")
+	depLine := fmt.Sprintf("dep\tgithub.com/bnema/purego-cef2gtk\t%s", depVersion)
+	if replacement {
+		depLine += " => ./local-override"
+	}
+	buildLine := ""
+	if vcsRevision != "" {
+		buildLine = fmt.Sprintf("build\tvcs.revision=%s", vcsRevision)
+	}
 	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "list" ] && [ "$2" = "-m" ] && [ "$3" = "-json" ] && [ "$4" = "github.com/bnema/purego-cef2gtk" ]; then
-  printf '%%s\n' '%s'
-  exit 0
-fi
-if [ "$1" = "mod" ] && [ "$2" = "download" ] && [ "$3" = "-json" ] && [ "$4" = "github.com/bnema/purego-cef2gtk@%s" ]; then
-  printf '%%s\n' '%s'
+if [ "$1" = "version" ] && [ "$2" = "-m" ]; then
+  printf '%%s\n' 'path\tgithub.com/bnema/dumber/cmd/dumber' 'mod\tgithub.com/bnema/dumber\t(devel)' '%s' '%s'
   exit 0
 fi
 exit 1
-`, selectedJSON, version, downloadedJSON)
+`, depLine, buildLine)
 	require.NoError(t, os.WriteFile(goBin, []byte(script), 0o755))
 	return goBin
+}
+
+// collectorProvenanceGo is retained for compatibility with earlier test
+// revisions; it delegates to the binary-bound fake.
+func collectorProvenanceGo(t *testing.T, temp, version, revision, ref string) string {
+	t.Helper()
+	_ = ref
+	return collectorFakeGo(t, temp, version, testSourceRevision, false)
+}
+
+func collectorManifest(t *testing.T, temp, binary, sourceRevision, depVersion, depRevision string) string {
+	t.Helper()
+	contents, err := os.ReadFile(binary)
+	require.NoError(t, err)
+	sum := sha256.Sum256(contents)
+	manifest := map[string]any{
+		"binary_sha256":   hex.EncodeToString(sum[:]),
+		"source_revision": sourceRevision,
+		"modules": map[string]any{
+			"github.com/bnema/purego-cef2gtk": map[string]string{
+				"version":  depVersion,
+				"revision": depRevision,
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	path := filepath.Join(temp, "build-manifest.json")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	return path
+}
+
+// collectorFakeCEFRuntime builds a tiny shared library exposing the
+// header-verified cef_version_info(int) entries with a controlled Chrome
+// major. It exercises the real ctypes probe path without copying a full
+// multi-hundred-megabyte runtime per test.
+func collectorFakeCEFRuntime(t *testing.T, chromeMajor int) string {
+	t.Helper()
+	runtime := t.TempDir()
+	source := fmt.Sprintf(`int cef_version_info(int entry) {
+  switch (entry) {
+    case 0: return 150;
+    case 1: return 0;
+    case 2: return 0;
+    case 3: return 0;
+    case 4: return %d;
+    case 5: return 0;
+    case 6: return 0;
+    case 7: return 0;
+    default: return 0;
+  }
+}
+`, chromeMajor)
+	src := filepath.Join(runtime, "fake_cef.c")
+	require.NoError(t, os.WriteFile(src, []byte(source), 0o600))
+	lib := filepath.Join(runtime, "libcef.so")
+	cmd := exec.Command("gcc", "-shared", "-fPIC", "-o", lib, src)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to build fake libcef: %s", out)
+	return runtime
 }
 
 func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 	stateHome := filepath.Join(temp, "state")
-	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -319,6 +582,7 @@ func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testin
 		"WAYLAND_DISPLAY=",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"DUMBER_MACHINE_GPU_PROFILE=integrated-gpu",
 		"XDG_STATE_HOME="+stateHome,
@@ -347,23 +611,19 @@ func envWithout(name string) []string {
 	return environment
 }
 
-func TestFirstPresentationCollectorReadsProvenanceWithScopedGitSafeDirectory(t *testing.T) {
+func TestFirstPresentationCollectorBindsBinaryNotCheckoutGit(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
 	require.NoError(t, err)
 	temp := t.TempDir()
-	runtime := filepath.Join(temp, "cef-147-runtime")
-	require.NoError(t, os.Mkdir(runtime, 0o755))
+	runtime := collectorFakeCEFRuntime(t, 150)
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
-	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+	goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+	manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 	gitDir := filepath.Join(temp, "gitbin")
 	require.NoError(t, os.Mkdir(gitDir, 0o755))
 	git := filepath.Join(gitDir, "git")
 	require.NoError(t, os.WriteFile(git, []byte(`#!/bin/sh
-if [ "$1" = "-c" ] && [ "$2" = "safe.directory=$EXPECTED_SAFE_DIRECTORY" ] && [ "$3" = "rev-parse" ] && [ "$4" = "HEAD" ]; then
-  echo 0123456789abcdef0123456789abcdef01234567
-  exit 0
-fi
 echo "fatal: detected dubious ownership in repository" >&2
 exit 128
 `), 0o755))
@@ -375,13 +635,13 @@ exit 128
 		"DISPLAY=:test",
 		"DUMBER_CEF_DIR="+runtime,
 		"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+		"DUMBER_BUILD_MANIFEST="+manifest,
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
-		"EXPECTED_SAFE_DIRECTORY="+repoRoot,
 		"PATH="+gitDir+":"+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 	)
 	result, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "collector failed: %s", result)
+	require.NoErrorf(t, err, "collector depends on checkout git: %s", result)
 
 	var metadata struct {
 		MeasuredSourceRevision string `json:"measured_source_revision"`
@@ -389,7 +649,7 @@ exit 128
 	contents, err := os.ReadFile(filepath.Join(output, "metadata.json"))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(contents, &metadata))
-	require.Equal(t, "0123456789abcdef0123456789abcdef01234567", metadata.MeasuredSourceRevision)
+	require.Equal(t, testSourceRevision, metadata.MeasuredSourceRevision)
 }
 
 func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
@@ -408,12 +668,12 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			temp := t.TempDir()
-			runtime := filepath.Join(temp, "cef-147-runtime")
-			require.NoError(t, os.Mkdir(runtime, 0o755))
+			runtime := collectorFakeCEFRuntime(t, 150)
 			binary := filepath.Join(temp, "dumber")
 			log := strings.Replace(validFirstPresentationLog, test.old, test.new, 1)
 			require.NoError(t, os.WriteFile(binary, collectorTestBinary(log), 0o755))
-			goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+			goBin := collectorFakeGo(t, temp, testUpstreamVersion, testSourceRevision, false)
+			manifest := collectorManifest(t, temp, binary, testSourceRevision, testUpstreamVersion, testUpstreamRevision)
 
 			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 			cmd.Dir = repoRoot
@@ -421,6 +681,7 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 				"DISPLAY=:test",
 				"DUMBER_CEF_DIR="+runtime,
 				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
+				"DUMBER_BUILD_MANIFEST="+manifest,
 				"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
 				"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -504,14 +504,6 @@ exit 1
 	return goBin
 }
 
-// collectorProvenanceGo is retained for compatibility with earlier test
-// revisions; it delegates to the binary-bound fake.
-func collectorProvenanceGo(t *testing.T, temp, version, revision, ref string) string {
-	t.Helper()
-	_ = ref
-	return collectorFakeGo(t, temp, version, testSourceRevision, false)
-}
-
 func collectorManifest(t *testing.T, temp, binary, sourceRevision, depVersion, depRevision string) string {
 	t.Helper()
 	contents, err := os.ReadFile(binary)

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -491,6 +491,7 @@ func collectorFakeGo(t *testing.T, temp, depVersion, vcsRevision string, replace
 	}
 	buildLine := ""
 	if vcsRevision != "" {
+		// Real `go version -m` format is "build vcs.revision=<hex>".
 		buildLine = fmt.Sprintf("build\tvcs.revision=%s", vcsRevision)
 	}
 	script := fmt.Sprintf(`#!/bin/sh

--- a/internal/infrastructure/cef/first_presentation_collector_test.go
+++ b/internal/infrastructure/cef/first_presentation_collector_test.go
@@ -310,6 +310,7 @@ func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testin
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
 	stateHome := filepath.Join(temp, "state")
+	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
 
 	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 	cmd.Dir = repoRoot
@@ -321,6 +322,7 @@ func TestFirstPresentationCollectorDefaultsToXDGStateEvidenceDirectory(t *testin
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"DUMBER_MACHINE_GPU_PROFILE=integrated-gpu",
 		"XDG_STATE_HOME="+stateHome,
+		"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 	)
 	result, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "collector failed: %s", result)
@@ -353,7 +355,8 @@ func TestFirstPresentationCollectorReadsProvenanceWithScopedGitSafeDirectory(t *
 	require.NoError(t, os.Mkdir(runtime, 0o755))
 	binary := filepath.Join(temp, "dumber")
 	require.NoError(t, os.WriteFile(binary, collectorTestBinary(validFirstPresentationLog), 0o755))
-	gitDir := filepath.Join(temp, "bin")
+	goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
+	gitDir := filepath.Join(temp, "gitbin")
 	require.NoError(t, os.Mkdir(gitDir, 0o755))
 	git := filepath.Join(gitDir, "git")
 	require.NoError(t, os.WriteFile(git, []byte(`#!/bin/sh
@@ -375,7 +378,7 @@ exit 128
 		"DUMBER_FIRST_PRESENTATION_OUTPUT="+output,
 		"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
 		"EXPECTED_SAFE_DIRECTORY="+repoRoot,
-		"PATH="+gitDir+":"+os.Getenv("PATH"),
+		"PATH="+gitDir+":"+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 	)
 	result, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "collector failed: %s", result)
@@ -410,6 +413,7 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 			binary := filepath.Join(temp, "dumber")
 			log := strings.Replace(validFirstPresentationLog, test.old, test.new, 1)
 			require.NoError(t, os.WriteFile(binary, collectorTestBinary(log), 0o755))
+			goBin := collectorProvenanceGo(t, temp, "v0.8.5-0.20300102030405-bbd397409ebe", "bbd397409ebed75a5979c1e4566a2ef319f6a484", "")
 
 			cmd := exec.Command(filepath.Join(repoRoot, "scripts", "collect_first_presentation.sh"))
 			cmd.Dir = repoRoot
@@ -419,6 +423,7 @@ func TestFirstPresentationCollectorRejectsInconsistentTiming(t *testing.T) {
 				"DUMBER_FIRST_PRESENTATION_BIN="+binary,
 				"DUMBER_FIRST_PRESENTATION_OUTPUT="+filepath.Join(temp, "artifacts"),
 				"DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS=1",
+				"PATH="+filepath.Dir(goBin)+":"+os.Getenv("PATH"),
 			)
 			result, err := cmd.CombinedOutput()
 			require.Errorf(t, err, "collector accepted malformed timing artifact: %s", result)

--- a/internal/infrastructure/cef/pool.go
+++ b/internal/infrastructure/cef/pool.go
@@ -110,6 +110,19 @@ func (p *WebViewPool) Size() int {
 	return len(p.pool)
 }
 
+// pooledViewBrowserReady reports whether a pooled reserve holds a live
+// browser. Wrapper-only reserves (allocated struct, no OnAfterCreated yet)
+// are never reported browser-ready. Viewport validity and first blank frame
+// require native validation and stay outside this predicate.
+func pooledViewBrowserReady(wv *WebView) bool {
+	if wv == nil || wv.destroyed.Load() {
+		return false
+	}
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	return wv.browser != nil
+}
+
 // Close shuts down the pool and destroys all pooled WebViews.
 func (p *WebViewPool) Close() {
 	p.mu.Lock()

--- a/internal/infrastructure/cef/pool_test.go
+++ b/internal/infrastructure/cef/pool_test.go
@@ -1,0 +1,39 @@
+package cef
+
+import (
+	"context"
+	"testing"
+
+	cefmocks "github.com/bnema/purego-cef/cef/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolZeroCountCreatesNothing(t *testing.T) {
+	pool := &WebViewPool{}
+	pool.Prewarm(0)
+	pool.Prewarm(-3)
+	pool.PrewarmAsync(context.Background(), 0)
+	require.Equal(t, 0, pool.Size())
+}
+
+func TestPoolReserveReadinessRequiresBrowser(t *testing.T) {
+	// A wrapper-only reserve (no browser yet) is never browser-ready.
+	require.False(t, pooledViewBrowserReady(nil))
+	require.False(t, pooledViewBrowserReady(&WebView{}))
+
+	browser := cefmocks.NewMockBrowser(t)
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	require.True(t, pooledViewBrowserReady(wv))
+
+	wv.Destroy()
+	require.False(t, pooledViewBrowserReady(wv), "destroyed views leave the ready set")
+}
+
+func TestPoolReleaseDestroysAndIgnoresNil(t *testing.T) {
+	pool := &WebViewPool{}
+	require.NotPanics(t, func() { pool.Release(nil) })
+
+	wv := &WebView{ctx: context.Background()}
+	pool.Release(wv)
+	require.True(t, wv.destroyed.Load(), "Release destroys user-loaded views")
+}

--- a/internal/infrastructure/cef/runtime_activity.go
+++ b/internal/infrastructure/cef/runtime_activity.go
@@ -151,19 +151,16 @@ func (t *RuntimeActivityTracker) NoteDownloadStarted(browserID int32, downloadID
 func (t *RuntimeActivityTracker) NoteDownloadProgress(_ int32, _ uint32) {}
 
 // NoteDownloadTerminal records one terminal download event (complete,
-// cancel, or failure). Duplicate terminals are idempotent; terminals for
-// unknown IDs resolve no owner and change nothing.
-func (t *RuntimeActivityTracker) NoteDownloadTerminal(downloadID uint32) {
+// cancel, or failure) for the exact owning browser. Duplicate terminals are
+// idempotent; terminals for unknown owners change nothing, so one browser
+// completing a download ID never clears another browser's same ID.
+func (t *RuntimeActivityTracker) NoteDownloadTerminal(browserID int32, downloadID uint32) {
 	if t == nil {
 		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for owner := range t.downloads {
-		if owner.downloadID == downloadID {
-			delete(t.downloads, owner)
-		}
-	}
+	delete(t.downloads, downloadOwner{browserID: browserID, downloadID: downloadID})
 	t.notifyLocked()
 }
 

--- a/internal/infrastructure/cef/runtime_activity.go
+++ b/internal/infrastructure/cef/runtime_activity.go
@@ -1,0 +1,232 @@
+package cef
+
+import (
+	"sync"
+
+	"github.com/bnema/dumber/internal/application/port"
+)
+
+// downloadOwner identifies one download by its owning browser and the CEF
+// download ID. Filename and destination are never identity: they can collide
+// or change mid-download.
+type downloadOwner struct {
+	browserID  int32
+	downloadID uint32
+}
+
+// RuntimeActivityTracker implements port.RuntimeActivity for the CEF engine.
+// It counts accepted creations through OnAfterCreated/failure, registered
+// live views, outstanding GTK cleanup, and unterminated downloads. All
+// methods are safe for concurrent use from CEF callbacks; subscriber
+// delivery is sequenced under the tracker lock snapshot.
+type RuntimeActivityTracker struct {
+	mu          sync.Mutex
+	pending     int
+	active      int
+	cleanup     int
+	downloads   map[downloadOwner]struct{}
+	subscribers map[uint64]func(port.RuntimeActivitySnapshot)
+	nextSub     uint64
+}
+
+// NewRuntimeActivityTracker returns an idle tracker.
+func NewRuntimeActivityTracker() *RuntimeActivityTracker {
+	return &RuntimeActivityTracker{
+		downloads:   make(map[downloadOwner]struct{}),
+		subscribers: make(map[uint64]func(port.RuntimeActivitySnapshot)),
+	}
+}
+
+// Snapshot returns the current outstanding-work counts.
+func (t *RuntimeActivityTracker) Snapshot() port.RuntimeActivitySnapshot {
+	if t == nil {
+		return port.RuntimeActivitySnapshot{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.snapshotLocked()
+}
+
+// Subscribe delivers the current snapshot synchronously, then every later
+// transition in subscription order. The returned function unsubscribes.
+func (t *RuntimeActivityTracker) Subscribe(fn func(port.RuntimeActivitySnapshot)) (unsubscribe func()) {
+	if fn == nil {
+		return func() {}
+	}
+	if t == nil {
+		return func() {}
+	}
+	t.mu.Lock()
+	id := t.nextSub
+	t.nextSub++
+	t.subscribers[id] = fn
+	snapshot := t.snapshotLocked()
+	t.mu.Unlock()
+	fn(snapshot)
+	return func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		delete(t.subscribers, id)
+	}
+}
+
+// NoteCreationAccepted records one accepted browser creation.
+func (t *RuntimeActivityTracker) NoteCreationAccepted() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.pending++
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteCreationResolved records one creation resolved through OnAfterCreated
+// (registered) or a definitive failure. Over-resolution is clamped at zero.
+func (t *RuntimeActivityTracker) NoteCreationResolved() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.pending > 0 {
+		t.pending--
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteViewRegistered records one live view registration.
+func (t *RuntimeActivityTracker) NoteViewRegistered() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.active++
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteViewCloseStarted records one native close: the view leaves the active
+// set and enters GTK-teardown outstanding.
+func (t *RuntimeActivityTracker) NoteViewCloseStarted() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.active > 0 {
+		t.active--
+	}
+	t.cleanup++
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteCleanupCompleted records one finished GTK bridge/popup cleanup.
+func (t *RuntimeActivityTracker) NoteCleanupCompleted() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.cleanup > 0 {
+		t.cleanup--
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteDownloadStarted records one download start keyed by owning browser and
+// CEF download ID.
+func (t *RuntimeActivityTracker) NoteDownloadStarted(browserID int32, downloadID uint32) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.downloads[downloadOwner{browserID: browserID, downloadID: downloadID}] = struct{}{}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// NoteDownloadProgress is observed without effect: only start and terminal
+// events change activity. Progress without a start never creates work.
+func (t *RuntimeActivityTracker) NoteDownloadProgress(_ int32, _ uint32) {}
+
+// NoteDownloadTerminal records one terminal download event (complete,
+// cancel, or failure). Duplicate terminals are idempotent; terminals for
+// unknown IDs resolve no owner and change nothing.
+func (t *RuntimeActivityTracker) NoteDownloadTerminal(downloadID uint32) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	for owner := range t.downloads {
+		if owner.downloadID == downloadID {
+			delete(t.downloads, owner)
+		}
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+// DropBrowser reconciles owner destruction through the native lifecycle:
+// entries owned by a destroyed browser can never receive terminal events.
+// It is never driven by window removal alone.
+func (t *RuntimeActivityTracker) DropBrowser(browserID int32) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	changed := false
+	for owner := range t.downloads {
+		if owner.browserID == browserID {
+			delete(t.downloads, owner)
+			changed = true
+		}
+	}
+	if !changed {
+		t.mu.Unlock()
+		return
+	}
+	snapshot := t.snapshotLocked()
+	subs := t.subscribersLocked()
+	t.mu.Unlock()
+	notifyRuntimeActivitySubscribers(subs, snapshot)
+}
+
+func (t *RuntimeActivityTracker) snapshotLocked() port.RuntimeActivitySnapshot {
+	return port.RuntimeActivitySnapshot{
+		PendingCreations: t.pending,
+		ActiveViews:      t.active,
+		PendingCleanup:   t.cleanup,
+		ActiveDownloads:  len(t.downloads),
+	}
+}
+
+func (t *RuntimeActivityTracker) subscribersLocked() []func(port.RuntimeActivitySnapshot) {
+	subs := make([]func(port.RuntimeActivitySnapshot), 0, len(t.subscribers))
+	for id := uint64(0); id < t.nextSub; id++ {
+		if fn, ok := t.subscribers[id]; ok {
+			subs = append(subs, fn)
+		}
+	}
+	return subs
+}
+
+func notifyRuntimeActivitySubscribers(subs []func(port.RuntimeActivitySnapshot), snapshot port.RuntimeActivitySnapshot) {
+	for _, fn := range subs {
+		fn(snapshot)
+	}
+}

--- a/internal/infrastructure/cef/runtime_activity.go
+++ b/internal/infrastructure/cef/runtime_activity.go
@@ -17,8 +17,10 @@ type downloadOwner struct {
 // RuntimeActivityTracker implements port.RuntimeActivity for the CEF engine.
 // It counts accepted creations through OnAfterCreated/failure, registered
 // live views, outstanding GTK cleanup, and unterminated downloads. All
-// methods are safe for concurrent use from CEF callbacks; subscriber
-// delivery is sequenced under the tracker lock snapshot.
+// methods are safe for concurrent use from CEF callbacks. Delivery is
+// serialized under the state lock, so the initial snapshot and every later
+// transition arrive in order; subscribers must not reenter the tracker.
+// A nil tracker is a safe no-op sink.
 type RuntimeActivityTracker struct {
 	mu          sync.Mutex
 	pending     int
@@ -48,21 +50,19 @@ func (t *RuntimeActivityTracker) Snapshot() port.RuntimeActivitySnapshot {
 }
 
 // Subscribe delivers the current snapshot synchronously, then every later
-// transition in subscription order. The returned function unsubscribes.
+// transition in subscription order. Delivery holds the state lock, so
+// callbacks must not call back into the tracker. The returned function
+// unsubscribes.
 func (t *RuntimeActivityTracker) Subscribe(fn func(port.RuntimeActivitySnapshot)) (unsubscribe func()) {
-	if fn == nil {
-		return func() {}
-	}
-	if t == nil {
+	if t == nil || fn == nil {
 		return func() {}
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	id := t.nextSub
 	t.nextSub++
 	t.subscribers[id] = fn
-	snapshot := t.snapshotLocked()
-	t.mu.Unlock()
-	fn(snapshot)
+	fn(t.snapshotLocked())
 	return func() {
 		t.mu.Lock()
 		defer t.mu.Unlock()
@@ -76,11 +76,9 @@ func (t *RuntimeActivityTracker) NoteCreationAccepted() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.pending++
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteCreationResolved records one creation resolved through OnAfterCreated
@@ -90,13 +88,11 @@ func (t *RuntimeActivityTracker) NoteCreationResolved() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.pending > 0 {
 		t.pending--
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteViewRegistered records one live view registration.
@@ -105,11 +101,9 @@ func (t *RuntimeActivityTracker) NoteViewRegistered() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.active++
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteViewCloseStarted records one native close: the view leaves the active
@@ -119,14 +113,12 @@ func (t *RuntimeActivityTracker) NoteViewCloseStarted() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.active > 0 {
 		t.active--
 	}
 	t.cleanup++
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteCleanupCompleted records one finished GTK bridge/popup cleanup.
@@ -135,13 +127,11 @@ func (t *RuntimeActivityTracker) NoteCleanupCompleted() {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.cleanup > 0 {
 		t.cleanup--
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteDownloadStarted records one download start keyed by owning browser and
@@ -151,11 +141,9 @@ func (t *RuntimeActivityTracker) NoteDownloadStarted(browserID int32, downloadID
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.downloads[downloadOwner{browserID: browserID, downloadID: downloadID}] = struct{}{}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // NoteDownloadProgress is observed without effect: only start and terminal
@@ -170,15 +158,13 @@ func (t *RuntimeActivityTracker) NoteDownloadTerminal(downloadID uint32) {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	for owner := range t.downloads {
 		if owner.downloadID == downloadID {
 			delete(t.downloads, owner)
 		}
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
+	t.notifyLocked()
 }
 
 // DropBrowser reconciles owner destruction through the native lifecycle:
@@ -189,6 +175,7 @@ func (t *RuntimeActivityTracker) DropBrowser(browserID int32) {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	changed := false
 	for owner := range t.downloads {
 		if owner.browserID == browserID {
@@ -196,14 +183,9 @@ func (t *RuntimeActivityTracker) DropBrowser(browserID int32) {
 			changed = true
 		}
 	}
-	if !changed {
-		t.mu.Unlock()
-		return
+	if changed {
+		t.notifyLocked()
 	}
-	snapshot := t.snapshotLocked()
-	subs := t.subscribersLocked()
-	t.mu.Unlock()
-	notifyRuntimeActivitySubscribers(subs, snapshot)
 }
 
 func (t *RuntimeActivityTracker) snapshotLocked() port.RuntimeActivitySnapshot {
@@ -215,18 +197,14 @@ func (t *RuntimeActivityTracker) snapshotLocked() port.RuntimeActivitySnapshot {
 	}
 }
 
-func (t *RuntimeActivityTracker) subscribersLocked() []func(port.RuntimeActivitySnapshot) {
-	subs := make([]func(port.RuntimeActivitySnapshot), 0, len(t.subscribers))
+// notifyLocked delivers the current snapshot to subscribers in subscription
+// order. The caller must hold t.mu and must not reenter the tracker from a
+// callback.
+func (t *RuntimeActivityTracker) notifyLocked() {
+	snapshot := t.snapshotLocked()
 	for id := uint64(0); id < t.nextSub; id++ {
 		if fn, ok := t.subscribers[id]; ok {
-			subs = append(subs, fn)
+			fn(snapshot)
 		}
-	}
-	return subs
-}
-
-func notifyRuntimeActivitySubscribers(subs []func(port.RuntimeActivitySnapshot), snapshot port.RuntimeActivitySnapshot) {
-	for _, fn := range subs {
-		fn(snapshot)
 	}
 }

--- a/internal/infrastructure/cef/runtime_activity_test.go
+++ b/internal/infrastructure/cef/runtime_activity_test.go
@@ -1,0 +1,111 @@
+package cef
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/port"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeActivityTrackerStartsQuiescent(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerCreationLifecycle(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	tracker.NoteCreationAccepted()
+	require.Equal(t, 1, tracker.Snapshot().PendingCreations)
+	require.False(t, tracker.Snapshot().Quiescent())
+
+	tracker.NoteCreationResolved()
+	require.True(t, tracker.Snapshot().Quiescent())
+
+	// Over-resolution clamps instead of going negative.
+	tracker.NoteCreationResolved()
+	require.Equal(t, 0, tracker.Snapshot().PendingCreations)
+}
+
+func TestRuntimeActivityTrackerViewLifecycle(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	tracker.NoteViewRegistered()
+	tracker.NoteViewRegistered()
+	require.Equal(t, 2, tracker.Snapshot().ActiveViews)
+
+	tracker.NoteViewCloseStarted()
+	snapshot := tracker.Snapshot()
+	require.Equal(t, 1, snapshot.ActiveViews)
+	require.Equal(t, 1, snapshot.PendingCleanup)
+	require.False(t, snapshot.Quiescent())
+
+	tracker.NoteCleanupCompleted()
+	tracker.NoteViewCloseStarted()
+	tracker.NoteCleanupCompleted()
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerDownloads(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+
+	// Same filename on two browsers are distinct owners.
+	tracker.NoteDownloadStarted(7, 100)
+	tracker.NoteDownloadStarted(9, 100)
+	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
+
+	// Progress without a start never creates work.
+	tracker.NoteDownloadProgress(7, 999)
+	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
+
+	// Terminal resolves every owner sharing the CEF download ID.
+	tracker.NoteDownloadTerminal(100)
+	require.Equal(t, 0, tracker.Snapshot().ActiveDownloads)
+
+	// Duplicate terminals are idempotent; unknown IDs change nothing.
+	tracker.NoteDownloadTerminal(100)
+	tracker.NoteDownloadTerminal(424242)
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerDropBrowser(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	tracker.NoteDownloadStarted(7, 100)
+	tracker.NoteDownloadStarted(9, 200)
+	tracker.DropBrowser(7)
+	snapshot := tracker.Snapshot()
+	require.Equal(t, 1, snapshot.ActiveDownloads)
+
+	tracker.NoteDownloadTerminal(200)
+	require.True(t, tracker.Snapshot().Quiescent())
+
+	// Dropping an unknown browser notifies nobody and changes nothing.
+	tracker.DropBrowser(12345)
+	require.True(t, tracker.Snapshot().Quiescent())
+}
+
+func TestRuntimeActivityTrackerSubscribeSequenced(t *testing.T) {
+	tracker := NewRuntimeActivityTracker()
+	var mu sync.Mutex
+	var seen []port.RuntimeActivitySnapshot
+	unsubscribe := tracker.Subscribe(func(snapshot port.RuntimeActivitySnapshot) {
+		mu.Lock()
+		seen = append(seen, snapshot)
+		mu.Unlock()
+	})
+	// Initial delivery is synchronous and quiescent.
+	mu.Lock()
+	require.Len(t, seen, 1)
+	require.True(t, seen[0].Quiescent())
+	mu.Unlock()
+
+	tracker.NoteCreationAccepted()
+	tracker.NoteCreationResolved()
+	unsubscribe()
+	tracker.NoteViewRegistered()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seen, 3, "unsubscribe stops delivery")
+	require.Equal(t, 1, seen[1].PendingCreations)
+	require.True(t, seen[2].Quiescent())
+}

--- a/internal/infrastructure/cef/runtime_activity_test.go
+++ b/internal/infrastructure/cef/runtime_activity_test.go
@@ -57,13 +57,16 @@ func TestRuntimeActivityTrackerDownloads(t *testing.T) {
 	tracker.NoteDownloadProgress(7, 999)
 	require.Equal(t, 2, tracker.Snapshot().ActiveDownloads)
 
-	// Terminal resolves every owner sharing the CEF download ID.
-	tracker.NoteDownloadTerminal(100)
+	// Terminal resolves only the exact owner sharing the CEF download ID.
+	tracker.NoteDownloadTerminal(7, 100)
+	require.Equal(t, 1, tracker.Snapshot().ActiveDownloads)
+
+	tracker.NoteDownloadTerminal(9, 100)
 	require.Equal(t, 0, tracker.Snapshot().ActiveDownloads)
 
-	// Duplicate terminals are idempotent; unknown IDs change nothing.
-	tracker.NoteDownloadTerminal(100)
-	tracker.NoteDownloadTerminal(424242)
+	// Duplicate terminals are idempotent; unknown owners change nothing.
+	tracker.NoteDownloadTerminal(9, 100)
+	tracker.NoteDownloadTerminal(7, 424242)
 	require.True(t, tracker.Snapshot().Quiescent())
 }
 
@@ -75,7 +78,7 @@ func TestRuntimeActivityTrackerDropBrowser(t *testing.T) {
 	snapshot := tracker.Snapshot()
 	require.Equal(t, 1, snapshot.ActiveDownloads)
 
-	tracker.NoteDownloadTerminal(200)
+	tracker.NoteDownloadTerminal(9, 200)
 	require.True(t, tracker.Snapshot().Quiescent())
 
 	// Dropping an unknown browser notifies nobody and changes nothing.

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2006,19 +2006,6 @@ func (wv *WebView) schedulePendingNavigationReplay(attempt int) {
 	})
 }
 
-func (wv *WebView) replayPendingNavigation(attempt int) {
-	if wv == nil || wv.destroyed.Load() {
-		return
-	}
-	wv.mu.RLock()
-	intentID := wv.pendingIntentID
-	wv.mu.RUnlock()
-	if intentID == 0 {
-		return
-	}
-	wv.replayPendingNavigationForIntent(attempt, intentID)
-}
-
 // replayPendingNavigationForIntent submits at most one LoadURL per navigation
 // intent. Duplicate scheduled tasks for an already-issued intent return
 // without resubmitting; stale tasks for a replaced intent return as well.
@@ -2064,17 +2051,24 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 	currentURL := frame.GetURL()
 	if pendingURIEquivalent(currentURL, uri) {
 		wv.mu.Lock()
-		if wv.pendingIntentID == intentID {
+		submitted := wv.pendingIntentID == intentID && wv.pendingIssued
+		if submitted {
 			wv.clearPendingNavigationIfEquivalentLocked(uri)
 		}
 		wv.mu.Unlock()
-		if wv.ctx != nil {
-			logging.FromContext(wv.ctx).Debug().
-				Int("attempt", attempt).
-				Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
-				Msg("cef: pending navigation already active")
+		if submitted {
+			if wv.ctx != nil {
+				logging.FromContext(wv.ctx).Debug().
+					Int("attempt", attempt).
+					Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
+					Msg("cef: pending navigation already active")
+			}
+			return
 		}
-		return
+		// Unissued explicit intent for the current URL (e.g. a same-URL
+		// reload): browsers always bootstrap on about:blank, so this is a
+		// fresh request that must proceed to the claim below, not be
+		// cleared as already active.
 	}
 	// Claim submission only for the current unissued intent with a valid
 	// frame; see claimPendingNavigationSubmission. Mark issued before the

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2106,8 +2106,12 @@ const (
 // claimPendingNavigationSubmission re-reads state and claims submission for
 // intentID only when it is still the current unissued intent. Browsers are
 // correlated by identifier, matching codebase convention; all foreign calls
-// happen outside the state lock. The issued mark is set before the caller
-// performs the foreign LoadURL.
+// happen outside the state lock. The final claim additionally requires the
+// attached browser to still be the instance observed before the lock: a
+// replacement between the identifier check and the claim is reported as
+// replaced so the caller retries against the current browser instead of
+// marking the intent issued and submitting to a stale frame. The issued
+// mark is set before the caller performs the foreign LoadURL.
 func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID int32) (string, pendingClaimResult) {
 	wv.mu.RLock()
 	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
@@ -2123,6 +2127,12 @@ func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID i
 	defer wv.mu.Unlock()
 	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
 		return "", pendingClaimStale
+	}
+	// Interface identity comparison is safe here: attached browsers are
+	// always the pointer wrappers delivered by CEF callbacks (mocks are
+	// pointers as well), and no foreign call happens under the lock.
+	if wv.browser != currentBrowser {
+		return "", pendingClaimReplaced
 	}
 	wv.pendingIssued = true
 	uri := wv.pendingURI

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -1264,6 +1264,11 @@ func (wv *WebView) Destroy() {
 	if !wv.destroyed.CompareAndSwap(false, true) {
 		return
 	}
+	// Native close begins here: the view leaves the active set and enters
+	// GTK-teardown outstanding for the quiescence boundary.
+	if wv.engine != nil {
+		wv.engine.activity.NoteViewCloseStarted()
+	}
 	// Retire scroll motion the moment destruction begins, regardless of
 	// calling thread; GTK-only cleanup follows through the owning
 	// dispatcher without waiting for the deferred native browser close.

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2081,12 +2081,31 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 		wv.schedulePendingNavigationReplay(attempt + 1)
 	case pendingClaimReady:
 		frame.LoadURL(submitURI)
+		wv.resubmitIfBrowserReplaced(attempt, intentID, browser)
 	}
 	if wv.ctx != nil {
 		logging.FromContext(wv.ctx).Debug().
 			Int("attempt", attempt).
 			Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
 			Msg("cef: replayed pending navigation")
+	}
+}
+
+// resubmitIfBrowserReplaced re-checks the attached browser after the
+// claim's foreign LoadURL: a replacement in between leaves the navigation on
+// a stale frame while the intent reads issued. Clearing the issuance while
+// the intent is still current keeps it replayable, and the retry goes to
+// the current browser instead of dropping the navigation. Instance
+// comparison follows the same pointer-wrapper convention as the claim.
+func (wv *WebView) resubmitIfBrowserReplaced(attempt int, intentID uint64, submitted purecef.Browser) {
+	wv.mu.Lock()
+	replaced := wv.pendingIntentID == intentID && wv.pendingIssued && wv.browser != submitted
+	if replaced {
+		wv.pendingIssued = false
+	}
+	wv.mu.Unlock()
+	if replaced {
+		wv.schedulePendingNavigationReplay(attempt + 1)
 	}
 }
 

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -179,9 +179,17 @@ type WebView struct {
 	initialBrowserCreateResizeHandled bool
 
 	// pendingURI is set when LoadURI is called before the browser exists.
+	// Each explicit navigation request installs a new monotonically increasing
+	// pendingIntentID (including repeated same-URL requests); lifecycle replay
+	// never creates an intent. pendingIssued tracks whether the current intent
+	// has been submitted via LoadURL; duplicate scheduled tasks for an issued
+	// intent return without resubmitting.
 	pendingURI          string
 	pendingURISetAt     time.Time
 	pendingURIStartedAt time.Time
+	pendingIntentID     uint64
+	pendingIssued       bool
+	pendingIntentNext   uint64
 
 	// GTK sync dispatch hooks are injectable for tests. Production uses the GTK
 	// default main context through runOnGTK and isOnGTKThread.
@@ -1905,11 +1913,17 @@ func (wv *WebView) pendingNavigationURI() string {
 func (wv *WebView) setPendingNavigationLocked(uri string, at time.Time) {
 	wv.pendingURI = uri
 	wv.pendingURIStartedAt = time.Time{}
+	wv.pendingIssued = false
 	if uri == "" {
 		wv.pendingURISetAt = time.Time{}
+		wv.pendingIntentID = 0
 		return
 	}
 	wv.pendingURISetAt = at
+	// Every explicit request installs a new intent, including repeated
+	// same-URL requests; lifecycle replay never calls this.
+	wv.pendingIntentNext++
+	wv.pendingIntentID = wv.pendingIntentNext
 }
 
 func (wv *WebView) markPendingNavigationStartedLocked(uri string, at time.Time) {
@@ -1924,6 +1938,8 @@ func (wv *WebView) clearPendingNavigationLocked() string {
 	wv.pendingURI = ""
 	wv.pendingURISetAt = time.Time{}
 	wv.pendingURIStartedAt = time.Time{}
+	wv.pendingIntentID = 0
+	wv.pendingIssued = false
 	return cleared
 }
 
@@ -1949,8 +1965,16 @@ func (wv *WebView) schedulePendingNavigationReplay(attempt int) {
 	if wv == nil || wv.destroyed.Load() {
 		return
 	}
+	// Capture the intent at schedule time; a rapid replacement installs a new
+	// intent and stale tasks for the old ID must return without submitting.
+	wv.mu.RLock()
+	intentID := wv.pendingIntentID
+	wv.mu.RUnlock()
+	if intentID == 0 {
+		return
+	}
 	task := cefNewTask(cefTaskFunc(func() {
-		wv.replayPendingNavigation(attempt)
+		wv.replayPendingNavigationForIntent(attempt, intentID)
 	}))
 	if task == nil {
 		return
@@ -1987,10 +2011,34 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 		return
 	}
 	wv.mu.RLock()
+	intentID := wv.pendingIntentID
+	wv.mu.RUnlock()
+	if intentID == 0 {
+		return
+	}
+	wv.replayPendingNavigationForIntent(attempt, intentID)
+}
+
+// replayPendingNavigationForIntent submits at most one LoadURL per navigation
+// intent. Duplicate scheduled tasks for an already-issued intent return
+// without resubmitting; stale tasks for a replaced intent return as well.
+// Missing-frame and task-post failures retry only that same intent ID.
+func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64) {
+	if wv == nil || wv.destroyed.Load() {
+		return
+	}
+	wv.mu.RLock()
 	uri := wv.pendingURI
 	browser := wv.browser
+	currentID := wv.pendingIntentID
+	issued := wv.pendingIssued
 	wv.mu.RUnlock()
-	if uri == "" || browser == nil {
+	if uri == "" || browser == nil || currentID == 0 || intentID != currentID {
+		return
+	}
+	if issued {
+		// Already submitted for this intent; a blank OnLoadEnd scheduling a
+		// second replay must not resubmit an in-flight navigation.
 		return
 	}
 	frame := browser.GetMainFrame()
@@ -2016,7 +2064,9 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 	currentURL := frame.GetURL()
 	if pendingURIEquivalent(currentURL, uri) {
 		wv.mu.Lock()
-		wv.clearPendingNavigationIfEquivalentLocked(uri)
+		if wv.pendingIntentID == intentID {
+			wv.clearPendingNavigationIfEquivalentLocked(uri)
+		}
 		wv.mu.Unlock()
 		if wv.ctx != nil {
 			logging.FromContext(wv.ctx).Debug().
@@ -2026,7 +2076,22 @@ func (wv *WebView) replayPendingNavigation(attempt int) {
 		}
 		return
 	}
+	// Re-read the current browser under the state lock and claim submission
+	// only for the current unissued intent with a valid frame. Mark issued
+	// before the foreign LoadURL, outside the lock.
 	wv.mu.Lock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		wv.mu.Unlock()
+		return
+	}
+	if wv.browser != browser {
+		// Browser was replaced between frame acquisition and claim; retry
+		// the same intent so the new browser is used at execution time.
+		wv.mu.Unlock()
+		wv.schedulePendingNavigationReplay(attempt + 1)
+		return
+	}
+	wv.pendingIssued = true
 	wv.markPendingNavigationStartedLocked(uri, time.Now())
 	wv.mu.Unlock()
 	frame.LoadURL(uri)

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2077,18 +2077,25 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 		return
 	}
 	// Re-read the current browser under the state lock and claim submission
-	// only for the current unissued intent with a valid frame. Mark issued
-	// before the foreign LoadURL, outside the lock.
+	// only for the current unissued intent with a valid frame. Browsers are
+	// correlated by identifier (never interface equality); foreign calls stay
+	// outside the lock. Mark issued before the foreign LoadURL, outside lock.
+	wv.mu.RLock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		wv.mu.RUnlock()
+		return
+	}
+	currentBrowser := wv.browser
+	wv.mu.RUnlock()
+	if currentBrowser.GetIdentifier() != browser.GetIdentifier() {
+		// Browser was replaced between frame acquisition and claim; retry
+		// the same intent so the new browser is used at execution time.
+		wv.schedulePendingNavigationReplay(attempt + 1)
+		return
+	}
 	wv.mu.Lock()
 	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
 		wv.mu.Unlock()
-		return
-	}
-	if wv.browser != browser {
-		// Browser was replaced between frame acquisition and claim; retry
-		// the same intent so the new browser is used at execution time.
-		wv.mu.Unlock()
-		wv.schedulePendingNavigationReplay(attempt + 1)
 		return
 	}
 	wv.pendingIssued = true

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -278,12 +278,12 @@ type WebView struct {
 	loadDiagLastLoadStateAt time.Time
 
 	// Atomic state.
-	destroyed                     atomic.Bool
-	fullscreen                    atomic.Bool
+	destroyed  atomic.Bool
+	fullscreen atomic.Bool
 	// bridgeTeardownNoted gates quiescence accounting exactly once per
 	// view: every bridge teardown is scheduled through the Sync/Async
 	// wrappers below and completes in destroyViewBridgeOnGTKThread.
-	bridgeTeardownNoted         atomic.Bool
+	bridgeTeardownNoted           atomic.Bool
 	generation                    atomic.Uint64
 	audioPlaying                  atomic.Bool
 	zoomFactor                    atomic.Value // float64, initialized to 1.0

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2076,38 +2076,64 @@ func (wv *WebView) replayPendingNavigationForIntent(attempt int, intentID uint64
 		}
 		return
 	}
-	// Re-read the current browser under the state lock and claim submission
-	// only for the current unissued intent with a valid frame. Browsers are
-	// correlated by identifier (never interface equality); foreign calls stay
-	// outside the lock. Mark issued before the foreign LoadURL, outside lock.
-	wv.mu.RLock()
-	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
-		wv.mu.RUnlock()
-		return
-	}
-	currentBrowser := wv.browser
-	wv.mu.RUnlock()
-	if currentBrowser.GetIdentifier() != browser.GetIdentifier() {
+	// Claim submission only for the current unissued intent with a valid
+	// frame; see claimPendingNavigationSubmission. Mark issued before the
+	// foreign LoadURL, outside the lock.
+	submitURI, claim := wv.claimPendingNavigationSubmission(intentID, browser.GetIdentifier())
+	switch claim {
+	case pendingClaimReplaced:
 		// Browser was replaced between frame acquisition and claim; retry
 		// the same intent so the new browser is used at execution time.
 		wv.schedulePendingNavigationReplay(attempt + 1)
-		return
+	case pendingClaimReady:
+		frame.LoadURL(submitURI)
 	}
-	wv.mu.Lock()
-	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
-		wv.mu.Unlock()
-		return
-	}
-	wv.pendingIssued = true
-	wv.markPendingNavigationStartedLocked(uri, time.Now())
-	wv.mu.Unlock()
-	frame.LoadURL(uri)
 	if wv.ctx != nil {
 		logging.FromContext(wv.ctx).Debug().
 			Int("attempt", attempt).
 			Str("uri", logging.TruncateURL(uri, logging.PermissionLogURLMaxLen)).
 			Msg("cef: replayed pending navigation")
 	}
+}
+
+type pendingClaimResult int
+
+const (
+	// pendingClaimStale means the intent changed, was issued, or was cleared:
+	// the caller must return without submitting.
+	pendingClaimStale pendingClaimResult = iota
+	// pendingClaimReplaced means the browser was replaced between frame
+	// acquisition and claim: the caller must retry the same intent.
+	pendingClaimReplaced
+	// pendingClaimReady means the intent was claimed: the caller submits uri.
+	pendingClaimReady
+)
+
+// claimPendingNavigationSubmission re-reads state and claims submission for
+// intentID only when it is still the current unissued intent. Browsers are
+// correlated by identifier, matching codebase convention; all foreign calls
+// happen outside the state lock. The issued mark is set before the caller
+// performs the foreign LoadURL.
+func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID int32) (string, pendingClaimResult) {
+	wv.mu.RLock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		wv.mu.RUnlock()
+		return "", pendingClaimStale
+	}
+	currentBrowser := wv.browser
+	wv.mu.RUnlock()
+	if currentBrowser.GetIdentifier() != browserID {
+		return "", pendingClaimReplaced
+	}
+	wv.mu.Lock()
+	defer wv.mu.Unlock()
+	if wv.pendingIntentID != intentID || wv.pendingIssued || wv.browser == nil {
+		return "", pendingClaimStale
+	}
+	wv.pendingIssued = true
+	uri := wv.pendingURI
+	wv.markPendingNavigationStartedLocked(uri, time.Now())
+	return uri, pendingClaimReady
 }
 
 func pendingURIEquivalent(a, b string) bool {

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -280,6 +280,10 @@ type WebView struct {
 	// Atomic state.
 	destroyed                     atomic.Bool
 	fullscreen                    atomic.Bool
+	// bridgeTeardownNoted gates quiescence accounting exactly once per
+	// view: every bridge teardown is scheduled through the Sync/Async
+	// wrappers below and completes in destroyViewBridgeOnGTKThread.
+	bridgeTeardownNoted         atomic.Bool
 	generation                    atomic.Uint64
 	audioPlaying                  atomic.Bool
 	zoomFactor                    atomic.Value // float64, initialized to 1.0
@@ -1264,11 +1268,6 @@ func (wv *WebView) Destroy() {
 	if !wv.destroyed.CompareAndSwap(false, true) {
 		return
 	}
-	// Native close begins here: the view leaves the active set and enters
-	// GTK-teardown outstanding for the quiescence boundary.
-	if wv.engine != nil {
-		wv.engine.activity.NoteViewCloseStarted()
-	}
 	// Retire scroll motion the moment destruction begins, regardless of
 	// calling thread; GTK-only cleanup follows through the owning
 	// dispatcher without waiting for the deferred native browser close.
@@ -1323,6 +1322,7 @@ func (wv *WebView) destroyViewBridgeOnGTKSync() {
 	if wv == nil || wv.viewBridge == nil {
 		return
 	}
+	wv.noteBridgeTeardownScheduled()
 	wv.runOnGTKSyncLabelAllowLateStart("cef.destroy_view_bridge", true, func() {
 		wv.destroyViewBridgeOnGTKThread()
 	})
@@ -1332,9 +1332,27 @@ func (wv *WebView) destroyViewBridgeOnGTKAsync() {
 	if wv == nil || wv.viewBridge == nil {
 		return
 	}
+	wv.noteBridgeTeardownScheduled()
 	wv.runOnGTK(func() {
 		wv.destroyViewBridgeOnGTKThread()
 	})
+}
+
+// noteBridgeTeardownScheduled records one outstanding GTK teardown for the
+// quiescence boundary. Exactly one caller wins per view however often the
+// Sync/Async wrappers race; the matching completion lands in
+// destroyViewBridgeOnGTKThread, which runs exactly once per view because it
+// nils the bridge on completion.
+func (wv *WebView) noteBridgeTeardownScheduled() {
+	if wv == nil {
+		return
+	}
+	if !wv.bridgeTeardownNoted.CompareAndSwap(false, true) {
+		return
+	}
+	if wv.engine != nil {
+		wv.engine.activity.NoteViewCloseStarted()
+	}
 }
 
 func (wv *WebView) destroyViewBridgeOnGTKThread() {
@@ -1355,6 +1373,11 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 	_ = wv.viewBridge.Destroy()
 	wv.viewBridge = nil
 	wv.nativeWidget = nil
+	// The bridge actually tore down here (second arrivals return early on
+	// the nil guard above), completing the outstanding teardown exactly once.
+	if wv.engine != nil {
+		wv.engine.activity.NoteCleanupCompleted()
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -841,6 +841,11 @@ func (h *handlerSet) OnAfterCreated(browser purecef.Browser) {
 	host := browser.GetHost()
 	if host == nil {
 		log.Warn().Msg("cef: OnAfterCreated returned nil host")
+		if h.wv.engine != nil {
+			// No view will ever attach to this browser: resolve the
+			// pending count so quiescence cannot strand on it.
+			h.wv.engine.activity.NoteCreationResolved()
+		}
 		return
 	}
 
@@ -1091,7 +1096,7 @@ func (h *handlerSet) OnBeforeDownload(
 }
 
 func (h *handlerSet) OnDownloadUpdated(
-	_ purecef.Browser,
+	browser purecef.Browser,
 	downloadItem purecef.DownloadItem,
 	callback purecef.DownloadItemCallback,
 ) {
@@ -1099,7 +1104,7 @@ func (h *handlerSet) OnDownloadUpdated(
 	if handler == nil {
 		return
 	}
-	handler.onDownloadUpdated(h.currentContext(), downloadItem, callback)
+	handler.onDownloadUpdated(h.currentContext(), browser, downloadItem, callback)
 }
 
 func (h *handlerSet) downloadHandler() *downloadHandler {

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -828,6 +828,11 @@ func (h *handlerSet) OnAfterCreated(browser purecef.Browser) {
 	log := logging.FromContext(h.wv.ctx)
 	if browser == nil {
 		log.Warn().Msg("cef: OnAfterCreated called with nil browser")
+		if h.wv.engine != nil {
+			// No browser will ever complete this creation: resolve the
+			// pending count so quiescence cannot strand on it.
+			h.wv.engine.activity.NoteCreationResolved()
+		}
 		return
 	}
 	browserID := browser.GetIdentifier()
@@ -845,6 +850,9 @@ func (h *handlerSet) OnAfterCreated(browser purecef.Browser) {
 			Int32("browser_id", browserID).
 			Int32("existing_browser_id", state.duplicateBrowserID).
 			Msg("cef: duplicate popup browser attached after shell already had a browser; closing duplicate")
+		if h.wv.engine != nil {
+			h.wv.engine.activity.NoteCreationResolved()
+		}
 		host.CloseBrowser(1)
 		return
 	}

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -429,3 +429,83 @@ func TestWebViewReplayPendingNavigation_SameURLReloadSubmits(t *testing.T) {
 	defer wv.mu.RUnlock()
 	require.True(t, wv.pendingIssued)
 }
+
+func TestWebViewReplayPendingNavigation_ClearsIssuanceWhenBrowserReplacedAfterClaim(t *testing.T) {
+	const uri = "https://example.com/replaced-after-claim"
+	browserA := cefmocks.NewMockBrowser(t)
+	browserB := cefmocks.NewMockBrowser(t)
+	frameA := cefmocks.NewMockFrame(t)
+	frameB := cefmocks.NewMockFrame(t)
+
+	browserA.EXPECT().GetIdentifier().Return(int32(7)).Twice()
+	browserA.EXPECT().GetMainFrame().Return(frameA).Once()
+	frameA.EXPECT().GetURL().Return("").Once()
+	entered := make(chan struct{})
+	var enterOnce sync.Once
+	proceed := make(chan struct{})
+	frameA.EXPECT().LoadURL(uri).RunAndReturn(func(string) {
+		enterOnce.Do(func() { close(entered) })
+		<-proceed
+	}).Once()
+
+	browserB.EXPECT().GetIdentifier().Return(int32(7)).Twice()
+	browserB.EXPECT().GetMainFrame().Return(frameB).Once()
+	frameB.EXPECT().GetURL().Return("").Once()
+	frameB.EXPECT().LoadURL(uri).Once()
+
+	oldTask := cefNewTask
+	oldDelayed := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldTask
+		cefPostDelayedTask = oldDelayed
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	var scheduled purecef.Task
+	// The post-claim retry schedules with attempt+1, which takes the
+	// delayed-task path; capture it to drive the retry synchronously.
+	cefPostDelayedTask = func(_ purecef.ThreadID, task purecef.Task, _ int64) int32 {
+		scheduled = task
+		return 1
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browserA}
+	wv.setPendingNavigationLocked(uri, time.Now())
+	intentID := wv.pendingIntentID
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wv.replayPendingNavigationForIntent(0, intentID)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("replay did not reach LoadURL")
+	}
+
+	// Replace the attached browser while LoadURL is in flight on the stale
+	// frame: the claim already marked the intent issued.
+	wv.mu.Lock()
+	wv.browser = browserB
+	wv.mu.Unlock()
+	close(proceed)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("replay did not return after LoadURL")
+	}
+
+	wv.mu.RLock()
+	require.False(t, wv.pendingIssued, "post-claim replacement must reopen the issuance for retry")
+	require.Equal(t, intentID, wv.pendingIntentID, "the intent itself must survive the replacement")
+	wv.mu.RUnlock()
+	require.NotNil(t, scheduled, "a retry against the current browser must be scheduled")
+
+	// Driving the retry submits the surviving intent to the new browser.
+	scheduled.Execute()
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.True(t, wv.pendingIssued, "retry must issue the intent on the current browser")
+}

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -16,6 +16,7 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("https://github.com/bnema").Once()
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 
 	wv := &WebView{ctx: context.Background(), browser: browser}
 	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
@@ -104,6 +105,7 @@ func TestWebViewReplayPendingNavigation_UsesCurrentBrowserAtExecutionTime(t *tes
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("https://github.com/bnema").Once()
 	activeBrowser.EXPECT().GetMainFrame().Return(frame).Once()
+	activeBrowser.EXPECT().GetIdentifier().Return(int32(2)).Twice()
 
 	oldTask := cefNewTask
 	oldPost := cefPostTask
@@ -134,6 +136,7 @@ func TestWebViewLoadURI_QueuesPendingNavigationReplayForExistingBrowser(t *testi
 	browser := cefmocks.NewMockBrowser(t)
 	frame := cefmocks.NewMockFrame(t)
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("github.com/bnema").Once()
 
@@ -236,6 +239,7 @@ func TestWebViewReplayPendingNavigation_SubmitsOncePerIntent(t *testing.T) {
 	frame.EXPECT().GetURL().Return("about:blank")
 	frame.EXPECT().LoadURL("https://example.com/target").Once()
 	browser.EXPECT().GetMainFrame().Return(frame)
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 
 	oldTask := cefNewTask
 	oldPost := cefPostTask
@@ -270,6 +274,7 @@ func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T)
 	frame.EXPECT().GetURL().Return("").Once()
 	frame.EXPECT().LoadURL("https://example.com/second").Once()
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
 
 	oldTask := cefNewTask
 	oldPost := cefPostTask

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -20,7 +20,7 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 
 	wv := &WebView{ctx: context.Background(), browser: browser}
 	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
-	wv.replayPendingNavigation(0)
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
 
 	wv.mu.RLock()
 	defer wv.mu.RUnlock()
@@ -50,7 +50,7 @@ func TestWebViewReplayPendingNavigation_RetriesWhenMainFrameUnavailable(t *testi
 
 	wv := &WebView{ctx: context.Background(), browser: browser}
 	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
-	wv.replayPendingNavigation(0)
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
 
 	require.True(t, scheduled)
 	wv.mu.RLock()
@@ -298,7 +298,7 @@ func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T)
 	wv.setPendingNavigationLocked("https://example.com/second", time.Now())
 	stale.Execute()
 	// Current intent still unissued; a fresh replay submits it once.
-	wv.replayPendingNavigation(0)
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
 }
 
 // TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost ensures a
@@ -352,4 +352,24 @@ func TestWebViewSetPendingNavigation_RepeatedSameURLInstallsNewIntent(t *testing
 	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
 	require.NotEqual(t, first, wv.pendingIntentID)
 	require.False(t, wv.pendingIssued)
+}
+
+// TestWebViewReplayPendingNavigation_SameURLReloadSubmits verifies an
+// unissued explicit intent for the currently displayed URL proceeds to
+// LoadURL instead of being cleared as already active.
+func TestWebViewReplayPendingNavigation_SameURLReloadSubmits(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().GetURL().Return("https://example.com/page").Once()
+	frame.EXPECT().LoadURL("https://example.com/page").Once()
+	browser.EXPECT().GetMainFrame().Return(frame).Once()
+	browser.EXPECT().GetIdentifier().Return(int32(1)).Twice()
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
+	wv.replayPendingNavigationForIntent(0, wv.pendingIntentID)
+
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.True(t, wv.pendingIssued)
 }

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -2,6 +2,7 @@ package cef
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,61 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 	wv.mu.RLock()
 	defer wv.mu.RUnlock()
 	require.Equal(t, "https://github.com/bnema", wv.pendingURI)
+}
+
+// TestWebViewClaimPendingNavigationSubmission_RejectsInstanceReplacement
+// reproduces a browser swap landing between the identifier check and the
+// final claim: the replacement carries the same identifier, so only the
+// instance-identity guard can catch it. The claim must report replaced
+// without marking the intent issued, leaving the retry path able to submit
+// against the current browser.
+func TestWebViewClaimPendingNavigationSubmission_RejectsInstanceReplacement(t *testing.T) {
+	browserA := cefmocks.NewMockBrowser(t)
+	browserB := cefmocks.NewMockBrowser(t)
+	entered := make(chan struct{})
+	var enterOnce sync.Once
+	proceed := make(chan struct{})
+	browserA.EXPECT().GetIdentifier().RunAndReturn(func() int32 {
+		enterOnce.Do(func() { close(entered) })
+		<-proceed
+		return int32(7)
+	}).Once()
+
+	wv := &WebView{ctx: context.Background(), browser: browserA}
+	wv.setPendingNavigationLocked("https://example.com", time.Now())
+	intentID := wv.pendingIntentID
+	require.NotZero(t, intentID)
+
+	claimed := make(chan pendingClaimResult, 1)
+	go func() {
+		_, result := wv.claimPendingNavigationSubmission(intentID, int32(7))
+		claimed <- result
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("claim did not reach the identifier check")
+	}
+
+	// Swap the attached browser while the claim is past the snapshot: same
+	// identifier, different instance.
+	wv.mu.Lock()
+	wv.browser = browserB
+	wv.mu.Unlock()
+	close(proceed)
+
+	select {
+	case result := <-claimed:
+		require.Equal(t, pendingClaimReplaced, result, "instance replacement must not claim the intent")
+	case <-time.After(10 * time.Second):
+		t.Fatal("claim did not return after the swap")
+	}
+
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.False(t, wv.pendingIssued, "replaced claim must leave the intent unissued for retry")
+	require.Equal(t, intentID, wv.pendingIntentID)
 }
 
 func TestWebViewReplayPendingNavigation_RetriesWhenMainFrameUnavailable(t *testing.T) {

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -245,7 +245,7 @@ func TestWebViewReplayPendingNavigation_SubmitsOncePerIntent(t *testing.T) {
 	}()
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
 	var scheduled []purecef.Task
-	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+	cefPostTask = func(_ purecef.ThreadID, task purecef.Task) int32 {
 		scheduled = append(scheduled, task)
 		return 1
 	}
@@ -279,7 +279,7 @@ func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T)
 	}()
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
 	var scheduled []purecef.Task
-	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+	cefPostTask = func(_ purecef.ThreadID, task purecef.Task) int32 {
 		scheduled = append(scheduled, task)
 		return 1
 	}
@@ -310,11 +310,11 @@ func TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost(t *testing
 		cefScheduleAfter = oldAfter
 	}()
 	cefNewTask = func(task purecef.Task) purecef.Task { return task }
-	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+	cefPostTask = func(_ purecef.ThreadID, _ purecef.Task) int32 {
 		return 0
 	}
 	scheduledAfter := false
-	cefScheduleAfter = func(delay time.Duration, fn func()) {
+	cefScheduleAfter = func(delay time.Duration, _ func()) {
 		require.Equal(t, pendingNavigationRetryDelay, delay)
 		scheduledAfter = true
 	}

--- a/internal/infrastructure/cef/webview_navigation_test.go
+++ b/internal/infrastructure/cef/webview_navigation_test.go
@@ -17,7 +17,8 @@ func TestWebViewReplayPendingNavigation_LoadsQueuedURIWhenMainFrameAvailable(t *
 	frame.EXPECT().LoadURL("https://github.com/bnema").Once()
 	browser.EXPECT().GetMainFrame().Return(frame).Once()
 
-	wv := &WebView{ctx: context.Background(), browser: browser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.replayPendingNavigation(0)
 
 	wv.mu.RLock()
@@ -46,7 +47,8 @@ func TestWebViewReplayPendingNavigation_RetriesWhenMainFrameUnavailable(t *testi
 		return 1
 	}
 
-	wv := &WebView{ctx: context.Background(), browser: browser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.replayPendingNavigation(0)
 
 	require.True(t, scheduled)
@@ -88,7 +90,8 @@ func TestWebViewSchedulePendingNavigationReplay_RetriesWhenTaskPostFails(t *test
 		return 1
 	}
 
-	wv := &WebView{ctx: context.Background(), browser: browser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.schedulePendingNavigationReplay(0)
 
 	require.True(t, retried)
@@ -116,7 +119,8 @@ func TestWebViewReplayPendingNavigation_UsesCurrentBrowserAtExecutionTime(t *tes
 		return 1
 	}
 
-	wv := &WebView{ctx: context.Background(), browser: staleBrowser, pendingURI: "https://github.com/bnema"}
+	wv := &WebView{ctx: context.Background(), browser: staleBrowser}
+	wv.setPendingNavigationLocked("https://github.com/bnema", time.Now())
 	wv.schedulePendingNavigationReplay(0)
 	wv.mu.Lock()
 	wv.browser = activeBrowser
@@ -220,4 +224,127 @@ func TestWebViewUpdateLoadState_KeepsPendingNavigationWhileLoading(t *testing.T)
 	wv.updateLoadState(true, true, false)
 
 	require.Equal(t, pending, wv.pendingNavigationURI())
+}
+
+// TestWebViewReplayPendingNavigation_SubmitsOncePerIntent reproduces the
+// fresh-window race: queue an intent, run OnAfterCreated replay with the
+// frame URL still blank, then deliver blank OnLoadEnd before commit. Exactly
+// one LoadURL must be issued for the intent.
+func TestWebViewReplayPendingNavigation_SubmitsOncePerIntent(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().GetURL().Return("about:blank")
+	frame.EXPECT().LoadURL("https://example.com/target").Once()
+	browser.EXPECT().GetMainFrame().Return(frame)
+
+	oldTask := cefNewTask
+	oldPost := cefPostTask
+	defer func() {
+		cefNewTask = oldTask
+		cefPostTask = oldPost
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	var scheduled []purecef.Task
+	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/target", time.Now())
+	// OnAfterCreated schedules replay...
+	wv.schedulePendingNavigationReplay(0)
+	// ...and blank OnLoadEnd schedules a second replay before commit.
+	wv.schedulePendingNavigationReplay(0)
+	require.Len(t, scheduled, 2)
+	for _, task := range scheduled {
+		task.Execute()
+	}
+}
+
+// TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit verifies a
+// rapid replacement URL invalidates the previously scheduled task.
+func TestWebViewReplayPendingNavigation_StaleIntentDoesNotResubmit(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().GetURL().Return("").Once()
+	frame.EXPECT().LoadURL("https://example.com/second").Once()
+	browser.EXPECT().GetMainFrame().Return(frame).Once()
+
+	oldTask := cefNewTask
+	oldPost := cefPostTask
+	defer func() {
+		cefNewTask = oldTask
+		cefPostTask = oldPost
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	var scheduled []purecef.Task
+	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/first", time.Now())
+	wv.schedulePendingNavigationReplay(0)
+	require.Len(t, scheduled, 1)
+	stale := scheduled[0]
+	// Replacement installs a new intent; the stale task must not submit.
+	wv.setPendingNavigationLocked("https://example.com/second", time.Now())
+	stale.Execute()
+	// Current intent still unissued; a fresh replay submits it once.
+	wv.replayPendingNavigation(0)
+}
+
+// TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost ensures a
+// failed task post retries without consuming or duplicating the intent.
+func TestWebViewReplayPendingNavigation_RetriesSameIntentOnFailedPost(t *testing.T) {
+	browser := cefmocks.NewMockBrowser(t)
+
+	oldTask := cefNewTask
+	oldPost := cefPostTask
+	oldAfter := cefScheduleAfter
+	defer func() {
+		cefNewTask = oldTask
+		cefPostTask = oldPost
+		cefScheduleAfter = oldAfter
+	}()
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	cefPostTask = func(threadID purecef.ThreadID, task purecef.Task) int32 {
+		return 0
+	}
+	scheduledAfter := false
+	cefScheduleAfter = func(delay time.Duration, fn func()) {
+		require.Equal(t, pendingNavigationRetryDelay, delay)
+		scheduledAfter = true
+	}
+
+	wv := &WebView{ctx: context.Background(), browser: browser}
+	wv.setPendingNavigationLocked("https://example.com/target", time.Now())
+	wv.mu.RLock()
+	intent := wv.pendingIntentID
+	wv.mu.RUnlock()
+	wv.schedulePendingNavigationReplay(0)
+	require.True(t, scheduledAfter)
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	require.Equal(t, intent, wv.pendingIntentID)
+	require.False(t, wv.pendingIssued)
+	require.Equal(t, "https://example.com/target", wv.pendingURI)
+}
+
+// TestWebViewSetPendingNavigation_RepeatedSameURLInstallsNewIntent ensures
+// explicit reloads and repeated navigations still work: each request is a
+// new intent even for an identical URL.
+func TestWebViewSetPendingNavigation_RepeatedSameURLInstallsNewIntent(t *testing.T) {
+	wv := &WebView{ctx: context.Background()}
+	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
+	first := wv.pendingIntentID
+	require.NotZero(t, first)
+	wv.mu.Lock()
+	wv.pendingIssued = true
+	wv.mu.Unlock()
+	wv.setPendingNavigationLocked("https://example.com/page", time.Now())
+	require.NotEqual(t, first, wv.pendingIntentID)
+	require.False(t, wv.pendingIssued)
 }

--- a/internal/infrastructure/config/engine.go
+++ b/internal/infrastructure/config/engine.go
@@ -112,6 +112,11 @@ type CEFEngineConfig struct {
 	WindowlessFrameRateMax int32 `mapstructure:"windowless_frame_rate_max" toml:"windowless_frame_rate_max" yaml:"windowless_frame_rate_max"` //nolint:lll // struct tags exceed lll limit
 	// Input controls GTK input translation before events are forwarded to CEF.
 	Input CEFInputConfig `mapstructure:"input" toml:"input" yaml:"input"`
+	// IdleRuntimeTimeoutMs bounds opt-in CEF runtime residency after the last
+	// user window closes. Integer milliseconds, default 0 (disabled),
+	// accepted range 0..300000. Read once at process startup; changes require
+	// a restart and are never partially hot-applied.
+	IdleRuntimeTimeoutMs int `mapstructure:"idle_runtime_timeout_ms" toml:"idle_runtime_timeout_ms" yaml:"idle_runtime_timeout_ms"`
 	// EnableAudioHandler opts into the experimental CEF AudioHandler bridge.
 	EnableAudioHandler bool `mapstructure:"enable_audio_handler" toml:"enable_audio_handler" yaml:"enable_audio_handler"`
 	// TraceHandlers enables purego-cef handler/refcount tracing for diagnostics.

--- a/internal/infrastructure/config/idle_runtime_timeout_test.go
+++ b/internal/infrastructure/config/idle_runtime_timeout_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleRuntimeTimeoutDefaultsToDisabled(t *testing.T) {
+	require.Equal(t, 0, DefaultConfig().Engine.CEF.IdleRuntimeTimeoutMs)
+}
+
+func TestIdleRuntimeTimeoutFileOverride(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\nidle_runtime_timeout_ms = 60000\n"), 0o600))
+
+	m := &Manager{viper: viper.New()}
+	m.viper.SetConfigFile(configPath)
+	m.viper.SetConfigType("toml")
+	m.configureAutomaticEnv()
+	m.setDefaults()
+	require.NoError(t, m.viper.ReadInConfig())
+
+	require.Equal(t, 60000, m.viper.GetInt("engine.cef.idle_runtime_timeout_ms"))
+}
+
+func TestIdleRuntimeTimeoutEnvMapping(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\n"), 0o600))
+	t.Setenv("DUMBER_ENGINE_CEF_IDLE_RUNTIME_TIMEOUT_MS", "45000")
+
+	m := &Manager{viper: viper.New()}
+	m.viper.SetConfigFile(configPath)
+	m.viper.SetConfigType("toml")
+	m.configureAutomaticEnv()
+	m.setDefaults()
+	require.NoError(t, m.viper.ReadInConfig())
+
+	require.Equal(t, 45000, m.viper.GetInt("engine.cef.idle_runtime_timeout_ms"))
+}
+
+func TestIdleRuntimeTimeoutStableAcrossUnrelatedReload(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\nidle_runtime_timeout_ms = 60000\n"), 0o600))
+
+	load := func() int {
+		m := &Manager{viper: viper.New()}
+		m.viper.SetConfigFile(configPath)
+		m.viper.SetConfigType("toml")
+		m.configureAutomaticEnv()
+		m.setDefaults()
+		require.NoError(t, m.viper.ReadInConfig())
+		return m.viper.GetInt("engine.cef.idle_runtime_timeout_ms")
+	}
+	require.Equal(t, 60000, load())
+
+	require.NoError(t, os.WriteFile(configPath, []byte("[engine.cef]\nidle_runtime_timeout_ms = 60000\nlog_severity = 3\n"), 0o600))
+	require.Equal(t, 60000, load(), "unrelated reload must not change the effective timeout")
+}

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -808,6 +808,7 @@ func (m *Manager) setEngineDefaults(defaults *Config) {
 	m.viper.SetDefault("engine.cef.windowless_frame_rate_max", ce.CEFWindowlessFrameRateMax())
 	m.viper.SetDefault("engine.cef.enable_audio_handler", ce.EnableAudioHandler)
 	m.viper.SetDefault("engine.cef.trace_handlers", ce.TraceHandlers)
+	m.viper.SetDefault("engine.cef.idle_runtime_timeout_ms", ce.IdleRuntimeTimeoutMs)
 	m.setCEFInputDefaults(ce.Input)
 
 	wk := e.WebKit

--- a/internal/infrastructure/config/schema_provider.go
+++ b/internal/infrastructure/config/schema_provider.go
@@ -1118,6 +1118,14 @@ func (*SchemaProvider) getPerformanceKeys(defaults *Config) []entity.ConfigKeyIn
 			Section:     SectionPerformance,
 		},
 		{
+			Key:         "engine.cef.idle_runtime_timeout_ms",
+			Type:        "int",
+			Default:     fmt.Sprintf("%d", defaults.Engine.CEF.IdleRuntimeTimeoutMs),
+			Description: "Bounded opt-in CEF runtime residency in milliseconds after the last window closes; 0 disables, changes require restart",
+			Range:       "0..300000",
+			Section:     SectionPerformance,
+		},
+		{
 			Key:         "engine.cef.input.scroll_wheel_multiplier",
 			Type:        "float64",
 			Default:     fmt.Sprintf("%.2f", defaults.Engine.CEF.Input.ScrollWheelMultiplier),

--- a/internal/infrastructure/config/validation.go
+++ b/internal/infrastructure/config/validation.go
@@ -501,6 +501,9 @@ func validateCEF(config *Config) []string {
 	if config.Engine.CEF.WindowlessFrameRateMax < 0 {
 		validationErrors = append(validationErrors, "engine.cef.windowless_frame_rate_max must be >= 0")
 	}
+	if config.Engine.CEF.IdleRuntimeTimeoutMs < 0 || config.Engine.CEF.IdleRuntimeTimeoutMs > 300000 {
+		validationErrors = append(validationErrors, "engine.cef.idle_runtime_timeout_ms must be within 0..300000")
+	}
 
 	input := config.Engine.CEF.Input
 	if invalidPositiveFloat(input.ScrollWheelMultiplier) {

--- a/internal/infrastructure/config/validation_test.go
+++ b/internal/infrastructure/config/validation_test.go
@@ -198,6 +198,36 @@ func TestValidateConfig_CEFConfig(t *testing.T) {
 			wantText: "engine.cef.windowless_frame_rate",
 		},
 		{
+			name: "zero idle residency timeout disables",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = 0
+			},
+			wantErr: false,
+		},
+		{
+			name: "maximum idle residency timeout accepted",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = 300000
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative idle residency timeout",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = -1
+			},
+			wantErr:  true,
+			wantText: "engine.cef.idle_runtime_timeout_ms",
+		},
+		{
+			name: "oversized idle residency timeout",
+			mutate: func(cfg *Config) {
+				cfg.Engine.CEF.IdleRuntimeTimeoutMs = 300001
+			},
+			wantErr:  true,
+			wantText: "engine.cef.idle_runtime_timeout_ms",
+		},
+		{
 			name: "zero wheel multiplier",
 			mutate: func(cfg *Config) {
 				cfg.Engine.CEF.Input.ScrollWheelMultiplier = 0

--- a/internal/infrastructure/desktop/adapter.go
+++ b/internal/infrastructure/desktop/adapter.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/domain/entity"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/logging"
 )
 
@@ -500,7 +501,10 @@ func launchBrowserURL(
 	}
 
 	cmd := exec.Command(execPath, "browse", uri)
-	cmd.Env = withoutEnvKeys(sanitizedChildEnv(os.Environ()), FreshWindowLaunchEnvVar)
+	// Prepare the child environment with the shared safety merge after
+	// sanitization so application-spawned browser processes start safe.
+	childEnv, _ := process.MergeRuntimeSafety(sanitizedChildEnv(os.Environ()))
+	cmd.Env = withoutEnvKeys(childEnv, FreshWindowLaunchEnvVar)
 	if freshWindow {
 		cmd.Env = append(cmd.Env, FreshWindowLaunchEnvVar+"=1")
 	}
@@ -599,7 +603,8 @@ func (s *SessionSpawner) SpawnWithSession(sessionID entity.SessionID) error {
 	// Start dumber browse with session ID in environment
 	cmd := exec.Command(execPath, "browse")
 
-	sanitizedEnv := withoutEnvKeys(sanitizedChildEnv(os.Environ()), RestoreSessionEnvVar)
+	sanitizedEnv, _ := process.MergeRuntimeSafety(sanitizedChildEnv(os.Environ()))
+	sanitizedEnv = withoutEnvKeys(sanitizedEnv, RestoreSessionEnvVar)
 	overrides := []string{RestoreSessionEnvVar + "=" + string(sessionID)}
 	if s.spawnEnv != nil {
 		sanitizedEnv = withoutEnvKeys(sanitizedEnv, s.spawnEnv.RootCacheEnvVar())

--- a/internal/infrastructure/desktop/adapter_test.go
+++ b/internal/infrastructure/desktop/adapter_test.go
@@ -292,3 +292,24 @@ func requireNoError(t *testing.T, err error) {
 		t.Fatal(err)
 	}
 }
+
+func TestLaunchBrowserBrowseURL_ChildEnvMergesRuntimeSafety(t *testing.T) {
+	t.Setenv("GODEBUG", "gctrace=1")
+
+	err := launchBrowserBrowseURL(
+		"https://example.com",
+		func() (string, error) { return "/usr/bin/dumber", nil },
+		func(cmd *exec.Cmd) error {
+			found := false
+			for _, entry := range cmd.Env {
+				if entry == "GODEBUG=gctrace=1,gcshrinkstackoff=1" {
+					found = true
+				}
+			}
+			assert.True(t, found, "child env must merge safety after sanitization: %#v", cmd.Env)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+}

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/bnema/dumber/internal/logging"
+	"github.com/rs/zerolog"
 )
 
 const browserLaunchSocketName = "browser-launch.sock"
@@ -55,7 +56,25 @@ type browserLaunchAction string
 const (
 	browserLaunchActionOpenExternalURL browserLaunchAction = "open-external-url"
 	browserLaunchActionOpenFreshWindow browserLaunchAction = "open-fresh-window"
+	// browserLaunchActionCloseAllWindows is a diagnostic-only action for the
+	// residency harness: it closes every user window through the standard
+	// removal path. It is honored only when the OWNING process sets
+	// DUMBER_DIAGNOSTIC_WINDOW_CLOSE=1; otherwise it is rejected before
+	// acknowledgement. It is never a general unauthenticated shutdown
+	// command: the relay socket itself remains owner-only (0700, uid).
+	browserLaunchActionCloseAllWindows browserLaunchAction = "close-all-windows"
 )
+
+// diagnosticWindowCloseEnvVar gates the diagnostic close action on the
+// owning (server) process environment.
+const diagnosticWindowCloseEnvVar = "DUMBER_DIAGNOSTIC_WINDOW_CLOSE"
+
+// windowCloseOpener is implemented by openers that support the diagnostic
+// close action. It is matched structurally so the port interface is
+// unchanged.
+type windowCloseOpener interface {
+	CloseAllWindows(ctx context.Context) error
+}
 
 type browserLaunchResponse struct {
 	RequestID string `json:"request_id,omitempty"`
@@ -343,6 +362,47 @@ func (l *browserLaunchRelayListener) serve(ctx context.Context, opener port.Brow
 	}
 }
 
+// admitRelayConnection acquires one admission lease for the decoded request
+// and enforces pre-acknowledgement eligibility. It returns nil after sending
+// an error response (closed admission or unauthorized diagnostic action);
+// the caller must return without acknowledging. An admitted lease is released
+// by the caller on early failure and by dispatch completion otherwise.
+func admitRelayConnection(
+	conn *net.UnixConn,
+	configured *process.AdmissionGate,
+	request browserLaunchRequest,
+	requestID string,
+	log *zerolog.Logger,
+) *process.AdmissionGate {
+	gate := configured
+	if gate == nil {
+		gate = process.NewAdmissionGate()
+	}
+	refuse := func(errorBody string) *process.AdmissionGate {
+		if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
+			return nil
+		}
+		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Error: errorBody})
+		return nil
+	}
+	if !gate.Acquire() {
+		log.Debug().
+			Str("request_id", requestID).
+			Msg("browser launch relay refused request after admission closed")
+		return refuse("shutting down")
+	}
+	// The diagnostic close action is rejected before acknowledgement
+	// unless the owning process explicitly enables it.
+	if request.Action == browserLaunchActionCloseAllWindows && os.Getenv(diagnosticWindowCloseEnvVar) != "1" {
+		gate.Release()
+		log.Warn().
+			Str("request_id", requestID).
+			Msg("browser launch relay rejected diagnostic close without owner opt-in")
+		return refuse("diagnostic close not enabled")
+	}
+	return gate
+}
+
 func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn *net.UnixConn, opener port.BrowserWindowOpener) {
 	defer func() { _ = conn.Close() }()
 	log := logging.FromContext(ctx)
@@ -367,18 +427,8 @@ func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn 
 	// error response here, never an acknowledgement for work that will not
 	// run. Acknowledgement still precedes expensive UI dispatch below, and
 	// unconfirmed delivery keeps its no-duplicate-fallback semantics.
-	gate := l.admission
+	gate := admitRelayConnection(conn, l.admission, request, requestID, log)
 	if gate == nil {
-		gate = process.NewAdmissionGate()
-	}
-	if !gate.Acquire() {
-		if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
-			return
-		}
-		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Error: "shutting down"})
-		log.Debug().
-			Str("request_id", requestID).
-			Msg("browser launch relay refused request after admission closed")
 		return
 	}
 
@@ -423,6 +473,12 @@ func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn 
 			err = opener.OpenExternalURL(ctx, request.URL)
 		case browserLaunchActionOpenFreshWindow:
 			err = opener.OpenFreshWindow(ctx, request.URL)
+		case browserLaunchActionCloseAllWindows:
+			if closer, ok := opener.(windowCloseOpener); ok {
+				err = closer.CloseAllWindows(ctx)
+			} else {
+				err = errors.New("browser launch relay opener does not support diagnostic close")
+			}
 		default:
 			log.Warn().
 				Str("request_id", requestID).

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/bnema/dumber/internal/logging"
 )
@@ -36,6 +37,11 @@ var ErrBrowserLaunchRelayUnconfirmed = errors.New("browser launch relay did not 
 
 type browserLaunchRelay struct {
 	ipc runtimeprofile.IPCPaths
+	// admission is the shared admission/work-lease boundary: a lease is
+	// acquired before sending Accepted and released when dispatch settles.
+	// Shutdown closes it so losing requests get an error response instead
+	// of an acknowledgement. Initialized eagerly; never nil.
+	admission *process.AdmissionGate
 }
 
 type browserLaunchRequest struct {
@@ -60,6 +66,7 @@ type browserLaunchResponse struct {
 type browserLaunchRelayListener struct {
 	listener   *net.UnixListener
 	socketPath string
+	admission  *process.AdmissionGate
 	once       sync.Once
 	err        error
 }
@@ -73,7 +80,21 @@ var newBrowserLaunchRequestID = func() string {
 }
 
 func NewBrowserLaunchRelay(ipc runtimeprofile.IPCPaths) port.BrowserLaunchRelay {
-	return &browserLaunchRelay{ipc: ipc}
+	return &browserLaunchRelay{ipc: ipc, admission: process.NewAdmissionGate()}
+}
+
+// AdmissionGateProvider exposes the relay's shared admission boundary
+// without extending the port interface or regenerating mocks.
+type AdmissionGateProvider interface {
+	AdmissionGate() *process.AdmissionGate
+}
+
+// AdmissionGate returns the shared admission/work-lease boundary.
+func (r *browserLaunchRelay) AdmissionGate() *process.AdmissionGate {
+	if r == nil || r.admission == nil {
+		return process.NewAdmissionGate()
+	}
+	return r.admission
 }
 
 func (r *browserLaunchRelay) DeliverOpenExternalURL(ctx context.Context, url string) (bool, error) {
@@ -269,7 +290,7 @@ func (r *browserLaunchRelay) Listen(ctx context.Context, opener port.BrowserWind
 		}
 	}
 
-	relayListener := &browserLaunchRelayListener{listener: listener, socketPath: socketPath}
+	relayListener := &browserLaunchRelayListener{listener: listener, socketPath: socketPath, admission: r.AdmissionGate()}
 	go relayListener.serve(ctx, opener)
 
 	return relayListener, nil
@@ -322,7 +343,7 @@ func (l *browserLaunchRelayListener) serve(ctx context.Context, opener port.Brow
 	}
 }
 
-func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *net.UnixConn, opener port.BrowserWindowOpener) {
+func (l *browserLaunchRelayListener) handleConnection(ctx context.Context, conn *net.UnixConn, opener port.BrowserWindowOpener) {
 	defer func() { _ = conn.Close() }()
 	log := logging.FromContext(ctx)
 	if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
@@ -342,7 +363,27 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 		Str("url_host", safeURLHost(request.URL)).
 		Msg("browser launch relay request received")
 
+	// Admit before acknowledgement: losing requests receive the existing
+	// error response here, never an acknowledgement for work that will not
+	// run. Acknowledgement still precedes expensive UI dispatch below, and
+	// unconfirmed delivery keeps its no-duplicate-fallback semantics.
+	gate := l.admission
+	if gate == nil {
+		gate = process.NewAdmissionGate()
+	}
+	if !gate.Acquire() {
+		if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
+			return
+		}
+		_ = json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Error: "shutting down"})
+		log.Debug().
+			Str("request_id", requestID).
+			Msg("browser launch relay refused request after admission closed")
+		return
+	}
+
 	if err := conn.SetDeadline(time.Now().Add(browserLaunchIOTimeout)); err != nil {
+		gate.Release()
 		return
 	}
 	if err := json.NewEncoder(conn).Encode(browserLaunchResponse{RequestID: requestID, Accepted: true}); err != nil {
@@ -350,6 +391,7 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 			Str("request_id", requestID).
 			Str("url_host", safeURLHost(request.URL)).
 			Msg("failed to encode browser launch response")
+		gate.Release()
 		return
 	}
 	log.Debug().
@@ -358,6 +400,11 @@ func (*browserLaunchRelayListener) handleConnection(ctx context.Context, conn *n
 		Msg("browser launch relay request accepted")
 
 	go func() {
+		// The lease spans acknowledgement through dispatch completion or
+		// definitive factory/dispatch failure. Factory/dispatch failure
+		// retains the documented existing failure semantics and never
+		// triggers duplicate fallback.
+		defer gate.Release()
 		if opener == nil {
 			log.Warn().
 				Str("request_id", requestID).

--- a/internal/infrastructure/desktop/browser_launch_relay.go
+++ b/internal/infrastructure/desktop/browser_launch_relay.go
@@ -108,6 +108,9 @@ type AdmissionGateProvider interface {
 	AdmissionGate() *process.AdmissionGate
 }
 
+// Compile-time check: the shared gate implements the application boundary.
+var _ port.AdmissionBoundary = (*process.AdmissionGate)(nil)
+
 // AdmissionGate returns the shared admission/work-lease boundary.
 func (r *browserLaunchRelay) AdmissionGate() *process.AdmissionGate {
 	if r == nil || r.admission == nil {

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/stretchr/testify/assert"
@@ -651,7 +652,7 @@ func TestBrowserLaunchRelay_SilentClientDoesNotStallListener(t *testing.T) {
 }
 
 type blockingRelayOpener struct {
-	release chan struct{}
+	release  chan struct{}
 	received chan string
 }
 
@@ -665,7 +666,7 @@ func (o *blockingRelayOpener) OpenFreshWindow(_ context.Context, url string) err
 	return o.OpenExternalURL(context.Background(), url)
 }
 
-func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) *browserLaunchRelay {
+func startLeaseTestListener(t *testing.T, opener port.BrowserWindowOpener) *browserLaunchRelay {
 	t.Helper()
 	ipc := testIPC(shortTempDir(t))
 	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
@@ -757,4 +758,50 @@ func TestBrowserLaunchRelay_ClosedAdmissionSendsErrorResponse(t *testing.T) {
 	case <-time.After(300 * time.Millisecond):
 	}
 	_ = delivered
+}
+
+type closeTrackingOpener struct {
+	*blockingRelayOpener
+	closed chan struct{}
+}
+
+func (o *closeTrackingOpener) CloseAllWindows(_ context.Context) error {
+	close(o.closed)
+	return nil
+}
+
+func sendRelayAction(t *testing.T, socketPath, action string) browserLaunchResponse {
+	t.Helper()
+	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: socketPath, Net: "unix"})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, conn.SetDeadline(time.Now().Add(3*time.Second)))
+	require.NoError(t, json.NewEncoder(conn).Encode(browserLaunchRequest{RequestID: "diag-1", Action: browserLaunchAction(action)}))
+	var response browserLaunchResponse
+	require.NoError(t, json.NewDecoder(conn).Decode(&response))
+	return response
+}
+
+func TestBrowserLaunchRelay_DiagnosticCloseRejectedWithoutOptIn(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
+	close(opener.release)
+	relay := startLeaseTestListener(t, opener)
+	response := sendRelayAction(t, relay.ipc.BrowserLaunchSocket, "close-all-windows")
+	require.False(t, response.Accepted, "rejected close must not acknowledge")
+	require.Contains(t, response.Error, "diagnostic close not enabled")
+}
+
+func TestBrowserLaunchRelay_DiagnosticCloseDispatchedWithOptIn(t *testing.T) {
+	t.Setenv(diagnosticWindowCloseEnvVar, "1")
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
+	close(opener.release)
+	tracker := &closeTrackingOpener{blockingRelayOpener: opener, closed: make(chan struct{})}
+	relay := startLeaseTestListener(t, tracker)
+	response := sendRelayAction(t, relay.ipc.BrowserLaunchSocket, "close-all-windows")
+	require.True(t, response.Accepted)
+	select {
+	case <-tracker.closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("diagnostic close never reached the opener")
+	}
 }

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -666,7 +665,7 @@ func (o *blockingRelayOpener) OpenFreshWindow(_ context.Context, url string) err
 	return o.OpenExternalURL(context.Background(), url)
 }
 
-func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) (*browserLaunchRelay, io.Closer) {
+func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) *browserLaunchRelay {
 	t.Helper()
 	ipc := testIPC(shortTempDir(t))
 	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
@@ -676,7 +675,7 @@ func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) (*browser
 	closer, err := relay.Listen(ctx, opener)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
-	return relay, closer
+	return relay
 }
 
 func waitForLeaseCount(t *testing.T, gate *process.AdmissionGate, want int) {
@@ -693,7 +692,7 @@ func waitForLeaseCount(t *testing.T, gate *process.AdmissionGate, want int) {
 
 func TestBrowserLaunchRelay_HoldsLeaseThroughDispatch(t *testing.T) {
 	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 2)}
-	relay, _ := startLeaseTestListener(t, opener)
+	relay := startLeaseTestListener(t, opener)
 	gate := relay.AdmissionGate()
 
 	delivered := make(chan error, 1)
@@ -721,7 +720,7 @@ func TestBrowserLaunchRelay_HoldsLeaseThroughDispatch(t *testing.T) {
 
 func TestBrowserLaunchRelay_SimultaneousOpensHoldLeases(t *testing.T) {
 	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 4)}
-	relay, _ := startLeaseTestListener(t, opener)
+	relay := startLeaseTestListener(t, opener)
 	gate := relay.AdmissionGate()
 
 	for range 2 {
@@ -743,7 +742,7 @@ func TestBrowserLaunchRelay_SimultaneousOpensHoldLeases(t *testing.T) {
 
 func TestBrowserLaunchRelay_ClosedAdmissionSendsErrorResponse(t *testing.T) {
 	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
-	relay, _ := startLeaseTestListener(t, opener)
+	relay := startLeaseTestListener(t, opener)
 	gate := relay.AdmissionGate()
 	close(opener.release)
 

--- a/internal/infrastructure/desktop/browser_launch_relay_test.go
+++ b/internal/infrastructure/desktop/browser_launch_relay_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/infrastructure/runtimeprofile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -647,4 +649,113 @@ func TestBrowserLaunchRelay_SilentClientDoesNotStallListener(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected opener to receive the URL")
 	}
+}
+
+type blockingRelayOpener struct {
+	release chan struct{}
+	received chan string
+}
+
+func (o *blockingRelayOpener) OpenExternalURL(_ context.Context, url string) error {
+	o.received <- url
+	<-o.release
+	return nil
+}
+
+func (o *blockingRelayOpener) OpenFreshWindow(_ context.Context, url string) error {
+	return o.OpenExternalURL(context.Background(), url)
+}
+
+func startLeaseTestListener(t *testing.T, opener *blockingRelayOpener) (*browserLaunchRelay, io.Closer) {
+	t.Helper()
+	ipc := testIPC(shortTempDir(t))
+	require.NoError(t, os.MkdirAll(ipc.RuntimeDir, 0o700))
+	relay := NewBrowserLaunchRelay(ipc).(*browserLaunchRelay)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	closer, err := relay.Listen(ctx, opener)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+	return relay, closer
+}
+
+func waitForLeaseCount(t *testing.T, gate *process.AdmissionGate, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if gate.Active() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("lease count = %d, want %d", gate.Active(), want)
+}
+
+func TestBrowserLaunchRelay_HoldsLeaseThroughDispatch(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 2)}
+	relay, _ := startLeaseTestListener(t, opener)
+	gate := relay.AdmissionGate()
+
+	delivered := make(chan error, 1)
+	go func() {
+		_, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/lease")
+		delivered <- err
+	}()
+	select {
+	case url := <-opener.received:
+		require.Equal(t, "https://example.com/lease", url)
+	case <-time.After(3 * time.Second):
+		t.Fatal("opener never received the request")
+	}
+	// Acknowledged and dispatched: the lease is held until dispatch settles.
+	waitForLeaseCount(t, gate, 1)
+	select {
+	case err := <-delivered:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("client never received acknowledgement")
+	}
+	close(opener.release)
+	waitForLeaseCount(t, gate, 0)
+}
+
+func TestBrowserLaunchRelay_SimultaneousOpensHoldLeases(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 4)}
+	relay, _ := startLeaseTestListener(t, opener)
+	gate := relay.AdmissionGate()
+
+	for range 2 {
+		go func() {
+			_, _ = relay.DeliverOpenExternalURL(context.Background(), "https://example.com/parallel")
+		}()
+	}
+	for range 2 {
+		select {
+		case <-opener.received:
+		case <-time.After(3 * time.Second):
+			t.Fatal("opener never received a parallel request")
+		}
+	}
+	waitForLeaseCount(t, gate, 2)
+	close(opener.release)
+	waitForLeaseCount(t, gate, 0)
+}
+
+func TestBrowserLaunchRelay_ClosedAdmissionSendsErrorResponse(t *testing.T) {
+	opener := &blockingRelayOpener{release: make(chan struct{}), received: make(chan string, 1)}
+	relay, _ := startLeaseTestListener(t, opener)
+	gate := relay.AdmissionGate()
+	close(opener.release)
+
+	gate.Close()
+	delivered, err := relay.DeliverOpenExternalURL(context.Background(), "https://example.com/late")
+	require.Error(t, err, "losing request must receive the error response")
+	require.Contains(t, err.Error(), "shutting down")
+	require.Equal(t, 0, gate.Active(), "refused requests hold no lease")
+	select {
+	case url := <-opener.received:
+		t.Fatalf("refused request reached the opener: %s", url)
+	case <-time.After(300 * time.Millisecond):
+	}
+	_ = delivered
 }

--- a/internal/infrastructure/persistence/sqlite/lazy_db.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -18,11 +19,14 @@ import (
 // example engine initialization) runs concurrently. Warmup registers its
 // background task synchronously, so a Close that observes Warmup's return
 // always waits for the task to settle instead of racing goroutine
-// scheduling. Close waits for an in-flight initialization to settle before
-// closing, so cleanup never orphans a connection that finishes opening
-// after Close returns. Ownership contract: Warmup must return before Close
-// is called; concurrent Warmup and Close from different goroutines without
-// external sequencing is not supported.
+// scheduling. Initialization admission is serialized with closure: once
+// Close begins, no new initialization can start and late callers receive a
+// closed-provider error, so no connection can open with nobody left to
+// close it. An initialization admitted before Close began runs to
+// completion (or aborts early via the owned init context) and its
+// connection is then released. Ownership contract: Warmup must return
+// before Close is called; concurrent Warmup and Close from different
+// goroutines without external sequencing is not supported.
 type LazyDB struct {
 	dbPath string
 	db     *sql.DB
@@ -42,14 +46,33 @@ type LazyDB struct {
 	// which happens after the once-initializer completes, so observing all
 	// closures implies initialization has settled.
 	warmTasks []chan struct{}
+	// closed is set by Close under mu. The once-initializer checks it under
+	// the same mutex before opening anything, which serializes admission
+	// with closure: init admitted before Close runs to completion and is
+	// then released; init arriving after is skipped with ErrLazyDBClosed.
+	closed bool
+	// dbClosed records that Close released the connection, making repeat
+	// Close calls idempotent.
+	dbClosed bool
+	// initCtx carries the connection work; initCancel aborts an admitted
+	// in-flight initialization when Close begins so shutdown (and the
+	// engine-build error path) is not stuck behind a doomed migration.
+	// Canceling a settled provider is a no-op for later callers because
+	// closure already rejects them.
+	initCtx    context.Context
+	initCancel context.CancelFunc
 }
 
 // Compile-time interface check.
 var _ port.DatabaseProvider = (*LazyDB)(nil)
 
-// initGateForTest, when non-nil, runs at the start of the once-initializer
-// before the connection is opened. Tests use it to hold initialization in
-// flight and prove Close waits for it to settle. It must remain nil in
+// ErrLazyDBClosed is returned to callers arriving after the provider was
+// closed, including initializations that lose the admission race.
+var ErrLazyDBClosed = errors.New("sqlite: database provider closed")
+
+// initGateForTest, when non-nil, runs inside the once-initializer after
+// admission is granted and before the connection is opened. Tests use it to
+// hold an admitted initialization in flight. It must remain nil in
 // production.
 var initGateForTest func()
 
@@ -57,22 +80,44 @@ var initGateForTest func()
 // The actual connection is not established until DB() is called, or until a
 // Warmup task triggers initialization in the background.
 func NewLazyDB(dbPath string) *LazyDB {
-	return &LazyDB{dbPath: dbPath, started: make(chan struct{}), done: make(chan struct{})}
+	initCtx, initCancel := context.WithCancel(context.Background())
+	return &LazyDB{
+		dbPath:     dbPath,
+		started:    make(chan struct{}),
+		done:       make(chan struct{}),
+		initCtx:    initCtx,
+		initCancel: initCancel,
+	}
 }
 
 // DB returns the database connection, initializing it if necessary.
-// This method is thread-safe and will only initialize once.
+// This method is thread-safe and will only initialize once. Calls arriving
+// after Close receive ErrLazyDBClosed without starting initialization.
 func (l *LazyDB) DB(ctx context.Context) (*sql.DB, error) {
 	l.once.Do(func() {
 		close(l.started)
 		defer close(l.done)
+		l.mu.Lock()
+		admitted := !l.closed
+		l.mu.Unlock()
+		if !admitted {
+			l.mu.Lock()
+			l.err = ErrLazyDBClosed
+			l.mu.Unlock()
+			logging.FromContext(ctx).Debug().Msg("lazy database initialization skipped: provider closed")
+			return
+		}
 		if initGateForTest != nil {
 			initGateForTest()
 		}
 		log := logging.FromContext(ctx)
 		log.Debug().Str("path", l.dbPath).Msg("lazy database initialization starting")
 
-		db, err := NewConnection(ctx, l.dbPath)
+		// The owned init context carries the connection work so Close can
+		// abort a doomed initialization; caller values are preserved for
+		// logging above. Shutdown cancellation can no longer poison the
+		// cache because closure rejects later callers.
+		db, err := NewConnection(l.initCtx, l.dbPath)
 
 		// Acquire lock before assigning to ensure IsInitialized() sees
 		// a consistent state when reading l.db under RLock.
@@ -89,11 +134,17 @@ func (l *LazyDB) DB(ctx context.Context) (*sql.DB, error) {
 	})
 
 	l.mu.RLock()
-	db, err := l.db, l.err
+	db, err, closed := l.db, l.err, l.closed
 	l.mu.RUnlock()
 
 	if err != nil {
+		if errors.Is(err, ErrLazyDBClosed) {
+			return nil, ErrLazyDBClosed
+		}
 		return nil, fmt.Errorf("database initialization failed: %w", err)
+	}
+	if closed {
+		return nil, ErrLazyDBClosed
 	}
 	return db, nil
 }
@@ -115,16 +166,24 @@ func (l *LazyDB) Warmup(ctx context.Context) {
 	}()
 }
 
-// Close closes the database connection if it was initialized. A registered
-// Warmup task is settled first, then an in-flight initialization (for
-// example from a direct DB call) is awaited, so the resulting connection
-// is closed rather than orphaned. Close never triggers initialization:
-// closing a provider that was never used is a no-op.
+// Close seals the provider against new initialization, aborts admitted
+// in-flight connection work via the owned init context, settles every
+// registered Warmup task and awaited initialization, then releases the
+// connection. No connection can open after Close begins: late initializers
+// are skipped with ErrLazyDBClosed and admitted ones are awaited and
+// closed. Close never triggers initialization itself, and repeat calls are
+// idempotent.
 func (l *LazyDB) Close() error {
-	l.mu.RLock()
+	// Abort doomed connection work first so shutdown and the engine-build
+	// error path are not stuck behind a hung open or migration. Safe to
+	// call repeatedly and on settled providers.
+	l.initCancel()
+
+	l.mu.Lock()
+	l.closed = true
 	tasks := make([]chan struct{}, len(l.warmTasks))
 	copy(tasks, l.warmTasks)
-	l.mu.RUnlock()
+	l.mu.Unlock()
 	for _, task := range tasks {
 		<-task
 	}
@@ -139,10 +198,12 @@ func (l *LazyDB) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.db != nil {
-		return l.db.Close()
+	if l.dbClosed || l.db == nil {
+		return nil
 	}
-	return nil
+	err := l.db.Close()
+	l.dbClosed = true
+	return err
 }
 
 // IsInitialized returns true if the database has been initialized.

--- a/internal/infrastructure/persistence/sqlite/lazy_db.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db.go
@@ -15,9 +15,14 @@ import (
 // connection and migration overhead until actually needed.
 //
 // Callers may warm the provider with Warmup while other startup work (for
-// example engine initialization) runs concurrently. Close waits for an
-// in-flight initialization to settle before closing, so cleanup never
-// orphans a connection that finishes opening after Close returns.
+// example engine initialization) runs concurrently. Warmup registers its
+// background task synchronously, so a Close that observes Warmup's return
+// always waits for the task to settle instead of racing goroutine
+// scheduling. Close waits for an in-flight initialization to settle before
+// closing, so cleanup never orphans a connection that finishes opening
+// after Close returns. Ownership contract: Warmup must return before Close
+// is called; concurrent Warmup and Close from different goroutines without
+// external sequencing is not supported.
 type LazyDB struct {
 	dbPath string
 	db     *sql.DB
@@ -29,6 +34,14 @@ type LazyDB struct {
 	// from "initialization in flight" without triggering initialization.
 	started chan struct{}
 	done    chan struct{}
+	// warmTasks tracks one completion channel per Warmup call, registered
+	// synchronously under mu. Close waits for every registered task, so a
+	// Close that observes Warmup's return settles the background task even
+	// when the once-initializer has not been scheduled yet. Each channel is
+	// closed exactly once by its own goroutine after its DB call returns,
+	// which happens after the once-initializer completes, so observing all
+	// closures implies initialization has settled.
+	warmTasks []chan struct{}
 }
 
 // Compile-time interface check.
@@ -89,18 +102,33 @@ func (l *LazyDB) DB(ctx context.Context) (*sql.DB, error) {
 // returns immediately. Initialization errors are cached and reported to
 // later DB callers; pass a detached context (for example
 // context.WithoutCancel) so shutdown cancellation cannot poison the cached
-// result.
+// result. The task is registered synchronously, so Close called after
+// Warmup returns settles it (see the ownership contract on LazyDB).
 func (l *LazyDB) Warmup(ctx context.Context) {
+	task := make(chan struct{})
+	l.mu.Lock()
+	l.warmTasks = append(l.warmTasks, task)
+	l.mu.Unlock()
 	go func() {
+		defer close(task)
 		_, _ = l.DB(ctx)
 	}()
 }
 
-// Close closes the database connection if it was initialized. When an
-// initialization is in flight, Close waits for it to settle first so the
-// resulting connection is closed rather than orphaned. Close never triggers
-// initialization: closing a provider that was never used is a no-op.
+// Close closes the database connection if it was initialized. A registered
+// Warmup task is settled first, then an in-flight initialization (for
+// example from a direct DB call) is awaited, so the resulting connection
+// is closed rather than orphaned. Close never triggers initialization:
+// closing a provider that was never used is a no-op.
 func (l *LazyDB) Close() error {
+	l.mu.RLock()
+	tasks := make([]chan struct{}, len(l.warmTasks))
+	copy(tasks, l.warmTasks)
+	l.mu.RUnlock()
+	for _, task := range tasks {
+		<-task
+	}
+
 	select {
 	case <-l.started:
 		<-l.done

--- a/internal/infrastructure/persistence/sqlite/lazy_db.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db.go
@@ -11,34 +11,51 @@ import (
 )
 
 // LazyDB implements port.DatabaseProvider with lazy initialization.
-// The database connection is created on first access, deferring the ~300-400ms
-// WASM compilation and migration overhead until actually needed.
+// The database connection is created on first access, deferring the
+// connection and migration overhead until actually needed.
 //
-// Currently unused: the application uses eager initialization via OpenDatabase
-// in RunParallelDBWebKit. This implementation is kept for potential future use
-// in scenarios where deferring database initialization past first paint provides
-// additional latency benefits, or for CLI commands that may not need DB access.
+// Callers may warm the provider with Warmup while other startup work (for
+// example engine initialization) runs concurrently. Close waits for an
+// in-flight initialization to settle before closing, so cleanup never
+// orphans a connection that finishes opening after Close returns.
 type LazyDB struct {
 	dbPath string
 	db     *sql.DB
 	err    error
 	once   sync.Once
 	mu     sync.RWMutex
+	// started is closed when the first initialization begins; done is
+	// closed when it completes. They let Close distinguish "never used"
+	// from "initialization in flight" without triggering initialization.
+	started chan struct{}
+	done    chan struct{}
 }
 
 // Compile-time interface check.
 var _ port.DatabaseProvider = (*LazyDB)(nil)
 
+// initGateForTest, when non-nil, runs at the start of the once-initializer
+// before the connection is opened. Tests use it to hold initialization in
+// flight and prove Close waits for it to settle. It must remain nil in
+// production.
+var initGateForTest func()
+
 // NewLazyDB creates a new lazy database provider.
-// The actual connection is not established until DB() is called.
+// The actual connection is not established until DB() is called, or until a
+// Warmup task triggers initialization in the background.
 func NewLazyDB(dbPath string) *LazyDB {
-	return &LazyDB{dbPath: dbPath}
+	return &LazyDB{dbPath: dbPath, started: make(chan struct{}), done: make(chan struct{})}
 }
 
 // DB returns the database connection, initializing it if necessary.
 // This method is thread-safe and will only initialize once.
 func (l *LazyDB) DB(ctx context.Context) (*sql.DB, error) {
 	l.once.Do(func() {
+		close(l.started)
+		defer close(l.done)
+		if initGateForTest != nil {
+			initGateForTest()
+		}
 		log := logging.FromContext(ctx)
 		log.Debug().Str("path", l.dbPath).Msg("lazy database initialization starting")
 
@@ -68,8 +85,29 @@ func (l *LazyDB) DB(ctx context.Context) (*sql.DB, error) {
 	return db, nil
 }
 
-// Close closes the database connection if it was initialized.
+// Warmup triggers database initialization in an owned background task and
+// returns immediately. Initialization errors are cached and reported to
+// later DB callers; pass a detached context (for example
+// context.WithoutCancel) so shutdown cancellation cannot poison the cached
+// result.
+func (l *LazyDB) Warmup(ctx context.Context) {
+	go func() {
+		_, _ = l.DB(ctx)
+	}()
+}
+
+// Close closes the database connection if it was initialized. When an
+// initialization is in flight, Close waits for it to settle first so the
+// resulting connection is closed rather than orphaned. Close never triggers
+// initialization: closing a provider that was never used is a no-op.
 func (l *LazyDB) Close() error {
+	select {
+	case <-l.started:
+		<-l.done
+	default:
+		return nil
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/internal/infrastructure/persistence/sqlite/lazy_db_settle_internal_test.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db_settle_internal_test.go
@@ -1,0 +1,75 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLazyDB_CloseBlocksWhileInitInflight holds the once-initializer open
+// with initGateForTest and proves Close waits for it to settle instead of
+// returning early and orphaning the connection that finishes opening after
+// Close returns.
+func TestLazyDB_CloseBlocksWhileInitInflight(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var enteredOnce atomic.Bool
+	initGateForTest = func() {
+		if enteredOnce.CompareAndSwap(false, true) {
+			close(entered)
+		}
+		<-release
+	}
+	defer func() { initGateForTest = nil }()
+
+	lazy := NewLazyDB(filepath.Join(t.TempDir(), "test.db"))
+
+	dbErr := make(chan error, 1)
+	go func() {
+		_, err := lazy.DB(context.Background())
+		dbErr <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("initializer did not start")
+	}
+
+	closeReturned := make(chan error, 1)
+	go func() {
+		closeReturned <- lazy.Close()
+	}()
+
+	select {
+	case err := <-closeReturned:
+		t.Fatalf("Close returned while initialization was in flight: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case err := <-dbErr:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("initializer did not finish after release")
+	}
+
+	select {
+	case err := <-closeReturned:
+		require.NoError(t, err, "Close must settle and release the warmed connection")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not return after initialization settled")
+	}
+
+	assert.True(t, lazy.IsInitialized(), "settled initialization must be recorded")
+	db, err := lazy.DB(context.Background())
+	require.NoError(t, err)
+	require.Error(t, db.Ping(), "settled connection must be closed, not orphaned")
+}

--- a/internal/infrastructure/persistence/sqlite/lazy_db_settle_internal_test.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db_settle_internal_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLazyDB_CloseBlocksWhileInitInflight holds the once-initializer open
-// with initGateForTest and proves Close waits for it to settle instead of
-// returning early and orphaning the connection that finishes opening after
-// Close returns.
-func TestLazyDB_CloseBlocksWhileInitInflight(t *testing.T) {
+// TestLazyDB_CloseSettlesAdmittedInit holds an admitted initialization open
+// with initGateForTest and proves Close seals admission, settles the
+// in-flight work, and leaves no usable connection behind: after Close,
+// every DB call fails instead of escaping with an orphaned pool.
+func TestLazyDB_CloseSettlesAdmittedInit(t *testing.T) {
 	entered := make(chan struct{}, 1)
 	release := make(chan struct{})
 	var enteredOnce atomic.Bool
@@ -38,7 +38,7 @@ func TestLazyDB_CloseBlocksWhileInitInflight(t *testing.T) {
 	select {
 	case <-entered:
 	case <-time.After(10 * time.Second):
-		t.Fatal("initializer did not start")
+		t.Fatal("admitted initializer did not start")
 	}
 
 	closeReturned := make(chan error, 1)
@@ -48,7 +48,7 @@ func TestLazyDB_CloseBlocksWhileInitInflight(t *testing.T) {
 
 	select {
 	case err := <-closeReturned:
-		t.Fatalf("Close returned while initialization was in flight: %v", err)
+		t.Fatalf("Close returned while admitted initialization was in flight: %v", err)
 	case <-time.After(100 * time.Millisecond):
 	}
 
@@ -56,20 +56,43 @@ func TestLazyDB_CloseBlocksWhileInitInflight(t *testing.T) {
 
 	select {
 	case err := <-dbErr:
-		require.NoError(t, err)
+		require.Error(t, err, "admitted init racing Close must not yield a usable connection")
 	case <-time.After(10 * time.Second):
 		t.Fatal("initializer did not finish after release")
 	}
 
 	select {
 	case err := <-closeReturned:
-		require.NoError(t, err, "Close must settle and release the warmed connection")
+		require.NoError(t, err, "Close must settle admitted init and release its connection")
 	case <-time.After(10 * time.Second):
 		t.Fatal("Close did not return after initialization settled")
 	}
 
-	assert.True(t, lazy.IsInitialized(), "settled initialization must be recorded")
-	db, err := lazy.DB(context.Background())
-	require.NoError(t, err)
-	require.Error(t, db.Ping(), "settled connection must be closed, not orphaned")
+	_, err := lazy.DB(context.Background())
+	require.Error(t, err, "no usable connection may escape Close")
+
+	require.NoError(t, lazy.Close(), "repeat Close must be idempotent")
+}
+
+// TestLazyDB_CloseRejectsLateAdmission proves the admission/closure
+// serialization: a DB call arriving after Close began never opens anything
+// and receives the closed-provider error.
+func TestLazyDB_CloseRejectsLateAdmission(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	initGateForTest = func() { close(entered) }
+	defer func() { initGateForTest = nil }()
+
+	lazy := NewLazyDB(filepath.Join(t.TempDir(), "test.db"))
+
+	require.NoError(t, lazy.Close())
+
+	_, err := lazy.DB(context.Background())
+	require.ErrorIs(t, err, ErrLazyDBClosed)
+
+	select {
+	case <-entered:
+		t.Fatal("initialization must not be admitted after Close")
+	default:
+	}
+	assert.False(t, lazy.IsInitialized())
 }

--- a/internal/infrastructure/persistence/sqlite/lazy_db_test.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/bnema/dumber/internal/infrastructure/persistence/sqlite"
 	"github.com/stretchr/testify/assert"
@@ -95,9 +96,10 @@ func TestLazyDB_CloseBeforeInit(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	lazy := sqlite.NewLazyDB(dbPath)
 
-	// Close without ever calling DB() should not error
-	err := lazy.Close()
-	assert.NoError(t, err)
+	// Close without ever calling DB() should not error and must not trigger
+	// initialization.
+	require.NoError(t, lazy.Close())
+	assert.False(t, lazy.IsInitialized(), "Close must not trigger initialization")
 }
 
 func TestLazyDB_Path(t *testing.T) {
@@ -122,4 +124,81 @@ func TestLazyDB_DBIsUsable(t *testing.T) {
 	assert.Equal(t, 1, result)
 
 	require.NoError(t, lazy.Close())
+}
+
+func TestLazyDB_WarmupInitializesInBackground(t *testing.T) {
+	ctx := testCtx()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	lazy := sqlite.NewLazyDB(dbPath)
+
+	// Warmup returns immediately and initializes the provider concurrently.
+	lazy.Warmup(ctx)
+
+	require.Eventually(t, func() bool {
+		return lazy.IsInitialized()
+	}, 10*time.Second, 5*time.Millisecond, "warmup should initialize the provider without a direct DB call")
+
+	db, err := lazy.DB(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	require.NoError(t, lazy.Close())
+}
+
+func TestLazyDB_CloseWaitsForInflightInit(t *testing.T) {
+	ctx := testCtx()
+	// Warmup is asynchronous: Close called before the warmup goroutine runs
+	// is a legitimate no-op, so wait for initialization to be underway
+	// before asserting Close settles and releases the provider cleanly.
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	lazy := sqlite.NewLazyDB(dbPath)
+
+	lazy.Warmup(ctx)
+	require.Eventually(t, func() bool {
+		return lazy.IsInitialized()
+	}, 10*time.Second, 5*time.Millisecond, "warmup should initialize the provider")
+
+	require.NoError(t, lazy.Close())
+}
+
+func TestLazyDB_ConcurrentWarmupAccessAndClose(t *testing.T) {
+	ctx := testCtx()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	lazy := sqlite.NewLazyDB(dbPath)
+
+	const workers = 8
+	var wg sync.WaitGroup
+	wg.Add(workers + 1)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			_, _ = lazy.DB(ctx)
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		lazy.Warmup(ctx)
+	}()
+	wg.Wait()
+
+	db, err := lazy.DB(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	require.NoError(t, lazy.Close())
+}
+
+func TestLazyDB_InitErrorPropagated(t *testing.T) {
+	ctx := testCtx()
+	// An empty path always fails connection setup; the error must be cached
+	// and reported to every later caller without panicking.
+	lazy := sqlite.NewLazyDB("")
+
+	_, err := lazy.DB(ctx)
+	require.Error(t, err, "initialization failure must propagate to the first caller")
+
+	_, err = lazy.DB(ctx)
+	require.Error(t, err, "initialization failure must propagate to later callers")
+
+	// Closing a failed provider must not error: there is no connection.
+	require.NoError(t, lazy.Close())
+	assert.False(t, lazy.IsInitialized())
 }

--- a/internal/infrastructure/persistence/sqlite/lazy_db_test.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db_test.go
@@ -146,18 +146,20 @@ func TestLazyDB_WarmupInitializesInBackground(t *testing.T) {
 
 func TestLazyDB_CloseWaitsForInflightInit(t *testing.T) {
 	ctx := testCtx()
-	// Warmup is asynchronous: Close called before the warmup goroutine runs
-	// is a legitimate no-op, so wait for initialization to be underway
-	// before asserting Close settles and releases the provider cleanly.
+	// Regression test for untracked-warmup orphaning: Warmup registers its
+	// task synchronously, so an immediate Close (no scheduling delay) must
+	// settle the background initialization and release the connection
+	// instead of returning early and leaking it.
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	lazy := sqlite.NewLazyDB(dbPath)
 
 	lazy.Warmup(ctx)
-	require.Eventually(t, func() bool {
-		return lazy.IsInitialized()
-	}, 10*time.Second, 5*time.Millisecond, "warmup should initialize the provider")
-
 	require.NoError(t, lazy.Close())
+
+	require.True(t, lazy.IsInitialized(), "Close must settle warmup initialization, not race its scheduling")
+	db, err := lazy.DB(ctx)
+	require.NoError(t, err)
+	require.Error(t, db.Ping(), "settled connection must be closed, not orphaned")
 }
 
 func TestLazyDB_ConcurrentWarmupAccessAndClose(t *testing.T) {

--- a/internal/infrastructure/persistence/sqlite/lazy_db_test.go
+++ b/internal/infrastructure/persistence/sqlite/lazy_db_test.go
@@ -96,10 +96,12 @@ func TestLazyDB_CloseBeforeInit(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	lazy := sqlite.NewLazyDB(dbPath)
 
-	// Close without ever calling DB() should not error and must not trigger
-	// initialization.
+	// Close without ever calling DB() seals the provider without triggering
+	// initialization; late callers are rejected with the closed error.
 	require.NoError(t, lazy.Close())
 	assert.False(t, lazy.IsInitialized(), "Close must not trigger initialization")
+	_, err := lazy.DB(testCtx())
+	require.ErrorIs(t, err, sqlite.ErrLazyDBClosed)
 }
 
 func TestLazyDB_Path(t *testing.T) {
@@ -146,20 +148,18 @@ func TestLazyDB_WarmupInitializesInBackground(t *testing.T) {
 
 func TestLazyDB_CloseWaitsForInflightInit(t *testing.T) {
 	ctx := testCtx()
-	// Regression test for untracked-warmup orphaning: Warmup registers its
-	// task synchronously, so an immediate Close (no scheduling delay) must
-	// settle the background initialization and release the connection
-	// instead of returning early and leaking it.
+	// Sealing and settlement: whether the warmup task is admitted or loses
+	// the admission race, an immediate Close leaves no usable connection
+	// behind and every later call fails closed.
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	lazy := sqlite.NewLazyDB(dbPath)
 
 	lazy.Warmup(ctx)
 	require.NoError(t, lazy.Close())
 
-	require.True(t, lazy.IsInitialized(), "Close must settle warmup initialization, not race its scheduling")
-	db, err := lazy.DB(ctx)
-	require.NoError(t, err)
-	require.Error(t, db.Ping(), "settled connection must be closed, not orphaned")
+	_, err := lazy.DB(ctx)
+	require.ErrorIs(t, err, sqlite.ErrLazyDBClosed)
+	require.NoError(t, lazy.Close(), "repeat Close must be idempotent")
 }
 
 func TestLazyDB_ConcurrentWarmupAccessAndClose(t *testing.T) {

--- a/internal/infrastructure/process/admission_gate.go
+++ b/internal/infrastructure/process/admission_gate.go
@@ -61,6 +61,15 @@ func (g *AdmissionGate) Close() {
 	g.closed = true
 }
 
+// Reopen resumes admission after a seal that no longer applies: an
+// invalidated deferred quit (e.g. a reopened window) must not leave the
+// surviving process permanently deaf to relay requests.
+func (g *AdmissionGate) Reopen() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.closed = false
+}
+
 // Closed reports whether admission is stopped.
 func (g *AdmissionGate) Closed() bool {
 	g.mu.Lock()

--- a/internal/infrastructure/process/admission_gate.go
+++ b/internal/infrastructure/process/admission_gate.go
@@ -1,0 +1,115 @@
+package process
+
+import (
+	"context"
+	"sync"
+)
+
+// AdmissionGate is a narrow thread-safe admission/work-lease boundary shared
+// by the relay listener and the shutdown/residency policy. A lease must be
+// acquired before sending an acknowledgement; shutdown atomically stops
+// admission while admitted work drains. It never blocks the holder: waiting
+// uses WaitDrained with a caller-provided bounded context.
+type AdmissionGate struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	closed   bool
+	active   int
+	onDrained []func()
+}
+
+// NewAdmissionGate returns an open gate with no active leases.
+func NewAdmissionGate() *AdmissionGate {
+	gate := &AdmissionGate{}
+	gate.cond = sync.NewCond(&gate.mu)
+	return gate
+}
+
+// Acquire takes one work lease. It reports false when admission is closed;
+// the caller must then send the existing error response before any
+// acknowledgement and must not dispatch.
+func (g *AdmissionGate) Acquire() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closed {
+		return false
+	}
+	g.active++
+	return true
+}
+
+// Release returns one work lease. The final release wakes drain waiters and
+// notifies drain subscribers.
+func (g *AdmissionGate) Release() {
+	g.mu.Lock()
+	var notify []func()
+	if g.active > 0 {
+		g.active--
+	}
+	if g.active == 0 {
+		g.cond.Broadcast()
+		notify = append([]func(){}, g.onDrained...)
+	}
+	g.mu.Unlock()
+	for _, fn := range notify {
+		fn()
+	}
+}
+
+// Close atomically stops admission. In-flight leases are unaffected; they
+// drain through Release.
+func (g *AdmissionGate) Close() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.closed = true
+}
+
+// Closed reports whether admission is stopped.
+func (g *AdmissionGate) Closed() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.closed
+}
+
+// Active reports the number of held leases.
+func (g *AdmissionGate) Active() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.active
+}
+
+// OnDrained registers a callback invoked (without holding the gate lock)
+// every time the active count reaches zero. Registration is not idempotent:
+// each call appends. There is no unsubscribe; gates are process-lifetime
+// owners. Callbacks must not call back into the gate.
+func (g *AdmissionGate) OnDrained(fn func()) {
+	if fn == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.onDrained = append(g.onDrained, fn)
+}
+
+// WaitDrained blocks until no leases are held or ctx ends. It reports false
+// on context expiry so shutdown never waits forever.
+func (g *AdmissionGate) WaitDrained(ctx context.Context) bool {
+	done := make(chan struct{})
+	go func() {
+		g.mu.Lock()
+		for g.active > 0 {
+			g.cond.Wait()
+		}
+		g.mu.Unlock()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-ctx.Done():
+		g.mu.Lock()
+		g.cond.Broadcast()
+		g.mu.Unlock()
+		return false
+	}
+}

--- a/internal/infrastructure/process/admission_gate.go
+++ b/internal/infrastructure/process/admission_gate.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // AdmissionGate is a narrow thread-safe admission/work-lease boundary shared
@@ -11,18 +12,15 @@ import (
 // admission while admitted work drains. It never blocks the holder: waiting
 // uses WaitDrained with a caller-provided bounded context.
 type AdmissionGate struct {
-	mu       sync.Mutex
-	cond     *sync.Cond
-	closed   bool
-	active   int
+	mu        sync.Mutex
+	closed    bool
+	active    int
 	onDrained []func()
 }
 
 // NewAdmissionGate returns an open gate with no active leases.
 func NewAdmissionGate() *AdmissionGate {
-	gate := &AdmissionGate{}
-	gate.cond = sync.NewCond(&gate.mu)
-	return gate
+	return &AdmissionGate{}
 }
 
 // Acquire takes one work lease. It reports false when admission is closed;
@@ -38,8 +36,8 @@ func (g *AdmissionGate) Acquire() bool {
 	return true
 }
 
-// Release returns one work lease. The final release wakes drain waiters and
-// notifies drain subscribers.
+// Release returns one work lease. The final release notifies drain
+// subscribers.
 func (g *AdmissionGate) Release() {
 	g.mu.Lock()
 	var notify []func()
@@ -47,7 +45,6 @@ func (g *AdmissionGate) Release() {
 		g.active--
 	}
 	if g.active == 0 {
-		g.cond.Broadcast()
 		notify = append([]func(){}, g.onDrained...)
 	}
 	g.mu.Unlock()
@@ -92,24 +89,22 @@ func (g *AdmissionGate) OnDrained(fn func()) {
 }
 
 // WaitDrained blocks until no leases are held or ctx ends. It reports false
-// on context expiry so shutdown never waits forever.
+// on context expiry so shutdown never waits forever. The short poll runs
+// only on shutdown/drain paths, never on any frame or event loop.
 func (g *AdmissionGate) WaitDrained(ctx context.Context) bool {
-	done := make(chan struct{})
-	go func() {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
 		g.mu.Lock()
-		for g.active > 0 {
-			g.cond.Wait()
+		drained := g.active == 0
+		g.mu.Unlock()
+		if drained {
+			return true
 		}
-		g.mu.Unlock()
-		close(done)
-	}()
-	select {
-	case <-done:
-		return true
-	case <-ctx.Done():
-		g.mu.Lock()
-		g.cond.Broadcast()
-		g.mu.Unlock()
-		return false
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
 	}
 }

--- a/internal/infrastructure/process/admission_gate_test.go
+++ b/internal/infrastructure/process/admission_gate_test.go
@@ -1,0 +1,96 @@
+package process
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdmissionGateAcquireRelease(t *testing.T) {
+	gate := NewAdmissionGate()
+	require.True(t, gate.Acquire())
+	require.True(t, gate.Acquire())
+	require.Equal(t, 2, gate.Active())
+	gate.Release()
+	require.Equal(t, 1, gate.Active())
+	gate.Release()
+	require.Equal(t, 0, gate.Active())
+}
+
+func TestAdmissionGateCloseStopsAdmission(t *testing.T) {
+	gate := NewAdmissionGate()
+	require.True(t, gate.Acquire())
+	gate.Close()
+	require.True(t, gate.Closed())
+	require.False(t, gate.Acquire(), "closed gate must refuse new leases")
+	require.Equal(t, 1, gate.Active(), "in-flight lease survives close")
+	gate.Release()
+	require.Equal(t, 0, gate.Active())
+}
+
+func TestAdmissionGateWaitDrained(t *testing.T) {
+	gate := NewAdmissionGate()
+	gate.Acquire()
+	done := make(chan bool, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		done <- gate.WaitDrained(ctx)
+	}()
+	select {
+	case <-done:
+		t.Fatal("drain must not complete while a lease is held")
+	case <-time.After(50 * time.Millisecond):
+	}
+	gate.Release()
+	select {
+	case drained := <-done:
+		require.True(t, drained)
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain must complete after release")
+	}
+}
+
+func TestAdmissionGateWaitDrainedExpiry(t *testing.T) {
+	gate := NewAdmissionGate()
+	gate.Acquire()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.False(t, gate.WaitDrained(ctx), "expiry must not hang shutdown")
+	gate.Release()
+}
+
+func TestAdmissionGateOnDrained(t *testing.T) {
+	gate := NewAdmissionGate()
+	var mu sync.Mutex
+	calls := 0
+	gate.OnDrained(func() {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	})
+	gate.Acquire()
+	gate.Release()
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, calls)
+}
+
+func TestAdmissionGateConcurrent(t *testing.T) {
+	gate := NewAdmissionGate()
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if gate.Acquire() {
+				gate.Release()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 0, gate.Active())
+}

--- a/internal/infrastructure/process/runtime_safety.go
+++ b/internal/infrastructure/process/runtime_safety.go
@@ -1,0 +1,63 @@
+// Package process provides dependency-leaf process-environment helpers.
+//
+// This file must not import bootstrap, desktop, or any other internal
+// package: both cmd/dumber and internal/infrastructure/desktop import it, and
+// bootstrap already imports desktop. Keep it to the standard library so the
+// merge rule can be shared without an import cycle.
+package process
+
+import "strings"
+
+// RuntimeSafetySetting is the GODEBUG key that must be set before any
+// goroutine or CEF subprocess is created. Go stack shrinking can invalidate
+// frames retained across foreign CEF/GTK stacks.
+const RuntimeSafetySetting = "gcshrinkstackoff"
+
+// EnvironmentValue returns the value for name in an environ slice.
+func EnvironmentValue(environ []string, name string) string {
+	prefix := name + "="
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}
+
+// ReplaceEnvironmentValue returns a copy of environ with name set to value.
+func ReplaceEnvironmentValue(environ []string, name, value string) []string {
+	prefix := name + "="
+	updated := make([]string, 0, len(environ)+1)
+	for _, entry := range environ {
+		if !strings.HasPrefix(entry, prefix) {
+			updated = append(updated, entry)
+		}
+	}
+	return append(updated, prefix+value)
+}
+
+// MergeRuntimeSafety returns a copy of environ with RuntimeSafetySetting=1
+// merged into GODEBUG, preserving all unrelated entries (including other
+// GODEBUG keys). It reports whether a change was applied. Duplicate or
+// conflicting gcshrinkstackoff entries collapse to a single =1 entry.
+func MergeRuntimeSafety(environ []string) ([]string, bool) {
+	updated := append([]string(nil), environ...)
+	parts := strings.Split(EnvironmentValue(updated, "GODEBUG"), ",")
+	kept := make([]string, 0, len(parts)+1)
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, _, _ := strings.Cut(part, "=")
+		if key == RuntimeSafetySetting {
+			continue
+		}
+		kept = append(kept, part)
+	}
+	merged := strings.Join(append(kept, RuntimeSafetySetting+"=1"), ",")
+	if EnvironmentValue(updated, "GODEBUG") == merged {
+		return updated, false
+	}
+	return ReplaceEnvironmentValue(updated, "GODEBUG", merged), true
+}

--- a/internal/infrastructure/process/runtime_safety.go
+++ b/internal/infrastructure/process/runtime_safety.go
@@ -38,12 +38,17 @@ func ReplaceEnvironmentValue(environ []string, name, value string) []string {
 
 // MergeRuntimeSafety returns a copy of environ with RuntimeSafetySetting=1
 // merged into GODEBUG, preserving all unrelated entries (including other
-// GODEBUG keys). It reports whether a change was applied. Duplicate or
-// conflicting gcshrinkstackoff entries collapse to a single =1 entry.
+// GODEBUG keys) and their relative order. It reports whether a change was
+// applied. An already-effective single setting entry is detected
+// independently of its position, so direct invocation never performs an
+// unnecessary self-exec; duplicate or conflicting entries still collapse to
+// one normalized trailing entry.
 func MergeRuntimeSafety(environ []string) ([]string, bool) {
 	updated := append([]string(nil), environ...)
-	parts := strings.Split(EnvironmentValue(updated, "GODEBUG"), ",")
+	current := EnvironmentValue(updated, "GODEBUG")
+	parts := strings.Split(current, ",")
 	kept := make([]string, 0, len(parts)+1)
+	var settingParts []string
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -51,12 +56,21 @@ func MergeRuntimeSafety(environ []string) ([]string, bool) {
 		}
 		key, _, _ := strings.Cut(part, "=")
 		if key == RuntimeSafetySetting {
+			settingParts = append(settingParts, part)
 			continue
 		}
 		kept = append(kept, part)
 	}
+	if len(settingParts) == 1 && settingParts[0] == RuntimeSafetySetting+"=1" {
+		// Exactly one effective entry: already safe in place, independent
+		// of its position among the other keys. Leave the order untouched
+		// so direct invocation performs no self-exec.
+		return updated, false
+	}
+	// Zero, duplicate, conflicting, or valueless entries collapse to one
+	// normalized trailing entry.
 	merged := strings.Join(append(kept, RuntimeSafetySetting+"=1"), ",")
-	if EnvironmentValue(updated, "GODEBUG") == merged {
+	if current == merged {
 		return updated, false
 	}
 	return ReplaceEnvironmentValue(updated, "GODEBUG", merged), true

--- a/internal/infrastructure/process/runtime_safety.go
+++ b/internal/infrastructure/process/runtime_safety.go
@@ -45,7 +45,16 @@ func ReplaceEnvironmentValue(environ []string, name, value string) []string {
 // one normalized trailing entry.
 func MergeRuntimeSafety(environ []string) ([]string, bool) {
 	updated := append([]string(nil), environ...)
-	current := EnvironmentValue(updated, "GODEBUG")
+	// Collect every GODEBUG entry: duplicates are legal in an environ
+	// slice and the first entry alone never describes the effective
+	// setting, so normalization must merge them all before deciding.
+	godebugValues := make([]string, 0, 1)
+	for _, entry := range updated {
+		if strings.HasPrefix(entry, "GODEBUG=") {
+			godebugValues = append(godebugValues, strings.TrimPrefix(entry, "GODEBUG="))
+		}
+	}
+	current := strings.Join(godebugValues, ",")
 	parts := strings.Split(current, ",")
 	kept := make([]string, 0, len(parts)+1)
 	var settingParts []string
@@ -61,10 +70,10 @@ func MergeRuntimeSafety(environ []string) ([]string, bool) {
 		}
 		kept = append(kept, part)
 	}
-	if len(settingParts) == 1 && settingParts[0] == RuntimeSafetySetting+"=1" {
-		// Exactly one effective entry: already safe in place, independent
-		// of its position among the other keys. Leave the order untouched
-		// so direct invocation performs no self-exec.
+	if len(godebugValues) == 1 && len(settingParts) == 1 && settingParts[0] == RuntimeSafetySetting+"=1" {
+		// Exactly one entry with one effective setting: already safe in
+		// place, independent of its position among the other keys. Leave
+		// the order untouched so direct invocation performs no self-exec.
 		return updated, false
 	}
 	// Zero, duplicate, conflicting, or valueless entries collapse to one

--- a/internal/infrastructure/process/runtime_safety_test.go
+++ b/internal/infrastructure/process/runtime_safety_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,12 +22,26 @@ func TestMergeRuntimeSafety(t *testing.T) {
 		{name: "collapses duplicates", environ: []string{"GODEBUG=gcshrinkstackoff=0,gcshrinkstackoff=1"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "bare key without value is unsafe", environ: []string{"GODEBUG=gcshrinkstackoff"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "preserves other debug keys", environ: []string{"GODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0"}, wantGODEBUG: "tracebacklabels=0,x509sslcertoverrideplatform=0,gcshrinkstackoff=1", wantChanged: true},
+		{name: "merges separate duplicate entries", environ: []string{"GODEBUG=gcshrinkstackoff=1", "GODEBUG=gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
+		{name: "safe first entry does not hide second entry keys", environ: []string{"GODEBUG=gcshrinkstackoff=1", "GODEBUG=cpu.all=off"}, wantGODEBUG: "cpu.all=off,gcshrinkstackoff=1", wantChanged: true},
+		{name: "unsafe first entry preserves second entry keys", environ: []string{"GODEBUG=cpu.all=off", "GODEBUG=gcshrinkstackoff=1,foo=bar"}, wantGODEBUG: "cpu.all=off,foo=bar,gcshrinkstackoff=1", wantChanged: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, changed := MergeRuntimeSafety(tt.environ)
 			require.Equal(t, tt.wantChanged, changed)
 			require.Equal(t, tt.wantGODEBUG, EnvironmentValue(got, "GODEBUG"))
+			if changed {
+				// Normalization always collapses to a single trailing
+				// entry; no duplicate GODEBUG may survive a change.
+				count := 0
+				for _, entry := range got {
+					if strings.HasPrefix(entry, "GODEBUG=") {
+						count++
+				}
+				}
+				require.Equal(t, 1, count, "changed environ must hold exactly one GODEBUG entry")
+			}
 		})
 	}
 }

--- a/internal/infrastructure/process/runtime_safety_test.go
+++ b/internal/infrastructure/process/runtime_safety_test.go
@@ -1,0 +1,39 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeRuntimeSafety(t *testing.T) {
+	tests := []struct {
+		name        string
+		environ     []string
+		wantGODEBUG string
+		wantChanged bool
+	}{
+		{name: "missing", environ: []string{"HOME=/tmp"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
+		{name: "preserves settings", environ: []string{"GODEBUG=gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
+		{name: "overrides unsafe value", environ: []string{"GODEBUG=gcshrinkstackoff=0,gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
+		{name: "already safe", environ: []string{"GODEBUG=gctrace=1,gcshrinkstackoff=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: false},
+		{name: "collapses duplicates", environ: []string{"GODEBUG=gcshrinkstackoff=0,gcshrinkstackoff=1"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
+		{name: "bare key without value is unsafe", environ: []string{"GODEBUG=gcshrinkstackoff"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
+		{name: "preserves other debug keys", environ: []string{"GODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0"}, wantGODEBUG: "tracebacklabels=0,x509sslcertoverrideplatform=0,gcshrinkstackoff=1", wantChanged: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := MergeRuntimeSafety(tt.environ)
+			require.Equal(t, tt.wantChanged, changed)
+			require.Equal(t, tt.wantGODEBUG, EnvironmentValue(got, "GODEBUG"))
+		})
+	}
+}
+
+func TestMergeRuntimeSafetyDoesNotMutateInput(t *testing.T) {
+	input := []string{"GODEBUG=gctrace=1"}
+	got, changed := MergeRuntimeSafety(input)
+	require.True(t, changed)
+	require.Equal(t, []string{"GODEBUG=gctrace=1"}, input)
+	require.Equal(t, "gctrace=1,gcshrinkstackoff=1", EnvironmentValue(got, "GODEBUG"))
+}

--- a/internal/infrastructure/process/runtime_safety_test.go
+++ b/internal/infrastructure/process/runtime_safety_test.go
@@ -17,6 +17,7 @@ func TestMergeRuntimeSafety(t *testing.T) {
 		{name: "preserves settings", environ: []string{"GODEBUG=gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
 		{name: "overrides unsafe value", environ: []string{"GODEBUG=gcshrinkstackoff=0,gctrace=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: true},
 		{name: "already safe", environ: []string{"GODEBUG=gctrace=1,gcshrinkstackoff=1"}, wantGODEBUG: "gctrace=1,gcshrinkstackoff=1", wantChanged: false},
+		{name: "safe first keeps position without exec", environ: []string{"GODEBUG=gcshrinkstackoff=1,gctrace=1"}, wantGODEBUG: "gcshrinkstackoff=1,gctrace=1", wantChanged: false},
 		{name: "collapses duplicates", environ: []string{"GODEBUG=gcshrinkstackoff=0,gcshrinkstackoff=1"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "bare key without value is unsafe", environ: []string{"GODEBUG=gcshrinkstackoff"}, wantGODEBUG: "gcshrinkstackoff=1", wantChanged: true},
 		{name: "preserves other debug keys", environ: []string{"GODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0"}, wantGODEBUG: "tracebacklabels=0,x509sslcertoverrideplatform=0,gcshrinkstackoff=1", wantChanged: true},

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -35,13 +35,15 @@ type Service struct {
 	retries    int
 	retryDelay time.Duration
 
-	mu     sync.Mutex
-	timer  *time.Timer
+	mu       sync.Mutex
+	timer    *time.Timer
 	timerGen uint64
-	dirty  bool
-	ready  bool // true when session is persisted to DB and snapshots can be saved
-	ctx    context.Context
-	cancel context.CancelFunc
+	// stopped latches Stop: no new debounce work schedules afterwards.
+	stopped bool
+	dirty   bool
+	ready   bool // true when session is persisted to DB and snapshots can be saved
+	ctx     context.Context
+	cancel  context.CancelFunc
 
 	// Drain boundary for the residency quiescence contract. inflight
 	// counts an executing capture/database save; lastErr records the
@@ -108,6 +110,8 @@ func (s *Service) SetReady() {
 // Stop stops the service and saves final state, then joins an
 // already-running save within a bounded wait so shutdown observes the
 // drain barrier instead of racing it. The wait never blocks forever.
+// Latching stopped also prevents any later debounce from scheduling work
+// on the dead service.
 func (s *Service) Stop(ctx context.Context) error {
 	s.mu.Lock()
 	if s.cancel != nil {
@@ -117,6 +121,7 @@ func (s *Service) Stop(ctx context.Context) error {
 		s.timer.Stop()
 		s.timer = nil
 	}
+	s.stopped = true
 	s.mu.Unlock()
 
 	// Final save on shutdown
@@ -130,11 +135,14 @@ func (s *Service) Stop(ctx context.Context) error {
 }
 
 // MarkDirty signals that state has changed.
-// Debounces saves to avoid excessive DB writes.
+// Debounces saves to avoid excessive DB writes. It is a no-op after Stop
+// so shutdown never resurrects debounce work on the dead service.
 func (s *Service) MarkDirty() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
+	if s.stopped {
+		return
+	}
 	s.dirty = true
 
 	// Reset or create timer
@@ -148,10 +156,17 @@ func (s *Service) MarkDirty() {
 		// Retire the owning timer as it fires: a non-nil timer means
 		// debounce work is outstanding, so leaving it set would strand
 		// the drain after the save settles. The generation check keeps
-		// a superseded timer from clearing its replacement.
-		if s.timerGen == gen {
-			s.timer = nil
+		// a superseded timer from clearing its replacement, and a
+		// superseded or stopped timer saves nothing: the replacement
+		// timer or Stop's own final save owns that work.
+		if s.timerGen != gen || s.stopped {
+			if s.timerGen == gen {
+				s.timer = nil
+			}
+			s.mu.Unlock()
+			return
 		}
+		s.timer = nil
 		ctx := s.ctx
 		s.mu.Unlock()
 
@@ -190,6 +205,13 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 		s.mu.Unlock()
 		return nil
 	}
+	// Claim the dirty work atomically: concurrent timer and SaveNow paths
+	// serialize here, so exactly one save runs and shutdown joins rather
+	// than duplicates the active save.
+	if !s.dirty {
+		s.mu.Unlock()
+		return nil
+	}
 	// Only clear dirty when we're actually going to save
 	s.dirty = false
 	s.lastErr = nil
@@ -204,7 +226,7 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	sessionID := s.provider.GetSessionID()
 
 	if sessionID == "" {
-		s.markDirty()
+		s.MarkDirty()
 		return nil
 	}
 
@@ -212,7 +234,7 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	// A nil window list with no active index means the snapshot is truly unavailable,
 	// not merely empty. Keep the session dirty so a later capture can retry.
 	if windows == nil && activeWindowIndex < 0 {
-		s.markDirty()
+		s.MarkDirty()
 		logging.FromContext(ctx).Warn().Msg("window snapshot unavailable; keeping session snapshot dirty")
 		return nil
 	}
@@ -246,11 +268,11 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 // later retry while lastErr records it, so the drain always terminates and
 // never loops forever merely because dirty remains set.
 func (s *Service) Active() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.inflight.Load() > 0 {
 		return true
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.timer != nil {
 		return true
 	}

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -37,6 +37,7 @@ type Service struct {
 
 	mu     sync.Mutex
 	timer  *time.Timer
+	timerGen uint64
 	dirty  bool
 	ready  bool // true when session is persisted to DB and snapshots can be saved
 	ctx    context.Context
@@ -104,7 +105,9 @@ func (s *Service) SetReady() {
 	}()
 }
 
-// Stop stops the service and saves final state.
+// Stop stops the service and saves final state, then joins an
+// already-running save within a bounded wait so shutdown observes the
+// drain barrier instead of racing it. The wait never blocks forever.
 func (s *Service) Stop(ctx context.Context) error {
 	s.mu.Lock()
 	if s.cancel != nil {
@@ -117,7 +120,13 @@ func (s *Service) Stop(ctx context.Context) error {
 	s.mu.Unlock()
 
 	// Final save on shutdown
-	return s.SaveNow(ctx)
+	err := s.SaveNow(ctx)
+	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	if waitErr := s.WaitSettled(drainCtx); waitErr != nil {
+		logging.FromContext(ctx).Warn().Err(waitErr).Msg("snapshot drain did not settle before shutdown")
+	}
+	return err
 }
 
 // MarkDirty signals that state has changed.
@@ -132,9 +141,17 @@ func (s *Service) MarkDirty() {
 	if s.timer != nil {
 		s.timer.Stop()
 	}
-
+	s.timerGen++
+	gen := s.timerGen
 	s.timer = time.AfterFunc(s.interval, func() {
 		s.mu.Lock()
+		// Retire the owning timer as it fires: a non-nil timer means
+		// debounce work is outstanding, so leaving it set would strand
+		// the drain after the save settles. The generation check keeps
+		// a superseded timer from clearing its replacement.
+		if s.timerGen == gen {
+			s.timer = nil
+		}
 		ctx := s.ctx
 		s.mu.Unlock()
 

--- a/internal/infrastructure/snapshot/service.go
+++ b/internal/infrastructure/snapshot/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
@@ -23,6 +24,9 @@ const (
 // Compile-time interface check.
 var _ port.SnapshotService = (*Service)(nil)
 
+// Compile-time drain boundary check.
+var _ port.PersistenceDrain = (*Service)(nil)
+
 // Service handles debounced session state snapshots.
 type Service struct {
 	snapshotUC *usecase.SnapshotSessionUseCase
@@ -37,6 +41,15 @@ type Service struct {
 	ready  bool // true when session is persisted to DB and snapshots can be saved
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// Drain boundary for the residency quiescence contract. inflight
+	// counts an executing capture/database save; lastErr records the
+	// terminal failure of the most recent save while dirty is preserved
+	// for reporting and later retry. Failed writes are settled-but-failed:
+	// the drain terminates instead of looping forever on dirty.
+	inflight  atomic.Int32
+	lastErr   error
+	onSettled []func()
 }
 
 // NewService creates a new snapshot service.
@@ -162,7 +175,14 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 	}
 	// Only clear dirty when we're actually going to save
 	s.dirty = false
+	s.lastErr = nil
+	s.inflight.Add(1)
 	s.mu.Unlock()
+
+	defer func() {
+		s.inflight.Add(-1)
+		s.notifyIfSettled()
+	}()
 
 	sessionID := s.provider.GetSessionID()
 
@@ -196,10 +216,88 @@ func (s *Service) saveSnapshot(ctx context.Context) error {
 
 	if err := s.executeWithRetry(ctx, input); err != nil {
 		s.markDirty()
+		s.setTerminalError(err)
 		return err
 	}
 
 	return nil
+}
+
+// Active reports whether snapshot work is outstanding: pending debounce,
+// an armed timer, or an in-flight capture/database save. A terminally
+// failed save is settled-but-failed: dirty is preserved for reporting and
+// later retry while lastErr records it, so the drain always terminates and
+// never loops forever merely because dirty remains set.
+func (s *Service) Active() bool {
+	if s.inflight.Load() > 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.timer != nil {
+		return true
+	}
+	if !s.dirty {
+		return false
+	}
+	return s.lastErr == nil
+}
+
+// LastError returns the terminal error of the most recent save, or nil.
+// Dirty is preserved alongside it for reporting and later retry.
+func (s *Service) LastError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastErr
+}
+
+// OnSettled registers a callback invoked when the service reaches a
+// settled state after a save completes. Callbacks run on the completing
+// goroutine and must be non-blocking; the UI wraps them with GTK dispatch.
+// There is no unsubscribe; services are process-lifetime owners.
+func (s *Service) OnSettled(fn func()) {
+	if fn == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onSettled = append(s.onSettled, fn)
+}
+
+// WaitSettled blocks until no snapshot work is outstanding or ctx ends.
+// It reports ctx.Err() on expiry so shutdown never waits forever. It must
+// never be called on the GTK thread when capture dispatches there.
+func (s *Service) WaitSettled(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if !s.Active() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Service) setTerminalError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastErr = err
+}
+
+func (s *Service) notifyIfSettled() {
+	if s.Active() {
+		return
+	}
+	s.mu.Lock()
+	callbacks := append([]func(){}, s.onSettled...)
+	s.mu.Unlock()
+	for _, fn := range callbacks {
+		fn()
+	}
 }
 
 func (s *Service) executeWithRetry(ctx context.Context, input usecase.SnapshotInput) error {

--- a/internal/infrastructure/snapshot/service_test.go
+++ b/internal/infrastructure/snapshot/service_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -324,4 +325,63 @@ func TestService_SaveNowPreservesLegacySingleEmptyWindowSentinel(t *testing.T) {
 	err := svc.saveSnapshot(context.Background())
 	require.NoError(t, err)
 	assert.False(t, svc.dirty)
+}
+
+func TestService_DebounceTimerClearsOnFire(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		Return(nil).Once()
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_fire", nil, 0), 1)
+	svc.ready = true
+	svc.ctx = context.Background()
+	svc.MarkDirty()
+	require.True(t, svc.Active())
+	// The fired timer retires itself; the save settles the drain.
+	require.Eventually(t, func() bool { return !svc.Active() }, 5*time.Second, 5*time.Millisecond)
+}
+
+func TestService_StopJoinsInFlightSave(t *testing.T) {
+	released := make(chan struct{})
+	var calls atomic.Int32
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		RunAndReturn(func(_ context.Context, _ *entity.SessionState) error {
+			calls.Add(1)
+			<-released
+			return nil
+		})
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_join", nil, 0), 1)
+	svc.ready = true
+	svc.dirty = true
+	saveDone := make(chan error, 1)
+	go func() { saveDone <- svc.saveSnapshot(context.Background()) }()
+	// The in-flight save reached the database: dirty is cleared and the
+	// provider was consumed exactly once, so Stop cannot start a second.
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, 5*time.Second, 5*time.Millisecond)
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- svc.Stop(context.Background()) }()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned while a save was still in flight: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(released)
+	select {
+	case err := <-saveDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight save never completed")
+	}
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("Stop did not join the in-flight save")
+	}
+	require.False(t, svc.Active())
+	require.Equal(t, int32(1), calls.Load(), "Stop must join, not duplicate, the save")
 }

--- a/internal/infrastructure/snapshot/service_test.go
+++ b/internal/infrastructure/snapshot/service_test.go
@@ -27,6 +27,80 @@ func newWindowStateProvider(
 	return provider
 }
 
+func TestService_DrainSettlesAfterDebounceAndSave(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		Return(nil).Once()
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_drain", nil, 0), 60000)
+	svc.ready = true
+	require.False(t, svc.Active())
+
+	svc.MarkDirty()
+	require.True(t, svc.Active(), "pending debounce is outstanding work")
+
+	require.NoError(t, svc.SaveNow(context.Background()))
+	require.False(t, svc.Active())
+	require.NoError(t, svc.LastError())
+}
+
+func TestService_FailedSaveIsSettledButFailed(t *testing.T) {
+	closedErr := errors.New("database is closed")
+	repo := repomocks.NewMockSessionStateRepository(t)
+	calls := 0
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		RunAndReturn(func(_ context.Context, _ *entity.SessionState) error {
+			calls++
+			return closedErr
+		})
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_closed", nil, 0), 60000)
+	svc.ready = true
+	svc.dirty = true
+
+	err := svc.SaveNow(context.Background())
+	require.ErrorIs(t, err, closedErr)
+	require.Equal(t, 1, calls, "no write retries after terminal database failure")
+	require.True(t, svc.dirty, "dirty preserved for reporting and later retry")
+	require.ErrorIs(t, svc.LastError(), closedErr)
+	require.False(t, svc.Active(), "terminal failure settles the drain")
+	require.NoError(t, svc.WaitSettled(context.Background()))
+}
+
+func TestService_WaitSettledExpiry(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, mocks.NewMockWindowStateProvider(t), 60000)
+	svc.MarkDirty()
+	require.True(t, svc.Active())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.Error(t, svc.WaitSettled(ctx), "drain must expire instead of looping forever")
+}
+
+func TestService_OnSettledFiresAfterSave(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		Return(nil).Once()
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_settled", nil, 0), 60000)
+	svc.ready = true
+	svc.dirty = true
+	settled := make(chan struct{}, 1)
+	svc.OnSettled(func() { settled <- struct{}{} })
+
+	require.NoError(t, svc.SaveNow(context.Background()))
+	select {
+	case <-settled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("settled callback must fire after save completes")
+	}
+}
+
 func TestService_SaveSnapshot_RetriesTransientFKAndSucceeds(t *testing.T) {
 	repo := repomocks.NewMockSessionStateRepository(t)
 	calls := 0

--- a/internal/infrastructure/snapshot/service_test.go
+++ b/internal/infrastructure/snapshot/service_test.go
@@ -385,3 +385,36 @@ func TestService_StopJoinsInFlightSave(t *testing.T) {
 	require.False(t, svc.Active())
 	require.Equal(t, int32(1), calls.Load(), "Stop must join, not duplicate, the save")
 }
+
+func TestService_MarkDirtyNoOpAfterStop(t *testing.T) {
+	repo := repomocks.NewMockSessionStateRepository(t)
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, mocks.NewMockWindowStateProvider(t), 1)
+	require.NoError(t, svc.Stop(context.Background()))
+	svc.MarkDirty()
+	require.False(t, svc.Active(), "stopped service schedules nothing")
+	time.Sleep(20 * time.Millisecond)
+	require.False(t, svc.Active())
+}
+
+func TestService_SupersededTimerSavesNothing(t *testing.T) {
+	var calls atomic.Int32
+	repo := repomocks.NewMockSessionStateRepository(t)
+	repo.EXPECT().
+		SaveSnapshot(mock.Anything, mock.AnythingOfType("*entity.SessionState")).
+		RunAndReturn(func(_ context.Context, _ *entity.SessionState) error {
+			calls.Add(1)
+			return nil
+		})
+	uc := usecase.NewSnapshotSessionUseCase(repo)
+	svc := NewService(uc, newWindowStateProvider(t, "20260207_120000_superseded", nil, 0), 1)
+	svc.ready = true
+	svc.MarkDirty()
+	// Stop consumes the pending work in its own final save and retires
+	// the debounce timer; the stopped timer callback must save nothing.
+	require.NoError(t, svc.Stop(context.Background()))
+	require.Equal(t, int32(1), calls.Load())
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), calls.Load(), "stopped timer must not save")
+	require.False(t, svc.Active())
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -367,6 +367,16 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	})
 	a.residency.SetQuiescentFunc(a.residencyQuiescent)
 	a.residency.SetSealFunc(a.closeRelayAdmission)
+	a.residency.SetUnsealFunc(func() {
+		if a.deps == nil {
+			return
+		}
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil {
+				gate.Reopen()
+			}
+		}
+	})
 	a.residency.AcquireHold(a.gtkApp)
 	defer a.residency.ReleaseHold(a.gtkApp)
 
@@ -3103,9 +3113,10 @@ func (a *App) onShutdown(ctx context.Context) {
 
 	// Stop relay admission before snapshot/update teardown so no new work
 	// starts while persistence drains. Admitted leases keep their sockets
-	// until dispatch settles; shutdown never waits on them unboundedly.
+	// until dispatch settles; off-thread quits already drained beforehand
+	// (see Quit), and on the GTK thread itself a drain wait is impossible,
+	// so teardown relies on close-then-teardown ordering here.
 	a.closeRelayAdmission()
-	a.waitRelayAdmissionDrained(ctx)
 	a.unsubscribeResidencyQuiescence()
 
 	// Persistence drain barriers, in teardown order. The snapshot service
@@ -3837,6 +3848,14 @@ func (a *App) Quit() {
 		}
 	}
 	glibCtx := glib.MainContextDefault()
+	if glibCtx == nil || !glibCtx.IsOwner() {
+		// Off-thread quits (signals, relay threads) drain admission and
+		// persistence BEFORE entering GTK shutdown, while the loop can
+		// still service admitted work. On the GTK thread itself this wait
+		// is impossible, so shutdown relies on close-then-teardown
+		// ordering instead; the dispatched closure below never blocks.
+		a.drainForShutdownOffThread()
+	}
 	if glibCtx != nil && glibCtx.IsOwner() {
 		quit()
 		return

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -144,6 +144,9 @@ type App struct {
 	// wholesale, so this field is never re-read from them; a changed value
 	// is reported as restart-required instead of partially hot-applied.
 	residencyTimeout time.Duration
+	// residency owns the opt-in idle hold and deadline. Always non-nil
+	// after Run starts; nil beforehand (e.g. in tests without Run).
+	residency *ResidencyController
 
 	// Web content (managed by content.Coordinator)
 	faviconAdapter *adapter.FaviconAdapter
@@ -347,6 +350,15 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	defer a.gtkApp.Unref()
 	a.dispatchOnMainThread = a.runOnMainThread
 
+	// Bounded opt-in residency owns exactly one application hold, taken
+	// only when enabled and released once on every Run exit (including
+	// activation failure before the shutdown signal).
+	a.residency = NewResidencyController(a.residencyTimeout, time.Now, nil, nil, a.Quit)
+	a.residency.schedule = a.residency.scheduleGLibTimeout
+	a.residency.cancel = a.residency.cancelGLibTimeout
+	a.residency.AcquireHold(a.gtkApp)
+	defer a.residency.ReleaseHold(a.gtkApp)
+
 	// Connect activate signal
 	activateCb := func(_ gio.Application) {
 		a.onActivate(ctx)
@@ -378,6 +390,12 @@ func (a *App) onActivate(ctx context.Context) {
 
 	if err := a.openInitialBrowserWindowShell(ctx, a.initialWindowURL()); err != nil {
 		log.Error().Err(err).Msg("failed to create main window")
+		// Reach bounded idle or orderly shutdown instead of lingering on
+		// the residency hold with no windows: disabled residency quits here
+		// exactly as before (GTK auto-exits holderless), enabled arms.
+		if a.residencyShouldQuitAfterLastWindow() {
+			a.Quit()
+		}
 		return
 	}
 
@@ -3246,9 +3264,13 @@ func (a *App) initTabCoordinator(ctx context.Context) {
 				bw.mainWindow.Destroy()
 			}
 		}
-		// Quit the app only when all browser windows are gone.
+		// Quit through residency when enabled rather than unconditionally:
+		// the last window close arms the bounded idle deadline instead.
+		// Disabled residency preserves the pre-existing unconditional Quit.
 		if len(a.browserWindows) == 0 {
-			a.Quit()
+			if a.residencyShouldQuitAfterLastWindow() {
+				a.Quit()
+			}
 		}
 	})
 	// Wire popup tab WebView attachment
@@ -3783,6 +3805,11 @@ func (a *App) MainWindow() *window.MainWindow {
 func (a *App) Quit() {
 	if a == nil || a.gtkApp == nil {
 		return
+	}
+	// Explicit quits and signals never wait for the idle deadline and must
+	// not bypass orderly cleanup: cancel any armed deadline first.
+	if a.residency != nil {
+		a.residency.NoteExplicitQuit()
 	}
 	quit := func() {
 		if a.gtkApp != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3286,14 +3286,8 @@ func (a *App) initTabCoordinator(ctx context.Context) {
 				bw.mainWindow.Destroy()
 			}
 		}
-		// Quit through residency when enabled rather than unconditionally:
-		// the last window close arms the bounded idle deadline instead.
-		// Disabled residency preserves the pre-existing unconditional Quit.
-		if len(a.browserWindows) == 0 {
-			if a.residencyShouldQuitAfterLastWindow() {
-				a.Quit()
-			}
-		}
+		// Quitting is decided inside removeBrowserWindow through residency;
+		// nothing further to do here.
 	})
 	// Wire popup tab WebView attachment
 	a.tabCoord.SetOnAttachPopupToTab(a.attachPopupToTab)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -139,6 +139,12 @@ type App struct {
 	// Engine
 	engine port.Engine
 
+	// residencyTimeout is the effective bounded-residency idle timeout
+	// latched once at process startup. Live config snapshots are replaced
+	// wholesale, so this field is never re-read from them; a changed value
+	// is reported as restart-required instead of partially hot-applied.
+	residencyTimeout time.Duration
+
 	// Web content (managed by content.Coordinator)
 	faviconAdapter *adapter.FaviconAdapter
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -147,6 +147,8 @@ type App struct {
 	// residency owns the opt-in idle hold and deadline. Always non-nil
 	// after Run starts; nil beforehand (e.g. in tests without Run).
 	residency *ResidencyController
+	// residencyUnsubscribe drops native quiescence subscriptions at shutdown.
+	residencyUnsubscribe []func()
 
 	// Web content (managed by content.Coordinator)
 	faviconAdapter *adapter.FaviconAdapter
@@ -356,6 +358,14 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	a.residency = NewResidencyController(a.residencyTimeout, time.Now, nil, nil, a.Quit)
 	a.residency.schedule = a.residency.scheduleGLibTimeout
 	a.residency.cancel = a.residency.cancelGLibTimeout
+	a.residency.SetDispatchToGTK(func(f func()) {
+		callback := glib.SourceFunc(func(_ uintptr) bool {
+			f()
+			return false
+		})
+		glib.IdleAdd(&callback, 0)
+	})
+	a.residency.SetQuiescentFunc(a.residencyQuiescent)
 	a.residency.AcquireHold(a.gtkApp)
 	defer a.residency.ReleaseHold(a.gtkApp)
 
@@ -412,6 +422,7 @@ func (a *App) onActivate(ctx context.Context) {
 	a.wireSessionManagerShortcut()
 	a.initSnapshotService(ctx)
 	a.initUpdateCoordinator(ctx)
+	a.subscribeResidencyQuiescence()
 	a.createInitialTab(ctx)
 	a.finalizeActivation(ctx)
 }
@@ -3089,6 +3100,17 @@ func (a *App) onShutdown(ctx context.Context) {
 	log := logging.FromContext(ctx)
 	log.Debug().Msg("GTK application shutting down")
 
+	// Stop relay admission before snapshot/update teardown so no new work
+	// starts while persistence drains. Admitted leases keep their sockets
+	// until dispatch settles; shutdown never waits on them unboundedly.
+	a.closeRelayAdmission()
+	a.unsubscribeResidencyQuiescence()
+
+	// Persistence drain barriers, in teardown order. The snapshot service
+	// owns debounced session writes (Stop performs the final synchronous
+	// save); the history recorder flushes synchronously on Close. All
+	// other persistence owners are synchronous use-case calls with no
+	// background work, so no additional drain exists.
 	// Save final session state before shutdown
 	if a.snapshotService != nil {
 		if err := a.snapshotService.Stop(ctx); err != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -366,6 +366,7 @@ func (a *App) Run(ctx context.Context, args []string) int {
 		glib.IdleAdd(&callback, 0)
 	})
 	a.residency.SetQuiescentFunc(a.residencyQuiescent)
+	a.residency.SetSealFunc(a.closeRelayAdmission)
 	a.residency.AcquireHold(a.gtkApp)
 	defer a.residency.ReleaseHold(a.gtkApp)
 
@@ -3104,6 +3105,7 @@ func (a *App) onShutdown(ctx context.Context) {
 	// starts while persistence drains. Admitted leases keep their sockets
 	// until dispatch settles; shutdown never waits on them unboundedly.
 	a.closeRelayAdmission()
+	a.waitRelayAdmissionDrained(ctx)
 	a.unsubscribeResidencyQuiescence()
 
 	// Persistence drain barriers, in teardown order. The snapshot service
@@ -3822,12 +3824,14 @@ func (a *App) Quit() {
 	if a == nil || a.gtkApp == nil {
 		return
 	}
-	// Explicit quits and signals never wait for the idle deadline and must
-	// not bypass orderly cleanup: cancel any armed deadline first.
-	if a.residency != nil {
-		a.residency.NoteExplicitQuit()
-	}
 	quit := func() {
+		// The whole residency/GTK quit transition runs on the GTK thread:
+		// canceling the idle timer touches GLib sources, which is only
+		// safe on its owner thread. Explicit quits and signals never wait
+		// for the idle deadline and must not bypass orderly cleanup.
+		if a.residency != nil {
+			a.residency.NoteExplicitQuit()
+		}
 		if a.gtkApp != nil {
 			a.gtkApp.Quit()
 		}

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -393,6 +393,7 @@ func (a *App) removeBrowserWindow(id string) {
 	if wasMainWindow {
 		a.clearMainBrowserWindowAfterRemoval(fallback)
 	}
+	a.residencyAfterWindowRemoved()
 }
 
 func (a *App) releaseNativePopupsForBrowserWindow(windowID string) {

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -126,14 +126,15 @@ func (bw *browserWindow) initChrome(ctx context.Context, a *App) {
 		return
 	}
 
+	// Hidden panels (history, favorites) are constructed on first request via
+	// ensureHistorySidebar/ensureFavoritesSidebar so window creation performs
+	// no hidden-panel queries or widget row rebuilds.
 	bw.initToasterOverlay(a)
 	bw.initTouchpadNavigationIndicator()
 	bw.initBorderOverlay(a)
 	bw.initAccentPicker(ctx, a)
 	bw.initSessionManager(ctx, a)
 	bw.initTabPicker(ctx, a)
-	bw.initHistorySidebar(ctx, a)
-	bw.initFavoritesSidebar(ctx, a)
 }
 
 func (bw *browserWindow) initToasterOverlay(a *App) {

--- a/internal/ui/browser_window.go
+++ b/internal/ui/browser_window.go
@@ -343,6 +343,7 @@ func (a *App) registerBrowserWindow(bw *browserWindow) {
 		return
 	}
 	a.browserWindowOrder = append(a.browserWindowOrder, bw.id)
+	a.residencyNoteWindowsChanged()
 }
 
 func (a *App) releaseTabWorkspace(ctx context.Context, tab *entity.Tab) {

--- a/internal/ui/browser_window_favorites_sidebar.go
+++ b/internal/ui/browser_window_favorites_sidebar.go
@@ -13,7 +13,8 @@ import (
 
 // newFavoritesSidebarComponent constructs the native favorites sidebar. It is
 // a package-level seam so headless tests can observe on-demand construction
-// without instantiating GTK widgets.
+// without instantiating GTK widgets. Mutable global: tests must restore it
+// via defer and must not use t.Parallel alongside seam users.
 var newFavoritesSidebarComponent = component.NewFavoritesSidebar
 
 // ensureFavoritesSidebar constructs the favorites sidebar on first request.

--- a/internal/ui/browser_window_favorites_sidebar.go
+++ b/internal/ui/browser_window_favorites_sidebar.go
@@ -11,24 +11,41 @@ import (
 	"github.com/bnema/dumber/internal/ui/component"
 )
 
-// initFavoritesSidebar creates the native favorites sidebar when favorites are configured.
-func (bw *browserWindow) initFavoritesSidebar(ctx context.Context, a *App) {
-	if bw == nil || a == nil || bw.mainWindow == nil || a.deps == nil || a.deps.FavoritesUC == nil {
-		return
+// newFavoritesSidebarComponent constructs the native favorites sidebar. It is
+// a package-level seam so headless tests can observe on-demand construction
+// without instantiating GTK widgets.
+var newFavoritesSidebarComponent = component.NewFavoritesSidebar
+
+// ensureFavoritesSidebar constructs the favorites sidebar on first request.
+// Construction is separated from mounting and shared visibility mutation:
+// the caller mounts and reveals through mountNativeSidebar/showFavoritesSidebar.
+// The component lifetime is detached from the caller's request context via
+// context.WithoutCancel so a short-lived window-creation or shortcut context
+// cannot cancel the sidebar's in-flight loads. It returns false when the
+// window, dependencies, or native construction are unavailable.
+func (bw *browserWindow) ensureFavoritesSidebar(ctx context.Context, a *App) bool {
+	if bw == nil || a == nil || bw.mainWindow == nil {
+		return false
+	}
+	if bw.favoritesSidebar != nil {
+		return true
+	}
+	if a.deps == nil || a.deps.FavoritesUC == nil {
+		return false
 	}
 	log := logging.FromContext(ctx)
 
 	cfg := a.buildFavoritesSidebarConfig(bw)
-	sidebar := component.NewFavoritesSidebar(ctx, cfg)
+	sidebar := newFavoritesSidebarComponent(context.WithoutCancel(ctx), cfg)
 	if sidebar == nil {
 		log.Warn().Msg("failed to create favorites sidebar")
-		return
+		return false
 	}
 
 	bw.favoritesSidebar = sidebar
-	bw.favoritesSidebar.Hide()
 	bw.applySidebarWidthConfig(a)
 	log.Debug().Msg("favorites sidebar initialized")
+	return true
 }
 
 //nolint:dupl // Favorites and history sidebar configs intentionally mirror each other for separate component types.
@@ -104,12 +121,12 @@ func (a *App) toggleFavoritesSidebarAction(ctx context.Context) error {
 	if bw == nil {
 		return fmt.Errorf("favorites sidebar unavailable: no focused browser window")
 	}
-	if bw.favoritesSidebar == nil {
-		return fmt.Errorf("favorites sidebar unavailable: native sidebar not initialized")
-	}
 	if bw.sidebarVisible && bw.activeSidebarKind == nativeSidebarFavorites {
 		a.hideAndRestoreFocusForBrowserWindow(bw)
 		return nil
+	}
+	if !bw.ensureFavoritesSidebar(ctx, a) {
+		return fmt.Errorf("favorites sidebar unavailable: native sidebar not initialized")
 	}
 	bw.toggleFavoritesSidebar()
 	return nil

--- a/internal/ui/browser_window_history_sidebar.go
+++ b/internal/ui/browser_window_history_sidebar.go
@@ -13,7 +13,8 @@ import (
 
 // newHistorySidebarComponent constructs the native history sidebar. It is a
 // package-level seam so headless tests can observe on-demand construction
-// without instantiating GTK widgets.
+// without instantiating GTK widgets. Mutable global: tests must restore it
+// via defer and must not use t.Parallel alongside seam users.
 var newHistorySidebarComponent = component.NewHistorySidebar
 
 // ensureHistorySidebar constructs the history sidebar on first request.

--- a/internal/ui/browser_window_history_sidebar.go
+++ b/internal/ui/browser_window_history_sidebar.go
@@ -11,36 +11,48 @@ import (
 	"github.com/bnema/dumber/internal/ui/window"
 )
 
-// initHistorySidebar creates and mounts the history sidebar into the
-// browser window's sidebar container. The sidebar is hidden by default.
-func (bw *browserWindow) initHistorySidebar(ctx context.Context, a *App) {
-	if bw == nil || a == nil || bw.mainWindow == nil || a.deps == nil || a.deps.HistoryUC == nil {
-		return
+// newHistorySidebarComponent constructs the native history sidebar. It is a
+// package-level seam so headless tests can observe on-demand construction
+// without instantiating GTK widgets.
+var newHistorySidebarComponent = component.NewHistorySidebar
+
+// ensureHistorySidebar constructs the history sidebar on first request.
+// Construction is separated from mounting and shared visibility mutation:
+// the caller mounts and reveals through mountNativeSidebar/showHistorySidebar.
+// The component lifetime is detached from the caller's request context via
+// context.WithoutCancel so a short-lived window-creation or shortcut context
+// cannot cancel the sidebar's in-flight loads. It returns false when the
+// window, dependencies, or native construction are unavailable.
+func (bw *browserWindow) ensureHistorySidebar(ctx context.Context, a *App) bool {
+	if bw == nil || a == nil || bw.mainWindow == nil {
+		return false
+	}
+	if bw.historySidebar != nil {
+		return true
+	}
+	if a.deps == nil || a.deps.HistoryUC == nil {
+		return false
 	}
 	log := logging.FromContext(ctx)
 
 	cfg := a.buildHistorySidebarConfig(bw)
 
-	sidebar := component.NewHistorySidebar(ctx, cfg)
+	sidebar := newHistorySidebarComponent(context.WithoutCancel(ctx), cfg)
 	if sidebar == nil {
 		log.Warn().Msg("failed to create history sidebar")
-		return
+		return false
 	}
 
 	bw.historySidebar = sidebar
 
-	// Mount into the main window's sidebar box.
-	bw.mainWindow.SetSidebarWidget(sidebar.Widget())
-	bw.historySidebar.Hide()
-	bw.mainWindow.SetSidebarVisible(false)
-	bw.sidebarVisible = false
-	bw.activeSidebarKind = nativeSidebarNone
-
 	// Apply sidebar width from config, falling back to the default 320px.
 	// The width is clamped to [280, 380] by SetSidebarWidth internally.
+	// Visibility is left untouched: the sidebar container keeps whatever
+	// panel (or none) is currently mounted until the caller reveals history.
 	bw.applySidebarWidthConfig(a)
 
 	log.Debug().Msg("history sidebar initialized")
+	return true
 }
 
 // buildHistorySidebarConfig constructs the HistorySidebarConfig for the given
@@ -164,18 +176,20 @@ func (bw *browserWindow) applySidebarWidthConfig(a *App) {
 }
 
 // toggleHistorySidebarAction is the keyboard-action handler for toggling the
-// history sidebar on the last focused browser window.
+// history sidebar on the last focused browser window. It ensures on-demand
+// construction before testing availability so shortcuts work without eager
+// window-creation work.
 func (a *App) toggleHistorySidebarAction(ctx context.Context) error {
 	bw := a.lastFocusedBrowserWindow()
 	if bw == nil {
 		return fmt.Errorf("history sidebar unavailable: no focused browser window")
 	}
-	if bw.historySidebar == nil {
-		return fmt.Errorf("history sidebar unavailable: native sidebar not initialized")
-	}
 	if bw.sidebarVisible && bw.activeSidebarKind == nativeSidebarHistory {
 		a.hideAndRestoreFocusForBrowserWindow(bw)
 		return nil
+	}
+	if !bw.ensureHistorySidebar(ctx, a) {
+		return fmt.Errorf("history sidebar unavailable: native sidebar not initialized")
 	}
 	bw.toggleHistorySidebar()
 	return nil

--- a/internal/ui/browser_window_sidebar_laziness_test.go
+++ b/internal/ui/browser_window_sidebar_laziness_test.go
@@ -1,0 +1,193 @@
+package ui
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bnema/dumber/internal/application/dto"
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/ui/component"
+	"github.com/bnema/dumber/internal/ui/window"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowCreation_DoesNotConstructHiddenSidebars(t *testing.T) {
+	ctx := context.Background()
+	app := &App{
+		deps: &Dependencies{
+			HistoryUC:   usecase.NewSearchHistoryUseCase(nil),
+			FavoritesUC: usecase.NewManageFavoritesUseCase(nil, nil),
+		},
+		browserWindows: map[string]*browserWindow{},
+	}
+	app.browserWindowFactory = func(ctx context.Context, url string) (*browserWindow, error) {
+		return &browserWindow{id: "w-1", initialURL: url, mainWindow: &window.MainWindow{}}, nil
+	}
+
+	created, err := app.createBrowserWindow(ctx, "https://example.com")
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Nil(t, created.historySidebar, "window creation must not construct the hidden history panel")
+	assert.Nil(t, created.favoritesSidebar, "window creation must not construct the hidden favorites panel")
+	assert.False(t, created.sidebarVisible)
+	assert.Equal(t, nativeSidebarNone, created.activeSidebarKind)
+}
+
+func TestEnsureSidebars_ConstructOnceAndReuse(t *testing.T) {
+	ctx := context.Background()
+	var historyConstructions atomic.Int64
+	var favoritesConstructions atomic.Int64
+	releaseHistorySeam := stubHistorySidebarConstructor(&historyConstructions)
+	defer releaseHistorySeam()
+	releaseFavoritesSeam := stubFavoritesSidebarConstructor(&favoritesConstructions)
+	defer releaseFavoritesSeam()
+
+	app := &App{
+		deps: &Dependencies{
+			HistoryUC:   usecase.NewSearchHistoryUseCase(nil),
+			FavoritesUC: usecase.NewManageFavoritesUseCase(nil, nil),
+		},
+		browserWindows: map[string]*browserWindow{},
+	}
+	bw := &browserWindow{id: "w-1", mainWindow: &window.MainWindow{}}
+	app.browserWindows[bw.id] = bw
+
+	require.True(t, bw.ensureHistorySidebar(ctx, app))
+	require.True(t, bw.ensureFavoritesSidebar(ctx, app))
+	assert.EqualValues(t, 1, historyConstructions.Load())
+	assert.EqualValues(t, 1, favoritesConstructions.Load())
+
+	// Reopening resolves the same instance without reconstructing.
+	firstHistory := bw.historySidebar
+	firstFavorites := bw.favoritesSidebar
+	require.True(t, bw.ensureHistorySidebar(ctx, app))
+	require.True(t, bw.ensureFavoritesSidebar(ctx, app))
+	assert.Same(t, firstHistory, bw.historySidebar)
+	assert.Same(t, firstFavorites, bw.favoritesSidebar)
+	assert.EqualValues(t, 1, historyConstructions.Load())
+	assert.EqualValues(t, 1, favoritesConstructions.Load())
+}
+
+func TestEnsureSidebars_UnavailableWithoutDeps(t *testing.T) {
+	ctx := context.Background()
+	bw := &browserWindow{id: "w-1", mainWindow: &window.MainWindow{}}
+	assert.False(t, bw.ensureHistorySidebar(ctx, &App{}))
+	assert.False(t, bw.ensureFavoritesSidebar(ctx, &App{}))
+	assert.False(t, (&browserWindow{}).ensureHistorySidebar(ctx, &App{deps: &Dependencies{}}))
+	assert.False(t, (&browserWindow{}).ensureFavoritesSidebar(ctx, &App{deps: &Dependencies{}}))
+	assert.False(t, (*browserWindow)(nil).ensureHistorySidebar(ctx, &App{}))
+	assert.False(t, (*browserWindow)(nil).ensureFavoritesSidebar(ctx, &App{}))
+}
+
+func TestToggleActions_EnsureOnDemandAndHideWithoutConstruction(t *testing.T) {
+	ctx := context.Background()
+	var historyConstructions atomic.Int64
+	releaseHistorySeam := stubHistorySidebarConstructor(&historyConstructions)
+	defer releaseHistorySeam()
+
+	// Close-before-open does nothing and constructs nothing.
+	quiet := &browserWindow{id: "quiet", mainWindow: &window.MainWindow{}}
+	quiet.hideHistorySidebar()
+	quiet.hideFavoritesSidebar()
+	quiet.toggleHistorySidebar()
+	quiet.toggleFavoritesSidebar()
+	assert.False(t, quiet.sidebarVisible)
+	assert.Zero(t, historyConstructions.Load())
+
+	// Keyboard shortcut constructs on first open.
+	app := &App{
+		deps:                &Dependencies{HistoryUC: usecase.NewSearchHistoryUseCase(nil)},
+		browserWindows:      map[string]*browserWindow{quiet.id: quiet},
+		lastFocusedWindowID: quiet.id,
+	}
+	require.NoError(t, app.toggleHistorySidebarAction(ctx))
+	assert.EqualValues(t, 1, historyConstructions.Load())
+	assert.True(t, quiet.sidebarVisible)
+	assert.Equal(t, nativeSidebarHistory, quiet.activeSidebarKind)
+
+	// Closing the visible panel hides without further construction.
+	require.NoError(t, app.toggleHistorySidebarAction(ctx))
+	assert.False(t, quiet.sidebarVisible)
+	assert.Equal(t, nativeSidebarNone, quiet.activeSidebarKind)
+	assert.EqualValues(t, 1, historyConstructions.Load())
+
+	// Reopening reuses the retained instance.
+	require.NoError(t, app.toggleHistorySidebarAction(ctx))
+	assert.True(t, quiet.sidebarVisible)
+	assert.EqualValues(t, 1, historyConstructions.Load())
+}
+
+func TestToggleActions_ErrorWhenUnavailable(t *testing.T) {
+	ctx := context.Background()
+	app := &App{browserWindows: map[string]*browserWindow{"w": {id: "w"}}, lastFocusedWindowID: "w"}
+	require.ErrorContains(t, app.toggleHistorySidebarAction(ctx), "history sidebar unavailable")
+	require.ErrorContains(t, app.toggleFavoritesSidebarAction(ctx), "favorites sidebar unavailable")
+
+	empty := &App{}
+	require.ErrorContains(t, empty.toggleHistorySidebarAction(ctx), "no focused browser window")
+	require.ErrorContains(t, empty.toggleFavoritesSidebarAction(ctx), "no focused browser window")
+}
+
+func TestSidebarConfigReload_DoesNotConstructPanels(t *testing.T) {
+	ctx := context.Background()
+	bw := &browserWindow{id: "w-1", mainWindow: &window.MainWindow{}}
+	app := &App{
+		deps: &Dependencies{
+			HistoryUC:   usecase.NewSearchHistoryUseCase(nil),
+			FavoritesUC: usecase.NewManageFavoritesUseCase(nil, nil),
+		},
+		browserWindows:      map[string]*browserWindow{bw.id: bw},
+		lastFocusedWindowID: bw.id,
+	}
+	app.runtimeConfig = newRuntimeConfigState(nil)
+
+	app.applyRuntimeConfigChange(ctx, app.runtimeConfigSnapshot())
+	assert.Nil(t, bw.historySidebar)
+	assert.Nil(t, bw.favoritesSidebar)
+
+	app.reloadVisibleFavoritesSidebars("config-reload")
+	app.refreshVisibleHistorySidebars(dto.HistoryChange{})
+	assert.Nil(t, bw.historySidebar)
+	assert.Nil(t, bw.favoritesSidebar)
+}
+
+func TestEnsureSidebars_MultipleWindowsIndependent(t *testing.T) {
+	ctx := context.Background()
+	var historyConstructions atomic.Int64
+	releaseHistorySeam := stubHistorySidebarConstructor(&historyConstructions)
+	defer releaseHistorySeam()
+
+	app := &App{
+		deps:           &Dependencies{HistoryUC: usecase.NewSearchHistoryUseCase(nil)},
+		browserWindows: map[string]*browserWindow{},
+	}
+	first := &browserWindow{id: "w-1", mainWindow: &window.MainWindow{}}
+	second := &browserWindow{id: "w-2", mainWindow: &window.MainWindow{}}
+	app.browserWindows[first.id] = first
+	app.browserWindows[second.id] = second
+
+	require.True(t, first.ensureHistorySidebar(ctx, app))
+	assert.NotNil(t, first.historySidebar)
+	assert.Nil(t, second.historySidebar)
+	assert.EqualValues(t, 1, historyConstructions.Load())
+}
+
+func stubHistorySidebarConstructor(calls *atomic.Int64) func() {
+	previous := newHistorySidebarComponent
+	newHistorySidebarComponent = func(ctx context.Context, cfg component.HistorySidebarConfig) *component.HistorySidebar {
+		calls.Add(1)
+		return &component.HistorySidebar{}
+	}
+	return func() { newHistorySidebarComponent = previous }
+}
+
+func stubFavoritesSidebarConstructor(calls *atomic.Int64) func() {
+	previous := newFavoritesSidebarComponent
+	newFavoritesSidebarComponent = func(ctx context.Context, cfg component.FavoritesSidebarConfig) *component.FavoritesSidebar {
+		calls.Add(1)
+		return &component.FavoritesSidebar{}
+	}
+	return func() { newFavoritesSidebarComponent = previous }
+}

--- a/internal/ui/component/favorites_sidebar.go
+++ b/internal/ui/component/favorites_sidebar.go
@@ -81,7 +81,11 @@ type FavoritesSidebar struct {
 	idleScheduler func(glib.SourceFunc)
 }
 
-// NewFavoritesSidebar creates a native favorites sidebar and starts loading data.
+// NewFavoritesSidebar creates a native favorites sidebar without loading
+// data. The initial load runs on the first Show so on-demand instances
+// (see the host ensure methods) issue exactly one GetAll/GetAllTags batch
+// instead of a discarded constructor generation plus the Show reload.
+// Reopening reloads through Show as before.
 func NewFavoritesSidebar(ctx context.Context, cfg FavoritesSidebarConfig) *FavoritesSidebar {
 	ctx, cancel := context.WithCancel(ctx)
 	fs := &FavoritesSidebar{
@@ -100,7 +104,6 @@ func NewFavoritesSidebar(ctx context.Context, cfg FavoritesSidebarConfig) *Favor
 	}
 	fs.setupSearchHandler()
 	fs.setupKeyboardNavigation()
-	fs.startLoad()
 	return fs
 }
 

--- a/internal/ui/component/favorites_sidebar_test.go
+++ b/internal/ui/component/favorites_sidebar_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -45,9 +46,12 @@ type fakeFavoritesSidebarUC struct {
 	errOnUntag       map[entity.TagID]error
 	failUntagOnCall  int
 	getAllCalled     chan struct{}
+	getAllCalls      atomic.Int64
+	getAllTagsCalls  atomic.Int64
 }
 
 func (f *fakeFavoritesSidebarUC) GetAll(context.Context) ([]*entity.Favorite, error) {
+	f.getAllCalls.Add(1)
 	if f.getAllCalled != nil {
 		select {
 		case f.getAllCalled <- struct{}{}:
@@ -57,6 +61,7 @@ func (f *fakeFavoritesSidebarUC) GetAll(context.Context) ([]*entity.Favorite, er
 	return f.favorites, f.err
 }
 func (f *fakeFavoritesSidebarUC) GetAllTags(context.Context) ([]*entity.Tag, error) {
+	f.getAllTagsCalls.Add(1)
 	return f.tags, f.err
 }
 func (f *fakeFavoritesSidebarUC) AddTag(_ context.Context, name, color string) (*entity.Tag, error) {
@@ -750,4 +755,37 @@ func TestFavoritesSidebarErrorsPreserveStateAndShowNotice(t *testing.T) {
 	assert.True(t, fs.submitForm())
 	assert.Equal(t, favoritesSidebarModeAdd, fs.mode)
 	assert.Equal(t, "add failed", fs.notice)
+}
+
+// TestFavoritesSidebar_FirstShowIssuesSingleQueryBatch proves the lazy-load
+// contract behind the on-demand host: a fresh instance issues zero queries
+// (construction performs no load), the first Show-equivalent load issues
+// exactly one GetAll/GetAllTags batch, and reopening reloads with one more
+// batch according to existing semantics.
+func TestFavoritesSidebar_FirstShowIssuesSingleQueryBatch(t *testing.T) {
+	fav := &entity.Favorite{ID: 1, URL: "https://example.com", Title: "Example"}
+	fs := newFavoritesSidebarHarness([]*entity.Favorite{fav}, nil)
+	uc := fs.favoritesUC.(*fakeFavoritesSidebarUC)
+	fs.ctx = context.Background()
+
+	// Fresh instance: construction must not have queried anything.
+	assert.Zero(t, uc.getAllCalls.Load())
+	assert.Zero(t, uc.getAllTagsCalls.Load())
+
+	// First Show issues exactly one batch.
+	fs.startLoad()
+	require.Eventually(t, func() bool {
+		fs.mu.RLock()
+		defer fs.mu.RUnlock()
+		return len(fs.allFavorites) == 1
+	}, 10*time.Second, 5*time.Millisecond, "first Show load must apply fetched favorites")
+	assert.EqualValues(t, 1, uc.getAllCalls.Load(), "first Show must issue exactly one GetAll batch")
+	assert.EqualValues(t, 1, uc.getAllTagsCalls.Load(), "first Show must issue exactly one GetAllTags batch")
+	assert.Equal(t, "https://example.com", fs.allFavorites[0].URL)
+
+	// Reopen reloads with one more batch.
+	fs.startLoad()
+	require.Eventually(t, func() bool {
+		return uc.getAllCalls.Load() == 2 && uc.getAllTagsCalls.Load() == 2
+	}, 10*time.Second, 5*time.Millisecond, "reopen must reload with one more batch")
 }

--- a/internal/ui/component/history_sidebar.go
+++ b/internal/ui/component/history_sidebar.go
@@ -138,7 +138,11 @@ type HistorySidebarConfig struct {
 	OnClose func()
 }
 
-// NewHistorySidebar creates a new HistorySidebar component.
+// NewHistorySidebar creates a new HistorySidebar component. Construction
+// performs no data queries: the initial load runs on the first Show so
+// on-demand instances (see the host ensure methods) never pay for a
+// discarded constructor generation before Show schedules its own Reload.
+// Reopening reloads through Show as before.
 func NewHistorySidebar(ctx context.Context, cfg HistorySidebarConfig) *HistorySidebar {
 	ctx, cancel := context.WithCancel(ctx)
 	log := logging.FromContext(ctx).With().Str("component", "history-sidebar").Logger()
@@ -197,9 +201,6 @@ func NewHistorySidebar(ctx context.Context, cfg HistorySidebarConfig) *HistorySi
 	hs.setupKeyboardNavigation()
 
 	log.Debug().Msg("history sidebar created")
-
-	// Start loading history asynchronously (background goroutine)
-	hs.startLoadHistory()
 
 	return hs
 }

--- a/internal/ui/component/history_sidebar_search_test.go
+++ b/internal/ui/component/history_sidebar_search_test.go
@@ -367,3 +367,57 @@ func TestFetchPage_StaleGenerationDoesNotMutateLoadingState(t *testing.T) {
 	assert.Equal(t, 0, hs.totalLoaded, "stale results must not update totalLoaded")
 	hs.mu.RUnlock()
 }
+
+// =============================================================================
+// First-Show single query batch: no constructor load, one batch per Show
+// =============================================================================
+
+// TestHistorySidebar_FirstShowIssuesSingleQueryBatch proves the lazy-load
+// contract behind the on-demand host: a fresh instance issues zero queries
+// (construction performs no load), the first Show-equivalent Reload issues
+// exactly one GetRecent batch, and reopening reloads with one more batch
+// according to existing semantics.
+func TestHistorySidebar_FirstShowIssuesSingleQueryBatch(t *testing.T) {
+	entries := []*entity.HistoryEntry{
+		{ID: 1, URL: "https://example.com", Title: "Example", LastVisited: time.Now()},
+	}
+	history := portmocks.NewMockHistorySidebarHistory(t)
+	history.EXPECT().
+		GetRecent(mock.Anything, sidebarPageSize, 0).
+		RunAndReturn(func(context.Context, int, int) ([]*entity.HistoryEntry, error) {
+			return entries, nil
+		}).
+		Times(2)
+
+	hs := newTestSidebarSearchHarness()
+	hs.historyUC = history
+	hs.ctx = t.Context()
+	hs.idleScheduler = func(cb glib.SourceFunc) { cb(0) }
+
+	// Fresh instance: construction must not have queried anything (the mock
+	// fails the test on any unexpected call at cleanup).
+	hs.mu.RLock()
+	assert.False(t, hs.loadStarted)
+	assert.False(t, hs.loadDone)
+	hs.mu.RUnlock()
+
+	waitLoaded := func(want int) {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			hs.mu.RLock()
+			defer hs.mu.RUnlock()
+			return hs.loadDone && len(hs.allEntries) == want
+		}, 10*time.Second, 5*time.Millisecond, "Show load must apply fetched entries")
+	}
+
+	// First Show loads exactly one batch.
+	hs.Reload()
+	waitLoaded(1)
+	hs.mu.RLock()
+	assert.Equal(t, "https://example.com", hs.allEntries[0].URL)
+	hs.mu.RUnlock()
+
+	// Reopen reloads with one more batch (Times(2) enforces the exact count).
+	hs.Reload()
+	waitLoaded(1)
+}

--- a/internal/ui/component/logo.go
+++ b/internal/ui/component/logo.go
@@ -2,6 +2,7 @@
 package component
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/bnema/dumber/assets"
@@ -9,26 +10,45 @@ import (
 	"github.com/bnema/puregotk/v4/glib"
 )
 
+var errLogoDecode = errors.New("logo decode failed")
+
 var (
 	logoTexture     *gdk.Texture
 	logoTextureOnce sync.Once
+	// logoAssetBytes supplies the raster logo bytes. Overridden in tests to
+	// count requests without native decoding.
+	logoAssetBytes = func() []byte { return assets.LogoPNG512 }
+	// logoDecodeTexture converts raster bytes to a texture. Overridden in
+	// tests with a fake; production keeps GBytes/texture lifetime by
+	// releasing the temporary byte reference after the native constructor
+	// no longer needs it.
+	logoDecodeTexture = func(data []byte) (*gdk.Texture, error) {
+		bytes := glib.NewBytes(data, uint(len(data)))
+		if bytes == nil {
+			return nil, errLogoDecode
+		}
+		texture, err := gdk.NewTextureFromBytes(bytes)
+		bytes.Unref()
+		if err != nil {
+			return nil, err
+		}
+		return texture, nil
+	}
 )
 
 // GetLogoTexture returns a cached GDK texture of the dumber logo.
 // Safe to call from any goroutine; lazily initializes on first call.
+// Decodes the packaged 512-pixel PNG raster asset; the displayed size and
+// one-texture-per-process lifetime are unchanged.
 // Returns nil if the logo cannot be loaded.
 func GetLogoTexture() *gdk.Texture {
 	logoTextureOnce.Do(func() {
-		data := assets.LogoSVG
+		data := logoAssetBytes()
 		if len(data) == 0 {
 			return
 		}
-		bytes := glib.NewBytes(data, uint(len(data)))
-		if bytes == nil {
-			return
-		}
-		texture, err := gdk.NewTextureFromBytes(bytes)
-		if err != nil {
+		texture, err := logoDecodeTexture(data)
+		if err != nil || texture == nil {
 			return
 		}
 		logoTexture = texture

--- a/internal/ui/component/logo_test.go
+++ b/internal/ui/component/logo_test.go
@@ -1,0 +1,97 @@
+package component
+
+import (
+	"encoding/binary"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bnema/dumber/assets"
+	"github.com/bnema/puregotk/v4/gdk"
+	"github.com/stretchr/testify/require"
+)
+
+func resetLogoForTest() {
+	logoTexture = nil
+	logoTextureOnce = sync.Once{}
+}
+
+func TestLogoPNG512AssetSignatureAndDimensions(t *testing.T) {
+	data := assets.LogoPNG512
+	require.NotEmpty(t, data)
+	require.Equal(t, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, data[:8])
+	require.GreaterOrEqual(t, len(data), 33)
+	require.Equal(t, "IHDR", string(data[12:16]))
+	width := binary.BigEndian.Uint32(data[16:20])
+	height := binary.BigEndian.Uint32(data[20:24])
+	require.Equal(t, uint32(512), width)
+	require.Equal(t, uint32(512), height)
+	require.NotEmpty(t, assets.LogoSVG, "SVG source for desktop icons must remain")
+}
+
+func TestGetLogoTextureRequestsRasterOnce(t *testing.T) {
+	resetLogoForTest()
+	origAsset, origDecode := logoAssetBytes, logoDecodeTexture
+	defer func() {
+		logoAssetBytes, logoDecodeTexture = origAsset, origDecode
+		resetLogoForTest()
+	}()
+	var calls atomic.Int32
+	logoAssetBytes = func() []byte {
+		calls.Add(1)
+		return assets.LogoPNG512
+	}
+	logoDecodeTexture = func(data []byte) (*gdk.Texture, error) {
+		require.Equal(t, assets.LogoPNG512, data)
+		return nil, errors.New("native unavailable in unit test")
+	}
+	require.NotPanics(t, func() {
+		require.Nil(t, GetLogoTexture())
+		require.Nil(t, GetLogoTexture())
+	})
+	require.Equal(t, int32(1), calls.Load(), "raster bytes must be requested once")
+}
+
+func TestGetLogoTextureConcurrentCallersShareResult(t *testing.T) {
+	resetLogoForTest()
+	origAsset, origDecode := logoAssetBytes, logoDecodeTexture
+	defer func() {
+		logoAssetBytes, logoDecodeTexture = origAsset, origDecode
+		resetLogoForTest()
+	}()
+	var calls atomic.Int32
+	logoAssetBytes = func() []byte {
+		calls.Add(1)
+		return assets.LogoPNG512
+	}
+	logoDecodeTexture = func([]byte) (*gdk.Texture, error) {
+		return nil, errors.New("native unavailable in unit test")
+	}
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = GetLogoTexture()
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestGetLogoTextureFailureDoesNotPanic(t *testing.T) {
+	resetLogoForTest()
+	origAsset, origDecode := logoAssetBytes, logoDecodeTexture
+	defer func() {
+		logoAssetBytes, logoDecodeTexture = origAsset, origDecode
+		resetLogoForTest()
+	}()
+	logoAssetBytes = func() []byte { return nil }
+	logoDecodeTexture = func([]byte) (*gdk.Texture, error) {
+		return nil, errors.New("must not be called with empty asset")
+	}
+	require.NotPanics(t, func() {
+		require.Nil(t, GetLogoTexture())
+	})
+}

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -1,0 +1,46 @@
+package ui
+
+import "time"
+
+// ResidencyTimeoutFromMillis resolves the effective bounded-residency idle
+// timeout for CEF from the startup configuration value in milliseconds.
+// Values outside 0..300000 are rejected by config validation; this resolver
+// additionally clamps defensively so an unvalidated caller can never arm an
+// unbounded or negative deadline.
+func ResidencyTimeoutFromMillis(timeoutMs int) time.Duration {
+	if timeoutMs <= 0 {
+		return 0
+	}
+	if timeoutMs > 300000 {
+		timeoutMs = 300000
+	}
+	return time.Duration(timeoutMs) * time.Millisecond
+}
+
+// SetResidencyTimeout latches the effective idle timeout once at process
+// startup. Call it before App.Run; later config reloads must use
+// ResidencyTimeoutRestartRequired instead of calling this again.
+func (a *App) SetResidencyTimeout(timeout time.Duration) {
+	if a == nil {
+		return
+	}
+	a.residencyTimeout = timeout
+}
+
+// LatchedResidencyTimeout returns the startup-latched idle timeout.
+func (a *App) LatchedResidencyTimeout() time.Duration {
+	if a == nil {
+		return 0
+	}
+	return a.residencyTimeout
+}
+
+// ResidencyTimeoutRestartRequired reports whether a reloaded configuration
+// value differs from the startup latch. A true result means the process must
+// restart to apply it; residency is never partially hot-applied.
+func (a *App) ResidencyTimeoutRestartRequired(timeoutMs int) bool {
+	if a == nil {
+		return false
+	}
+	return ResidencyTimeoutFromMillis(timeoutMs) != a.residencyTimeout
+}

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/bnema/dumber/internal/infrastructure/process"
+	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/glib"
 )
 
@@ -89,6 +90,9 @@ type ResidencyController struct {
 	pendingQuit   bool
 	quiescent     func() bool
 	dispatchToGTK func(func())
+	// seal stops new admissions before a quit commits, closing the race
+	// between the quiescence recheck and admitted work starting.
+	seal func()
 
 	timerCallback *glib.SourceFunc
 	timerTag      uint
@@ -157,6 +161,8 @@ func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecisio
 	for c.lastWindows < count {
 		c.lastWindows++
 		events = true
+		// A reopened window invalidates any deferred quit.
+		c.pendingQuit = false
 		decision = c.apply(c.policy.WindowOpened(now))
 	}
 	for c.lastWindows > count {
@@ -168,6 +174,10 @@ func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecisio
 		// No windows were ever reported (e.g. activation failure):
 		// evaluate once so the process reaches bounded idle or orderly
 		// shutdown instead of idling forever on the residency hold.
+		// An already-armed idle state stays put instead of re-arming.
+		if c.policy.IdleArmed() {
+			return usecase.ResidencyDecision{Action: usecase.ResidencyNone, Generation: c.policy.Generation()}
+		}
 		decision = c.apply(c.policy.WindowClosed(now))
 	}
 	return decision
@@ -231,7 +241,17 @@ func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.
 // Otherwise it defers: the next settling source rechecks via MaybeQuit.
 // Disabled residency quits unconditionally, preserving pre-existing behavior.
 func (c *ResidencyController) requestQuit() {
-	if c.enabled && c.quiescent != nil && !c.quiescent() {
+	if !c.enabled {
+		c.pendingQuit = false
+		c.doQuit()
+		return
+	}
+	// Seal admission first so no new work starts between the recheck and
+	// the quit. Draining leases then settle through MaybeQuit.
+	if c.seal != nil {
+		c.seal()
+	}
+	if c.quiescent != nil && !c.quiescent() {
 		c.pendingQuit = true
 		return
 	}
@@ -241,8 +261,14 @@ func (c *ResidencyController) requestQuit() {
 
 // MaybeQuit rechecks a deferred quit after sources settle. It is invoked
 // from settle callbacks (already dispatched to GTK) and busy transitions.
+// A reopened window invalidates the deferral: quitting then would bypass
+// the fresh idle interval.
 func (c *ResidencyController) MaybeQuit() {
 	if c == nil || !c.pendingQuit || c.quitting {
+		return
+	}
+	if c.lastWindows > 0 {
+		c.pendingQuit = false
 		return
 	}
 	if c.quiescent != nil && !c.quiescent() {
@@ -269,6 +295,16 @@ func (c *ResidencyController) SetDispatchToGTK(fn func(func())) {
 		return
 	}
 	c.dispatchToGTK = fn
+}
+
+// SetSealFunc installs the admission seal invoked before an enabled quit
+// commits, so no new relay work starts between the quiescence recheck and
+// the quit.
+func (c *ResidencyController) SetSealFunc(fn func()) {
+	if c == nil {
+		return
+	}
+	c.seal = fn
 }
 
 // DispatchToGTK runs fn on the GTK thread through the installed dispatch,
@@ -331,7 +367,12 @@ func (c *ResidencyController) scheduleGLibTimeout(d time.Duration, generation ui
 		ms = 1
 	}
 	callback := glib.SourceFunc(func(_ uintptr) bool {
+		// GLib retires this source on return; drop our tag on entry so a
+		// later cancel can never remove an expired or reused source ID.
+		// The callback stays retained through return.
+		c.timerTag = 0
 		c.OnTimerFired(generation)
+		c.timerCallback = nil
 		return false
 	})
 	c.timerCallback = &callback
@@ -500,5 +541,28 @@ func (a *App) closeRelayAdmission() {
 		if gate := provider.AdmissionGate(); gate != nil {
 			gate.Close()
 		}
+	}
+}
+
+// waitRelayAdmissionDrained settles admitted relay work before persistence
+// teardown within a short bound. Admitted dispatch may need the GTK loop,
+// so the wait never blocks shutdown forever; expiry only logs and the
+// sockets settle through their own completion paths.
+func (a *App) waitRelayAdmissionDrained(ctx context.Context) {
+	if a == nil || a.deps == nil {
+		return
+	}
+	provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider)
+	if !ok || provider == nil {
+		return
+	}
+	gate := provider.AdmissionGate()
+	if gate == nil || gate.Active() == 0 {
+		return
+	}
+	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+	if !gate.WaitDrained(drainCtx) {
+		logging.FromContext(ctx).Warn().Int("admitted", gate.Active()).Msg("relay admission did not drain before teardown")
 	}
 }

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"time"
 
 	"github.com/bnema/dumber/internal/application/port"
@@ -364,6 +365,43 @@ func (a *App) residencyShouldQuitAfterLastWindow() bool {
 		return true
 	}
 	return a.residency.SetWindowCount(len(a.browserWindows)).Action == usecase.ResidencyQuit
+}
+
+// residencyAfterWindowRemoved converges residency accounting after every
+// removal path (close-request, tab-empty, eject, failures) and quits when
+// the policy decides the empty state must exit. Disabled or missing
+// residency preserves unconditional Quit.
+func (a *App) residencyAfterWindowRemoved() {
+	if a == nil {
+		return
+	}
+	decision := a.residencyNoteWindowsChanged()
+	if len(a.browserWindows) == 0 && decision.Action == usecase.ResidencyQuit {
+		a.Quit()
+	}
+}
+
+// CloseAllWindows closes every user window through the standard removal
+// path, converging residency exactly like interactive closes. It runs on
+// the main thread via the window-URL dispatch.
+func (a *App) CloseAllWindows(ctx context.Context) error {
+	return a.dispatchWindowURLWork(ctx, "ui.close_all_windows", "", func(context.Context) error {
+		ids := make([]string, 0, len(a.browserWindows))
+		for id := range a.browserWindows {
+			ids = append(ids, id)
+		}
+		for _, id := range ids {
+			bw, ok := a.browserWindows[id]
+			if !ok || bw == nil {
+				continue
+			}
+			a.removeBrowserWindow(bw.id)
+			if bw.mainWindow != nil {
+				bw.mainWindow.Destroy()
+			}
+		}
+		return nil
+	})
 }
 
 // residencyNoteWindowsChanged converges residency accounting to the current

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -3,9 +3,14 @@ package ui
 import (
 	"time"
 
+	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/puregotk/v4/glib"
 )
+
+// ResidencyTimeoutMaxMs bounds the startup-only idle timeout in milliseconds.
+const ResidencyTimeoutMaxMs = 300000
 
 // ResidencyTimeoutFromMillis resolves the effective bounded-residency idle
 // timeout for CEF from the startup configuration value in milliseconds.
@@ -16,8 +21,8 @@ func ResidencyTimeoutFromMillis(timeoutMs int) time.Duration {
 	if timeoutMs <= 0 {
 		return 0
 	}
-	if timeoutMs > 300000 {
-		timeoutMs = 300000
+	if timeoutMs > ResidencyTimeoutMaxMs {
+		timeoutMs = ResidencyTimeoutMaxMs
 	}
 	return time.Duration(timeoutMs) * time.Millisecond
 }
@@ -75,6 +80,15 @@ type ResidencyController struct {
 	quitting    bool
 	held        bool
 
+	// Native quiescence inputs. Sources report busy/clear transitions;
+	// expiry commits to quit only after admitted work drains and every
+	// source settles. All methods must run on the GTK thread; cross-thread
+	// settle callbacks arrive through dispatchToGTK.
+	nativeBusy    map[string]bool
+	pendingQuit   bool
+	quiescent     func() bool
+	dispatchToGTK func(func())
+
 	timerCallback *glib.SourceFunc
 	timerTag      uint
 }
@@ -82,7 +96,12 @@ type ResidencyController struct {
 // NewResidencyController builds the UI-side residency owner. A zero timeout
 // keeps the controller disabled: decisions then always resolve to the
 // pre-existing last-window exit behavior.
-func NewResidencyController(timeout time.Duration, clock func() time.Time, schedule func(time.Duration, uint64), cancel func(), quit func()) *ResidencyController {
+func NewResidencyController(
+	timeout time.Duration,
+	clock func() time.Time,
+	schedule func(time.Duration, uint64),
+	cancel, quit func(),
+) *ResidencyController {
 	if clock == nil {
 		clock = time.Now
 	}
@@ -163,7 +182,7 @@ func (c *ResidencyController) Evaluate() usecase.ResidencyDecision {
 }
 
 // NoteExplicitQuit records an explicit quit or signal: the timer is
-// cancelled, the policy resolves Quit immediately, and the deadline is never
+// canceled, the policy resolves Quit immediately, and the deadline is never
 // waited on. It never invokes the quit function itself.
 func (c *ResidencyController) NoteExplicitQuit() {
 	if c == nil {
@@ -202,7 +221,88 @@ func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.
 			c.cancel()
 		}
 	case usecase.ResidencyQuit:
-		c.doQuit()
+		c.requestQuit()
+	}
+	return decision
+}
+
+// requestQuit commits to quit only when every native source has settled.
+// Otherwise it defers: the next settling source rechecks via MaybeQuit.
+// Disabled residency quits unconditionally, preserving pre-existing behavior.
+func (c *ResidencyController) requestQuit() {
+	if c.enabled && c.quiescent != nil && !c.quiescent() {
+		c.pendingQuit = true
+		return
+	}
+	c.pendingQuit = false
+	c.doQuit()
+}
+
+// MaybeQuit rechecks a deferred quit after sources settle. It is invoked
+// from settle callbacks (already dispatched to GTK) and busy transitions.
+func (c *ResidencyController) MaybeQuit() {
+	if c == nil || !c.pendingQuit || c.quitting {
+		return
+	}
+	if c.quiescent != nil && !c.quiescent() {
+		return
+	}
+	c.pendingQuit = false
+	c.doQuit()
+}
+
+// SetQuiescentFunc installs the composed quiescence predicate consulted
+// before an expiry commits to quit. A nil predicate means always settled.
+func (c *ResidencyController) SetQuiescentFunc(fn func() bool) {
+	if c == nil {
+		return
+	}
+	c.quiescent = fn
+}
+
+// SetDispatchToGTK installs the cross-thread dispatch used by settle
+// callbacks from CEF, relay, and persistence threads. A nil dispatch
+// invokes callbacks directly (tests only).
+func (c *ResidencyController) SetDispatchToGTK(fn func(func())) {
+	if c == nil {
+		return
+	}
+	c.dispatchToGTK = fn
+}
+
+// DispatchToGTK runs fn on the GTK thread through the installed dispatch,
+// or directly when none is installed. Settle callbacks must use this.
+func (c *ResidencyController) DispatchToGTK(fn func()) {
+	if c == nil || fn == nil {
+		return
+	}
+	if c.dispatchToGTK != nil {
+		c.dispatchToGTK(fn)
+		return
+	}
+	fn()
+}
+
+// SetNativeBusy records one native source busy (true) or settled (false).
+// Transitions drive policy work events so expiry never fires while required
+// work is outstanding; settling also rechecks a deferred quit.
+func (c *ResidencyController) SetNativeBusy(source string, busy bool) usecase.ResidencyDecision {
+	if c == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyNone}
+	}
+	if c.nativeBusy == nil {
+		c.nativeBusy = make(map[string]bool)
+	}
+	if c.nativeBusy[source] == busy {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyNone}
+	}
+	c.nativeBusy[source] = busy
+	var decision usecase.ResidencyDecision
+	if busy {
+		decision = c.apply(c.policy.WorkStarted(c.clock()))
+	} else {
+		decision = c.apply(c.policy.WorkFinished(c.clock()))
+		c.MaybeQuit()
 	}
 	return decision
 }
@@ -222,7 +322,7 @@ func (c *ResidencyController) doQuit() {
 
 // scheduleGLibTimeout arms a one-shot GLib timeout for the idle deadline.
 // The callback is retained on the controller until it fires or is
-// cancelled, and stale generations are rejected by the policy on fire.
+// canceled, and stale generations are rejected by the policy on fire.
 func (c *ResidencyController) scheduleGLibTimeout(d time.Duration, generation uint64) {
 	c.cancelGLibTimeout()
 	ms := uint(d.Milliseconds())
@@ -246,6 +346,16 @@ func (c *ResidencyController) cancelGLibTimeout() {
 	c.timerCallback = nil
 }
 
+// LatchResidencyTimeoutForApp latches the bounded-residency timeout once at
+// startup. Only CEF uses it, and only when nonzero; later config changes
+// are restart-required instead of partially hot-applied.
+func LatchResidencyTimeoutForApp(app *App, timeoutMs int, isCEF bool) {
+	if app == nil || !isCEF {
+		return
+	}
+	app.SetResidencyTimeout(ResidencyTimeoutFromMillis(timeoutMs))
+}
+
 // residencyShouldQuitAfterLastWindow reports whether the app must quit now
 // that no user windows remain. A nil controller (before Run) preserves
 // unconditional Quit.
@@ -263,4 +373,94 @@ func (a *App) residencyNoteWindowsChanged() usecase.ResidencyDecision {
 		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
 	}
 	return a.residency.SetWindowCount(len(a.browserWindows))
+}
+
+// relayAdmissionProvider exposes a relay admission boundary without
+// extending the port interface. It matches desktop's provider structurally.
+type relayAdmissionProvider interface {
+	AdmissionGate() *process.AdmissionGate
+}
+
+// residencyQuiescent composes every native quiescence input: CEF runtime
+// activity, snapshot persistence drain, and relay admission leases.
+func (a *App) residencyQuiescent() bool {
+	if a == nil {
+		return true
+	}
+	if eng, ok := a.engine.(interface{ RuntimeActivity() port.RuntimeActivity }); ok && eng != nil {
+		if act := eng.RuntimeActivity(); act != nil && !act.Snapshot().Quiescent() {
+			return false
+		}
+	}
+	if drain, ok := a.snapshotService.(port.PersistenceDrain); ok && drain != nil && drain.Active() {
+		return false
+	}
+	if a.deps != nil {
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil && gate.Active() > 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// subscribeResidencyQuiescence wires native settle callbacks into the
+// residency controller. CEF activity transitions drive policy work events;
+// persistence and relay settle paths recheck a deferred quit. Every
+// callback crosses into GTK through the controller dispatch: no GTK work
+// runs on CEF callbacks and no per-frame polling observes quiescence.
+func (a *App) subscribeResidencyQuiescence() {
+	r := a.residency
+	if a == nil || r == nil || !r.Enabled() {
+		return
+	}
+	dispatch := func(fn func()) { r.DispatchToGTK(fn) }
+	if eng, ok := a.engine.(interface{ RuntimeActivity() port.RuntimeActivity }); ok && eng != nil {
+		if act := eng.RuntimeActivity(); act != nil {
+			unsubscribe := act.Subscribe(func(snapshot port.RuntimeActivitySnapshot) {
+				busy := !snapshot.Quiescent()
+				dispatch(func() { r.SetNativeBusy("cef-activity", busy) })
+			})
+			a.residencyUnsubscribe = append(a.residencyUnsubscribe, unsubscribe)
+		}
+	}
+	if drain, ok := a.snapshotService.(port.PersistenceDrain); ok && drain != nil {
+		if notifier, ok := drain.(interface{ OnSettled(func()) }); ok {
+			notifier.OnSettled(func() { dispatch(func() { r.MaybeQuit() }) })
+		}
+	}
+	if a.deps != nil {
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil {
+				gate.OnDrained(func() { dispatch(func() { r.MaybeQuit() }) })
+			}
+		}
+	}
+}
+
+// unsubscribeResidencyQuiescence drops native subscriptions at shutdown.
+func (a *App) unsubscribeResidencyQuiescence() {
+	if a == nil {
+		return
+	}
+	for _, unsubscribe := range a.residencyUnsubscribe {
+		if unsubscribe != nil {
+			unsubscribe()
+		}
+	}
+	a.residencyUnsubscribe = nil
+}
+
+// closeRelayAdmission stops relay admission before snapshot/update
+// teardown so no new work starts while persistence drains.
+func (a *App) closeRelayAdmission() {
+	if a == nil || a.deps == nil {
+		return
+	}
+	if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+		if gate := provider.AdmissionGate(); gate != nil {
+			gate.Close()
+		}
+	}
 }

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -1,6 +1,11 @@
 package ui
 
-import "time"
+import (
+	"time"
+
+	"github.com/bnema/dumber/internal/application/usecase"
+	"github.com/bnema/puregotk/v4/glib"
+)
 
 // ResidencyTimeoutFromMillis resolves the effective bounded-residency idle
 // timeout for CEF from the startup configuration value in milliseconds.
@@ -43,4 +48,219 @@ func (a *App) ResidencyTimeoutRestartRequired(timeoutMs int) bool {
 		return false
 	}
 	return ResidencyTimeoutFromMillis(timeoutMs) != a.residencyTimeout
+}
+
+// residencyApplication is the application-lifetime subset used for bounded
+// residency: one hold while opt-in residency is enabled, released exactly
+// once on every Run exit. *gtk.Application satisfies it through embedding.
+type residencyApplication interface {
+	Hold()
+	Release()
+	Quit()
+}
+
+// ResidencyController owns one application hold and the idle timer for
+// bounded opt-in residency. It maps engine-neutral policy decisions to
+// scheduler operations; the clock and timer handles are injected so tests
+// use fakes while production uses the GLib main context. It never sleeps.
+type ResidencyController struct {
+	policy   *usecase.RuntimeResidency
+	clock    func() time.Time
+	schedule func(d time.Duration, generation uint64)
+	cancel   func()
+	quit     func()
+
+	enabled     bool
+	lastWindows int
+	quitting    bool
+	held        bool
+
+	timerCallback *glib.SourceFunc
+	timerTag      uint
+}
+
+// NewResidencyController builds the UI-side residency owner. A zero timeout
+// keeps the controller disabled: decisions then always resolve to the
+// pre-existing last-window exit behavior.
+func NewResidencyController(timeout time.Duration, clock func() time.Time, schedule func(time.Duration, uint64), cancel func(), quit func()) *ResidencyController {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &ResidencyController{
+		policy:   usecase.NewRuntimeResidency(timeout),
+		enabled:  timeout > 0,
+		clock:    clock,
+		schedule: schedule,
+		cancel:   cancel,
+		quit:     quit,
+	}
+}
+
+// Enabled reports whether opt-in residency is active (nonzero latch).
+// A disabled controller resolves every empty state to the pre-existing
+// last-window exit behavior.
+func (c *ResidencyController) Enabled() bool {
+	return c != nil && c.enabled
+}
+
+// AcquireHold takes exactly one application hold for enabled residency.
+// It is a no-op when disabled, already held, or given a nil application.
+// Pair every acquisition with ReleaseHold, typically via defer in Run so
+// all exits (including activation failure) match it exactly once.
+func (c *ResidencyController) AcquireHold(app residencyApplication) {
+	if c == nil || !c.enabled || c.held || app == nil {
+		return
+	}
+	app.Hold()
+	c.held = true
+}
+
+// ReleaseHold releases a previously acquired hold exactly once.
+func (c *ResidencyController) ReleaseHold(app residencyApplication) {
+	if c == nil || !c.held || app == nil {
+		return
+	}
+	c.held = false
+	app.Release()
+}
+
+// SetWindowCount converges the policy to the current user-window count.
+// Opens and closes funnel through here so duplicate or reordered events
+// cannot strand the count. It returns the final decision for this update.
+func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecision {
+	if c == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
+	}
+	now := c.clock()
+	var decision usecase.ResidencyDecision
+	events := false
+	for c.lastWindows < count {
+		c.lastWindows++
+		events = true
+		decision = c.apply(c.policy.WindowOpened(now))
+	}
+	for c.lastWindows > count {
+		c.lastWindows--
+		events = true
+		decision = c.apply(c.policy.WindowClosed(now))
+	}
+	if count == 0 && !events {
+		// No windows were ever reported (e.g. activation failure):
+		// evaluate once so the process reaches bounded idle or orderly
+		// shutdown instead of idling forever on the residency hold.
+		decision = c.apply(c.policy.WindowClosed(now))
+	}
+	return decision
+}
+
+// Evaluate forces one idle evaluation for paths that never report windows
+// (e.g. initial-shell failure). It returns the resulting decision.
+func (c *ResidencyController) Evaluate() usecase.ResidencyDecision {
+	if c == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
+	}
+	return c.apply(c.policy.WindowClosed(c.clock()))
+}
+
+// NoteExplicitQuit records an explicit quit or signal: the timer is
+// cancelled, the policy resolves Quit immediately, and the deadline is never
+// waited on. It never invokes the quit function itself.
+func (c *ResidencyController) NoteExplicitQuit() {
+	if c == nil {
+		return
+	}
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.policy.ShutdownRequested()
+}
+
+// OnTimerFired processes a fired idle timer for the given generation.
+// Stale generations are ignored by the policy.
+func (c *ResidencyController) OnTimerFired(generation uint64) {
+	if c == nil {
+		return
+	}
+	c.apply(c.policy.HandleExpiry(c.clock(), generation))
+}
+
+func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.ResidencyDecision {
+	switch decision.Action {
+	case usecase.ResidencyArm:
+		if c.cancel != nil {
+			c.cancel()
+		}
+		if c.schedule != nil {
+			delay := time.Until(decision.Deadline)
+			if delay < 0 {
+				delay = 0
+			}
+			c.schedule(delay, decision.Generation)
+		}
+	case usecase.ResidencyCancel:
+		if c.cancel != nil {
+			c.cancel()
+		}
+	case usecase.ResidencyQuit:
+		c.doQuit()
+	}
+	return decision
+}
+
+func (c *ResidencyController) doQuit() {
+	if c.quitting {
+		return
+	}
+	c.quitting = true
+	if c.cancel != nil {
+		c.cancel()
+	}
+	if c.quit != nil {
+		c.quit()
+	}
+}
+
+// scheduleGLibTimeout arms a one-shot GLib timeout for the idle deadline.
+// The callback is retained on the controller until it fires or is
+// cancelled, and stale generations are rejected by the policy on fire.
+func (c *ResidencyController) scheduleGLibTimeout(d time.Duration, generation uint64) {
+	c.cancelGLibTimeout()
+	ms := uint(d.Milliseconds())
+	if ms == 0 {
+		ms = 1
+	}
+	callback := glib.SourceFunc(func(_ uintptr) bool {
+		c.OnTimerFired(generation)
+		return false
+	})
+	c.timerCallback = &callback
+	c.timerTag = glib.TimeoutAdd(ms, &callback, 0)
+}
+
+// cancelGLibTimeout drops a pending idle timer and releases its callback.
+func (c *ResidencyController) cancelGLibTimeout() {
+	if c.timerTag != 0 {
+		glib.SourceRemove(c.timerTag)
+		c.timerTag = 0
+	}
+	c.timerCallback = nil
+}
+
+// residencyShouldQuitAfterLastWindow reports whether the app must quit now
+// that no user windows remain. A nil controller (before Run) preserves
+// unconditional Quit.
+func (a *App) residencyShouldQuitAfterLastWindow() bool {
+	if a == nil || a.residency == nil {
+		return true
+	}
+	return a.residency.SetWindowCount(len(a.browserWindows)).Action == usecase.ResidencyQuit
+}
+
+// residencyNoteWindowsChanged converges residency accounting to the current
+// window count after opens, closes, and activation outcomes.
+func (a *App) residencyNoteWindowsChanged() usecase.ResidencyDecision {
+	if a == nil || a.residency == nil {
+		return usecase.ResidencyDecision{Action: usecase.ResidencyQuit}
+	}
+	return a.residency.SetWindowCount(len(a.browserWindows))
 }

--- a/internal/ui/runtime_residency.go
+++ b/internal/ui/runtime_residency.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bnema/dumber/internal/application/port"
 	"github.com/bnema/dumber/internal/application/usecase"
-	"github.com/bnema/dumber/internal/infrastructure/process"
 	"github.com/bnema/dumber/internal/logging"
 	"github.com/bnema/puregotk/v4/glib"
 )
@@ -93,6 +92,10 @@ type ResidencyController struct {
 	// seal stops new admissions before a quit commits, closing the race
 	// between the quiescence recheck and admitted work starting.
 	seal func()
+	// unseal reopens admission when a deferred quit is invalidated (e.g.
+	// a reopened window); without it the surviving process would stay
+	// permanently deaf to relay requests.
+	unseal func()
 
 	timerCallback *glib.SourceFunc
 	timerTag      uint
@@ -161,8 +164,14 @@ func (c *ResidencyController) SetWindowCount(count int) usecase.ResidencyDecisio
 	for c.lastWindows < count {
 		c.lastWindows++
 		events = true
-		// A reopened window invalidates any deferred quit.
-		c.pendingQuit = false
+		// A reopened window invalidates any deferred quit, and with it
+		// the admission seal: the surviving process keeps serving relay.
+		if c.pendingQuit {
+			c.pendingQuit = false
+			if c.unseal != nil {
+				c.unseal()
+			}
+		}
 		decision = c.apply(c.policy.WindowOpened(now))
 	}
 	for c.lastWindows > count {
@@ -221,7 +230,9 @@ func (c *ResidencyController) apply(decision usecase.ResidencyDecision) usecase.
 			c.cancel()
 		}
 		if c.schedule != nil {
-			delay := time.Until(decision.Deadline)
+			// Delay derives from the injected clock, never wall time, so
+			// fake clocks in tests observe the policy deadline exactly.
+			delay := decision.Deadline.Sub(c.clock())
 			if delay < 0 {
 				delay = 0
 			}
@@ -262,13 +273,16 @@ func (c *ResidencyController) requestQuit() {
 // MaybeQuit rechecks a deferred quit after sources settle. It is invoked
 // from settle callbacks (already dispatched to GTK) and busy transitions.
 // A reopened window invalidates the deferral: quitting then would bypass
-// the fresh idle interval.
+// the fresh idle interval, so admission reopens with it.
 func (c *ResidencyController) MaybeQuit() {
 	if c == nil || !c.pendingQuit || c.quitting {
 		return
 	}
 	if c.lastWindows > 0 {
 		c.pendingQuit = false
+		if c.unseal != nil {
+			c.unseal()
+		}
 		return
 	}
 	if c.quiescent != nil && !c.quiescent() {
@@ -305,6 +319,15 @@ func (c *ResidencyController) SetSealFunc(fn func()) {
 		return
 	}
 	c.seal = fn
+}
+
+// SetUnsealFunc installs the admission reopen invoked when a deferred quit
+// is invalidated by a reopened window.
+func (c *ResidencyController) SetUnsealFunc(fn func()) {
+	if c == nil {
+		return
+	}
+	c.unseal = fn
 }
 
 // DispatchToGTK runs fn on the GTK thread through the installed dispatch,
@@ -456,8 +479,9 @@ func (a *App) residencyNoteWindowsChanged() usecase.ResidencyDecision {
 
 // relayAdmissionProvider exposes a relay admission boundary without
 // extending the port interface. It matches desktop's provider structurally.
+// The boundary type keeps application code off the concrete gate.
 type relayAdmissionProvider interface {
-	AdmissionGate() *process.AdmissionGate
+	AdmissionGate() port.AdmissionBoundary
 }
 
 // residencyQuiescent composes every native quiescence input: CEF runtime
@@ -544,25 +568,31 @@ func (a *App) closeRelayAdmission() {
 	}
 }
 
-// waitRelayAdmissionDrained settles admitted relay work before persistence
-// teardown within a short bound. Admitted dispatch may need the GTK loop,
-// so the wait never blocks shutdown forever; expiry only logs and the
-// sockets settle through their own completion paths.
-func (a *App) waitRelayAdmissionDrained(ctx context.Context) {
-	if a == nil || a.deps == nil {
+// drainForShutdownOffThread settles admission leases and persistence
+// before GTK shutdown, while the loop can still service admitted work.
+// It runs only off the GTK thread (see Quit); every wait is bounded and
+// expiry only logs.
+func (a *App) drainForShutdownOffThread() {
+	if a == nil {
 		return
 	}
-	provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider)
-	if !ok || provider == nil {
-		return
+	a.closeRelayAdmission()
+	if a.deps != nil {
+		if provider, ok := a.deps.BrowserLaunchRelay.(relayAdmissionProvider); ok && provider != nil {
+			if gate := provider.AdmissionGate(); gate != nil && gate.Active() > 0 {
+				drainCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				if !gate.WaitDrained(drainCtx) {
+					logging.FromContext(context.Background()).Warn().Int("admitted", gate.Active()).Msg("relay admission did not drain before shutdown")
+				}
+				cancel()
+			}
+		}
 	}
-	gate := provider.AdmissionGate()
-	if gate == nil || gate.Active() == 0 {
-		return
-	}
-	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
-	defer cancel()
-	if !gate.WaitDrained(drainCtx) {
-		logging.FromContext(ctx).Warn().Int("admitted", gate.Active()).Msg("relay admission did not drain before teardown")
+	if drain, ok := a.snapshotService.(port.PersistenceDrain); ok && drain != nil {
+		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := drain.WaitSettled(drainCtx); err != nil {
+			logging.FromContext(context.Background()).Warn().Err(err).Msg("persistence did not settle before shutdown")
+		}
+		cancel()
 	}
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -203,7 +203,9 @@ func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
 func TestResidencyControllerSealsBeforeCommit(t *testing.T) {
 	ctl, _, sched, quits := newResidencyTestController(time.Minute)
 	sealed := 0
+	unsealed := 0
 	ctl.SetSealFunc(func() { sealed++ })
+	ctl.SetUnsealFunc(func() { unsealed++ })
 	ctl.SetQuiescentFunc(func() bool { return true })
 	ctl.SetWindowCount(1)
 	ctl.SetWindowCount(0)
@@ -211,12 +213,15 @@ func TestResidencyControllerSealsBeforeCommit(t *testing.T) {
 	// Quiescent expiry seals admission, then commits the quit.
 	ctl.OnTimerFired(armed)
 	require.Equal(t, 1, sealed)
+	require.Equal(t, 0, unsealed)
 	require.Equal(t, 1, *quits)
 }
 
 func TestResidencyControllerReopenInvalidatesDeferredQuit(t *testing.T) {
 	ctl, _, sched, quits := newResidencyTestController(time.Minute)
 	quiescent := true
+	unsealed := 0
+	ctl.SetUnsealFunc(func() { unsealed++ })
 	ctl.SetQuiescentFunc(func() bool { return quiescent })
 	ctl.SetWindowCount(1)
 	ctl.SetWindowCount(0)
@@ -229,6 +234,7 @@ func TestResidencyControllerReopenInvalidatesDeferredQuit(t *testing.T) {
 	quiescent = true
 	ctl.MaybeQuit()
 	require.Equal(t, 0, *quits, "obsolete quit must not run after reopen")
+	require.Equal(t, 1, unsealed, "invalidation reopens admission")
 }
 
 func TestResidencyControllerDuplicateEmptyStaysArmed(t *testing.T) {

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -136,4 +136,64 @@ func TestResidencyControllerNilSafe(t *testing.T) {
 	ctl.OnTimerFired(7)
 	ctl.AcquireHold(nil)
 	ctl.ReleaseHold(nil)
+	ctl.SetQuiescentFunc(nil)
+	ctl.SetDispatchToGTK(nil)
+	ctl.DispatchToGTK(nil)
+	ctl.MaybeQuit()
+	require.Equal(t, usecase.ResidencyNone, ctl.SetNativeBusy("x", true).Action)
+}
+
+func TestResidencyControllerDefersQuitUntilSettled(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	quiescent := true
+	ctl.SetQuiescentFunc(func() bool { return quiescent })
+	ctl.SetWindowCount(1)
+	decision := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyArm, decision.Action)
+	armed := sched.generations[len(sched.generations)-1]
+
+	quiescent = false
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 0, *quits, "expiry defers while native work is outstanding")
+
+	quiescent = true
+	ctl.MaybeQuit()
+	require.Equal(t, 1, *quits, "settle recheck commits the deferred quit")
+	ctl.MaybeQuit()
+	require.Equal(t, 1, *quits, "quit commits exactly once")
+}
+
+func TestResidencyControllerNativeBusyDrivesPolicy(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+
+	decision := ctl.SetNativeBusy("cef-activity", true)
+	require.Equal(t, usecase.ResidencyNone, decision.Action)
+	decision = ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyNone, decision.Action, "close with native work outstanding arms nothing")
+	require.Empty(t, sched.scheduled)
+
+	decision = ctl.SetNativeBusy("cef-activity", false)
+	require.Equal(t, usecase.ResidencyArm, decision.Action, "settle re-arms idle")
+	require.NotEmpty(t, sched.scheduled)
+	require.Equal(t, 0, *quits)
+}
+
+func TestResidencyControllerDuplicateBusyIsSilent(t *testing.T) {
+	ctl, _, sched, _ := newResidencyTestController(time.Minute)
+	ctl.SetNativeBusy("downloads", true)
+	decision := ctl.SetNativeBusy("downloads", true)
+	require.Equal(t, usecase.ResidencyNone, decision.Action)
+	require.Empty(t, sched.scheduled)
+}
+
+func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
+	ctl, _, _, _ := newResidencyTestController(time.Minute)
+	var routed []string
+	ctl.SetDispatchToGTK(func(fn func()) {
+		routed = append(routed, "gtk")
+		fn()
+	})
+	ctl.DispatchToGTK(func() { routed = append(routed, "cb") })
+	require.Equal(t, []string{"gtk", "cb"}, routed)
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -82,7 +82,7 @@ func TestResidencyControllerDisabledPreservesQuit(t *testing.T) {
 }
 
 func TestResidencyControllerHoldMatchesReleaseOnce(t *testing.T) {
-	ctl, app, _, _ := newResidencyTestController(time.Minute)
+	ctl, app, _, quits := newResidencyTestController(time.Minute)
 	require.True(t, ctl.Enabled())
 	ctl.AcquireHold(app)
 	ctl.AcquireHold(app)
@@ -90,6 +90,7 @@ func TestResidencyControllerHoldMatchesReleaseOnce(t *testing.T) {
 	ctl.ReleaseHold(app)
 	ctl.ReleaseHold(app)
 	require.Equal(t, 1, app.releases, "exactly one release")
+	require.Equal(t, 0, *quits, "hold cycling never quits")
 }
 
 func TestResidencyControllerLastWindowArmsAndExpiryQuits(t *testing.T) {
@@ -188,7 +189,7 @@ func TestResidencyControllerDuplicateBusyIsSilent(t *testing.T) {
 }
 
 func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
-	ctl, _, _, _ := newResidencyTestController(time.Minute)
+	ctl, _, _, quits := newResidencyTestController(time.Minute)
 	var routed []string
 	ctl.SetDispatchToGTK(func(fn func()) {
 		routed = append(routed, "gtk")
@@ -196,4 +197,5 @@ func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
 	})
 	ctl.DispatchToGTK(func() { routed = append(routed, "cb") })
 	require.Equal(t, []string{"gtk", "cb"}, routed)
+	require.Equal(t, 0, *quits)
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bnema/dumber/internal/application/usecase"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,4 +31,109 @@ func TestResidencyTimeoutLatchAndRestartRequired(t *testing.T) {
 	nilApp.SetResidencyTimeout(time.Minute)
 	require.Equal(t, time.Duration(0), nilApp.LatchedResidencyTimeout())
 	require.False(t, nilApp.ResidencyTimeoutRestartRequired(60000))
+}
+
+type residencyFakeApp struct {
+	holds    int
+	releases int
+	quits    int
+}
+
+func (f *residencyFakeApp) Hold()    { f.holds++ }
+func (f *residencyFakeApp) Release() { f.releases++ }
+func (f *residencyFakeApp) Quit()    { f.quits++ }
+
+type residencyFakeScheduler struct {
+	scheduled   []time.Duration
+	generations []uint64
+	cancels     int
+}
+
+func (f *residencyFakeScheduler) schedule(d time.Duration, generation uint64) {
+	f.scheduled = append(f.scheduled, d)
+	f.generations = append(f.generations, generation)
+}
+
+func (f *residencyFakeScheduler) cancel() { f.cancels++ }
+
+func newResidencyTestController(timeout time.Duration) (*ResidencyController, *residencyFakeApp, *residencyFakeScheduler, *int) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	app := &residencyFakeApp{}
+	sched := &residencyFakeScheduler{}
+	quits := 0
+	ctl := NewResidencyController(timeout, clock, sched.schedule, sched.cancel, func() { quits++ })
+	return ctl, app, sched, &quits
+}
+
+func TestResidencyControllerDisabledPreservesQuit(t *testing.T) {
+	ctl, app, sched, quits := newResidencyTestController(0)
+	require.False(t, ctl.Enabled())
+	ctl.AcquireHold(app)
+	require.Equal(t, 0, app.holds, "disabled residency takes no hold")
+	ctl.ReleaseHold(app)
+	require.Equal(t, 0, app.releases)
+
+	ctl.SetWindowCount(1)
+	decision := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyQuit, decision.Action)
+	require.Equal(t, 1, *quits)
+	require.Empty(t, sched.scheduled)
+}
+
+func TestResidencyControllerHoldMatchesReleaseOnce(t *testing.T) {
+	ctl, app, _, _ := newResidencyTestController(time.Minute)
+	require.True(t, ctl.Enabled())
+	ctl.AcquireHold(app)
+	ctl.AcquireHold(app)
+	require.Equal(t, 1, app.holds, "exactly one hold")
+	ctl.ReleaseHold(app)
+	ctl.ReleaseHold(app)
+	require.Equal(t, 1, app.releases, "exactly one release")
+}
+
+func TestResidencyControllerLastWindowArmsAndExpiryQuits(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	decision := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyArm, decision.Action)
+	require.NotEmpty(t, sched.scheduled)
+	armed := sched.generations[len(sched.generations)-1]
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 1, *quits)
+}
+
+func TestResidencyControllerReopenCancelsTimer(t *testing.T) {
+	ctl, _, sched, _ := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	require.NotEmpty(t, sched.scheduled)
+	armed := sched.generations[len(sched.generations)-1]
+	cancels := sched.cancels
+	ctl.SetWindowCount(1)
+	require.Greater(t, sched.cancels, cancels, "reopen cancels the armed deadline")
+	ctl.OnTimerFired(armed)
+}
+
+func TestResidencyControllerExplicitQuitBypassesDeadline(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	require.NotEmpty(t, sched.scheduled)
+	armed := sched.generations[len(sched.generations)-1]
+	ctl.NoteExplicitQuit()
+	require.Equal(t, 0, *quits, "noting quit never invokes quit itself")
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 0, *quits, "deadline never fires after explicit quit")
+}
+
+func TestResidencyControllerNilSafe(t *testing.T) {
+	var ctl *ResidencyController
+	require.False(t, ctl.Enabled())
+	require.Equal(t, usecase.ResidencyQuit, ctl.SetWindowCount(0).Action)
+	require.Equal(t, usecase.ResidencyQuit, ctl.Evaluate().Action)
+	ctl.NoteExplicitQuit()
+	ctl.OnTimerFired(7)
+	ctl.AcquireHold(nil)
+	ctl.ReleaseHold(nil)
 }

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResidencyTimeoutFromMillis(t *testing.T) {
+	require.Equal(t, time.Duration(0), ResidencyTimeoutFromMillis(0))
+	require.Equal(t, time.Duration(0), ResidencyTimeoutFromMillis(-5))
+	require.Equal(t, 60*time.Second, ResidencyTimeoutFromMillis(60000))
+	require.Equal(t, 300000*time.Millisecond, ResidencyTimeoutFromMillis(300000))
+	require.Equal(t, 300000*time.Millisecond, ResidencyTimeoutFromMillis(999999))
+}
+
+func TestResidencyTimeoutLatchAndRestartRequired(t *testing.T) {
+	app := &App{}
+	require.Equal(t, time.Duration(0), app.LatchedResidencyTimeout())
+
+	app.SetResidencyTimeout(60 * time.Second)
+	require.Equal(t, 60*time.Second, app.LatchedResidencyTimeout())
+	require.False(t, app.ResidencyTimeoutRestartRequired(60000))
+	require.True(t, app.ResidencyTimeoutRestartRequired(0))
+	require.True(t, app.ResidencyTimeoutRestartRequired(120000))
+
+	// A nil app never panics and reports no change.
+	var nilApp *App
+	nilApp.SetResidencyTimeout(time.Minute)
+	require.Equal(t, time.Duration(0), nilApp.LatchedResidencyTimeout())
+	require.False(t, nilApp.ResidencyTimeoutRestartRequired(60000))
+}

--- a/internal/ui/runtime_residency_test.go
+++ b/internal/ui/runtime_residency_test.go
@@ -199,3 +199,48 @@ func TestResidencyControllerDispatchRoutesCallbacks(t *testing.T) {
 	require.Equal(t, []string{"gtk", "cb"}, routed)
 	require.Equal(t, 0, *quits)
 }
+
+func TestResidencyControllerSealsBeforeCommit(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	sealed := 0
+	ctl.SetSealFunc(func() { sealed++ })
+	ctl.SetQuiescentFunc(func() bool { return true })
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	armed := sched.generations[len(sched.generations)-1]
+	// Quiescent expiry seals admission, then commits the quit.
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 1, sealed)
+	require.Equal(t, 1, *quits)
+}
+
+func TestResidencyControllerReopenInvalidatesDeferredQuit(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	quiescent := true
+	ctl.SetQuiescentFunc(func() bool { return quiescent })
+	ctl.SetWindowCount(1)
+	ctl.SetWindowCount(0)
+	armed := sched.generations[len(sched.generations)-1]
+	quiescent = false
+	ctl.OnTimerFired(armed)
+	require.Equal(t, 0, *quits, "quit defers while unsettled")
+	// A reopened window invalidates the deferral.
+	ctl.SetWindowCount(1)
+	quiescent = true
+	ctl.MaybeQuit()
+	require.Equal(t, 0, *quits, "obsolete quit must not run after reopen")
+}
+
+func TestResidencyControllerDuplicateEmptyStaysArmed(t *testing.T) {
+	ctl, _, sched, quits := newResidencyTestController(time.Minute)
+	ctl.SetWindowCount(1)
+	first := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyArm, first.Action)
+	require.Len(t, sched.scheduled, 1)
+	// A repeated empty update (e.g. tab-empty after window removal)
+	// stays on the armed deadline instead of re-arming.
+	again := ctl.SetWindowCount(0)
+	require.Equal(t, usecase.ResidencyNone, again.Action)
+	require.Len(t, sched.scheduled, 1, "no duplicate timer")
+	require.Equal(t, 0, *quits)
+}

--- a/internal/ui/theme/manager.go
+++ b/internal/ui/theme/manager.go
@@ -25,6 +25,14 @@ type Manager struct {
 	transitionDurationMs int
 	cssProvider          *gtk.CssProvider
 	appliedFont          string
+	// appliedCSS is the effective CSS identity last loaded into cssProvider.
+	// appliedDisplayPtr is the native display address that provider was last
+	// added for. Both are plain values: no display reference is retained, so
+	// destroyed displays cannot leak through the manager. Native display
+	// addresses are unique among live displays; address reuse after a display
+	// is destroyed is pathological in single-display processes.
+	appliedCSS        string
+	appliedDisplayPtr uintptr
 }
 
 // NewManager creates a new theme manager from an already-resolved theme.
@@ -136,7 +144,17 @@ func shouldApplyGTKFontName(current, next string) bool {
 	return next != "" && next != current
 }
 
-// ApplyToDisplay loads the theme CSS into the display.
+// shouldSkipThemeReapply reports whether a theme application can be skipped
+// entirely: the provider exists, the effective CSS and font are unchanged,
+// and the target is the display the provider was last added for.
+func shouldSkipThemeReapply(hasProvider bool, appliedPtr, ptr uintptr, appliedCSS, css, appliedFont, font string) bool {
+	return hasProvider && ptr == appliedPtr && css == appliedCSS && font != "" && font == appliedFont
+}
+
+// ApplyToDisplay loads the theme CSS into the display, skipping the reload
+// and re-add when the same provider already carries the effective CSS on the
+// same display. A different display always gets the provider added; the CSS
+// is only re-parsed when its identity changed.
 func (m *Manager) ApplyToDisplay(ctx context.Context, display *gdk.Display) {
 	log := logging.FromContext(ctx)
 
@@ -151,6 +169,13 @@ func (m *Manager) ApplyToDisplay(ctx context.Context, display *gdk.Display) {
 	css := GenerateCSSFullWithTiming(palette, m.uiScale, m.fonts, m.modeColors, m.transitionDurationMs)
 	fontName := formatGTKFontName(m.gtkFont, m.uiScale)
 
+	if shouldSkipThemeReapply(m.cssProvider != nil, m.appliedDisplayPtr, display.Ptr, m.appliedCSS, css, m.appliedFont, fontName) {
+		log.Debug().
+			Bool("dark_mode", m.prefersDark).
+			Msg("theme CSS unchanged for display, skipping reapply")
+		return
+	}
+
 	settings := gtk.SettingsGetForDisplay(display)
 	if settings == nil {
 		log.Warn().Msg("cannot apply theme font scaling: settings unavailable")
@@ -163,8 +188,10 @@ func (m *Manager) ApplyToDisplay(ctx context.Context, display *gdk.Display) {
 	}
 
 	// Create CSS provider if needed
+	providerFresh := false
 	if m.cssProvider == nil {
 		m.cssProvider = gtk.NewCssProvider()
+		providerFresh = true
 	}
 
 	if m.cssProvider == nil {
@@ -172,13 +199,20 @@ func (m *Manager) ApplyToDisplay(ctx context.Context, display *gdk.Display) {
 		return
 	}
 
-	// Load CSS
-	m.cssProvider.LoadFromString(css)
+	// Load CSS only when its identity changed; the shared provider already
+	// carries the previous CSS for a display change with an unchanged theme.
+	// A freshly created provider always loads, even if the generated CSS is
+	// empty, so the skip identity can never mask a missing load.
+	if providerFresh || css != m.appliedCSS {
+		m.cssProvider.LoadFromString(css)
+	}
 	gtk.StyleContextAddProviderForDisplay(
 		display,
 		m.cssProvider,
 		uint(gtk.STYLE_PROVIDER_PRIORITY_APPLICATION),
 	)
+	m.appliedCSS = css
+	m.appliedDisplayPtr = display.Ptr
 
 	log.Debug().
 		Bool("dark_mode", m.prefersDark).

--- a/internal/ui/theme/manager.go
+++ b/internal/ui/theme/manager.go
@@ -24,7 +24,12 @@ type Manager struct {
 	modeColors           ModeColors // Modal mode indicator colors
 	transitionDurationMs int
 	cssProvider          *gtk.CssProvider
-	appliedFont          string
+	// appliedFonts records the GTK font name last set per display, keyed by
+	// native display address. GtkSettings are per display, so the font must
+	// be applied on every display even when the theme is unchanged. Keys
+	// are plain addresses: no display reference is retained, so destroyed
+	// displays cannot leak through the manager.
+	appliedFonts map[uintptr]string
 	// appliedCSS is the effective CSS identity last loaded into cssProvider.
 	// appliedDisplayPtr is the native display address that provider was last
 	// added for. Both are plain values: no display reference is retained, so
@@ -144,6 +149,27 @@ func shouldApplyGTKFontName(current, next string) bool {
 	return next != "" && next != current
 }
 
+// lastAppliedFontFor returns the GTK font name recorded for a display, or
+// "" when the manager has not applied a font there yet.
+func (m *Manager) lastAppliedFontFor(ptr uintptr) string {
+	if m == nil || m.appliedFonts == nil {
+		return ""
+	}
+	return m.appliedFonts[ptr]
+}
+
+// recordAppliedFontFor stores the GTK font name set on a display. The map
+// is created on first use so zero-value Managers stay usable.
+func (m *Manager) recordAppliedFontFor(ptr uintptr, font string) {
+	if m == nil {
+		return
+	}
+	if m.appliedFonts == nil {
+		m.appliedFonts = make(map[uintptr]string)
+	}
+	m.appliedFonts[ptr] = font
+}
+
 // shouldSkipThemeReapply reports whether a theme application can be skipped
 // entirely: the provider exists, the effective CSS and font are unchanged,
 // and the target is the display the provider was last added for.
@@ -168,8 +194,9 @@ func (m *Manager) ApplyToDisplay(ctx context.Context, display *gdk.Display) {
 	palette := m.GetCurrentPalette()
 	css := GenerateCSSFullWithTiming(palette, m.uiScale, m.fonts, m.modeColors, m.transitionDurationMs)
 	fontName := formatGTKFontName(m.gtkFont, m.uiScale)
+	displayFont := m.lastAppliedFontFor(display.Ptr)
 
-	if shouldSkipThemeReapply(m.cssProvider != nil, m.appliedDisplayPtr, display.Ptr, m.appliedCSS, css, m.appliedFont, fontName) {
+	if shouldSkipThemeReapply(m.cssProvider != nil, m.appliedDisplayPtr, display.Ptr, m.appliedCSS, css, displayFont, fontName) {
 		log.Debug().
 			Bool("dark_mode", m.prefersDark).
 			Msg("theme CSS unchanged for display, skipping reapply")
@@ -179,9 +206,9 @@ func (m *Manager) ApplyToDisplay(ctx context.Context, display *gdk.Display) {
 	settings := gtk.SettingsGetForDisplay(display)
 	if settings == nil {
 		log.Warn().Msg("cannot apply theme font scaling: settings unavailable")
-	} else if shouldApplyGTKFontName(m.appliedFont, fontName) {
+	} else if shouldApplyGTKFontName(displayFont, fontName) {
 		settings.SetPropertyGtkFontName(fontName)
-		m.appliedFont = fontName
+		m.recordAppliedFontFor(display.Ptr, fontName)
 		settings.Unref()
 	} else {
 		settings.Unref()

--- a/internal/ui/theme/manager_test.go
+++ b/internal/ui/theme/manager_test.go
@@ -182,3 +182,50 @@ func TestShouldApplyGTKFontName(t *testing.T) {
 	assert.False(t, shouldApplyGTKFontName("Fira Sans 14", "Fira Sans 14"))
 	assert.False(t, shouldApplyGTKFontName("Fira Sans 14", ""))
 }
+
+func TestShouldSkipThemeReapply(t *testing.T) {
+	const (
+		displayA  = uintptr(0x1000)
+		displayB  = uintptr(0x2000)
+		css       = "window{background:#000;}"
+		otherCSS  = "window{background:#fff;}"
+		font      = "Adwaita Sans 14"
+		otherFont = "Adwaita Sans 17"
+	)
+
+	// Same provider, display, CSS and font: skip the reload and re-add.
+	assert.True(t, shouldSkipThemeReapply(true, displayA, displayA, css, css, font, font),
+		"repeated window creation with an unchanged theme must skip reapply")
+	// No provider yet: full apply.
+	assert.False(t, shouldSkipThemeReapply(false, 0, displayA, "", css, "", font))
+	// Different display: the provider must be added for the new display even
+	// when the CSS is unchanged. Displays are never conflated.
+	assert.False(t, shouldSkipThemeReapply(true, displayA, displayB, css, css, font, font))
+	// Changed CSS (real theme change): reload.
+	assert.False(t, shouldSkipThemeReapply(true, displayA, displayA, css, otherCSS, font, font))
+	// Changed font (scale change): reapply for the font setting.
+	assert.False(t, shouldSkipThemeReapply(true, displayA, displayA, css, css, font, otherFont))
+	// Empty font identity never skips.
+	assert.False(t, shouldSkipThemeReapply(true, displayA, displayA, css, css, "", ""))
+}
+
+func TestEffectiveCSSIdentity_StableForUnchangedTheme(t *testing.T) {
+	ctx := context.Background()
+	first := NewManager(ctx, resolvedThemeFixture(true))
+	second := NewManager(ctx, resolvedThemeFixture(true))
+
+	cssOf := func(m *Manager) string {
+		return GenerateCSSFullWithTiming(m.GetCurrentPalette(), m.uiScale, m.fonts, m.modeColors, m.transitionDurationMs)
+	}
+
+	// The dedup relies on CSS identity: identical resolved themes must
+	// produce identical CSS so repeated window creation skips the reload.
+	assert.Equal(t, cssOf(first), cssOf(second))
+	assert.NotEmpty(t, cssOf(first))
+
+	// A real theme change must change the identity so it is never skipped.
+	changed := resolvedThemeFixture(true)
+	changed.DarkPalette.Background = "#000001"
+	other := NewManager(ctx, changed)
+	assert.NotEqual(t, cssOf(first), cssOf(other))
+}

--- a/internal/ui/theme/manager_test.go
+++ b/internal/ui/theme/manager_test.go
@@ -229,3 +229,36 @@ func TestEffectiveCSSIdentity_StableForUnchangedTheme(t *testing.T) {
 	other := NewManager(ctx, changed)
 	assert.NotEqual(t, cssOf(first), cssOf(other))
 }
+
+func TestManager_AppliedFontTrackedPerDisplay(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(ctx, resolvedThemeFixture(true))
+
+	const (
+		displayA = uintptr(0x1000)
+		displayB = uintptr(0x2000)
+		font     = "Adwaita Sans 14"
+	)
+
+	// No font recorded anywhere initially, including on a nil manager.
+	assert.Empty(t, m.lastAppliedFontFor(displayA))
+	assert.Empty(t, m.lastAppliedFontFor(displayB))
+	assert.Empty(t, (*Manager)(nil).lastAppliedFontFor(displayA))
+
+	// Recording for one display leaves the other untouched so its
+	// GtkSettings still get configured on first apply.
+	m.recordAppliedFontFor(displayA, font)
+	assert.Equal(t, font, m.lastAppliedFontFor(displayA))
+	assert.Empty(t, m.lastAppliedFontFor(displayB))
+
+	m.recordAppliedFontFor(displayB, font)
+	assert.Equal(t, font, m.lastAppliedFontFor(displayB))
+
+	// Updating one display does not disturb the other.
+	m.recordAppliedFontFor(displayA, "Adwaita Sans 17")
+	assert.Equal(t, "Adwaita Sans 17", m.lastAppliedFontFor(displayA))
+	assert.Equal(t, font, m.lastAppliedFontFor(displayB))
+
+	// Recording on a nil manager is a safe no-op.
+	assert.NotPanics(t, func() { (*Manager)(nil).recordAppliedFontFor(displayA, font) })
+}

--- a/scripts/cef_runtime_probe.py
+++ b/scripts/cef_runtime_probe.py
@@ -62,7 +62,12 @@ def main():
 
     try:
         with open(lib_name, "rb") as candidate:
-            library_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+            # Chunked streaming hash: hashlib.file_digest needs 3.11+,
+            # this stays compatible with older 3.x interpreters.
+            digest = hashlib.sha256()
+            for chunk in iter(lambda: candidate.read(65536), b""):
+                digest.update(chunk)
+            library_sha256 = digest.hexdigest()
     except OSError:
         fail("could not hash runtime library")
 

--- a/scripts/cef_runtime_probe.py
+++ b/scripts/cef_runtime_probe.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Report numeric CEF runtime version fields plus library hash.
+
+Opens only the explicitly selected trusted libcef.so using the standard
+library ctypes module and calls the header-verified cef_version_info(int)
+entries from /usr/include/cef/include/cef_version_info.h:
+
+  0 - CEF_VERSION_MAJOR
+  1 - CEF_VERSION_MINOR
+  2 - CEF_VERSION_PATCH
+  3 - CEF_COMMIT_NUMBER
+  4 - CHROME_VERSION_MAJOR
+  5 - CHROME_VERSION_MINOR
+  6 - CHROME_VERSION_BUILD
+  7 - CHROME_VERSION_PATCH
+
+Outputs JSON to stdout with numeric fields and the library SHA-256. Never
+outputs filesystem paths. This probe is not an ABI bypass: the candidate must
+still pass its normal loader ABI/version validation.
+"""
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+import sys
+
+
+ENTRIES = (
+    ("cef_version_major", 0),
+    ("cef_version_minor", 1),
+    ("cef_version_patch", 2),
+    ("cef_commit_number", 3),
+    ("chrome_version_major", 4),
+    ("chrome_version_minor", 5),
+    ("chrome_version_build", 6),
+    ("chrome_version_patch", 7),
+)
+
+
+def fail(message):
+    print("cef-runtime-probe: {}".format(message), file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Probe selected libcef.so version fields.")
+    parser.add_argument("--cef-dir", required=True, help="Selected CEF runtime directory.")
+    args = parser.parse_args()
+
+    cef_dir = args.cef_dir
+    if not cef_dir or not os.path.isabs(cef_dir):
+        fail("cef dir must be an absolute path")
+    lib_name = os.path.join(cef_dir, "libcef.so")
+    try:
+        is_file = os.path.isfile(lib_name) and not os.path.islink(lib_name)
+    except OSError:
+        fail("could not stat runtime library")
+    if not is_file:
+        fail("runtime library not found")
+
+    try:
+        with open(lib_name, "rb") as candidate:
+            library_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+    except OSError:
+        fail("could not hash runtime library")
+
+    try:
+        lib = ctypes.CDLL(lib_name)
+    except OSError:
+        fail("could not open runtime library")
+    try:
+        version_info = lib.cef_version_info
+    except AttributeError:
+        fail("cef_version_info symbol is unavailable")
+    version_info.argtypes = (ctypes.c_int,)
+    version_info.restype = ctypes.c_int
+
+    result = {}
+    for field, entry in ENTRIES:
+        try:
+            value = version_info(entry)
+        except (ctypes.ArgumentError, OSError, ValueError):
+            fail("version query failed")
+        if not isinstance(value, int) or value < 0:
+            fail("version query failed")
+        result[field] = value
+    result["libcef_sha256"] = library_sha256
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_first_presentation.sh
+++ b/scripts/collect_first_presentation.sh
@@ -59,7 +59,12 @@ def fail():
     raise SystemExit("first-presentation: immutable module provenance is unavailable")
 
 with open(binary, "rb") as candidate:
-    binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+    # Chunked streaming hash: hashlib.file_digest needs 3.11+, this stays
+    # compatible with older 3.x interpreters.
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: candidate.read(65536), b""):
+        digest.update(chunk)
+    binary_sha256 = digest.hexdigest()
 
 try:
     buildinfo = subprocess.check_output(["go", "version", "-m", binary], text=True, stderr=subprocess.DEVNULL)

--- a/scripts/collect_first_presentation.sh
+++ b/scripts/collect_first_presentation.sh
@@ -6,13 +6,24 @@ set -euo pipefail
 
 readonly runs=5
 readonly timeout_seconds="${DUMBER_FIRST_PRESENTATION_TIMEOUT_SECONDS:-45}"
-readonly runtime="${DUMBER_CEF_DIR:-$HOME/.local/share/cef-147-runtime}"
 readonly binary="${DUMBER_FIRST_PRESENTATION_BIN:-$PWD/dist/dumber}"
+readonly manifest="${DUMBER_BUILD_MANIFEST:-${binary}.manifest.json}"
 
 fail_unsafe_output() {
   echo "first-presentation: unsafe output path: $1" >&2
   exit 2
 }
+
+# The measured runtime is always explicit. Never default to a hardcoded path
+# or version: collection fails closed when the caller does not select one.
+if [[ -z "${DUMBER_CEF_DIR:-}" ]]; then
+  echo "first-presentation: DUMBER_CEF_DIR must be set to the selected CEF runtime directory" >&2
+  exit 2
+fi
+readonly runtime="${DUMBER_CEF_DIR}"
+# Never inherit a conflicting CEF_DIR override: the child environment below is
+# built with env -i and receives exactly this selected directory.
+readonly selected_cef_dir="${DUMBER_CEF_DIR}"
 
 if [[ -v DUMBER_FIRST_PRESENTATION_OUTPUT ]]; then
   output="$DUMBER_FIRST_PRESENTATION_OUTPUT"
@@ -31,85 +42,105 @@ else
 fi
 readonly output
 readonly upstream_module="github.com/bnema/purego-cef2gtk"
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly runtime_probe="$script_dir/cef_runtime_probe.py"
 
-# Resolve the version selected by this checkout, then obtain its immutable VCS
-# origin from Go's cached module metadata. Do not infer a revision from a tag,
-# a branch, or a truncated pseudo-version suffix.
-resolve_upstream_provenance() {
-  local selected_metadata selected_version downloaded_metadata
-
-  selected_metadata="$(GOFLAGS=-mod=mod go list -m -json "$upstream_module" 2>/dev/null)" || {
-    echo "first-presentation: immutable module provenance is unavailable" >&2
-    exit 2
-  }
-  selected_version="$(python3 - "$upstream_module" "$selected_metadata" <<'PY'
-import json, sys
-try:
-    metadata = json.loads(sys.argv[2])
-    if metadata.get("Path") != sys.argv[1] or not isinstance(metadata.get("Version"), str):
-        raise ValueError
-    print(metadata["Version"])
-except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
-    raise SystemExit("first-presentation: immutable module provenance is unavailable")
-PY
-)" || exit $?
-  downloaded_metadata="$(go mod download -json "$upstream_module@$selected_version" 2>/dev/null)" || {
-    echo "first-presentation: immutable module provenance is unavailable" >&2
-    exit 2
-  }
-
-  python3 - "$upstream_module" "$selected_metadata" "$downloaded_metadata" <<'PY'
-import json, re, sys
-
-module, selected_raw, downloaded_raw = sys.argv[1:]
+# Resolve provenance from the measured binary, not the collection checkout.
+# Reads embedded build info via `go version -m` and requires a build manifest
+# tied to the candidate SHA-256 when VCS data is absent (including
+# buildvcs=false builds). Never queries the checkout module graph.
+resolve_binary_provenance() {
+  python3 - "$binary" "$manifest" "$upstream_module" <<'PY'
+import hashlib, json, os, re, subprocess, sys
+binary, manifest_path, module = sys.argv[1:]
 
 def fail():
-    # Do not expose Go cache locations or other machine-local values.
+    # Do not expose cache locations or other machine-local values.
     raise SystemExit("first-presentation: immutable module provenance is unavailable")
 
+with open(binary, "rb") as candidate:
+    binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+
 try:
-    selected = json.loads(selected_raw)
-    downloaded = json.loads(downloaded_raw)
-    version = selected["Version"]
-    if selected.get("Path") != module or downloaded.get("Path") != module:
-        fail()
-    if downloaded.get("Version") != version:
-        fail()
-    # A pseudo-version identifies an immutable commit; a released semver tag is
-    # accepted only when Go records that exact tag and its immutable hash.
-    pseudo_match = re.fullmatch(r"(v\d+\.\d+\.\d+)-0\.\d{14}-([0-9a-f]{12})", version)
-    tag_match = re.fullmatch(r"v\d+\.\d+\.\d+", version)
-    if not pseudo_match and not tag_match:
-        fail()
-    info_path = downloaded.get("Info")
-    if not isinstance(info_path, str) or not info_path:
-        fail()
-    with open(info_path, encoding="utf-8") as info_file:
-        info = json.load(info_file)
-    origin = info.get("Origin") or downloaded.get("Origin")
-    if info.get("Version") != version or not isinstance(origin, dict):
-        fail()
-    revision = origin.get("Hash")
-    if origin.get("VCS") != "git" or origin.get("URL") != "https://github.com/bnema/purego-cef2gtk":
-        fail()
-    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40}", revision):
-        fail()
-    if pseudo_match:
-        if not revision.startswith(pseudo_match.group(2)):
-            fail()
-        # A named ref can move. Only the immutable hash itself is acceptable.
-        if origin.get("Ref") not in (None, "", revision):
-            fail()
-        tag = pseudo_match.group(1)
-    else:
-        if origin.get("Ref") != "refs/tags/" + version:
-            fail()
-        tag = version
-except (AttributeError, KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+    buildinfo = subprocess.check_output(["go", "version", "-m", binary], text=True, stderr=subprocess.DEVNULL)
+except (OSError, subprocess.CalledProcessError):
+    raise SystemExit("first-presentation: immutable module provenance is unavailable")
+if "=>" in buildinfo:
+    raise SystemExit("first-presentation: immutable module provenance is unavailable")
+
+mod_version = None
+dep_version = None
+vcs_revision = None
+for line in buildinfo.splitlines():
+    parts = line.split()
+    if len(parts) < 2:
+        continue
+    if parts[0] == "mod" and len(parts) >= 3 and parts[1] == "github.com/bnema/dumber":
+        mod_version = parts[2]
+    if parts[0] == "dep" and len(parts) >= 3 and parts[1] == module:
+        dep_version = parts[2]
+    if parts[0] == "build" and len(parts) >= 2 and parts[1].startswith("vcs.revision="):
+        vcs_revision = parts[1].split("=", 1)[1]
+if dep_version is None:
+    fail()
+pseudo_match = re.fullmatch(r"(v\d+\.\d+\.\d+)-0\.\d{14}-([0-9a-f]{12})", dep_version)
+tag_match = re.fullmatch(r"v\d+\.\d+\.\d+", dep_version)
+if not pseudo_match and not tag_match:
+    fail()
+if vcs_revision is not None and not re.fullmatch(r"[0-9a-f]{40}", vcs_revision):
     fail()
 
-print("\t".join((version, tag, revision)))
+try:
+    with open(manifest_path, encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
+except (OSError, ValueError):
+    manifest = None
+
+if manifest is None:
+    # Without embedded VCS data the binary cannot be attributed; fail closed.
+    if vcs_revision is None:
+        raise SystemExit("first-presentation: build manifest is required for binaries without embedded VCS data")
+    # Embedded VCS revision attributes the binary itself, but the full
+    # upstream revision is not in build info; the manifest must still bind it.
+    raise SystemExit("first-presentation: build manifest is required to bind dependency revisions")
+
+if not isinstance(manifest, dict):
+    raise SystemExit("first-presentation: build manifest is required for binaries without embedded VCS data")
+if manifest.get("binary_sha256") != binary_sha256:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+source_revision = manifest.get("source_revision")
+if not isinstance(source_revision, str) or not re.fullmatch(r"[0-9a-f]{40}", source_revision):
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+if vcs_revision is not None and vcs_revision != source_revision:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+modules = manifest.get("modules")
+if not isinstance(modules, dict) or module not in modules:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+entry = modules[module]
+if not isinstance(entry, dict) or entry.get("version") != dep_version:
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+revision = entry.get("revision")
+if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40}", revision):
+    raise SystemExit("first-presentation: build manifest does not match the measured binary")
+if pseudo_match:
+    if not revision.startswith(pseudo_match.group(2)):
+        raise SystemExit("first-presentation: build manifest does not match the measured binary")
+    tag = pseudo_match.group(1)
+else:
+    tag = dep_version
+
+print("\t".join((binary_sha256, source_revision, dep_version, tag, revision)))
 PY
+}
+
+# Probe the explicitly selected runtime in a separate bounded subprocess.
+# Reports numeric version fields plus library hash, never a path. The
+# candidate must still pass its normal loader ABI/version validation.
+probe_runtime() {
+  timeout --signal=TERM --kill-after=5s 30s python3 "$runtime_probe" --cef-dir "$selected_cef_dir" 2>/dev/null || {
+    echo "first-presentation: CEF runtime probe failed" >&2
+    exit 2
+  }
 }
 
 # The artifact destination is caller-controlled. Never empty or recursively
@@ -141,12 +172,22 @@ prepare_output() {
 
 prepare_output
 
-[[ -x "$binary" ]] || { echo "first-presentation: executable not found: $binary" >&2; exit 2; }
-[[ -d "$runtime" ]] || { echo "first-presentation: CEF runtime not found: $runtime" >&2; exit 2; }
+[[ -x "$binary" ]] || { echo "first-presentation: executable not found" >&2; exit 2; }
+[[ -d "$runtime" ]] || { echo "first-presentation: CEF runtime not found" >&2; exit 2; }
 [[ -n "${WAYLAND_DISPLAY:-}${DISPLAY:-}" ]] || { echo "first-presentation: a current Wayland/X11 display is required" >&2; exit 2; }
-upstream_provenance="$(resolve_upstream_provenance)" || exit $?
-IFS=$'\t' read -r upstream_version upstream_tag upstream_revision <<<"$upstream_provenance"
-readonly upstream_version upstream_tag upstream_revision
+binary_provenance="$(resolve_binary_provenance)" || exit $?
+IFS=$'\t' read -r binary_sha256 measured_source_revision upstream_version upstream_tag upstream_revision <<<"$binary_provenance"
+readonly binary_sha256 measured_source_revision upstream_version upstream_tag upstream_revision
+runtime_probe_json="$(probe_runtime)" || exit $?
+readonly runtime_probe_json
+# Enforce the loader minimum (CHROME_VERSION_MAJOR >= 150) at collection time.
+# This records the observed runtime; it never bypasses the candidate ABI check.
+python3 - "$runtime_probe_json" <<'PY'
+import json, sys
+probe = json.loads(sys.argv[1])
+if not isinstance(probe.get("chrome_version_major"), int) or probe["chrome_version_major"] < 150:
+    raise SystemExit("first-presentation: unsupported CEF runtime")
+PY
 
 # Raw logs and temporary XDG homes may contain machine-local paths. Keep them
 # outside the committed artifact directory and always remove them.
@@ -157,11 +198,10 @@ cleanup_work_root() {
   rm -rf -- "$work_root"
 }
 trap cleanup_work_root EXIT
-python3 - "$output/metadata.json" "$binary" "$timeout_seconds" "$upstream_module" "$upstream_version" "$upstream_tag" "$upstream_revision" <<'PY'
-import hashlib, json, os, platform, subprocess, sys
-path, binary, timeout, upstream_module, upstream_version, upstream_tag, upstream_revision = sys.argv[1:]
-with open(binary, "rb") as candidate:
-  binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+python3 - "$output/metadata.json" "$binary_sha256" "$timeout_seconds" "$upstream_module" "$upstream_version" "$upstream_tag" "$upstream_revision" "$measured_source_revision" "$runtime_probe_json" <<'PY'
+import json, os, platform, sys
+path, binary_sha256, timeout, upstream_module, upstream_version, upstream_tag, upstream_revision, measured_source_revision, probe_raw = sys.argv[1:]
+probe = json.loads(probe_raw)
 
 # These deliberately coarse labels support comparison without exposing a host,
 # device name, driver version, path, or environment dump.
@@ -175,10 +215,10 @@ if gpu_profile not in allowed_gpu_profiles:
 
 json.dump({
   "runs": 5,
-  "runtime": {"label": "cef", "version": "147"},
+  "runtime": {"label": "cef", "chrome_major": probe["chrome_version_major"], "cef_version_major": probe["cef_version_major"], "libcef_sha256": probe["libcef_sha256"]},
   "binary": {"label": "dumber", "sha256": binary_sha256},
   "timeout_seconds": int(timeout),
-  "measured_source_revision": subprocess.check_output(["git", "-c", f"safe.directory={os.getcwd()}", "rev-parse", "HEAD"], text=True).strip(),
+  "measured_source_revision": measured_source_revision,
   "upstream": {"module": upstream_module, "version": upstream_version, "tag": upstream_tag, "revision": upstream_revision},
   "comparison": {"os": os_label, "architecture": architecture, "display_protocol": display_protocol, "machine_gpu_profile": gpu_profile},
   "render_configuration": {"backend": "gdk-dmabuf", "buffer_sharing": "dmabuf", "renderer": "vulkan"}
@@ -197,16 +237,19 @@ format = "json"
 enable_file_log = false
 
 [engine.cef]
-cef_dir = "$runtime"
+cef_dir = "$selected_cef_dir"
 EOF
   # Every directory below is newly created for this one launch. Do not inherit
   # a profile, shader cache, CEF root cache, or mutable app configuration.
+  # CEF_DIR is set to exactly the selected runtime, never a conflicting
+  # inherited override.
   set +e
   env -i \
     HOME="$HOME" PATH="$PATH" LANG="${LANG:-C.UTF-8}" \
     WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-}" DISPLAY="${DISPLAY:-}" XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-}" \
     DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}" XAUTHORITY="${XAUTHORITY:-}" \
     XDG_CONFIG_HOME="$root/config" XDG_DATA_HOME="$root/data" XDG_STATE_HOME="$root/state" XDG_CACHE_HOME="$root/cache" \
+    CEF_DIR="$selected_cef_dir" DUMBER_CEF_DIR="$selected_cef_dir" \
     DUMBER_CEF_ROOT_CACHE_PATH="$root/cef-root-cache" DUMBER_RENDER_STACK="vulkan-dmabuf" \
     PUREGO_CEF2GTK_BACKEND="gdk-dmabuf" PUREGO_CEF2GTK_ANGLE_BACKEND="vulkan" GSK_RENDERER="vulkan" \
     timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" "$binary" browse about:blank >"$root/process.log" 2>&1

--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Generate the build manifest required by scripts/collect_first_presentation.sh.
+
+The collector binds the measured binary to its source and dependency
+revisions via `go version -m` plus this manifest, and fails closed when
+attribution is missing or mismatched. Generate the manifest at build time
+from the same tree that produced the binary:
+
+    python3 scripts/generate_build_manifest.py --binary dist/dumber
+    DUMBER_CEF_DIR=/path/to/cef-runtime scripts/collect_first_presentation.sh
+
+Manifest schema (JSON, sorted keys):
+    {
+      "binary_sha256": "<hex sha256 of the measured binary>",
+      "source_revision": "<40-hex git revision of the built source>",
+      "modules": {
+        "<module path>": {"version": "<exact version>", "revision": "<40-hex>"},
+        ...
+      }
+    }
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+UPSTREAM_MODULE = "github.com/bnema/purego-cef2gtk"
+VERSION_RE = r"(v\d+\.\d+\.\d+)-0\.\d{14}-([0-9a-f]{12})"
+TAG_RE = r"v\d+\.\d+\.\d+"
+
+
+def run(args, **kwargs):
+    return subprocess.check_output(args, text=True, **kwargs).strip()
+
+
+def fail(message):
+    print("generate-build-manifest: {}".format(message), file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a collector build manifest.")
+    parser.add_argument("--binary", required=True, help="Measured binary to attribute.")
+    parser.add_argument("--output", default=None, help="Manifest path (default: <binary>.manifest.json).")
+    parser.add_argument("--source-revision", default=None,
+                        help="40-hex source revision (default: git rev-parse HEAD).")
+    parser.add_argument("--module", default=UPSTREAM_MODULE, help="Dependency module to bind.")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.binary):
+        fail("binary not found")
+    output = args.output or (args.binary + ".manifest.json")
+
+    with open(args.binary, "rb") as candidate:
+        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+
+    try:
+        buildinfo = run(["go", "version", "-m", args.binary], stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        fail("could not read embedded build info")
+    if "=>" in buildinfo:
+        fail("binary was built with a replacement; refusing to attribute it")
+    dep_version = None
+    for line in buildinfo.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0] == "dep" and parts[1] == args.module:
+            dep_version = parts[2]
+    if dep_version is None:
+        fail("dependency {} not found in build info".format(args.module))
+    pseudo = re.fullmatch(VERSION_RE, dep_version)
+    tag = re.fullmatch(TAG_RE, dep_version)
+    if not pseudo and not tag:
+        fail("dependency version is not an immutable tag or pseudo-version")
+
+    try:
+        downloaded = json.loads(run(["go", "mod", "download", "-json", "{}@{}".format(args.module, dep_version)],
+                                    stderr=subprocess.DEVNULL))
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        fail("could not resolve dependency origin")
+    origin = downloaded.get("Origin") or {}
+    revision = origin.get("Hash", "")
+    if origin.get("VCS") != "git" or not re.fullmatch(r"[0-9a-f]{40}", revision):
+        fail("dependency origin is not an immutable git hash")
+    if pseudo and not revision.startswith(pseudo.group(2)):
+        fail("dependency revision does not match its pseudo-version")
+
+    source_revision = args.source_revision
+    if source_revision is None:
+        try:
+            source_revision = run(["git", "rev-parse", "HEAD"])
+        except (OSError, subprocess.CalledProcessError):
+            fail("could not determine source revision; pass --source-revision")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision or ""):
+        fail("source revision must be a 40-hex git revision")
+
+    manifest = {
+        "binary_sha256": binary_sha256,
+        "source_revision": source_revision,
+        "modules": {
+            args.module: {"version": dep_version, "revision": revision},
+        },
+    }
+    with open(output, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print("manifest: {}".format(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -56,7 +56,12 @@ def main():
     output = args.output or (args.binary + ".manifest.json")
 
     with open(args.binary, "rb") as candidate:
-        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+        # Chunked streaming hash: hashlib.file_digest needs 3.11+, this
+        # stays compatible with older 3.x interpreters.
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: candidate.read(65536), b""):
+            digest.update(chunk)
+        binary_sha256 = digest.hexdigest()
 
     try:
         buildinfo = run(["go", "version", "-m", args.binary], stderr=subprocess.DEVNULL)
@@ -65,10 +70,29 @@ def main():
     if "=>" in buildinfo:
         fail("binary was built with a replacement; refusing to attribute it")
     dep_version = None
+    vcs_revision = None
+    vcs_modified = None
     for line in buildinfo.splitlines():
         parts = line.split()
         if len(parts) >= 3 and parts[0] == "dep" and parts[1] == args.module:
             dep_version = parts[2]
+        # `go version -m` reports stamping as "build vcs.revision=<hex>"
+        # (two tab-separated fields, key=value form).
+        elif len(parts) >= 2 and parts[0] == "build" and parts[1].startswith("vcs."):
+            key, _, value = parts[1].partition("=")
+            if key == "vcs.revision":
+                vcs_revision = value
+            elif key == "vcs.modified":
+                vcs_modified = value
+    # The measured binary, not the ambient checkout, is the provenance
+    # source: build-manifest builds with VCS stamping enabled, so the
+    # embedded revision describes the exact built tree. Binaries without
+    # stamping (for example -buildvcs=false quick builds) or built from a
+    # dirty tree are rejected instead of inheriting the checkout HEAD.
+    if vcs_revision is None or not re.fullmatch(r"[0-9a-f]{40}", vcs_revision):
+        fail("binary lacks embedded VCS revision; rebuild with VCS stamping enabled")
+    if vcs_modified != "false":
+        fail("binary was built from a dirty checkout; refusing to attribute it")
     if dep_version is None:
         fail("dependency {} not found in build info".format(args.module))
     pseudo = re.fullmatch(VERSION_RE, dep_version)
@@ -88,14 +112,11 @@ def main():
     if pseudo and not revision.startswith(pseudo.group(2)):
         fail("dependency revision does not match its pseudo-version")
 
-    source_revision = args.source_revision
-    if source_revision is None:
-        try:
-            source_revision = run(["git", "rev-parse", "HEAD"])
-        except (OSError, subprocess.CalledProcessError):
-            fail("could not determine source revision; pass --source-revision")
+    source_revision = args.source_revision or vcs_revision
     if not re.fullmatch(r"[0-9a-f]{40}", source_revision or ""):
         fail("source revision must be a 40-hex git revision")
+    if source_revision != vcs_revision:
+        fail("source revision does not match the revision embedded in the binary")
 
     manifest = {
         "binary_sha256": binary_sha256,

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -382,6 +382,37 @@ def child_pids(root_pid):
     return children
 
 
+def proc_starttime(pid):
+    """Process start time (jiffies since boot) via /proc, or None.
+    Combined with the pid it forms an independently observed identity that
+    survives Popen-handle reuse and detects pid recycling."""
+    try:
+        with open("/proc/%d/stat" % pid) as handle:
+            parts = handle.read().rsplit(")", 1)[1].split()
+            return int(parts[19])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def wait_for_child_quiescence(owner_pid, settle_seconds=2.0, timeout_seconds=15.0):
+    """Wait until the owner's child count is stable across settle_seconds.
+    Window close is asynchronous: the relay acknowledgement only means the
+    request was accepted, so reopening must wait for an observable steady
+    state instead of a fixed sleep. Returns the stable child count."""
+    end = time.monotonic() + timeout_seconds
+    last_change = time.monotonic()
+    last_count = len(child_pids(owner_pid))
+    while time.monotonic() < end:
+        time.sleep(0.5)
+        count = len(child_pids(owner_pid))
+        if count != last_count:
+            last_count = count
+            last_change = time.monotonic()
+        elif time.monotonic() - last_change >= settle_seconds:
+            return count
+    return len(child_pids(owner_pid))
+
+
 def proc_rss_kb(pid):
     """Resident memory of pid in KiB via /proc, or None."""
     try:
@@ -433,14 +464,19 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
         reopen = None
         if scenario == "reopen-window" and owner is not None and owner_socket:
             owner_pid = owner.pid
+            owner_start = proc_starttime(owner_pid)
             children_before = child_pids(owner_pid)
             rss_before = proc_rss_kb(owner_pid)
             acknowledged = send_diagnostic_close(owner_socket)
-            time.sleep(0.5)
+            # The acknowledgement only means accepted: wait for an
+            # observable steady state before measuring the reopen.
+            quiescent_children = wait_for_child_quiescence(owner_pid)
             reopen = {
                 "owner_pid": owner_pid,
+                "owner_starttime": owner_start,
                 "close_acknowledged": acknowledged,
                 "browser_child_count_before": len(children_before),
+                "browser_child_count_quiescent": quiescent_children,
                 "owner_rss_kb_before": rss_before,
             }
         spawn_ts = time.monotonic()
@@ -533,9 +569,18 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             "fallback_spawn": scenario in ("relay-window", "reopen-window") and not relayed,
         }
         if reopen is not None:
+            # Owner identity is verified independently of the Popen handle:
+            # the same pid with a different start time is a recycled pid,
+            # not the same process. Unverifiable identity counts as different.
+            start_now = proc_starttime(reopen["owner_pid"]) if owner is not None else None
             owner_alive = owner is not None and owner.poll() is None
+            same = bool(
+                owner_alive
+                and reopen["owner_starttime"] is not None
+                and start_now == reopen["owner_starttime"]
+            )
             reopen["owner_alive_after"] = owner_alive
-            reopen["same_process"] = bool(owner_alive and reopen["owner_pid"] == owner.pid)
+            reopen["same_process"] = same
             reopen["browser_child_count_after"] = len(child_pids(owner.pid)) if owner_alive else 0
             reopen["owner_rss_kb_after"] = proc_rss_kb(owner.pid) if owner_alive else None
             result["reopen"] = reopen

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Local CEF startup harness with synthetic fixtures (stdlib only).
+
+Scenarios:
+  process-warm   new process, isolated previously initialized profile
+  profile-fresh  new process, new profile each sample
+  relay-window   existing browser owns relay; launch browse with
+                 DUMBER_BROWSER_FRESH_WINDOW=1 and the same isolated profile
+
+Fixtures (loopback only): static, delayed, redirect, cache.
+
+Protocol: the fixture pages embed a buffered PerformanceObserver that prints
+single-line JSON records with opaque run/navigation tokens and numeric fields
+only. The harness parses child stdout for those records plus the existing
+startup_trace milestones. External spawn-to-summary is recorded as an
+explicitly named observation duration, including output-delivery overhead; it
+is never presented as an exact child event timestamp.
+
+Clock domains are kept separate: child t_ms values are never subtracted from
+the harness wall clock. GTK after-paint is labeled GTK paint, never compositor
+presentation. Missing target FCP remains incomplete; the harness never stops
+on a blank GTK summary.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import secrets
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+TOKEN_RE = re.compile(r"^[0-9a-f]{16}$")
+NAV_RE = re.compile(r"^[0-9a-f]{16}$")
+POST_NAV_CUTOFF_SECONDS = 5.0
+
+
+class FixtureState:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.document_requests = []
+        self.subresource_requests = []
+
+
+def build_fixture_html(kind, run_token, nav_token):
+    observer = (
+        "<script>(function(){"
+        "var buf=[];"
+        "function emit(e){console.log(JSON.stringify(e));}"
+        "try{"
+        "var po=new PerformanceObserver(function(list){"
+        "list.getEntries().forEach(function(en){"
+        "if(en.name==='first-contentful-paint'||en.entryType==='largest-contentful-paint'){"
+        "buf.push({message:'cef-startup-fixture',event:en.name,"
+        "run_token:'%s',nav_token:'%s',value_ms:Math.round(en.startTime)});"
+        "}});"
+        "po.observe({type:'paint',buffered:true});"
+        "po.observe({type:'largest-contentful-paint',buffered:true});"
+        "}catch(e){}"
+        "window.addEventListener('load',function(){"
+        "setTimeout(function(){buf.forEach(emit);"
+        "emit({message:'cef-startup-fixture',event:'fixture-load',"
+        "run_token:'%s',nav_token:'%s',value_ms:0});},100);});"
+        "})();</script>" % (run_token, nav_token, run_token, nav_token)
+    )
+    if kind == "static":
+        return (
+            "<!doctype html><html><head><title>static</title>"
+            '<link rel="stylesheet" href="/app.css">'
+            "</head><body><h1>static</h1>"
+            '<img src="/pixel.png">'
+            + observer
+            + "</body></html>"
+        )
+    if kind == "delayed":
+        return (
+            "<!doctype html><html><head><title>delayed</title></head>"
+            "<body><h1>delayed</h1>" + observer + "</body></html>"
+        )
+    if kind == "redirect":
+        return (
+            "<!doctype html><html><head><title>target</title></head>"
+            "<body><h1>target</h1>" + observer + "</body></html>"
+        )
+    if kind == "cache":
+        return (
+            "<!doctype html><html><head><title>cache</title>"
+            '<script src="/cacheable.js"></script>'
+            "</head><body><h1>cache</h1>"
+            '<img src="/cacheable.png">'
+            + observer
+            + "</body></html>"
+        )
+    raise ValueError("unknown fixture: " + kind)
+
+
+class Handler(BaseHTTPRequestHandler):
+    state = None
+    fixture = "static"
+    run_token = ""
+    nav_token = ""
+    delay_seconds = 0.3
+
+    def log_message(self, *args):
+        pass
+
+    def _record(self, document):
+        with self.state.lock:
+            entry = {"path": self.path, "time": time.time()}
+            if document:
+                self.state.document_requests.append(entry)
+            else:
+                self.state.subresource_requests.append(entry)
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        if path in ("/", "/index.html", "/target"):
+            self._record(True)
+            if self.fixture == "delayed" and path == "/":
+                time.sleep(self.delay_seconds)
+            body = build_fixture_html(
+                "static" if self.fixture == "redirect" and path == "/" else self.fixture,
+                self.run_token,
+                self.nav_token,
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/redirect":
+            self._record(True)
+            target = "/target?run=%s&nav=%s" % (self.run_token, self.nav_token)
+            self.send_response(302)
+            self.send_header("Location", target)
+            self.end_headers()
+            return
+        if path in ("/app.css", "/pixel.png", "/cacheable.js", "/cacheable.png"):
+            self._record(False)
+            body = b"/* fixture */" if path.endswith((".css", ".js")) else bytes(64)
+            self.send_response(200)
+            if path.endswith(".css"):
+                self.send_header("Content-Type", "text/css")
+            elif path.endswith(".js"):
+                self.send_header("Content-Type", "application/javascript")
+            else:
+                self.send_header("Content-Type", "image/png")
+            if self.fixture == "cache":
+                self.send_header("Cache-Control", "private, max-age=3600")
+            else:
+                self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self._record(False)
+        self.send_response(404)
+        self.end_headers()
+
+
+def parse_child_output(lines, run_token):
+    milestones = []
+    fixture_events = []
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("message") == "cef-startup-fixture":
+            if (
+                isinstance(event.get("run_token"), str)
+                and TOKEN_RE.fullmatch(event["run_token"])
+                and isinstance(event.get("nav_token"), str)
+                and NAV_RE.fullmatch(event["nav_token"])
+                and event["run_token"] == run_token
+                and isinstance(event.get("value_ms"), int)
+                and event.get("event") in ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
+            ):
+                fixture_events.append(event)
+            continue
+        if event.get("message") == "startup_trace: milestone":
+            milestones.append(event)
+    return milestones, fixture_events
+
+
+def validate_tokens_unique(records):
+    seen = set()
+    for record in records:
+        key = (record.get("run_token"), record.get("nav_token"))
+        if key in seen:
+            return False
+        seen.add(key)
+    return True
+
+
+def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profile_dir, extra_env):
+    run_token = secrets.token_hex(8)
+    nav_token = secrets.token_hex(8)
+    state = FixtureState()
+    Handler.state = state
+    Handler.fixture = fixture
+    Handler.run_token = run_token
+    Handler.nav_token = nav_token
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05})
+    thread.daemon = True
+    thread.start()
+    try:
+        if fixture == "redirect":
+            url = "http://127.0.0.1:%d/redirect?run=%s&nav=%s" % (port, run_token, nav_token)
+        else:
+            url = "http://127.0.0.1:%d/?run=%s&nav=%s" % (port, run_token, nav_token)
+        run_dir = tempfile.mkdtemp(prefix="cef-startup-run-%02d-" % run_index)
+        config_dir = os.path.join(run_dir, "config")
+        os.makedirs(os.path.join(config_dir, "dumber"))
+        with open(os.path.join(config_dir, "dumber", "config.toml"), "w") as config:
+            config.write(
+                '[logging]\nlevel = "debug"\nformat = "json"\nenable_file_log = false\n\n'
+                '[engine.cef]\ncef_dir = "%s"\n' % cef_dir
+            )
+        env = {
+            "HOME": os.environ.get("HOME", ""),
+            "PATH": os.environ.get("PATH", ""),
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+            "DISPLAY": os.environ.get("DISPLAY", ""),
+            "WAYLAND_DISPLAY": os.environ.get("WAYLAND_DISPLAY", ""),
+            "XDG_CONFIG_HOME": config_dir,
+            "XDG_DATA_HOME": os.path.join(run_dir, "data"),
+            "XDG_STATE_HOME": os.path.join(run_dir, "state"),
+            "XDG_CACHE_HOME": os.path.join(run_dir, "cache"),
+            "CEF_DIR": cef_dir,
+            "DUMBER_CEF_DIR": cef_dir,
+            "DUMBER_CEF_ROOT_CACHE_PATH": os.path.join(run_dir, "cef-root-cache"),
+        }
+        if scenario == "relay-window":
+            env["DUMBER_BROWSER_FRESH_WINDOW"] = "1"
+        env.update(extra_env)
+        for key in ("XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"):
+            os.makedirs(env[key], exist_ok=True)
+        if scenario == "process-warm" and profile_dir is not None:
+            env["DUMBER_PROFILE_DIR"] = profile_dir
+        start = time.monotonic()
+        if scenario == "relay-window" and relay_proc is not None:
+            proc = subprocess.Popen(
+                [binary, "browse", url],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            relayed = relay_proc.poll() is None
+        else:
+            proc = subprocess.Popen(
+                [binary, "browse", url],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            relayed = False
+        try:
+            stdout, _ = proc.communicate(timeout=POST_NAV_CUTOFF_SECONDS + 10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, _ = proc.communicate()
+        observation_ms = int((time.monotonic() - start) * 1000)
+        lines = stdout.splitlines()
+        milestones, fixture_events = parse_child_output(lines, run_token)
+        fcp = [e for e in fixture_events if e["event"] == "first-contentful-paint"]
+        lcp = [e for e in fixture_events if e["event"] == "largest-contentful-paint"]
+        with state.lock:
+            document_count = len(state.document_requests)
+            subresource_count = len(state.subresource_requests)
+        if fixture == "redirect":
+            complete = document_count >= 1 and len(fcp) > 0
+        else:
+            complete = document_count == 1 and len(fcp) > 0
+        result = {
+            "run": run_index,
+            "scenario": scenario,
+            "fixture": fixture,
+            "run_token": run_token,
+            "nav_token": nav_token,
+            "observation_spawn_to_summary_ms": observation_ms,
+            "document_requests": document_count,
+            "subresource_requests": subresource_count,
+            "target_fcp_ms": fcp[0]["value_ms"] if fcp else None,
+            "target_lcp_through_cutoff_ms": lcp[-1]["value_ms"] if lcp else None,
+            "complete": complete,
+            "relayed": relayed,
+            "fallback_spawn": scenario == "relay-window" and not relayed,
+        }
+        return result
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Measure CEF startup against synthetic fixtures.")
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--cef-dir", required=True)
+    parser.add_argument(
+        "--scenario",
+        required=True,
+        choices=("process-warm", "profile-fresh", "relay-window"),
+    )
+    parser.add_argument(
+        "--fixture",
+        required=True,
+        choices=("static", "delayed", "redirect", "cache"),
+    )
+    parser.add_argument("--runs", type=int, default=30)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    if args.runs < 1 or args.runs > 100:
+        print("measure: --runs must be 1..100", file=sys.stderr)
+        raise SystemExit(2)
+    if not os.path.isabs(args.output) or os.path.exists(args.output) or os.path.islink(args.output):
+        print("measure: --output must be a fresh absolute directory", file=sys.stderr)
+        raise SystemExit(2)
+    parent = os.path.dirname(args.output)
+    if not os.path.isdir(parent) or os.path.islink(parent):
+        print("measure: --output parent must be an existing directory", file=sys.stderr)
+        raise SystemExit(2)
+    if not (os.path.isfile(args.binary) and os.access(args.binary, os.X_OK)):
+        print("measure: --binary must be executable", file=sys.stderr)
+        raise SystemExit(2)
+    if not os.path.isdir(args.cef_dir):
+        print("measure: --cef-dir must be a directory", file=sys.stderr)
+        raise SystemExit(2)
+    with open(args.binary, "rb") as candidate:
+        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+
+    os.makedirs(args.output)
+    profile_dir = None
+    if args.scenario == "process-warm":
+        profile_dir = os.path.join(args.output, "warm-profile")
+        os.makedirs(profile_dir)
+    relay_proc = None
+    if args.scenario == "relay-window":
+        relay_proc = subprocess.Popen(
+            [args.binary, "--relay-owner"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(0.5)
+        if relay_proc.poll() is not None:
+            relay_proc = None
+
+    results = []
+    try:
+        for index in range(1, args.runs + 1):
+            result = run_sample(
+                args.binary, args.cef_dir, args.scenario, args.fixture, index, relay_proc, profile_dir, {}
+            )
+            results.append(result)
+            with open(os.path.join(args.output, "run-%02d.json" % index), "w") as handle:
+                json.dump(result, handle, indent=2, sort_keys=True)
+    finally:
+        if relay_proc is not None and relay_proc.poll() is None:
+            relay_proc.terminate()
+            try:
+                relay_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                relay_proc.kill()
+
+    summary = {
+        "binary_sha256": binary_sha256,
+        "scenario": args.scenario,
+        "fixture": args.fixture,
+        "runs": len(results),
+        "complete_runs": sum(1 for r in results if r["complete"]),
+        "incomplete_runs": sum(1 for r in results if not r["complete"]),
+        "duplicate_document_runs": sum(
+            1 for r in results if r["document_requests"] != (1 if args.fixture != "redirect" else r["document_requests"])
+        ),
+    }
+    with open(os.path.join(args.output, "summary.json"), "w") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+    print("measure artifacts: %s" % args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -8,6 +8,10 @@ Scenarios:
   relay-window   a real long-lived owner browser holds the relay; samples
                  launch browse with DUMBER_BROWSER_FRESH_WINDOW=1 in that
                  same isolated profile
+  reopen-window  like relay-window, but each sample first closes all owner
+                 windows through the diagnostic relay action, then reopens
+                 through the relay; verifies the same owner process serves
+                 the reopen without a second CEF initialization
 
 Fixtures (loopback only): static, delayed, redirect, cache.
 
@@ -281,7 +285,7 @@ def wait_for_relay_socket(runtime_dir, timeout_seconds=30.0):
     return None
 
 
-def start_relay_owner(binary, cef_dir, scenario_dir):
+def start_relay_owner(binary, cef_dir, scenario_dir, diagnostic_close=False):
     dirs = {
         "config": os.path.join(scenario_dir, "owner-config"),
         "data": os.path.join(scenario_dir, "owner-data"),
@@ -291,6 +295,12 @@ def start_relay_owner(binary, cef_dir, scenario_dir):
         "root_cache": os.path.join(scenario_dir, "shared-profile"),
     }
     env = scenario_env(cef_dir, dirs)
+    if diagnostic_close:
+        # Owned window-close mechanism for the reopen scenario only: the
+        # relay honors it solely in processes carrying this variable. It is
+        # never a general unauthenticated shutdown command.
+        env = dict(env)
+        env["DUMBER_DIAGNOSTIC_WINDOW_CLOSE"] = "1"
     try:
         proc = subprocess.Popen(
             [binary, "browse", "about:blank"],
@@ -299,18 +309,19 @@ def start_relay_owner(binary, cef_dir, scenario_dir):
             env=env,
         )
     except OSError:
-        return None, None
+        return None, None, None
     time.sleep(0.5)
     if proc.poll() is not None:
-        return None, None
-    if wait_for_relay_socket(dirs["runtime"]) is None:
+        return None, None, None
+    socket_path = wait_for_relay_socket(dirs["runtime"])
+    if socket_path is None:
         proc.terminate()
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
-        return None, None
-    return proc, dirs
+        return None, None, None
+    return proc, dirs, socket_path
 
 
 def stop_proc(proc):
@@ -324,8 +335,67 @@ def stop_proc(proc):
         proc.wait(timeout=5)
 
 
+def send_diagnostic_close(socket_path, timeout_seconds=10.0):
+    """Ask the relay owner to close all windows. Returns True only on an
+    explicit acknowledgement. Never a general shutdown command: owners
+    honor it solely with DUMBER_DIAGNOSTIC_WINDOW_CLOSE=1."""
+    request = json.dumps({"request_id": secrets.token_hex(8), "action": "close-all-windows"}) + "\n"
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout_seconds)
+    try:
+        sock.connect(socket_path)
+        sock.sendall(request.encode())
+        received = b""
+        while b"\n" not in received:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            received += chunk
+        try:
+            response = json.loads(received.decode())
+        except ValueError:
+            return False
+        return bool(response.get("accepted")) and not response.get("error")
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def child_pids(root_pid):
+    """Direct child pids of root_pid via /proc (stdlib only)."""
+    children = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return children
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        try:
+            with open("/proc/%s/stat" % entry) as handle:
+                parts = handle.read().rsplit(")", 1)[1].split()
+                if int(parts[1]) == root_pid:
+                    children.append(int(entry))
+        except (OSError, ValueError, IndexError):
+            continue
+    return children
+
+
+def proc_rss_kb(pid):
+    """Resident memory of pid in KiB via /proc, or None."""
+    try:
+        with open("/proc/%d/status" % pid) as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
 def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_dirs=None,
-               shared_root_cache=None):
+               shared_root_cache=None, owner_socket=None):
     run_token = secrets.token_hex(8)
     nav_token = secrets.token_hex(8)
     cutoff = post_nav_cutoff_seconds()
@@ -345,7 +415,7 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             url = "http://127.0.0.1:%d/redirect?run=%s&nav=%s" % (port, run_token, nav_token)
         else:
             url = "http://127.0.0.1:%d/?run=%s&nav=%s" % (port, run_token, nav_token)
-        if scenario == "relay-window" and owner_dirs is not None:
+        if scenario in ("relay-window", "reopen-window") and owner_dirs is not None:
             dirs = dict(owner_dirs)
             extra = {"DUMBER_BROWSER_FRESH_WINDOW": "1"}
         else:
@@ -360,6 +430,19 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             extra = {}
         env = scenario_env(cef_dir, dirs, extra)
         owner_alive_at_start = owner is not None and owner.poll() is None
+        reopen = None
+        if scenario == "reopen-window" and owner is not None and owner_socket:
+            owner_pid = owner.pid
+            children_before = child_pids(owner_pid)
+            rss_before = proc_rss_kb(owner_pid)
+            acknowledged = send_diagnostic_close(owner_socket)
+            time.sleep(0.5)
+            reopen = {
+                "owner_pid": owner_pid,
+                "close_acknowledged": acknowledged,
+                "browser_child_count_before": len(children_before),
+                "owner_rss_kb_before": rss_before,
+            }
         spawn_ts = time.monotonic()
         proc = subprocess.Popen(
             [binary, "browse", url],
@@ -429,11 +512,11 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             observation_ms = int((decision_ts - spawn_ts) * 1000)
         expected_document_requests = 2 if fixture == "redirect" else 1
         complete = document_count == expected_document_requests and len(fcp) > 0
-        if scenario == "relay-window":
+        if scenario in ("relay-window", "reopen-window"):
             relayed = bool(owner_alive_at_start and self_exited)
         else:
             relayed = False
-        return {
+        result = {
             "run": run_index,
             "scenario": scenario,
             "fixture": fixture,
@@ -447,8 +530,16 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             "startup_milestones": len(milestones),
             "complete": complete,
             "relayed": relayed,
-            "fallback_spawn": scenario == "relay-window" and not relayed,
+            "fallback_spawn": scenario in ("relay-window", "reopen-window") and not relayed,
         }
+        if reopen is not None:
+            owner_alive = owner is not None and owner.poll() is None
+            reopen["owner_alive_after"] = owner_alive
+            reopen["same_process"] = bool(owner_alive and reopen["owner_pid"] == owner.pid)
+            reopen["browser_child_count_after"] = len(child_pids(owner.pid)) if owner_alive else 0
+            reopen["owner_rss_kb_after"] = proc_rss_kb(owner.pid) if owner_alive else None
+            result["reopen"] = reopen
+        return result
     finally:
         server.shutdown()
         server.server_close()
@@ -463,7 +554,7 @@ def main():
     parser.add_argument(
         "--scenario",
         required=True,
-        choices=("process-warm", "profile-fresh", "relay-window"),
+        choices=("process-warm", "profile-fresh", "relay-window", "reopen-window"),
     )
     parser.add_argument(
         "--fixture",
@@ -501,6 +592,7 @@ def main():
     os.makedirs(args.output)
     owner = None
     owner_dirs = None
+    owner_socket = None
     shared_root_cache = None
     warmup_discarded = False
     if args.scenario == "process-warm":
@@ -509,7 +601,12 @@ def main():
     if args.scenario == "relay-window":
         scenario_dir = os.path.join(args.output, "relay-scenario")
         os.makedirs(scenario_dir)
-        owner, owner_dirs = start_relay_owner(args.binary, args.cef_dir, scenario_dir)
+        owner, owner_dirs, owner_socket = start_relay_owner(args.binary, args.cef_dir, scenario_dir)
+    if args.scenario == "reopen-window":
+        scenario_dir = os.path.join(args.output, "reopen-scenario")
+        os.makedirs(scenario_dir)
+        owner, owner_dirs, owner_socket = start_relay_owner(
+            args.binary, args.cef_dir, scenario_dir, diagnostic_close=True)
 
     results = []
     try:
@@ -528,6 +625,7 @@ def main():
             result = run_sample(
                 args.binary, args.cef_dir, args.scenario, args.fixture, index,
                 owner=owner, owner_dirs=owner_dirs, shared_root_cache=shared_root_cache,
+                owner_socket=owner_socket,
             )
             results.append(result)
             with open(os.path.join(args.output, "run-%02d.json" % index), "w") as handle:

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -2,19 +2,21 @@
 """Local CEF startup harness with synthetic fixtures (stdlib only).
 
 Scenarios:
-  process-warm   new process, isolated previously initialized profile
+  process-warm   one unrecorded warm-up, then new processes sharing an
+                 isolated previously initialized CEF root-cache profile
   profile-fresh  new process, new profile each sample
-  relay-window   existing browser owns relay; launch browse with
-                 DUMBER_BROWSER_FRESH_WINDOW=1 and the same isolated profile
+  relay-window   a real long-lived owner browser holds the relay; samples
+                 launch browse with DUMBER_BROWSER_FRESH_WINDOW=1 in that
+                 same isolated profile
 
 Fixtures (loopback only): static, delayed, redirect, cache.
 
-Protocol: the fixture pages embed a buffered PerformanceObserver that prints
-single-line JSON records with opaque run/navigation tokens and numeric fields
-only. The harness parses child stdout for those records plus the existing
-startup_trace milestones. External spawn-to-summary is recorded as an
-explicitly named observation duration, including output-delivery overhead; it
-is never presented as an exact child event timestamp.
+Protocol: fixture pages report PerformanceObserver results through a
+token-authenticated loopback beacon (/__beacon with run/nav/event/value
+parameters) served by the harness HTTP server. Beacon arrivals carry the
+harness monotonic timestamp. External spawn-to-arrival is recorded as an
+explicitly named observation duration, including output-delivery overhead;
+it is never presented as an exact child event timestamp.
 
 Clock domains are kept separate: child t_ms values are never subtracted from
 the harness wall clock. GTK after-paint is labeled GTK paint, never compositor
@@ -28,17 +30,28 @@ import json
 import os
 import re
 import secrets
+import shutil
+import socket
 import subprocess
 import sys
 import tempfile
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 TOKEN_RE = re.compile(r"^[0-9a-f]{16}$")
 NAV_RE = re.compile(r"^[0-9a-f]{16}$")
-POST_NAV_CUTOFF_SECONDS = 5.0
+BEACON_EVENTS = ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
+DEFAULT_POST_NAV_CUTOFF_SECONDS = 5.0
+
+
+def post_nav_cutoff_seconds():
+    try:
+        value = float(os.environ.get("DUMBER_MEASURE_CUTOFF_SECONDS", DEFAULT_POST_NAV_CUTOFF_SECONDS))
+    except ValueError:
+        return DEFAULT_POST_NAV_CUTOFF_SECONDS
+    return min(30.0, max(0.1, value))
 
 
 class FixtureState:
@@ -46,28 +59,29 @@ class FixtureState:
         self.lock = threading.Lock()
         self.document_requests = []
         self.subresource_requests = []
+        self.beacons = []
+        self.first_document_monotonic = None
 
 
 def build_fixture_html(kind, run_token, nav_token):
     observer = (
         "<script>(function(){"
-        "var buf=[];"
-        "function emit(e){console.log(JSON.stringify(e));}"
+        "function beacon(event, value){"
+        "fetch('/__beacon?run=%s&nav=%s&event='+event+'&value='+value,"
+        "{cache:'no-store'}).catch(function(){});"
+        "}"
         "try{"
         "var po=new PerformanceObserver(function(list){"
         "list.getEntries().forEach(function(en){"
-        "if(en.name==='first-contentful-paint'||en.entryType==='largest-contentful-paint'){"
-        "buf.push({message:'cef-startup-fixture',event:en.name,"
-        "run_token:'%s',nav_token:'%s',value_ms:Math.round(en.startTime)});"
+        "if(en.name==='first-contentful-paint'){beacon('first-contentful-paint',Math.round(en.startTime));}"
+        "else if(en.entryType==='largest-contentful-paint'){beacon('largest-contentful-paint',Math.round(en.startTime));}"
         "}});"
         "po.observe({type:'paint',buffered:true});"
         "po.observe({type:'largest-contentful-paint',buffered:true});"
         "}catch(e){}"
         "window.addEventListener('load',function(){"
-        "setTimeout(function(){buf.forEach(emit);"
-        "emit({message:'cef-startup-fixture',event:'fixture-load',"
-        "run_token:'%s',nav_token:'%s',value_ms:0});},100);});"
-        "})();</script>" % (run_token, nav_token, run_token, nav_token)
+        "setTimeout(function(){beacon('fixture-load',0);},100);});"
+        "})();</script>" % (run_token, nav_token)
     )
     if kind == "static":
         return (
@@ -112,15 +126,20 @@ class Handler(BaseHTTPRequestHandler):
 
     def _record(self, document):
         with self.state.lock:
-            entry = {"path": self.path, "time": time.time()}
+            entry = {"path": self.path, "time": time.monotonic()}
             if document:
                 self.state.document_requests.append(entry)
+                if self.state.first_document_monotonic is None:
+                    self.state.first_document_monotonic = entry["time"]
             else:
                 self.state.subresource_requests.append(entry)
 
     def do_GET(self):
         parsed = urlparse(self.path)
         path = parsed.path
+        if path == "/__beacon":
+            self._handle_beacon(parsed)
+            return
         if path in ("/", "/index.html", "/target"):
             self._record(True)
             if self.fixture == "delayed" and path == "/":
@@ -165,47 +184,139 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(404)
         self.end_headers()
 
+    def _handle_beacon(self, parsed):
+        query = parse_qs(parsed.query)
+        run = query.get("run", [None])[0]
+        nav = query.get("nav", [None])[0]
+        event = query.get("event", [None])[0]
+        value_raw = query.get("value", [None])[0]
+        valid = (
+            isinstance(run, str) and TOKEN_RE.fullmatch(run) and run == self.run_token
+            and isinstance(nav, str) and NAV_RE.fullmatch(nav) and nav == self.nav_token
+            and event in BEACON_EVENTS
+        )
+        try:
+            value = int(value_raw) if valid else None
+            valid = valid and value is not None and value >= 0
+        except (TypeError, ValueError):
+            valid = False
+        if not valid:
+            self.send_response(400)
+            self.end_headers()
+            return
+        with self.state.lock:
+            self.state.beacons.append({
+                "event": event,
+                "value_ms": value,
+                "arrival_monotonic": time.monotonic(),
+            })
+        self.send_response(204)
+        self.end_headers()
 
-def parse_child_output(lines, run_token):
+
+def parse_child_output(lines):
     milestones = []
-    fixture_events = []
     for line in lines:
         try:
             event = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
-        if not isinstance(event, dict):
-            continue
-        if event.get("message") == "cef-startup-fixture":
-            if (
-                isinstance(event.get("run_token"), str)
-                and TOKEN_RE.fullmatch(event["run_token"])
-                and isinstance(event.get("nav_token"), str)
-                and NAV_RE.fullmatch(event["nav_token"])
-                and event["run_token"] == run_token
-                and isinstance(event.get("value_ms"), int)
-                and event.get("event") in ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
-            ):
-                fixture_events.append(event)
-            continue
-        if event.get("message") == "startup_trace: milestone":
+        if isinstance(event, dict) and event.get("message") == "startup_trace: milestone":
             milestones.append(event)
-    return milestones, fixture_events
+    return milestones
 
 
-def validate_tokens_unique(records):
-    seen = set()
-    for record in records:
-        key = (record.get("run_token"), record.get("nav_token"))
-        if key in seen:
-            return False
-        seen.add(key)
-    return True
+def scenario_env(cef_dir, dirs, extra=None):
+    env = {
+        "HOME": os.environ.get("HOME", ""),
+        "PATH": os.environ.get("PATH", ""),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "DISPLAY": os.environ.get("DISPLAY", ""),
+        "WAYLAND_DISPLAY": os.environ.get("WAYLAND_DISPLAY", ""),
+        "XDG_CONFIG_HOME": dirs["config"],
+        "XDG_DATA_HOME": dirs["data"],
+        "XDG_STATE_HOME": dirs["state"],
+        "XDG_CACHE_HOME": dirs["cache"],
+        "XDG_RUNTIME_DIR": dirs["runtime"],
+        "CEF_DIR": cef_dir,
+        "DUMBER_CEF_DIR": cef_dir,
+        "DUMBER_CEF_ROOT_CACHE_PATH": dirs["root_cache"],
+    }
+    if extra:
+        env.update(extra)
+    for key in ("config", "data", "state", "cache", "runtime"):
+        os.makedirs(dirs[key], exist_ok=True)
+    os.makedirs(dirs["root_cache"], exist_ok=True)
+    return env
 
 
-def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profile_dir, extra_env):
+def wait_for_relay_socket(runtime_dir, timeout_seconds=30.0):
+    end = time.monotonic() + timeout_seconds
+    while time.monotonic() < end:
+        for root, _, files in os.walk(runtime_dir):
+            if "browser-launch.sock" in files:
+                path = os.path.join(root, "browser-launch.sock")
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.settimeout(2.0)
+                try:
+                    sock.connect(path)
+                    return path
+                except OSError:
+                    pass
+                finally:
+                    sock.close()
+        time.sleep(0.2)
+    return None
+
+
+def start_relay_owner(binary, cef_dir, scenario_dir):
+    dirs = {
+        "config": os.path.join(scenario_dir, "owner-config"),
+        "data": os.path.join(scenario_dir, "owner-data"),
+        "state": os.path.join(scenario_dir, "owner-state"),
+        "cache": os.path.join(scenario_dir, "owner-cache"),
+        "runtime": os.path.join(scenario_dir, "owner-runtime"),
+        "root_cache": os.path.join(scenario_dir, "shared-profile"),
+    }
+    env = scenario_env(cef_dir, dirs)
+    try:
+        proc = subprocess.Popen(
+            [binary, "browse", "about:blank"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+    except OSError:
+        return None, None
+    time.sleep(0.5)
+    if proc.poll() is not None:
+        return None, None
+    if wait_for_relay_socket(dirs["runtime"]) is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        return None, None
+    return proc, dirs
+
+
+def stop_proc(proc):
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_dirs=None,
+               shared_root_cache=None):
     run_token = secrets.token_hex(8)
     nav_token = secrets.token_hex(8)
+    cutoff = post_nav_cutoff_seconds()
     state = FixtureState()
     Handler.state = state
     Handler.fixture = fixture
@@ -216,77 +327,103 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profil
     thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05})
     thread.daemon = True
     thread.start()
+    run_dir = tempfile.mkdtemp(prefix="cef-startup-run-%02d-" % run_index)
     try:
         if fixture == "redirect":
             url = "http://127.0.0.1:%d/redirect?run=%s&nav=%s" % (port, run_token, nav_token)
         else:
             url = "http://127.0.0.1:%d/?run=%s&nav=%s" % (port, run_token, nav_token)
-        run_dir = tempfile.mkdtemp(prefix="cef-startup-run-%02d-" % run_index)
-        config_dir = os.path.join(run_dir, "config")
-        os.makedirs(os.path.join(config_dir, "dumber"))
-        with open(os.path.join(config_dir, "dumber", "config.toml"), "w") as config:
-            config.write(
-                '[logging]\nlevel = "debug"\nformat = "json"\nenable_file_log = false\n\n'
-                '[engine.cef]\ncef_dir = "%s"\n' % cef_dir
-            )
-        env = {
-            "HOME": os.environ.get("HOME", ""),
-            "PATH": os.environ.get("PATH", ""),
-            "LANG": os.environ.get("LANG", "C.UTF-8"),
-            "DISPLAY": os.environ.get("DISPLAY", ""),
-            "WAYLAND_DISPLAY": os.environ.get("WAYLAND_DISPLAY", ""),
-            "XDG_CONFIG_HOME": config_dir,
-            "XDG_DATA_HOME": os.path.join(run_dir, "data"),
-            "XDG_STATE_HOME": os.path.join(run_dir, "state"),
-            "XDG_CACHE_HOME": os.path.join(run_dir, "cache"),
-            "CEF_DIR": cef_dir,
-            "DUMBER_CEF_DIR": cef_dir,
-            "DUMBER_CEF_ROOT_CACHE_PATH": os.path.join(run_dir, "cef-root-cache"),
-        }
-        if scenario == "relay-window":
-            env["DUMBER_BROWSER_FRESH_WINDOW"] = "1"
-        env.update(extra_env)
-        for key in ("XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"):
-            os.makedirs(env[key], exist_ok=True)
-        if scenario == "process-warm" and profile_dir is not None:
-            env["DUMBER_PROFILE_DIR"] = profile_dir
-        start = time.monotonic()
-        if scenario == "relay-window" and relay_proc is not None:
-            proc = subprocess.Popen(
-                [binary, "browse", url],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
-            relayed = relay_proc.poll() is None
+        if scenario == "relay-window" and owner_dirs is not None:
+            dirs = dict(owner_dirs)
+            extra = {"DUMBER_BROWSER_FRESH_WINDOW": "1"}
         else:
-            proc = subprocess.Popen(
-                [binary, "browse", url],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
-            relayed = False
+            dirs = {
+                "config": os.path.join(run_dir, "config"),
+                "data": os.path.join(run_dir, "data"),
+                "state": os.path.join(run_dir, "state"),
+                "cache": os.path.join(run_dir, "cache"),
+                "runtime": os.path.join(run_dir, "runtime"),
+                "root_cache": shared_root_cache or os.path.join(run_dir, "cef-root-cache"),
+            }
+            extra = {}
+        env = scenario_env(cef_dir, dirs, extra)
+        owner_alive_at_start = owner is not None and owner.poll() is None
+        spawn_ts = time.monotonic()
+        proc = subprocess.Popen(
+            [binary, "browse", url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+        arrivals = []
+
+        def pump():
+            try:
+                for line in proc.stdout:
+                    arrivals.append((time.monotonic(), line))
+            except ValueError:
+                pass
+
+        pump_thread = threading.Thread(target=pump)
+        pump_thread.daemon = True
+        pump_thread.start()
+        hard_end = spawn_ts + cutoff + 25.0
+        while True:
+            now = time.monotonic()
+            with state.lock:
+                navigated_at = state.first_document_monotonic
+                fixture_done = any(
+                    b["event"] == "fixture-load" for b in state.beacons
+                )
+            exited = proc.poll() is not None
+            if navigated_at is not None:
+                if fixture_done and now >= navigated_at + cutoff:
+                    break
+                if now >= navigated_at + cutoff + 5.0:
+                    break
+            elif now >= spawn_ts + cutoff + 5.0 or exited:
+                break
+            if now >= hard_end:
+                break
+            time.sleep(0.05)
+        self_exited = proc.poll() is not None
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        pump_thread.join(timeout=5)
         try:
-            stdout, _ = proc.communicate(timeout=POST_NAV_CUTOFF_SECONDS + 10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            stdout, _ = proc.communicate()
-        observation_ms = int((time.monotonic() - start) * 1000)
-        lines = stdout.splitlines()
-        milestones, fixture_events = parse_child_output(lines, run_token)
-        fcp = [e for e in fixture_events if e["event"] == "first-contentful-paint"]
-        lcp = [e for e in fixture_events if e["event"] == "largest-contentful-paint"]
+            proc.stdout.close()
+        except (AttributeError, ValueError):
+            pass
+        decision_ts = time.monotonic()
+        milestones = parse_child_output([line for _, line in arrivals])
         with state.lock:
+            beacons = list(state.beacons)
             document_count = len(state.document_requests)
             subresource_count = len(state.subresource_requests)
+        fcp = [b for b in beacons if b["event"] == "first-contentful-paint"]
+        lcp = [b for b in beacons if b["event"] == "largest-contentful-paint"]
+        if fcp:
+            observation_ms = int((fcp[0]["arrival_monotonic"] - spawn_ts) * 1000)
+        elif beacons:
+            observation_ms = int((beacons[-1]["arrival_monotonic"] - spawn_ts) * 1000)
+        else:
+            observation_ms = int((decision_ts - spawn_ts) * 1000)
         if fixture == "redirect":
             complete = document_count >= 1 and len(fcp) > 0
         else:
             complete = document_count == 1 and len(fcp) > 0
-        result = {
+        if scenario == "relay-window":
+            relayed = bool(owner_alive_at_start and self_exited)
+        else:
+            relayed = False
+        return {
             "run": run_index,
             "scenario": scenario,
             "fixture": fixture,
@@ -297,15 +434,16 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, relay_proc, profil
             "subresource_requests": subresource_count,
             "target_fcp_ms": fcp[0]["value_ms"] if fcp else None,
             "target_lcp_through_cutoff_ms": lcp[-1]["value_ms"] if lcp else None,
+            "startup_milestones": len(milestones),
             "complete": complete,
             "relayed": relayed,
             "fallback_spawn": scenario == "relay-window" and not relayed,
         }
-        return result
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
+        shutil.rmtree(run_dir, ignore_errors=True)
 
 
 def main():
@@ -346,37 +484,36 @@ def main():
         binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
 
     os.makedirs(args.output)
-    profile_dir = None
+    owner = None
+    owner_dirs = None
+    shared_root_cache = None
+    warmup_discarded = False
     if args.scenario == "process-warm":
-        profile_dir = os.path.join(args.output, "warm-profile")
-        os.makedirs(profile_dir)
-    relay_proc = None
+        shared_root_cache = os.path.join(args.output, "warm-profile", "cef-root-cache")
+        os.makedirs(shared_root_cache)
     if args.scenario == "relay-window":
-        relay_proc = subprocess.Popen(
-            [args.binary, "--relay-owner"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        time.sleep(0.5)
-        if relay_proc.poll() is not None:
-            relay_proc = None
+        scenario_dir = os.path.join(args.output, "relay-scenario")
+        os.makedirs(scenario_dir)
+        owner, owner_dirs = start_relay_owner(args.binary, args.cef_dir, scenario_dir)
 
     results = []
     try:
+        if args.scenario == "process-warm":
+            # One unrecorded warm-up initializes the shared profile; only the
+            # recorded samples below count toward the report.
+            run_sample(args.binary, args.cef_dir, args.scenario, args.fixture,
+                       0, shared_root_cache=shared_root_cache)
+            warmup_discarded = True
         for index in range(1, args.runs + 1):
             result = run_sample(
-                args.binary, args.cef_dir, args.scenario, args.fixture, index, relay_proc, profile_dir, {}
+                args.binary, args.cef_dir, args.scenario, args.fixture, index,
+                owner=owner, owner_dirs=owner_dirs, shared_root_cache=shared_root_cache,
             )
             results.append(result)
             with open(os.path.join(args.output, "run-%02d.json" % index), "w") as handle:
                 json.dump(result, handle, indent=2, sort_keys=True)
     finally:
-        if relay_proc is not None and relay_proc.poll() is None:
-            relay_proc.terminate()
-            try:
-                relay_proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                relay_proc.kill()
+        stop_proc(owner)
 
     summary = {
         "binary_sha256": binary_sha256,
@@ -386,8 +523,10 @@ def main():
         "complete_runs": sum(1 for r in results if r["complete"]),
         "incomplete_runs": sum(1 for r in results if not r["complete"]),
         "duplicate_document_runs": sum(
-            1 for r in results if r["document_requests"] != (1 if args.fixture != "redirect" else r["document_requests"])
+            1 for r in results if args.fixture != "redirect" and r["document_requests"] != 1
         ),
+        "warmup_discarded": warmup_discarded,
+        "relay_owner_ready": owner is not None,
     }
     with open(os.path.join(args.output, "summary.json"), "w") as handle:
         json.dump(summary, handle, indent=2, sort_keys=True)

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -45,6 +45,15 @@ NAV_RE = re.compile(r"^[0-9a-f]{16}$")
 BEACON_EVENTS = ("first-contentful-paint", "largest-contentful-paint", "fixture-load")
 DEFAULT_POST_NAV_CUTOFF_SECONDS = 5.0
 
+# Deterministic 1x1 RGBA PNG so image endpoints exercise a successful decode
+# and paint instead of the decode-failure path.
+FIXTURE_PNG = bytes.fromhex(
+    "89504e470d0a1a0a"
+    "0000000d49484452000000010000000108060000001f15c489"
+    "0000000b4944415478da6360000300000700012122db13"
+    "0000000049454e44ae426082"
+)
+
 
 def post_nav_cutoff_seconds():
     try:
@@ -164,7 +173,10 @@ class Handler(BaseHTTPRequestHandler):
             return
         if path in ("/app.css", "/pixel.png", "/cacheable.js", "/cacheable.png"):
             self._record(False)
-            body = b"/* fixture */" if path.endswith((".css", ".js")) else bytes(64)
+            if path.endswith(".png"):
+                body = FIXTURE_PNG
+            else:
+                body = b"/* fixture */"
             self.send_response(200)
             if path.endswith(".css"):
                 self.send_header("Content-Type", "text/css")

--- a/scripts/measure_cef_startup.py
+++ b/scripts/measure_cef_startup.py
@@ -427,10 +427,8 @@ def run_sample(binary, cef_dir, scenario, fixture, run_index, owner=None, owner_
             observation_ms = int((beacons[-1]["arrival_monotonic"] - spawn_ts) * 1000)
         else:
             observation_ms = int((decision_ts - spawn_ts) * 1000)
-        if fixture == "redirect":
-            complete = document_count >= 1 and len(fcp) > 0
-        else:
-            complete = document_count == 1 and len(fcp) > 0
+        expected_document_requests = 2 if fixture == "redirect" else 1
+        complete = document_count == expected_document_requests and len(fcp) > 0
         if scenario == "relay-window":
             relayed = bool(owner_alive_at_start and self_exited)
         else:
@@ -493,7 +491,12 @@ def main():
         print("measure: --cef-dir must be a directory", file=sys.stderr)
         raise SystemExit(2)
     with open(args.binary, "rb") as candidate:
-        binary_sha256 = hashlib.file_digest(candidate, "sha256").hexdigest()
+        # Chunked streaming hash: hashlib.file_digest needs 3.11+, this
+        # stays compatible with older 3.x interpreters.
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: candidate.read(65536), b""):
+            digest.update(chunk)
+        binary_sha256 = digest.hexdigest()
 
     os.makedirs(args.output)
     owner = None
@@ -512,9 +515,14 @@ def main():
     try:
         if args.scenario == "process-warm":
             # One unrecorded warm-up initializes the shared profile; only the
-            # recorded samples below count toward the report.
-            run_sample(args.binary, args.cef_dir, args.scenario, args.fixture,
+            # recorded samples below count toward the report. A failed
+            # warm-up aborts the scenario: later runs must never use an
+            # uninitialized profile.
+            warmup = run_sample(args.binary, args.cef_dir, args.scenario, args.fixture,
                        0, shared_root_cache=shared_root_cache)
+            if not warmup["complete"]:
+                print("measure: process-warm warm-up was incomplete", file=sys.stderr)
+                raise SystemExit(1)
             warmup_discarded = True
         for index in range(1, args.runs + 1):
             result = run_sample(
@@ -535,7 +543,9 @@ def main():
         "complete_runs": sum(1 for r in results if r["complete"]),
         "incomplete_runs": sum(1 for r in results if not r["complete"]),
         "duplicate_document_runs": sum(
-            1 for r in results if args.fixture != "redirect" and r["document_requests"] != 1
+            1
+            for r in results
+            if r["document_requests"] != (2 if args.fixture == "redirect" else 1)
         ),
         "warmup_discarded": warmup_discarded,
         "relay_owner_ready": owner is not None,

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Unit tests for measure_cef_startup.py (stdlib only)."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import measure_cef_startup as harness
+
+
+class ParseTest(unittest.TestCase):
+    def test_accepts_valid_fixture_event(self):
+        token = "a" * 16
+        nav = "b" * 16
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": token, "nav_token": nav, "value_ms": 12}),
+        ]
+        _, events = harness.parse_child_output(lines, token)
+        self.assertEqual(len(events), 1)
+
+    def test_rejects_wrong_token(self):
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": "c" * 16, "nav_token": "d" * 16, "value_ms": 12}),
+        ]
+        _, events = harness.parse_child_output(lines, "a" * 16)
+        self.assertEqual(events, [])
+
+    def test_rejects_non_numeric_value(self):
+        token = "a" * 16
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": token, "nav_token": "b" * 16, "value_ms": "12"}),
+        ]
+        _, events = harness.parse_child_output(lines, token)
+        self.assertEqual(events, [])
+
+    def test_rejects_malformed_token(self):
+        lines = [
+            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
+                        "run_token": "short", "nav_token": "b" * 16, "value_ms": 12}),
+        ]
+        _, events = harness.parse_child_output(lines, "short")
+        self.assertEqual(events, [])
+
+
+class CliValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "measure_cef_startup.py")
+        self.temp = tempfile.mkdtemp()
+        self.binary = os.path.join(self.temp, "fakebin")
+        with open(self.binary, "w") as handle:
+            handle.write("#!/bin/sh\nexit 0\n")
+        os.chmod(self.binary, 0o755)
+        self.cef_dir = os.path.join(self.temp, "cef")
+        os.makedirs(self.cef_dir)
+
+    def run_harness(self, *extra):
+        cmd = [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+               "--scenario", "profile-fresh", "--fixture", "static", "--runs", "1"] + list(extra)
+        return subprocess.run(cmd, capture_output=True, text=True)
+
+    def test_rejects_existing_output(self):
+        existing = os.path.join(self.temp, "exists")
+        os.makedirs(existing)
+        result = self.run_harness("--output", existing)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("fresh absolute directory", result.stderr)
+
+    def test_rejects_relative_output(self):
+        result = self.run_harness("--output", "relative/path")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_missing_binary(self):
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", os.path.join(self.temp, "missing"),
+             "--cef-dir", self.cef_dir, "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "1", "--output", os.path.join(self.temp, "out")],
+            capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_bad_runs(self):
+        result = self.run_harness("--output", os.path.join(self.temp, "out"), "--runs", "0")
+        # argparse passes --runs twice; last wins; use explicit override instead
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+             "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "0", "--output", os.path.join(self.temp, "out2")],
+            capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+
+
+class FakeBinaryLifetimeTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkdtemp()
+        self.cef_dir = os.path.join(self.temp, "cef")
+        os.makedirs(self.cef_dir)
+
+    def make_binary(self, body):
+        path = os.path.join(self.temp, "fake-%d" % len(os.listdir(self.temp)))
+        with open(path, "w") as handle:
+            handle.write("#!/bin/sh\n" + body + "\n")
+        os.chmod(path, 0o755)
+        return path
+
+    def test_duplicate_documents_marked(self):
+        binary = self.make_binary("exit 0")
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        # No fixture events and no document requests through the real binary:
+        # the sample must report incomplete, never synthesized success.
+        self.assertFalse(result["complete"])
+        self.assertIsNone(result["target_fcp_ms"])
+
+    def test_absent_fcp_is_incomplete(self):
+        binary = self.make_binary("echo '{\"message\":\"startup_trace: milestone\"}'; exit 0")
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        self.assertFalse(result["complete"])
+
+    def test_relay_fallback_recorded(self):
+        binary = self.make_binary("exit 0")
+        result = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 1, None, None, {})
+        self.assertTrue(result["fallback_spawn"])
+        self.assertFalse(result["relayed"])
+
+    def test_second_window_uses_observation_not_process_summary(self):
+        binary = self.make_binary("exit 0")
+        first = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        second = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 2, None, None, {})
+        self.assertIn("observation_spawn_to_summary_ms", first)
+        self.assertIn("observation_spawn_to_summary_ms", second)
+        self.assertNotIn("total_ms", second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -211,5 +211,66 @@ class FakeBinaryLifetimeTest(unittest.TestCase):
         self.assertLess(result["observation_spawn_to_summary_ms"], 15000)
 
 
+class ReopenWindowTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkdtemp()
+        self.cef_dir = os.path.join(self.temp, "cef")
+        os.makedirs(self.cef_dir)
+
+    def test_diagnostic_close_acknowledged(self):
+        import json
+        import socket
+        socket_path = os.path.join(self.temp, "test.sock")
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(socket_path)
+        listener.listen(1)
+        listener.settimeout(5)
+
+        def serve_once():
+            conn, _ = listener.accept()
+            with conn:
+                conn.settimeout(5)
+                data = b""
+                while b"\n" not in data:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+                request = json.loads(data.decode())
+                assert request["action"] == "close-all-windows"
+                conn.sendall(json.dumps({"request_id": request["request_id"],
+                                         "accepted": True}).encode() + b"\n")
+
+        thread = threading.Thread(target=serve_once)
+        thread.daemon = True
+        thread.start()
+        try:
+            self.assertTrue(harness.send_diagnostic_close(socket_path))
+        finally:
+            thread.join(timeout=5)
+            listener.close()
+
+    def test_diagnostic_close_refused_without_server(self):
+        self.assertFalse(harness.send_diagnostic_close(os.path.join(self.temp, "missing.sock"), 1.0))
+
+    def test_proc_helpers_observe_current_process(self):
+        self.assertIsInstance(harness.child_pids(os.getpid()), list)
+        rss = harness.proc_rss_kb(os.getpid())
+        self.assertIsNotNone(rss)
+        self.assertGreater(rss, 0)
+        self.assertIsNone(harness.proc_rss_kb(2 ** 30))
+
+    def test_reopen_without_owner_falls_back(self):
+        binary = os.path.join(self.temp, "fakebin")
+        with open(binary, "w") as handle:
+            handle.write("#!/bin/sh\nexit 0\n")
+        os.chmod(binary, 0o755)
+        result = harness.run_sample(binary, self.cef_dir, "reopen-window", "static", 1,
+                                    owner=None, owner_dirs=None, owner_socket=None)
+        self.assertTrue(result["fallback_spawn"])
+        self.assertFalse(result["relayed"])
+        self.assertNotIn("reopen", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -1,53 +1,81 @@
 #!/usr/bin/env python3
-"""Unit tests for measure_cef_startup.py (stdlib only)."""
+"""Unit tests for measure_cef_startup.py (stdlib only).
 
-import json
+Run headless: python3 -m unittest discover -s scripts -p 'test_measure_cef_startup.py'
+Set DUMBER_MEASURE_CUTOFF_SECONDS=0.2 for fast streaming tests (default 5.0).
+"""
+
 import os
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import measure_cef_startup as harness
 
 
-class ParseTest(unittest.TestCase):
-    def test_accepts_valid_fixture_event(self):
-        token = "a" * 16
-        nav = "b" * 16
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": token, "nav_token": nav, "value_ms": 12}),
-        ]
-        _, events = harness.parse_child_output(lines, token)
-        self.assertEqual(len(events), 1)
+class BeaconTest(unittest.TestCase):
+    def setUp(self):
+        self.state = harness.FixtureState()
+        harness.Handler.state = self.state
+        harness.Handler.fixture = "static"
+        harness.Handler.run_token = "a" * 16
+        harness.Handler.nav_token = "b" * 16
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), harness.Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, kwargs={"poll_interval": 0.05})
+        self.thread.daemon = True
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    def get(self, query):
+        url = "http://127.0.0.1:%d/__beacon?%s" % (self.port, query)
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                return response.status
+        except urllib.error.HTTPError as exc:
+            exc.read()
+            return exc.code
+
+    def test_accepts_valid_beacon(self):
+        status = self.get("run=%s&nav=%s&event=%s&value=12" % ("a" * 16, "b" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 204)
+        self.assertEqual(len(self.state.beacons), 1)
+        self.assertEqual(self.state.beacons[0]["value_ms"], 12)
 
     def test_rejects_wrong_token(self):
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": "c" * 16, "nav_token": "d" * 16, "value_ms": 12}),
-        ]
-        _, events = harness.parse_child_output(lines, "a" * 16)
-        self.assertEqual(events, [])
-
-    def test_rejects_non_numeric_value(self):
-        token = "a" * 16
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": token, "nav_token": "b" * 16, "value_ms": "12"}),
-        ]
-        _, events = harness.parse_child_output(lines, token)
-        self.assertEqual(events, [])
+        status = self.get("run=%s&nav=%s&event=%s&value=12" % ("c" * 16, "d" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
 
     def test_rejects_malformed_token(self):
-        lines = [
-            json.dumps({"message": "cef-startup-fixture", "event": "first-contentful-paint",
-                        "run_token": "short", "nav_token": "b" * 16, "value_ms": 12}),
-        ]
-        _, events = harness.parse_child_output(lines, "short")
-        self.assertEqual(events, [])
+        status = self.get("run=short&nav=%s&event=%s&value=12" % ("b" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
+
+    def test_rejects_non_numeric_value(self):
+        status = self.get("run=%s&nav=%s&event=%s&value=abc" % ("a" * 16, "b" * 16, "first-contentful-paint"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
+
+    def test_rejects_unknown_event(self):
+        status = self.get("run=%s&nav=%s&event=%s&value=1" % ("a" * 16, "b" * 16, "bogus"))
+        self.assertEqual(status, 400)
+        self.assertEqual(self.state.beacons, [])
+
+    def test_milestones_still_parsed(self):
+        lines = ['{"message":"startup_trace: milestone","milestone":"process_entry"}', "not json"]
+        self.assertEqual(len(harness.parse_child_output(lines)), 1)
 
 
 class CliValidationTest(unittest.TestCase):
@@ -61,20 +89,23 @@ class CliValidationTest(unittest.TestCase):
         self.cef_dir = os.path.join(self.temp, "cef")
         os.makedirs(self.cef_dir)
 
-    def run_harness(self, *extra):
-        cmd = [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
-               "--scenario", "profile-fresh", "--fixture", "static", "--runs", "1"] + list(extra)
-        return subprocess.run(cmd, capture_output=True, text=True)
-
     def test_rejects_existing_output(self):
         existing = os.path.join(self.temp, "exists")
         os.makedirs(existing)
-        result = self.run_harness("--output", existing)
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+             "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "1", "--output", existing],
+            capture_output=True, text=True)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("fresh absolute directory", result.stderr)
 
     def test_rejects_relative_output(self):
-        result = self.run_harness("--output", "relative/path")
+        result = subprocess.run(
+            [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
+             "--scenario", "profile-fresh", "--fixture", "static",
+             "--runs", "1", "--output", "relative/path"],
+            capture_output=True, text=True)
         self.assertNotEqual(result.returncode, 0)
 
     def test_rejects_missing_binary(self):
@@ -86,8 +117,6 @@ class CliValidationTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
 
     def test_rejects_bad_runs(self):
-        result = self.run_harness("--output", os.path.join(self.temp, "out"), "--runs", "0")
-        # argparse passes --runs twice; last wins; use explicit override instead
         result = subprocess.run(
             [sys.executable, self.script, "--binary", self.binary, "--cef-dir", self.cef_dir,
              "--scenario", "profile-fresh", "--fixture", "static",
@@ -101,40 +130,69 @@ class FakeBinaryLifetimeTest(unittest.TestCase):
         self.temp = tempfile.mkdtemp()
         self.cef_dir = os.path.join(self.temp, "cef")
         os.makedirs(self.cef_dir)
+        self.counter = 0
 
     def make_binary(self, body):
-        path = os.path.join(self.temp, "fake-%d" % len(os.listdir(self.temp)))
+        self.counter += 1
+        path = os.path.join(self.temp, "fake-%d" % self.counter)
         with open(path, "w") as handle:
             handle.write("#!/bin/sh\n" + body + "\n")
         os.chmod(path, 0o755)
         return path
 
-    def test_duplicate_documents_marked(self):
+    def make_fetch_binary(self):
+        # Fetches the fixture URL passed as argv[2] (argv: browse <url>),
+        # then exits: exercises document counting without a real browser.
+        path = os.path.join(self.temp, "fetch-%d" % self.counter)
+        self.counter += 1
+        with open(path, "w") as handle:
+            handle.write("#!/usr/bin/env python3\nimport sys, urllib.request\n"
+                         "urllib.request.urlopen(sys.argv[2], timeout=10).read()\n")
+        os.chmod(path, 0o755)
+        return path
+
+    def test_duplicate_documents_marked_incomplete(self):
         binary = self.make_binary("exit 0")
-        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
-        # No fixture events and no document requests through the real binary:
-        # the sample must report incomplete, never synthesized success.
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
         self.assertFalse(result["complete"])
         self.assertIsNone(result["target_fcp_ms"])
 
     def test_absent_fcp_is_incomplete(self):
-        binary = self.make_binary("echo '{\"message\":\"startup_trace: milestone\"}'; exit 0")
-        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
+        binary = self.make_fetch_binary()
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        self.assertEqual(result["document_requests"], 1)
+        self.assertIsNone(result["target_fcp_ms"])
         self.assertFalse(result["complete"])
 
-    def test_relay_fallback_recorded(self):
+    def test_relay_fallback_recorded_without_owner(self):
         binary = self.make_binary("exit 0")
-        result = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 1, None, None, {})
+        result = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 1)
         self.assertTrue(result["fallback_spawn"])
         self.assertFalse(result["relayed"])
 
     def test_second_window_uses_observation_not_process_summary(self):
         binary = self.make_binary("exit 0")
-        first = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1, None, None, {})
-        second = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 2, None, None, {})
+        first = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        second = harness.run_sample(binary, self.cef_dir, "relay-window", "static", 2)
         self.assertIn("observation_spawn_to_summary_ms", first)
         self.assertIn("observation_spawn_to_summary_ms", second)
         self.assertNotIn("total_ms", second)
+
+    def test_run_dir_cleaned_up(self):
+        before = set(os.listdir(tempfile.gettempdir()))
+        binary = self.make_binary("exit 0")
+        harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        after = set(os.listdir(tempfile.gettempdir()))
+        leaked = [name for name in (after - before) if name.startswith("cef-startup-run-")]
+        self.assertEqual(leaked, [])
+
+    def test_streaming_returns_without_process_exit(self):
+        # A hanging GUI must not pin the harness: with a short cutoff the
+        # sample decides from streamed output, then terminates the child.
+        binary = self.make_binary("exec sleep 30")
+        result = harness.run_sample(binary, self.cef_dir, "profile-fresh", "static", 1)
+        self.assertFalse(result["complete"])
+        self.assertLess(result["observation_spawn_to_summary_ms"], 15000)
 
 
 if __name__ == "__main__":

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -260,6 +260,18 @@ class ReopenWindowTest(unittest.TestCase):
         self.assertGreater(rss, 0)
         self.assertIsNone(harness.proc_rss_kb(2 ** 30))
 
+    def test_proc_starttime_identifies_current_process(self):
+        first = harness.proc_starttime(os.getpid())
+        self.assertIsNotNone(first)
+        self.assertGreaterEqual(first, 0)
+        self.assertEqual(first, harness.proc_starttime(os.getpid()))
+        self.assertIsNone(harness.proc_starttime(2 ** 30))
+
+    def test_child_quiescence_returns_stable_count(self):
+        count = harness.wait_for_child_quiescence(os.getpid(), settle_seconds=0.2, timeout_seconds=5.0)
+        self.assertIsInstance(count, int)
+        self.assertGreaterEqual(count, 0)
+
     def test_reopen_without_owner_falls_back(self):
         binary = os.path.join(self.temp, "fakebin")
         with open(binary, "w") as handle:

--- a/scripts/test_measure_cef_startup.py
+++ b/scripts/test_measure_cef_startup.py
@@ -77,6 +77,22 @@ class BeaconTest(unittest.TestCase):
         lines = ['{"message":"startup_trace: milestone","milestone":"process_entry"}', "not json"]
         self.assertEqual(len(harness.parse_child_output(lines)), 1)
 
+    def test_image_endpoint_serves_decodable_png(self):
+        import struct
+        import zlib
+        url = "http://127.0.0.1:%d/pixel.png" % self.port
+        with urllib.request.urlopen(url, timeout=5) as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.headers.get_content_type(), "image/png")
+            body = response.read()
+        self.assertEqual(body[:8], bytes.fromhex("89504e470d0a1a0a"))
+        width, height = struct.unpack(">II", body[16:24])
+        self.assertEqual((width, height), (1, 1))
+        idat_len = struct.unpack(">I", body[33:37])[0]
+        self.assertEqual(body[37:41], b"IDAT")
+        zlib.decompress(body[41:41 + idat_len])
+        self.assertEqual(body[-8:-4], b"IEND")
+
 
 class CliValidationTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Stacked on #411 (perf/cef-startup-02). Implements Plan 03, the immediately-actionable lots; gated research phases end in explicit no-change records below.

## What changes (issues #396, #398, #399, #402)

- **On-demand hidden panels (#396):** window creation no longer constructs the history/favorites sidebars or queries their use cases. New `ensureHistorySidebar`/`ensureFavoritesSidebar` build each panel once on first open with a detached lifetime context; mounting/visibility stays on the existing show path. Outer keyboard-action handlers ensure before testing availability; hide paths construct nothing.
- **Managed DB warmup (#398):** non-restore startup creates the single LazyDB provider before CEF init and warms it in an owned background task (detached context). Each Warmup task is registered synchronously and Close settles all registered tasks plus in-flight init before releasing the connection; Close never triggers init.
- **Engine-scoped deferred diagnostics (#399):** automatic startup skips WebKit pkg-config and GStreamer media diagnostics under CEF. Explicit doctor/media commands still invoke the checks directly.
- **Theme reapply dedup (#402, partial):** unchanged theme on the same display skips the CSS reload and provider re-add (CSS identity + native display address, no display retention). Applied GTK font is tracked per display so every display gets its GtkSettings configured.

## Gated follow-ups (no change shipped, per plan gates)

- **P2.2/P2.2a** (zoom versioning, nonblocking early repo actions): no proven post-zoom frame-readiness mechanism; no reveal gate ships on setter return. Warmup covers the common slow-DB case.
- **P2.4** (target-observation port): no verified navigation-correlated paint mechanism; no new observer port added.
- **P3.1/P3.2** (allocation spans, creation scheduling): no change to the first-valid-size one-shot path without measured queue data.
- **P4** (first-import priority experiment): no-change report; no measured queue bottleneck establishes it.

## Checks

- V1 (ui, component, coordinator/content, bootstrap, sqlite): green
- V2 (infra/cef, ui/theme): green
- V6 (usecase, dispatcher): green
- `git diff --check`, `make lint`: clean
- `make test` / `make check`: green except pre-existing `internal/ui/input` SIGSEGV, reproduced on clean main (display-required native suite, untouched by this stack)
- Go review: 1 GO + 2 NO-GO findings, both addressed (warmup task tracking with deterministic orphan regression test; per-display font tracking with unit tests; probe-hook proof of diagnostic non-invocation)

## Display/GPU validation needed (cannot run headless)

- First-open of each panel functional and current; favorites-first ordering; close-during-load
- Repeated window creation with unchanged theme skips reapply (log line), real theme change reapplies
- Slow-DB fixture: no GTK stall on first access