### PR TITLE
perf(cef): web navigation, filtering and cache policy

### DIFF
--- a/cmd/dumber/main.go
+++ b/cmd/dumber/main.go
@@ -328,7 +328,7 @@ func runGUI(cfg *config.Config, timing startupTiming) int {
 
 	engine.SetHandlerContext(ctx)
 
-	useCases := createUseCases(repos, cfg)
+	useCases := createUseCases(ctx, repos, cfg)
 	defer useCases.Close()
 	if needsEagerDB {
 		handleAutoRestore(ctx, cfg, useCases, browserSession.Session.ID)
@@ -388,7 +388,7 @@ func runStandaloneOmnibox() int {
 		defer dbCleanup()
 	}
 
-	useCases := createUseCases(repos, cfg)
+	useCases := createUseCases(ctx, repos, cfg)
 	defer useCases.Close()
 	uiDeps, err := buildUIDependencies(
 		ctx,
@@ -898,13 +898,19 @@ type useCases struct {
 }
 
 func (uc *useCases) Close() {
-	if uc == nil || uc.historyRecorder == nil {
+	if uc == nil {
+		return
+	}
+	if uc.faviconUC != nil {
+		uc.faviconUC.Close()
+	}
+	if uc.historyRecorder == nil {
 		return
 	}
 	uc.historyRecorder.Close()
 }
 
-func createUseCases(repos *repositories, cfg *config.Config) *useCases {
+func createUseCases(ctx context.Context, repos *repositories, cfg *config.Config) *useCases {
 	const idAlphabetSize = 26
 	idCounter := uint64(0)
 	idGenerator := func() string {
@@ -923,6 +929,9 @@ func createUseCases(repos *repositories, cfg *config.Config) *useCases {
 			Converter:  infrafavicon.NewImageConverter(),
 			Fetcher:    infrafavicon.NewFetcher(),
 			Scheduler:  infrafavicon.NewRefreshScheduler(),
+			// Owned lifetime: the use case derives a cancelable scope
+			// for background refresh, aborted by Close on shutdown.
+			Background: ctx,
 		})
 	}
 	xdgDirs, _ := config.GetXDGDirs()

--- a/docs/cef-cache-contract.md
+++ b/docs/cef-cache-contract.md
@@ -1,0 +1,42 @@
+# CEF cache contract
+
+Current product behavior for the CEF engine. No configuration change is
+proposed here; setting an explicit `CachePath` requires the P3.3
+compatibility decision with data-preservation tests and approval.
+
+## Configured settings
+
+- `RootCachePath` is set to the resolved state root (`DUMBER_CEF_ROOT_CACHE_PATH`
+  override, engine cache dir, data dir, or profile default, in that order).
+- `CachePath` is intentionally left empty: the global request context
+  derives its on-disk cache location from `RootCachePath` per CEF default
+  semantics. Locked by
+  `TestPrepareCEFSettings_LeavesCachePathToCEFDefault`.
+- Browsers are created with a nil request context (`factory.go`), so every
+  window shares the global request context and its storage. No per-window
+  isolation is claimed.
+
+## Observed behavior
+
+Orderly-restart tests showed HTTP asset reuse and localStorage persistence
+across restarts with this configuration. Empty `CachePath` is therefore a
+contract description, not a proven cache-loss bug.
+
+## Display-side verification (pending)
+
+The binding exposes everything the probe needs; no new API is required:
+
+1. `RequestContextGetGlobalContext()` plus
+   `BrowserHost.GetRequestContext()` identity comparison proves windows
+   share the global context.
+2. `RequestContext.GetCachePath()` equality/containment against the
+   configured state root proves the effective on-disk location. Export
+   only equality and persistence assertions, never paths.
+3. Seed/read-only probes: seed cacheable assets, localStorage, and
+   synthetic cookies at a stable fixture origin, restart orderly, and read
+   before any reseeding. Distinct-profile probes also read before writing.
+   Include a no-store control and distinguish no-request hits from
+   conditional revalidation. Assert no non-fixture destination is
+   contacted (favicon-provider egress control included).
+4. Never infer storage behavior from forcibly killed helpers; always shut
+   down gracefully and let CEF stop its helpers.

--- a/docs/cef-cache-contract.md
+++ b/docs/cef-cache-contract.md
@@ -8,9 +8,11 @@ compatibility decision with data-preservation tests and approval.
 
 - `RootCachePath` is set to the resolved state root (`DUMBER_CEF_ROOT_CACHE_PATH`
   override, engine cache dir, data dir, or profile default, in that order).
-- `CachePath` is intentionally left empty: the global request context
-  derives its on-disk cache location from `RootCachePath` per CEF default
-  semantics. Locked by
+- `CachePath` is intentionally left empty: with an empty `CachePath` CEF runs
+  the global request context incognito-style, with in-memory-only storage.
+  `RootCachePath` does NOT implicitly supply `CachePath` and does not grant
+  persistent `localStorage`: HTML5 storage only persists across sessions with
+  a non-empty `CachePath`. Locked by
   `TestPrepareCEFSettings_LeavesCachePathToCEFDefault`.
 - Browsers are created with a nil request context (`factory.go`), so every
   window shares the global request context and its storage. No per-window
@@ -18,9 +20,15 @@ compatibility decision with data-preservation tests and approval.
 
 ## Observed behavior
 
-Orderly-restart tests showed HTTP asset reuse and localStorage persistence
-across restarts with this configuration. Empty `CachePath` is therefore a
-contract description, not a proven cache-loss bug.
+Orderly-restart runs once suggested HTTP asset reuse and localStorage
+persistence across restarts with this configuration, but that observation is
+unverified against CEF semantics: with an empty `CachePath` the global
+context is incognito-style and profile data (including `localStorage`) is
+expected to be memory-only, so restart persistence must NOT be assumed. The
+seed/read-only probes below are the only accepted proof; until they run
+green on a display host, treat this configuration as non-persistent.
+Setting an explicit `CachePath` under `RootCachePath` requires the P3.3
+compatibility decision with data-preservation tests and approval.
 
 ## Display-side verification (pending)
 

--- a/internal/application/port/content_filter.go
+++ b/internal/application/port/content_filter.go
@@ -1,0 +1,31 @@
+package port
+
+// FilterAction is the content-filter decision for one request.
+type FilterAction int
+
+const (
+	// FilterAllow lets the request continue.
+	FilterAllow FilterAction = iota
+	// FilterBlock cancels the request.
+	FilterBlock
+)
+
+// FilterRequest describes one request offered to a ContentFilter. URL is
+// the full request URL; IsMainFrame reports a main-frame document load
+// (as opposed to a subresource); IsNavigation reports a navigation versus
+// an in-page resource load.
+type FilterRequest struct {
+	URL          string
+	IsMainFrame  bool
+	IsNavigation bool
+}
+
+// ContentFilter decides synchronously whether one request may proceed.
+// This is a test-only feasibility seam for the CEF filtering gate: no
+// production matcher is wired, and none may be added without the separately
+// approved implementation design. Matchers must be pure decision functions
+// over the request; they never fetch lists, mutate state, or touch the
+// network.
+type ContentFilter interface {
+	Decide(req FilterRequest) FilterAction
+}

--- a/internal/application/port/content_filter.go
+++ b/internal/application/port/content_filter.go
@@ -11,9 +11,10 @@ const (
 )
 
 // FilterRequest describes one request offered to a ContentFilter. URL is
-// the full request URL; IsMainFrame reports a main-frame document load
-// (as opposed to a subresource); IsNavigation reports a navigation versus
-// an in-page resource load.
+// the full request URL; IsMainFrame reports that the request belongs to the
+// main frame (a main-frame document load or one of its subresources), as
+// opposed to an iframe/subframe document or its resources; IsNavigation
+// reports a navigation versus an in-page resource load.
 type FilterRequest struct {
 	URL          string
 	IsMainFrame  bool

--- a/internal/application/port/favicon_errors.go
+++ b/internal/application/port/favicon_errors.go
@@ -5,5 +5,40 @@ import "errors"
 // ErrFaviconMiss is returned when a favicon cannot be found or served from allowed sources.
 var ErrFaviconMiss = errors.New("favicon miss")
 
+// ErrFaviconBusy is returned to direct refresh callers when the shared
+// refresh admission budget is exhausted. It is deliberately distinct from
+// ErrFaviconMiss: overload is not a miss and must never read as success.
+var ErrFaviconBusy = errors.New("favicon refresh overloaded")
+
+// FaviconFetchError classifies a failed fetch while preserving
+// ErrFaviconMiss matching for existing callers. StatusCode carries the
+// HTTP status for HTTP failures and is zero for validation, transport,
+// cancellation, or DNS failures, which must never be negatively cached.
+type FaviconFetchError struct {
+	StatusCode int
+}
+
+func (e *FaviconFetchError) Error() string {
+	if e == nil || e.StatusCode == 0 {
+		return "favicon fetch failed"
+	}
+	return "favicon fetch failed: unexpected HTTP status"
+}
+
+// Is preserves ErrFaviconMiss matching so callers that treat every fetch
+// failure as a miss keep working; use FetchStatusCode for classification.
+func (*FaviconFetchError) Is(target error) bool {
+	return target == ErrFaviconMiss
+}
+
+// FetchStatusCode returns the HTTP status carried by err, if any.
+func FetchStatusCode(err error) (int, bool) {
+	var fetchErr *FaviconFetchError
+	if errors.As(err, &fetchErr) && fetchErr != nil {
+		return fetchErr.StatusCode, true
+	}
+	return 0, false
+}
+
 // ErrFaviconInvalidInput is returned when favicon storage receives invalid input.
 var ErrFaviconInvalidInput = errors.New("invalid favicon input")

--- a/internal/application/port/favicon_errors.go
+++ b/internal/application/port/favicon_errors.go
@@ -10,6 +10,10 @@ var ErrFaviconMiss = errors.New("favicon miss")
 // ErrFaviconMiss: overload is not a miss and must never read as success.
 var ErrFaviconBusy = errors.New("favicon refresh overloaded")
 
+// ErrFaviconShutdown is returned to refresh callers arriving after the
+// use case began closing. Like overload, it is distinct from a miss.
+var ErrFaviconShutdown = errors.New("favicon refresh shutting down")
+
 // FaviconFetchError classifies a failed fetch while preserving
 // ErrFaviconMiss matching for existing callers. StatusCode carries the
 // HTTP status for HTTP failures and is zero for validation, transport,

--- a/internal/application/usecase/favicon.go
+++ b/internal/application/usecase/favicon.go
@@ -328,22 +328,36 @@ func (uc *FaviconUseCase) RefreshFromIconURLs(ctx context.Context, pageURL strin
 	if !ok {
 		return ErrFaviconMiss
 	}
-	if uc.cachedMiss(key) {
+	// Sealed admission wins over a cached absence: one atomic check so a
+	// refresh arriving after Close reports shutdown, never a stale miss.
+	if closed, miss := uc.sealedOrMiss(key); closed {
+		return appport.ErrFaviconShutdown
+	} else if miss {
 		return ErrFaviconMiss
 	}
 	return uc.joinRefreshOp(ctx, key, func(opCtx context.Context, startEpoch uint64) error {
 		var lastMiss error
+		// allMissesCacheable tracks whether EVERY attempted candidate
+		// failed with a cacheable genuine absence (verified 404/410).
+		// A single non-cacheable miss (401/403, 5xx, validation,
+		// transport) poisons the batch: the next call must retry the
+		// transient candidate instead of reading a cached absence.
+		allMissesCacheable := true
 		for _, iconURL := range candidates {
 			if err := opCtx.Err(); err != nil {
 				return err
 			}
 			fetched, err := uc.fetcher.Fetch(opCtx, appport.FaviconFetchRequest{PageURL: pageURL, IconURL: iconURL})
 			if err != nil {
-				if _, classified := appport.FetchStatusCode(err); classified {
+				if status, classified := appport.FetchStatusCode(err); classified {
+					if status != 404 && status != 410 {
+						allMissesCacheable = false
+					}
 					lastMiss = err
 					continue
 				}
 				if errors.Is(err, ErrFaviconMiss) {
+					allMissesCacheable = false
 					lastMiss = err
 					continue
 				}
@@ -354,6 +368,7 @@ func (uc *FaviconUseCase) RefreshFromIconURLs(ctx context.Context, pageURL strin
 			}
 			err = uc.observeFetched(opCtx, pageURL, fetched)
 			if errors.Is(err, ErrFaviconMiss) {
+				allMissesCacheable = false
 				lastMiss = err
 				continue
 			}
@@ -367,8 +382,11 @@ func (uc *FaviconUseCase) RefreshFromIconURLs(ctx context.Context, pageURL strin
 		if lastMiss != nil {
 			// Only a fully missed request populates the negative cache:
 			// recording per candidate would poison later candidates
-			// that were never tried.
-			uc.noteMiss(key, lastMiss)
+			// that were never tried, and a mixed batch must never
+			// suppress retry of its transient candidates.
+			if allMissesCacheable {
+				uc.noteMiss(key, lastMiss)
+			}
 			return lastMiss
 		}
 		if uc.epochValue() != startEpoch {
@@ -485,8 +503,14 @@ func (uc *FaviconUseCase) EnsureSized(ctx context.Context, key favicon.Key, size
 }
 
 func (uc *FaviconUseCase) Invalidate(ctx context.Context, key favicon.Key) error {
-	// Invalidation advances the epoch so in-flight completions that predate
-	// it cannot repopulate the cleared entries.
+	// Invalidation advances the epoch so in-flight completions that have not
+	// yet passed their pre-commit epoch check cannot repopulate the cleared
+	// entries. This is best-effort suppression, not a transactional commit:
+	// a completion that already passed its check may still write after the
+	// clear (a transient stale icon until the next refresh), because the
+	// check and the blob/repository writes are not atomic. Closing that
+	// residual window would require versioned commits in the repository
+	// layer and is out of scope for this stack.
 	uc.bumpEpoch()
 	if uc.blobs != nil {
 		if err := uc.blobs.RemoveDerived(ctx, key); err != nil {

--- a/internal/application/usecase/favicon.go
+++ b/internal/application/usecase/favicon.go
@@ -78,6 +78,8 @@ type FaviconUseCase struct {
 	now          func() time.Time
 	ttl          time.Duration
 	background   context.Context
+	bgCancel     context.CancelFunc
+	shared       *refreshCoordinator
 }
 
 type FaviconDeps struct {
@@ -90,7 +92,11 @@ type FaviconDeps struct {
 	Invalidators appport.FaviconInvalidators
 	Now          func() time.Time
 	TTL          time.Duration
-	Background   context.Context
+	// Background scopes background refresh work to the application
+	// lifetime. The use case derives its own cancelable scope from it,
+	// aborted by Close; callers pass the owning context (nil defaults to
+	// context.Background with shutdown drain only).
+	Background context.Context
 }
 
 func NewFaviconUseCase(deps FaviconDeps) *FaviconUseCase {
@@ -100,9 +106,13 @@ func NewFaviconUseCase(deps FaviconDeps) *FaviconUseCase {
 	if deps.TTL == 0 {
 		deps.TTL = favicon.DefaultTTL
 	}
-	if deps.Background == nil {
-		deps.Background = context.Background()
+	background := deps.Background
+	if background == nil {
+		background = context.Background()
 	}
+	// Owned cancelable scope for background refresh: parent cancellation
+	// propagates, and Close aborts it before draining shared operations.
+	background, bgCancel := context.WithCancel(background)
 	registry := &faviconInvalidatorRegistry{}
 	if deps.Invalidators != nil {
 		registry.fallback = deps.Invalidators
@@ -117,7 +127,9 @@ func NewFaviconUseCase(deps FaviconDeps) *FaviconUseCase {
 		invalidators: registry,
 		now:          deps.Now,
 		ttl:          deps.TTL,
-		background:   deps.Background,
+		background:   background,
+		bgCancel:     bgCancel,
+		shared:       newRefreshCoordinator(),
 	}
 }
 
@@ -312,30 +324,56 @@ func (uc *FaviconUseCase) RefreshFromIconURLs(ctx context.Context, pageURL strin
 	if uc.fetcher == nil {
 		return ErrFaviconMiss
 	}
-	var lastMiss error
-	for _, iconURL := range iconURLs {
-		if err := ctx.Err(); err != nil {
+	key, candidates, ok := refreshRequestKey(pageURL, iconURLs)
+	if !ok {
+		return ErrFaviconMiss
+	}
+	if uc.cachedMiss(key) {
+		return ErrFaviconMiss
+	}
+	// Explicit refresh advances the invalidation epoch so older in-flight
+	// completions cannot repopulate entries this refresh supersedes.
+	uc.bumpEpoch()
+	startEpoch := uc.epochValue()
+	return uc.joinRefreshOp(ctx, key, func(opCtx context.Context) error {
+		var lastMiss error
+		for _, iconURL := range candidates {
+			if err := opCtx.Err(); err != nil {
+				return err
+			}
+			fetched, err := uc.fetcher.Fetch(opCtx, appport.FaviconFetchRequest{PageURL: pageURL, IconURL: iconURL})
+			if err != nil {
+				if status, classified := appport.FetchStatusCode(err); classified {
+					if status == 404 || status == 410 {
+						uc.noteMiss(key, err)
+					}
+					lastMiss = err
+					continue
+				}
+				if errors.Is(err, ErrFaviconMiss) {
+					lastMiss = err
+					continue
+				}
+				return err
+			}
+			if uc.epochValue() != startEpoch {
+				return nil
+			}
+			err = uc.observeFetched(opCtx, pageURL, fetched)
+			if errors.Is(err, ErrFaviconMiss) {
+				lastMiss = err
+				continue
+			}
 			return err
 		}
-		fetched, err := uc.fetcher.Fetch(ctx, appport.FaviconFetchRequest{PageURL: pageURL, IconURL: iconURL})
-		if errors.Is(err, ErrFaviconMiss) {
-			lastMiss = err
-			continue
+		if lastMiss != nil {
+			return lastMiss
 		}
-		if err != nil {
-			return err
+		if uc.epochValue() != startEpoch {
+			return nil
 		}
-		err = uc.observeFetched(ctx, pageURL, fetched)
-		if errors.Is(err, ErrFaviconMiss) {
-			lastMiss = err
-			continue
-		}
-		return err
-	}
-	if lastMiss != nil {
-		return lastMiss
-	}
-	return uc.RefreshIfStale(ctx, pageURL)
+		return uc.RefreshIfStale(opCtx, pageURL)
+	})
 }
 
 func (uc *FaviconUseCase) refresh(ctx context.Context, pageURL string, force bool) error {
@@ -363,7 +401,16 @@ func (uc *FaviconUseCase) refreshKey(ctx context.Context, key favicon.Key, pageU
 	if meta != nil && !favicon.ShouldRefresh(meta, uc.now(), uc.ttl) {
 		return nil
 	}
-	return uc.fetchAndObserve(ctx, pageURL)
+	// Scheduler-backed work joins the same admission budget as direct
+	// refreshes; discovery has no upfront candidates, so it shares the
+	// page-scoped discovery identity.
+	discoveryKey, _, ok := refreshRequestKey(pageURL, nil)
+	if !ok {
+		return ErrFaviconMiss
+	}
+	return uc.joinRefreshOp(ctx, discoveryKey, func(opCtx context.Context) error {
+		return uc.fetchAndObserve(opCtx, pageURL)
+	})
 }
 
 func (uc *FaviconUseCase) anyCandidateFresh(ctx context.Context, keys []favicon.Key) (bool, error) {
@@ -436,6 +483,9 @@ func (uc *FaviconUseCase) EnsureSized(ctx context.Context, key favicon.Key, size
 }
 
 func (uc *FaviconUseCase) Invalidate(ctx context.Context, key favicon.Key) error {
+	// Invalidation advances the epoch so in-flight completions that predate
+	// it cannot repopulate the cleared entries.
+	uc.bumpEpoch()
 	if uc.blobs != nil {
 		if err := uc.blobs.RemoveDerived(ctx, key); err != nil {
 			return err
@@ -469,4 +519,16 @@ func (uc *FaviconUseCase) scheduleRefresh(key favicon.Key, pageURL string) bool 
 		return false
 	}
 	return uc.scheduler.Schedule(uc.background, key, func(ctx context.Context) { _ = uc.refreshKey(ctx, key, pageURL) })
+}
+
+// Close aborts owned background refresh work and drains shared in-flight
+// operations. It is safe to call on a nil receiver and more than once.
+func (uc *FaviconUseCase) Close() {
+	if uc == nil {
+		return
+	}
+	if uc.bgCancel != nil {
+		uc.bgCancel()
+	}
+	uc.drainRefreshOps()
 }

--- a/internal/application/usecase/favicon.go
+++ b/internal/application/usecase/favicon.go
@@ -331,11 +331,7 @@ func (uc *FaviconUseCase) RefreshFromIconURLs(ctx context.Context, pageURL strin
 	if uc.cachedMiss(key) {
 		return ErrFaviconMiss
 	}
-	// Explicit refresh advances the invalidation epoch so older in-flight
-	// completions cannot repopulate entries this refresh supersedes.
-	uc.bumpEpoch()
-	startEpoch := uc.epochValue()
-	return uc.joinRefreshOp(ctx, key, func(opCtx context.Context) error {
+	return uc.joinRefreshOp(ctx, key, func(opCtx context.Context, startEpoch uint64) error {
 		var lastMiss error
 		for _, iconURL := range candidates {
 			if err := opCtx.Err(); err != nil {
@@ -343,10 +339,7 @@ func (uc *FaviconUseCase) RefreshFromIconURLs(ctx context.Context, pageURL strin
 			}
 			fetched, err := uc.fetcher.Fetch(opCtx, appport.FaviconFetchRequest{PageURL: pageURL, IconURL: iconURL})
 			if err != nil {
-				if status, classified := appport.FetchStatusCode(err); classified {
-					if status == 404 || status == 410 {
-						uc.noteMiss(key, err)
-					}
+				if _, classified := appport.FetchStatusCode(err); classified {
 					lastMiss = err
 					continue
 				}
@@ -364,9 +357,18 @@ func (uc *FaviconUseCase) RefreshFromIconURLs(ctx context.Context, pageURL strin
 				lastMiss = err
 				continue
 			}
+			if err == nil {
+				// Success contradicts any earlier absence record for
+				// this request: drop it instead of letting it linger.
+				uc.clearMiss(key)
+			}
 			return err
 		}
 		if lastMiss != nil {
+			// Only a fully missed request populates the negative cache:
+			// recording per candidate would poison later candidates
+			// that were never tried.
+			uc.noteMiss(key, lastMiss)
 			return lastMiss
 		}
 		if uc.epochValue() != startEpoch {
@@ -408,7 +410,7 @@ func (uc *FaviconUseCase) refreshKey(ctx context.Context, key favicon.Key, pageU
 	if !ok {
 		return ErrFaviconMiss
 	}
-	return uc.joinRefreshOp(ctx, discoveryKey, func(opCtx context.Context) error {
+	return uc.joinRefreshOp(ctx, discoveryKey, func(opCtx context.Context, _ uint64) error {
 		return uc.fetchAndObserve(opCtx, pageURL)
 	})
 }
@@ -522,11 +524,16 @@ func (uc *FaviconUseCase) scheduleRefresh(key favicon.Key, pageURL string) bool 
 }
 
 // Close aborts owned background refresh work and drains shared in-flight
-// operations. It is safe to call on a nil receiver and more than once.
+// operations. Admission is sealed first so no refresh can start after the
+// drain observes zero active operations. It is safe to call on a nil
+// receiver and more than once.
 func (uc *FaviconUseCase) Close() {
 	if uc == nil {
 		return
 	}
+	uc.shared.mu.Lock()
+	uc.shared.closed = true
+	uc.shared.mu.Unlock()
 	if uc.bgCancel != nil {
 		uc.bgCancel()
 	}

--- a/internal/application/usecase/favicon_refresh.go
+++ b/internal/application/usecase/favicon_refresh.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -49,7 +51,7 @@ func refreshRequestKey(pageURL string, iconURLs []string) (string, []string, boo
 	if err != nil || page.Hostname() == "" {
 		return "", nil, false
 	}
-	accepted := make([]string, 0, len(iconURLs))
+	accepted := make([]string, 0, min(len(iconURLs), maxRefreshCandidates))
 	for _, raw := range iconURLs {
 		raw = strings.TrimSpace(raw)
 		if raw == "" || len(raw) > maxRefreshCandidateLen {
@@ -69,7 +71,13 @@ func refreshRequestKey(pageURL string, iconURLs []string) (string, []string, boo
 		candidate.Host = strings.ToLower(candidate.Host)
 		if host, port, ok := splitHostPort(candidate.Host); ok {
 			if isDefaultPort(candidate.Scheme, port) {
-				candidate.Host = host
+				// Re-bracket IPv6 literals: SplitHostPort strips
+				// brackets, and url.URL requires them in Host.
+				if strings.Contains(host, ":") {
+					candidate.Host = "[" + host + "]"
+				} else {
+					candidate.Host = host
+				}
 			}
 		}
 		accepted = append(accepted, candidate.String())
@@ -81,9 +89,12 @@ func refreshRequestKey(pageURL string, iconURLs []string) (string, []string, boo
 	return hex.EncodeToString(sum[:]), accepted, true
 }
 
+// splitHostPort splits an explicit host:port pair. Bracketed IPv6 literals
+// (as produced by url.URL.Host) require net.SplitHostPort; a bare
+// strings.Cut on ":" misparses them. Hosts without a port report false.
 func splitHostPort(hostport string) (string, string, bool) {
-	host, port, found := strings.Cut(hostport, ":")
-	if !found {
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
 		return "", "", false
 	}
 	return host, port, true
@@ -119,6 +130,13 @@ type refreshCoordinator struct {
 	mu     sync.Mutex
 	active map[string]*refreshCall
 	slots  chan struct{}
+	// wg tracks every spawned executor independently of the active map:
+	// a fresh same-key operation may replace a canceled-but-still-running
+	// call in active, so the map alone cannot prove shutdown quiescence.
+	// Adds happen under mu before the goroutine starts; Done runs when the
+	// executor finishes. Sealed admission (closed) guarantees no Add can
+	// race a completed Wait.
+	wg     sync.WaitGroup
 	epoch  uint64
 	// closed seals admission: set by Close before cancel/drain, so no
 	// refresh can start after the drain observes zero active operations.
@@ -152,18 +170,31 @@ func (uc *FaviconUseCase) bumpEpoch() {
 
 // cachedMiss reports whether key holds an unexpired genuine-absence entry.
 func (uc *FaviconUseCase) cachedMiss(key string) bool {
+	_, miss := uc.sealedOrMiss(key)
+	return miss
+}
+
+// sealedOrMiss atomically reports coordinator shutdown and negative-cache
+// state under one lock acquisition, giving late refreshes a single
+// linearization point: sealed admission always wins over a cached absence,
+// so a refresh arriving after Close reports ErrFaviconShutdown even when
+// the key holds a cached 404/410.
+func (uc *FaviconUseCase) sealedOrMiss(key string) (closed, miss bool) {
 	now := uc.now()
 	uc.shared.mu.Lock()
 	defer uc.shared.mu.Unlock()
-	miss, ok := uc.shared.misses[key]
+	if uc.shared.closed {
+		return true, false
+	}
+	m, ok := uc.shared.misses[key]
 	if !ok {
-		return false
+		return false, false
 	}
-	if !now.Before(miss.expiresAt) {
+	if !now.Before(m.expiresAt) {
 		delete(uc.shared.misses, key)
-		return false
+		return false, false
 	}
-	return true
+	return false, true
 }
 
 // clearMiss drops any absence record for key: a later success proves the
@@ -198,19 +229,28 @@ func (uc *FaviconUseCase) noteMiss(key string, fetchErr error) {
 	}
 }
 
-// compactMissOrderLocked drops order names with no live entry, bounding
-// the backlog. Caller must hold refresh.mu.
+// compactMissOrderLocked drops order names with no live entry and collapses
+// duplicates to one entry per live key, keeping the newest occurrence.
+// Eviction removes entries from the map but not from order, so an evicted
+// key that is reinserted would otherwise leave a stale duplicate behind:
+// repeated cycles grow order without bound and let an old duplicate evict
+// the live entry early. Caller must hold refresh.mu.
 func (uc *FaviconUseCase) compactMissOrderLocked() {
-	kept := uc.shared.order[:0]
-	for _, key := range uc.shared.order {
+	last := make(map[string]int, len(uc.shared.misses))
+	for i, key := range uc.shared.order {
 		if _, ok := uc.shared.misses[key]; ok {
-			kept = append(kept, key)
+			last[key] = i
 		}
 	}
-	for i := len(kept); i < len(uc.shared.order); i++ {
+	ordered := make([]string, 0, len(last))
+	for key := range last {
+		ordered = append(ordered, key)
+	}
+	slices.SortFunc(ordered, func(a, b string) int { return last[a] - last[b] })
+	for i := len(ordered); i < len(uc.shared.order); i++ {
 		uc.shared.order[i] = ""
 	}
-	uc.shared.order = kept
+	uc.shared.order = append(uc.shared.order[:0], ordered...)
 }
 
 // evictMissLocked removes one entry: expired first, oldest otherwise.
@@ -272,9 +312,11 @@ func (uc *FaviconUseCase) joinRefreshOp(ctx context.Context, key string, exec fu
 	startEpoch := uc.shared.epoch
 	call := &refreshCall{done: make(chan struct{}), waiters: 1, cancel: cancel}
 	uc.shared.active[key] = call
+	uc.shared.wg.Add(1)
 	uc.shared.mu.Unlock()
 
 	go func() {
+		defer uc.shared.wg.Done()
 		err := exec(opCtx, startEpoch)
 		<-uc.shared.slots
 		cancel()
@@ -314,23 +356,24 @@ func (uc *FaviconUseCase) awaitRefreshCall(ctx context.Context, call *refreshCal
 	}
 }
 
-// drainRefreshOps waits until no shared refresh operation remains active,
-// up to a bounded multiple of the operation deadline. Callers cancel first
-// (see Close); cooperative operations observe the background cancellation
-// and finish promptly, so hitting the bound means stuck work that shutdown
+// drainRefreshOps waits until every spawned executor finished, up to a
+// bounded multiple of the operation deadline. It waits on the executor
+// wait group rather than the active map: a replaced
+// canceled-but-still-running call no longer occupies its map entry, but
+// its executor may still touch repositories. Callers cancel first (see
+// Close); cooperative operations observe the background cancellation and
+// finish promptly, so hitting the bound means stuck work that shutdown
 // must not wait out.
 func (uc *FaviconUseCase) drainRefreshOps() {
-	deadline := time.Now().Add(3 * refreshOpTimeout)
-	for {
-		uc.shared.mu.Lock()
-		remaining := len(uc.shared.active)
-		uc.shared.mu.Unlock()
-		if remaining == 0 {
-			return
-		}
-		if time.Now().After(deadline) {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		uc.shared.wg.Wait()
+		close(done)
+	}()
+	deadline := time.NewTimer(3 * refreshOpTimeout)
+	defer deadline.Stop()
+	select {
+	case <-done:
+	case <-deadline.C:
 	}
 }

--- a/internal/application/usecase/favicon_refresh.go
+++ b/internal/application/usecase/favicon_refresh.go
@@ -1,0 +1,282 @@
+package usecase
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	appport "github.com/bnema/dumber/internal/application/port"
+	"github.com/bnema/dumber/internal/domain/favicon"
+)
+
+const (
+	// maxRefreshCandidates bounds how many icon URLs one refresh operation
+	// accepts; extras are skipped, never queued.
+	maxRefreshCandidates = 16
+	// maxRefreshCandidateLen bounds a single candidate URL length; longer
+	// inputs are skipped as invalid rather than fetched.
+	maxRefreshCandidateLen = 8 * 1024
+	// maxActiveRefreshes bounds distinct concurrent refresh operations
+	// across direct and scheduler-backed paths. Overload skips optional
+	// background work or reports ErrFaviconBusy to direct callers.
+	maxActiveRefreshes = 8
+	// refreshOpTimeout bounds a whole refresh operation, including
+	// context-aware DNS/validation, not per candidate.
+	refreshOpTimeout = 5 * time.Second
+	// faviconMissTTL bounds negative-cache entries for genuine absence.
+	faviconMissTTL = 30 * time.Second
+	// maxMissEntries bounds the negative cache; oldest entries are evicted.
+	maxMissEntries = 256
+)
+
+// refreshRequestKey builds a fixed-size digest identifying request-equivalent
+// refresh work: the validated page origin plus the ordered, normalized
+// candidate list. Scheme, host, port, path, and query are significant;
+// fragments are dropped and hosts lowercased. Relative candidates resolve
+// against the page URL. At most maxRefreshCandidates URLs of at most
+// maxRefreshCandidateLen bytes are accepted; the rest are skipped. It
+// returns false when the page URL has no valid origin hierarchy.
+func refreshRequestKey(pageURL string, iconURLs []string) (string, []string, bool) {
+	pageKey, ok := favicon.CanonicalKey(pageURL)
+	if !ok {
+		return "", nil, false
+	}
+	page, err := url.Parse(strings.TrimSpace(pageURL))
+	if err != nil || page.Hostname() == "" {
+		return "", nil, false
+	}
+	accepted := make([]string, 0, len(iconURLs))
+	for _, raw := range iconURLs {
+		raw = strings.TrimSpace(raw)
+		if raw == "" || len(raw) > maxRefreshCandidateLen {
+			continue
+		}
+		candidate, err := page.Parse(raw)
+		if err != nil {
+			continue
+		}
+		if candidate.Scheme != "http" && candidate.Scheme != "https" {
+			continue
+		}
+		if candidate.Hostname() == "" {
+			continue
+		}
+		candidate.Fragment = ""
+		candidate.Host = strings.ToLower(candidate.Host)
+		if host, port, ok := splitHostPort(candidate.Host); ok {
+			if isDefaultPort(candidate.Scheme, port) {
+				candidate.Host = host
+			}
+		}
+		accepted = append(accepted, candidate.String())
+		if len(accepted) >= maxRefreshCandidates {
+			break
+		}
+	}
+	sum := sha256.Sum256([]byte(string(pageKey) + "\x00" + strings.Join(accepted, "\x00")))
+	return hex.EncodeToString(sum[:]), accepted, true
+}
+
+func splitHostPort(hostport string) (string, string, bool) {
+	host, port, found := strings.Cut(hostport, ":")
+	if !found {
+		return "", "", false
+	}
+	return host, port, true
+}
+
+func isDefaultPort(scheme, port string) bool {
+	return (scheme == "http" && port == "80") || (scheme == "https" && port == "443")
+}
+
+// refreshCall is one shared in-flight refresh operation. Waiters join by
+// request key; the first waiter executes while the rest observe. One
+// canceled waiter never cancels the others; the operation is canceled only
+// when the last waiter leaves.
+type refreshCall struct {
+	done    chan struct{}
+	err     error
+	waiters int
+	cancel  context.CancelFunc
+}
+
+// refreshMiss records a negatively cached genuine absence.
+type refreshMiss struct {
+	expiresAt time.Time
+}
+
+// refreshCoordinator state lives on FaviconUseCase; see favicon.go.
+type refreshCoordinator struct {
+	mu     sync.Mutex
+	active map[string]*refreshCall
+	slots  chan struct{}
+	epoch  uint64
+	misses map[string]refreshMiss
+	order  []string
+}
+
+func newRefreshCoordinator() *refreshCoordinator {
+	return &refreshCoordinator{
+		active: make(map[string]*refreshCall),
+		slots:  make(chan struct{}, maxActiveRefreshes),
+		misses: make(map[string]refreshMiss),
+	}
+}
+
+// epochValue returns the current invalidation epoch.
+func (uc *FaviconUseCase) epochValue() uint64 {
+	uc.shared.mu.Lock()
+	defer uc.shared.mu.Unlock()
+	return uc.shared.epoch
+}
+
+// bumpEpoch advances the invalidation epoch so older in-flight completions
+// cannot repopulate invalidated entries.
+func (uc *FaviconUseCase) bumpEpoch() {
+	uc.shared.mu.Lock()
+	defer uc.shared.mu.Unlock()
+	uc.shared.epoch++
+}
+
+// cachedMiss reports whether key holds an unexpired genuine-absence entry.
+func (uc *FaviconUseCase) cachedMiss(key string) bool {
+	now := uc.now()
+	uc.shared.mu.Lock()
+	defer uc.shared.mu.Unlock()
+	miss, ok := uc.shared.misses[key]
+	if !ok {
+		return false
+	}
+	if !now.Before(miss.expiresAt) {
+		delete(uc.shared.misses, key)
+		return false
+	}
+	return true
+}
+
+// noteMiss records a genuine absence (verified 404/410) for request key.
+// Only 404/410 are cacheable: 401/403, 5xx, cancellation, DNS/transport,
+// and validation failures must never suppress a later retry.
+func (uc *FaviconUseCase) noteMiss(key string, fetchErr error) {
+	status, ok := appport.FetchStatusCode(fetchErr)
+	if !ok || (status != 404 && status != 410) {
+		return
+	}
+	uc.shared.mu.Lock()
+	defer uc.shared.mu.Unlock()
+	if _, exists := uc.shared.misses[key]; !exists {
+		for len(uc.shared.misses) >= maxMissEntries {
+			uc.evictMissLocked()
+		}
+		uc.shared.order = append(uc.shared.order, key)
+	}
+	uc.shared.misses[key] = refreshMiss{expiresAt: uc.now().Add(faviconMissTTL)}
+}
+
+// evictMissLocked removes one entry: expired first, oldest otherwise.
+// Caller must hold refresh.mu.
+func (uc *FaviconUseCase) evictMissLocked() {
+	now := uc.now()
+	for key, miss := range uc.shared.misses {
+		if !now.Before(miss.expiresAt) {
+			delete(uc.shared.misses, key)
+			return
+		}
+	}
+	for len(uc.shared.order) > 0 {
+		oldest := uc.shared.order[0]
+		uc.shared.order = uc.shared.order[1:]
+		if _, ok := uc.shared.misses[oldest]; ok {
+			delete(uc.shared.misses, oldest)
+			return
+		}
+	}
+	for key := range uc.shared.misses {
+		delete(uc.shared.misses, key)
+		return
+	}
+}
+
+// joinRefreshOp shares equivalent in-flight work identified by key. The
+// first waiter executes exec under a whole-operation deadline derived from
+// the owned background context; joiners observe the result. A canceled
+// waiter leaves without affecting others; the operation is canceled when
+// the last waiter is gone. When the admission budget is exhausted, direct
+// callers receive ErrFaviconBusy (never false success).
+func (uc *FaviconUseCase) joinRefreshOp(ctx context.Context, key string, exec func(opCtx context.Context) error) error {
+	uc.shared.mu.Lock()
+	if call, ok := uc.shared.active[key]; ok {
+		call.waiters++
+		uc.shared.mu.Unlock()
+		return uc.awaitRefreshCall(ctx, call)
+	}
+	select {
+	case uc.shared.slots <- struct{}{}:
+	default:
+		uc.shared.mu.Unlock()
+		return appport.ErrFaviconBusy
+	}
+	opCtx, cancel := context.WithTimeout(uc.background, refreshOpTimeout)
+	call := &refreshCall{done: make(chan struct{}), waiters: 1, cancel: cancel}
+	uc.shared.active[key] = call
+	uc.shared.mu.Unlock()
+
+	go func() {
+		err := exec(opCtx)
+		<-uc.shared.slots
+		cancel()
+		uc.shared.mu.Lock()
+		call.err = err
+		delete(uc.shared.active, key)
+		uc.shared.mu.Unlock()
+		close(call.done)
+	}()
+
+	return uc.awaitRefreshCall(ctx, call)
+}
+
+// awaitRefreshCall waits for a shared operation or the waiter's own
+// cancellation, releasing the waiter slot exactly once.
+func (uc *FaviconUseCase) awaitRefreshCall(ctx context.Context, call *refreshCall) error {
+	select {
+	case <-call.done:
+		uc.shared.mu.Lock()
+		err := call.err
+		uc.shared.mu.Unlock()
+		return err
+	case <-ctx.Done():
+		uc.shared.mu.Lock()
+		call.waiters--
+		last := call.waiters <= 0
+		uc.shared.mu.Unlock()
+		if last {
+			call.cancel()
+		}
+		return ctx.Err()
+	}
+}
+
+// drainRefreshOps waits until no shared refresh operation remains active,
+// up to a bounded multiple of the operation deadline. Callers cancel first
+// (see Close); cooperative operations observe the background cancellation
+// and finish promptly, so hitting the bound means stuck work that shutdown
+// must not wait out.
+func (uc *FaviconUseCase) drainRefreshOps() {
+	deadline := time.Now().Add(3 * refreshOpTimeout)
+	for {
+		uc.shared.mu.Lock()
+		remaining := len(uc.shared.active)
+		uc.shared.mu.Unlock()
+		if remaining == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/internal/application/usecase/favicon_refresh.go
+++ b/internal/application/usecase/favicon_refresh.go
@@ -96,12 +96,17 @@ func isDefaultPort(scheme, port string) bool {
 // refreshCall is one shared in-flight refresh operation. Waiters join by
 // request key; the first waiter executes while the rest observe. One
 // canceled waiter never cancels the others; the operation is canceled only
-// when the last waiter leaves.
+// when the last waiter leaves, decided atomically under the coordinator
+// lock so no joiner can observe a half-canceled call.
 type refreshCall struct {
 	done    chan struct{}
 	err     error
 	waiters int
 	cancel  context.CancelFunc
+	// closing marks a call whose last waiter left: it still occupies its
+	// slot and map entry until the executor finishes, but no new waiter
+	// may join it; joiners create a fresh operation instead.
+	closing bool
 }
 
 // refreshMiss records a negatively cached genuine absence.
@@ -115,6 +120,9 @@ type refreshCoordinator struct {
 	active map[string]*refreshCall
 	slots  chan struct{}
 	epoch  uint64
+	// closed seals admission: set by Close before cancel/drain, so no
+	// refresh can start after the drain observes zero active operations.
+	closed bool
 	misses map[string]refreshMiss
 	order  []string
 }
@@ -158,6 +166,14 @@ func (uc *FaviconUseCase) cachedMiss(key string) bool {
 	return true
 }
 
+// clearMiss drops any absence record for key: a later success proves the
+// resource exists and must not stay suppressed.
+func (uc *FaviconUseCase) clearMiss(key string) {
+	uc.shared.mu.Lock()
+	defer uc.shared.mu.Unlock()
+	delete(uc.shared.misses, key)
+}
+
 // noteMiss records a genuine absence (verified 404/410) for request key.
 // Only 404/410 are cacheable: 401/403, 5xx, cancellation, DNS/transport,
 // and validation failures must never suppress a later retry.
@@ -175,6 +191,26 @@ func (uc *FaviconUseCase) noteMiss(key string, fetchErr error) {
 		uc.shared.order = append(uc.shared.order, key)
 	}
 	uc.shared.misses[key] = refreshMiss{expiresAt: uc.now().Add(faviconMissTTL)}
+	// Expired names linger in order until evicted; compact before the
+	// backlog can grow without bound.
+	if len(uc.shared.order) > 4*maxMissEntries {
+		uc.compactMissOrderLocked()
+	}
+}
+
+// compactMissOrderLocked drops order names with no live entry, bounding
+// the backlog. Caller must hold refresh.mu.
+func (uc *FaviconUseCase) compactMissOrderLocked() {
+	kept := uc.shared.order[:0]
+	for _, key := range uc.shared.order {
+		if _, ok := uc.shared.misses[key]; ok {
+			kept = append(kept, key)
+		}
+	}
+	for i := len(kept); i < len(uc.shared.order); i++ {
+		uc.shared.order[i] = ""
+	}
+	uc.shared.order = kept
 }
 
 // evictMissLocked removes one entry: expired first, oldest otherwise.
@@ -203,13 +239,21 @@ func (uc *FaviconUseCase) evictMissLocked() {
 
 // joinRefreshOp shares equivalent in-flight work identified by key. The
 // first waiter executes exec under a whole-operation deadline derived from
-// the owned background context; joiners observe the result. A canceled
-// waiter leaves without affecting others; the operation is canceled when
-// the last waiter is gone. When the admission budget is exhausted, direct
-// callers receive ErrFaviconBusy (never false success).
-func (uc *FaviconUseCase) joinRefreshOp(ctx context.Context, key string, exec func(opCtx context.Context) error) error {
+// the owned background context; joiners observe the result. The creating
+// waiter also advances the invalidation epoch, so concurrent joiners never
+// invalidate the operation they joined. A canceled waiter leaves without
+// affecting others; the operation is canceled atomically when the last
+// waiter leaves, and late joiners start a fresh operation instead of
+// observing a dying call. When the admission budget is exhausted, or the
+// coordinator is closed, direct callers receive ErrFaviconBusy or
+// ErrFaviconShutdown respectively (never false success).
+func (uc *FaviconUseCase) joinRefreshOp(ctx context.Context, key string, exec func(opCtx context.Context, startEpoch uint64) error) error {
 	uc.shared.mu.Lock()
-	if call, ok := uc.shared.active[key]; ok {
+	if uc.shared.closed {
+		uc.shared.mu.Unlock()
+		return appport.ErrFaviconShutdown
+	}
+	if call, ok := uc.shared.active[key]; ok && !call.closing {
 		call.waiters++
 		uc.shared.mu.Unlock()
 		return uc.awaitRefreshCall(ctx, call)
@@ -221,17 +265,24 @@ func (uc *FaviconUseCase) joinRefreshOp(ctx context.Context, key string, exec fu
 		return appport.ErrFaviconBusy
 	}
 	opCtx, cancel := context.WithTimeout(uc.background, refreshOpTimeout)
+	// The creator advances the epoch with creation itself: older
+	// completions cannot repopulate entries this operation supersedes,
+	// and joiners share the creator's epoch instead of invalidating it.
+	uc.shared.epoch++
+	startEpoch := uc.shared.epoch
 	call := &refreshCall{done: make(chan struct{}), waiters: 1, cancel: cancel}
 	uc.shared.active[key] = call
 	uc.shared.mu.Unlock()
 
 	go func() {
-		err := exec(opCtx)
+		err := exec(opCtx, startEpoch)
 		<-uc.shared.slots
 		cancel()
 		uc.shared.mu.Lock()
 		call.err = err
-		delete(uc.shared.active, key)
+		if uc.shared.active[key] == call {
+			delete(uc.shared.active, key)
+		}
 		uc.shared.mu.Unlock()
 		close(call.done)
 	}()
@@ -240,7 +291,10 @@ func (uc *FaviconUseCase) joinRefreshOp(ctx context.Context, key string, exec fu
 }
 
 // awaitRefreshCall waits for a shared operation or the waiter's own
-// cancellation, releasing the waiter slot exactly once.
+// cancellation, releasing the waiter slot exactly once. The last waiter to
+// leave marks the call closing and cancels it atomically under the lock:
+// context cancellation only signals, so invoking it while holding the
+// coordinator mutex cannot block.
 func (uc *FaviconUseCase) awaitRefreshCall(ctx context.Context, call *refreshCall) error {
 	select {
 	case <-call.done:
@@ -251,11 +305,11 @@ func (uc *FaviconUseCase) awaitRefreshCall(ctx context.Context, call *refreshCal
 	case <-ctx.Done():
 		uc.shared.mu.Lock()
 		call.waiters--
-		last := call.waiters <= 0
-		uc.shared.mu.Unlock()
-		if last {
+		if call.waiters <= 0 && !call.closing {
+			call.closing = true
 			call.cancel()
 		}
+		uc.shared.mu.Unlock()
 		return ctx.Err()
 	}
 }

--- a/internal/application/usecase/favicon_refresh_test.go
+++ b/internal/application/usecase/favicon_refresh_test.go
@@ -127,6 +127,8 @@ func TestRefreshFromIconURLs_CancelOneWaiterKeepsOthers(t *testing.T) {
 
 	page := "https://example.com/a"
 	candidates := []string{"https://example.com/favicon.ico"}
+	key, _, ok := refreshRequestKey(page, candidates)
+	require.True(t, ok, "test page and candidates must form a refresh key")
 	leaving, cancelLeaving := context.WithCancel(context.Background())
 	left := make(chan error, 1)
 	go func() {
@@ -136,7 +138,14 @@ func TestRefreshFromIconURLs_CancelOneWaiterKeepsOthers(t *testing.T) {
 	go func() {
 		staying <- uc.RefreshFromIconURLs(context.Background(), page, candidates)
 	}()
-	time.Sleep(100 * time.Millisecond)
+	// Both waiters must share one operation before either leaves: two
+	// waiters on the same call proves sharing, not two separate fetches.
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		call, ok := uc.shared.active[key]
+		return ok && !call.closing && call.waiters == 2
+	}, 10*time.Second, 5*time.Millisecond, "both waiters must join one shared operation")
 	cancelLeaving()
 	select {
 	case err := <-left:
@@ -288,7 +297,12 @@ func TestRefreshOp_WholeDeadline(t *testing.T) {
 // cancels the shared operation instead of leaking it.
 func TestRefreshLastWaiterCancelAbortsOp(t *testing.T) {
 	observedCancel := make(chan struct{}, 1)
+	entered := make(chan struct{}, 1)
 	fetcher := refreshFetcherMock(t, func(ctx context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
 		select {
 		case <-ctx.Done():
 			observedCancel <- struct{}{}
@@ -304,7 +318,14 @@ func TestRefreshLastWaiterCancelAbortsOp(t *testing.T) {
 	go func() {
 		done <- uc.RefreshFromIconURLs(waiter, "https://example.com/a", []string{"https://example.com/favicon.ico"})
 	}()
-	time.Sleep(100 * time.Millisecond)
+	// Cancel only after the executor entered the fetch: len(active) == 1
+	// alone cannot prove the executor is blocked inside Fetch, and an early
+	// cancel could race operation creation instead of aborting shared work.
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("executor did not enter the fetch")
+	}
 	cancel()
 	select {
 	case err := <-done:
@@ -692,4 +713,86 @@ func TestRefreshSharing_ScopedToUseCaseInstance(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.EqualValues(t, 2, calls.Load(), "sharing must not cross use-case instances")
+}
+
+// TestRefreshMixedStatusBatchNotCached proves a batch mixing a transient
+// failure with a genuine absence never populates the negative cache: the
+// last miss alone must not decide cacheability.
+func TestRefreshMixedStatusBatchNotCached(t *testing.T) {
+	var calls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		if req.IconURL == "https://example.com/denied.ico" {
+			return nil, &appport.FaviconFetchError{StatusCode: 403}
+		}
+		return nil, &appport.FaviconFetchError{StatusCode: 404}
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/denied.ico", "https://example.com/gone.ico"}
+	require.ErrorIs(t, uc.RefreshFromIconURLs(context.Background(), page, candidates), ErrFaviconMiss)
+	key, _, ok := refreshRequestKey(page, candidates)
+	require.True(t, ok)
+	require.False(t, uc.cachedMiss(key), "mixed 403+404 batch must not be negatively cached")
+	require.ErrorIs(t, uc.RefreshFromIconURLs(context.Background(), page, candidates), ErrFaviconMiss)
+	require.EqualValues(t, 4, calls.Load(), "second refresh must retry instead of reading a cached absence")
+}
+
+// TestRefreshClosedWinsOverCachedMiss proves sealed admission takes
+// precedence over a cached absence: after Close, refresh reports shutdown
+// even for a key holding a genuine 404.
+func TestRefreshClosedWinsOverCachedMiss(t *testing.T) {
+	var calls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(_ context.Context, _ appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		return nil, &appport.FaviconFetchError{StatusCode: 404}
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/gone.ico"}
+	key, _, ok := refreshRequestKey(page, candidates)
+	require.True(t, ok)
+	uc.noteMiss(key, &appport.FaviconFetchError{StatusCode: 404})
+	require.True(t, uc.cachedMiss(key))
+	uc.Close()
+	err := uc.RefreshFromIconURLs(context.Background(), page, candidates)
+	require.ErrorIs(t, err, appport.ErrFaviconShutdown)
+	require.NotErrorIs(t, err, ErrFaviconMiss, "shutdown must stay distinct from a miss")
+	require.Zero(t, calls.Load(), "sealed refresh must not reach the fetcher")
+}
+
+// TestCompactMissOrderDedupsReinsertedKeys proves compaction collapses
+// stale duplicates: an evicted key that is reinserted keeps exactly one
+// order entry, so the backlog cannot grow across expire/reinsert cycles.
+func TestCompactMissOrderDedupsReinsertedKeys(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	uc := refreshTestUC(t, refreshFetcherMock(t, func(_ context.Context, _ appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		return nil, &appport.FaviconFetchError{StatusCode: 404}
+	}), &now, nil)
+
+	uc.shared.mu.Lock()
+	uc.shared.misses["live"] = refreshMiss{expiresAt: now.Add(faviconMissTTL)}
+	// Simulate eviction (map entry removed, order name left behind) plus
+	// reinsertion: the same key appears twice in order.
+	uc.shared.order = []string{"stale-a", "live", "stale-b", "live"}
+	uc.compactMissOrderLocked()
+	order := append([]string(nil), uc.shared.order...)
+	uc.shared.mu.Unlock()
+	require.Equal(t, []string{"live"}, order, "compaction must keep one entry per live key")
+}
+
+// TestRefreshRequestKey_IPv6DefaultPortEquivalence proves bracketed IPv6
+// hosts with an explicit default port share identity with the bare form:
+// without bracket-aware parsing the two spellings hash differently and
+// bypass in-flight sharing.
+func TestRefreshRequestKey_IPv6DefaultPortEquivalence(t *testing.T) {
+	page := "https://[2001:db8::1]/a"
+	withPort, withPortAccepted, ok := refreshRequestKey(page, []string{"https://[2001:db8::1]:443/favicon.ico"})
+	require.True(t, ok)
+	bare, bareAccepted, ok := refreshRequestKey(page, []string{"https://[2001:db8::1]/favicon.ico"})
+	require.True(t, ok)
+	require.Equal(t, bare, withPort, "explicit default port must not change the request key")
+	require.Equal(t, bareAccepted, withPortAccepted)
 }

--- a/internal/application/usecase/favicon_refresh_test.go
+++ b/internal/application/usecase/favicon_refresh_test.go
@@ -479,6 +479,190 @@ func TestRefreshInvalidate_DropsStaleCompletion(t *testing.T) {
 	require.Empty(t, repo.byKey, "stale completion must not repopulate invalidated entries")
 }
 
+// TestRefreshJoinerSharesCreatorEpoch proves concurrent joiners never
+// invalidate the operation they joined: overlapping identical refreshes
+// both succeed and the fetched icon is stored.
+func TestRefreshJoinerSharesCreatorEpoch(t *testing.T) {
+	release := make(chan struct{})
+	var calls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		<-release
+		return fetchedIcon(req.IconURL), nil
+	})
+	repo := newFaviconRepoState()
+	uc := NewFaviconUseCase(FaviconDeps{
+		Repository:   mockFaviconRepository(t, repo),
+		BlobStore:    mockFaviconBlobStore(t, newFaviconBlobStoreState()),
+		Converter:    mockFaviconConverter(t, &faviconConverterState{}),
+		Scheduler:    mockFaviconScheduler(t, &faviconSchedulerState{seen: map[favicon.Key]bool{}}),
+		Invalidators: mockFaviconInvalidators(t, &faviconInvalidatorsState{}),
+		Fetcher:      fetcher,
+		Now:          time.Now,
+		Background:   context.Background(),
+	})
+
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/favicon.ico"}
+	key, _, ok := refreshRequestKey(page, candidates)
+	require.True(t, ok)
+	first := make(chan error, 1)
+	go func() {
+		first <- uc.RefreshFromIconURLs(context.Background(), page, candidates)
+	}()
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		return len(uc.shared.active) == 1
+	}, 10*time.Second, 5*time.Millisecond)
+	second := make(chan error, 1)
+	go func() {
+		second <- uc.RefreshFromIconURLs(context.Background(), page, candidates)
+	}()
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		call, ok := uc.shared.active[key]
+		return ok && call.waiters == 2
+	}, 10*time.Second, 5*time.Millisecond, "joiner must share the creator operation")
+	close(release)
+	select {
+	case err := <-first:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("creator did not complete")
+	}
+	select {
+	case err := <-second:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("joiner did not complete")
+	}
+	require.EqualValues(t, 1, calls.Load())
+	require.NotEmpty(t, repo.byKey, "shared success must be stored, not dropped by a joiner epoch bump")
+}
+
+// TestRefreshPartialMissDoesNotPoisonLaterCandidates proves request-level
+// negative caching happens only for fully missed requests: a 404 on the
+// first candidate followed by a successful second candidate stores the
+// icon and records no miss.
+func TestRefreshPartialMissDoesNotPoisonLaterCandidates(t *testing.T) {
+	var calls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		if req.IconURL == "https://example.com/gone.ico" {
+			return nil, &appport.FaviconFetchError{StatusCode: 404}
+		}
+		return fetchedIcon(req.IconURL), nil
+	})
+	repo := newFaviconRepoState()
+	uc := NewFaviconUseCase(FaviconDeps{
+		Repository:   mockFaviconRepository(t, repo),
+		BlobStore:    mockFaviconBlobStore(t, newFaviconBlobStoreState()),
+		Converter:    mockFaviconConverter(t, &faviconConverterState{}),
+		Scheduler:    mockFaviconScheduler(t, &faviconSchedulerState{seen: map[favicon.Key]bool{}}),
+		Invalidators: mockFaviconInvalidators(t, &faviconInvalidatorsState{}),
+		Fetcher:      fetcher,
+		Now:          time.Now,
+		Background:   context.Background(),
+	})
+
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/gone.ico", "https://example.com/good.ico"}
+	require.NoError(t, uc.RefreshFromIconURLs(context.Background(), page, candidates))
+	require.NotEmpty(t, repo.byKey, "successful candidate must be stored")
+	key, _, ok := refreshRequestKey(page, candidates)
+	require.True(t, ok)
+	require.False(t, uc.cachedMiss(key), "partial miss must not populate the request miss cache")
+}
+
+// TestRefreshCanceledCallNotJoined proves a waiter arriving after the last
+// waiter canceled starts a fresh operation instead of observing the dying
+// call.
+func TestRefreshCanceledCallNotJoined(t *testing.T) {
+	release := make(chan struct{})
+	var calls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(ctx context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		select {
+		case <-release:
+			return fetchedIcon(req.IconURL), nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/favicon.ico"}
+	leaving, cancel := context.WithCancel(context.Background())
+	left := make(chan error, 1)
+	go func() {
+		left <- uc.RefreshFromIconURLs(leaving, page, candidates)
+	}()
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		return len(uc.shared.active) == 1
+	}, 10*time.Second, 5*time.Millisecond)
+	cancel()
+	select {
+	case err := <-left:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("canceled waiter did not return")
+	}
+	// The dying call still occupies the map entry until its executor
+	// finishes; the next waiter must start fresh rather than join it.
+	fresh := make(chan error, 1)
+	go func() {
+		fresh <- uc.RefreshFromIconURLs(context.Background(), page, candidates)
+	}()
+	require.Eventually(t, func() bool {
+		return calls.Load() == 2
+	}, 10*time.Second, 5*time.Millisecond, "late joiner must start a fresh operation")
+	close(release)
+	select {
+	case err := <-fresh:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("fresh operation did not complete")
+	}
+}
+
+// TestRefreshCloseSealsAdmission proves no refresh can start after Close
+// began: late callers receive a distinct shutdown error instead of racing
+// the drain.
+func TestRefreshCloseSealsAdmission(t *testing.T) {
+	uc := refreshTestUC(t, refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		return fetchedIcon(req.IconURL), nil
+	}), nil, nil)
+
+	uc.Close()
+	err := uc.RefreshFromIconURLs(context.Background(), "https://example.com/a", []string{"https://example.com/favicon.ico"})
+	require.ErrorIs(t, err, appport.ErrFaviconShutdown)
+	require.NotErrorIs(t, err, ErrFaviconMiss, "shutdown must stay distinct from a miss")
+}
+
+// TestRefreshMissOrderBounded proves the negative-cache order backlog
+// cannot grow without bound under distinct misses.
+func TestRefreshMissOrderBounded(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	fetcher := refreshFetcherMock(t, func(_ context.Context, _ appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		return nil, &appport.FaviconFetchError{StatusCode: 404}
+	})
+	uc := refreshTestUC(t, fetcher, &now, nil)
+
+	for i := range 3 * maxMissEntries {
+		icon := "https://example.com/missing-" + string(rune('a'+i%26)) + "-" + string(rune('0'+i/26%10)) + ".ico"
+		require.ErrorIs(t, uc.RefreshFromIconURLs(context.Background(), "https://example.com/a", []string{icon}), ErrFaviconMiss)
+	}
+	uc.shared.mu.Lock()
+	defer uc.shared.mu.Unlock()
+	require.LessOrEqual(t, len(uc.shared.misses), maxMissEntries)
+	require.LessOrEqual(t, len(uc.shared.order), 4*maxMissEntries, "order backlog must stay bounded")
+}
+
 // TestRefreshSharing_ScopedToUseCaseInstance proves profile isolation:
 // identical requests on different use-case instances never share fetches.
 func TestRefreshSharing_ScopedToUseCaseInstance(t *testing.T) {

--- a/internal/application/usecase/favicon_refresh_test.go
+++ b/internal/application/usecase/favicon_refresh_test.go
@@ -1,0 +1,511 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	appport "github.com/bnema/dumber/internal/application/port"
+	portmocks "github.com/bnema/dumber/internal/application/port/mocks"
+	"github.com/bnema/dumber/internal/domain/favicon"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// refreshTestUC builds a FaviconUseCase with a custom fetcher and
+// controllable clock for refresh-coordinator tests.
+func refreshTestUC(t *testing.T, fetcher appport.FaviconFetcher, now *time.Time, background context.Context) *FaviconUseCase {
+	t.Helper()
+	if background == nil {
+		background = context.Background()
+	}
+	nowFn := time.Now
+	if now != nil {
+		nowFn = func() time.Time { return *now }
+	}
+	return NewFaviconUseCase(FaviconDeps{
+		Repository:   mockFaviconRepository(t, newFaviconRepoState()),
+		BlobStore:    mockFaviconBlobStore(t, newFaviconBlobStoreState()),
+		Converter:    mockFaviconConverter(t, &faviconConverterState{}),
+		Scheduler:    mockFaviconScheduler(t, &faviconSchedulerState{seen: map[favicon.Key]bool{}}),
+		Invalidators: mockFaviconInvalidators(t, &faviconInvalidatorsState{}),
+		Fetcher:      fetcher,
+		Now:          nowFn,
+		Background:   background,
+	})
+}
+
+func refreshFetcherMock(t *testing.T, fetch func(context.Context, appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error)) *portmocks.MockFaviconFetcher {
+	t.Helper()
+	fetcher := portmocks.NewMockFaviconFetcher(t)
+	fetcher.EXPECT().Fetch(mock.Anything, mock.Anything).RunAndReturn(fetch).Maybe()
+	return fetcher
+}
+
+func fetchedIcon(iconURL string) *appport.FaviconFetchedIcon {
+	return &appport.FaviconFetchedIcon{
+		IconURL:     iconURL,
+		Bytes:       []byte("icon-bytes"),
+		ContentType: "image/png",
+	}
+}
+
+// TestRefreshFromIconURLs_ConcurrentIdenticalSharesOneFetch reproduces the
+// P1.1 bypass: concurrent identical candidate requests must share a single
+// fetch instead of issuing one fetch per caller.
+func TestRefreshFromIconURLs_ConcurrentIdenticalSharesOneFetch(t *testing.T) {
+	var calls atomic.Int64
+	entered := make(chan struct{}, 8)
+	release := make(chan struct{})
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		entered <- struct{}{}
+		<-release
+		return fetchedIcon(req.IconURL), nil
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	const waiters = 5
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/favicon.ico"}
+	key, _, ok := refreshRequestKey(page, candidates)
+	require.True(t, ok)
+	results := make(chan error, waiters)
+	var wg sync.WaitGroup
+	for range waiters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- uc.RefreshFromIconURLs(context.Background(), page, candidates)
+		}()
+	}
+	// All five waiters must join the single shared operation before the
+	// fetch completes; the waiter count is the deterministic join signal.
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		call, ok := uc.shared.active[key]
+		return ok && call.waiters == waiters
+	}, 10*time.Second, 5*time.Millisecond, "waiters did not join the shared operation")
+	close(release)
+	wg.Wait()
+	close(results)
+	for err := range results {
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 1, calls.Load(), "identical concurrent refreshes must share one fetch")
+}
+
+// TestRefreshFromIconURLs_ChangingCandidatesDoNotShare verifies that
+// different candidate lists are distinct operations.
+func TestRefreshFromIconURLs_ChangingCandidatesDoNotShare(t *testing.T) {
+	var calls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		return fetchedIcon(req.IconURL), nil
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	require.NoError(t, uc.RefreshFromIconURLs(context.Background(), "https://example.com/a", []string{"https://example.com/one.ico"}))
+	require.NoError(t, uc.RefreshFromIconURLs(context.Background(), "https://example.com/a", []string{"https://example.com/two.ico"}))
+	require.EqualValues(t, 2, calls.Load())
+}
+
+// TestRefreshFromIconURLs_CancelOneWaiterKeepsOthers proves waiter
+// independence: a canceled waiter leaves while the shared operation serves
+// the rest.
+func TestRefreshFromIconURLs_CancelOneWaiterKeepsOthers(t *testing.T) {
+	release := make(chan struct{})
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		<-release
+		return fetchedIcon(req.IconURL), nil
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/favicon.ico"}
+	leaving, cancelLeaving := context.WithCancel(context.Background())
+	left := make(chan error, 1)
+	go func() {
+		left <- uc.RefreshFromIconURLs(leaving, page, candidates)
+	}()
+	staying := make(chan error, 1)
+	go func() {
+		staying <- uc.RefreshFromIconURLs(context.Background(), page, candidates)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancelLeaving()
+	select {
+	case err := <-left:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("canceled waiter did not return")
+	}
+	close(release)
+	select {
+	case err := <-staying:
+		require.NoError(t, err, "remaining waiter must still be served")
+	case <-time.After(10 * time.Second):
+		t.Fatal("remaining waiter was dropped with the canceled one")
+	}
+}
+
+// TestRefreshFromIconURLs_InvalidPageHierarchyRejected verifies invalid
+// origins never reach the fetcher.
+func TestRefreshFromIconURLs_InvalidPageHierarchyRejected(t *testing.T) {
+	var calls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		return fetchedIcon(req.IconURL), nil
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	for _, page := range []string{"", "not a url", "ftp://example.com/a", "dumb://internal"} {
+		require.ErrorIs(t, uc.RefreshFromIconURLs(context.Background(), page, []string{"https://example.com/favicon.ico"}), ErrFaviconMiss)
+	}
+	require.Zero(t, calls.Load())
+}
+
+// TestRefreshRequestKey_Distinctions covers origin and candidate
+// significance: scheme/port/query matter, fragments/case/default ports do
+// not, relative candidates resolve against the page, over-long and excess
+// candidates are skipped.
+func TestRefreshRequestKey_Distinctions(t *testing.T) {
+	page := "https://example.com:8443/a?x=1"
+	keyOf := func(candidates ...string) (string, bool) {
+		key, _, ok := refreshRequestKey(page, candidates)
+		return key, ok
+	}
+	base, ok := keyOf("https://example.com:8443/icon.png")
+	require.True(t, ok)
+
+	other, _ := keyOf("https://example.com:8443/other.png")
+	require.NotEqual(t, base, other, "different candidates must not share")
+
+	portKey, _ := keyOf("https://example.com:9443/icon.png")
+	require.NotEqual(t, base, portKey, "ports are significant")
+
+	queryKey, _ := keyOf("https://example.com:8443/icon.png?v=2")
+	require.NotEqual(t, base, queryKey, "queries are significant")
+
+	fragKey, _ := keyOf("https://example.com:8443/icon.png#frag")
+	require.Equal(t, base, fragKey, "fragments must not split sharing")
+
+	caseKey, _ := keyOf("HTTPS://EXAMPLE.COM:8443/icon.png")
+	require.Equal(t, base, caseKey, "scheme/host case must not split sharing")
+
+	defaultPort, _ := keyOf("https://example.com:443/icon.png")
+	otherPage, _, ok := refreshRequestKey("https://example.com/icon", []string{"https://example.com:443/icon.png"})
+	require.True(t, ok)
+	require.NotEqual(t, defaultPort, otherPage, "page origin is part of the identity")
+
+	relKey, relCandidates, ok := refreshRequestKey("https://example.com/a", []string{"/icon.png"})
+	require.True(t, ok)
+	require.Equal(t, []string{"https://example.com/icon.png"}, relCandidates, "relative candidates resolve against the page")
+	require.NotEqual(t, relKey, base, "different pages must not share")
+
+	long := "https://example.com/" + string(make([]byte, maxRefreshCandidateLen))
+	_, kept, ok := refreshRequestKey(page, []string{long, "https://example.com:8443/icon.png"})
+	require.True(t, ok)
+	require.Len(t, kept, 1, "over-long candidates are skipped")
+
+	many := make([]string, maxRefreshCandidates+4)
+	for i := range many {
+		many[i] = "https://example.com:8443/icon.png"
+	}
+	_, kept, ok = refreshRequestKey(page, many)
+	require.True(t, ok)
+	require.Len(t, kept, maxRefreshCandidates, "candidates are capped")
+
+	_, _, ok = refreshRequestKey("not a url", []string{"https://example.com/icon.png"})
+	require.False(t, ok, "invalid page hierarchy is rejected")
+}
+
+// TestRefreshAdmission_BusyWhenExhausted fills the shared budget with
+// blocked operations and proves the next direct caller gets a distinct
+// busy outcome instead of false success.
+func TestRefreshAdmission_BusyWhenExhausted(t *testing.T) {
+	release := make(chan struct{})
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		<-release
+		return fetchedIcon(req.IconURL), nil
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	var wg sync.WaitGroup
+	for i := range maxActiveRefreshes {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Distinct candidates per holder fill distinct budget slots;
+			// identical requests would share one.
+			icon := fmt.Sprintf("https://example.com/icon-%d.png", i)
+			_ = uc.RefreshFromIconURLs(context.Background(), "https://example.com/page", []string{icon})
+		}(i)
+	}
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		return len(uc.shared.active) == maxActiveRefreshes
+	}, 10*time.Second, 5*time.Millisecond, "budget must fill")
+
+	err := uc.RefreshFromIconURLs(context.Background(), "https://other.example/", []string{"https://other.example/icon.png"})
+	require.ErrorIs(t, err, appport.ErrFaviconBusy)
+	require.NotErrorIs(t, err, ErrFaviconMiss, "overload must stay distinct from a miss")
+
+	close(release)
+	wg.Wait()
+	require.NoError(t, uc.RefreshFromIconURLs(context.Background(), "https://other.example/", []string{"https://other.example/icon.png"}))
+}
+
+// TestRefreshOp_WholeDeadline verifies the shared operation carries the
+// bounded whole-operation deadline without waiting it out.
+func TestRefreshOp_WholeDeadline(t *testing.T) {
+	deadlines := make(chan time.Time, 1)
+	fetcher := refreshFetcherMock(t, func(ctx context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		if deadline, ok := ctx.Deadline(); ok {
+			deadlines <- deadline
+		}
+		return fetchedIcon(req.IconURL), nil
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	require.NoError(t, uc.RefreshFromIconURLs(context.Background(), "https://example.com/a", []string{"https://example.com/favicon.ico"}))
+	select {
+	case deadline := <-deadlines:
+		remaining := time.Until(deadline)
+		require.Greater(t, remaining, 4*time.Second)
+		require.LessOrEqual(t, remaining, refreshOpTimeout)
+	case <-time.After(10 * time.Second):
+		t.Fatal("fetch did not observe the operation deadline")
+	}
+}
+
+// TestRefreshLastWaiterCancelAbortsOp proves a lone waiter that leaves
+// cancels the shared operation instead of leaking it.
+func TestRefreshLastWaiterCancelAbortsOp(t *testing.T) {
+	observedCancel := make(chan struct{}, 1)
+	fetcher := refreshFetcherMock(t, func(ctx context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		select {
+		case <-ctx.Done():
+			observedCancel <- struct{}{}
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Second):
+			return fetchedIcon(req.IconURL), nil
+		}
+	})
+	uc := refreshTestUC(t, fetcher, nil, nil)
+
+	waiter, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- uc.RefreshFromIconURLs(waiter, "https://example.com/a", []string{"https://example.com/favicon.ico"})
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("canceled lone waiter did not return")
+	}
+	select {
+	case <-observedCancel:
+	case <-time.After(10 * time.Second):
+		t.Fatal("operation was not canceled with its last waiter")
+	}
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		return len(uc.shared.active) == 0
+	}, 10*time.Second, 5*time.Millisecond, "canceled operation must release its slot")
+}
+
+// TestFaviconUseCase_CloseCancelsAndDrains proves shutdown wiring: Close
+// aborts owned background work and returns once nothing is active.
+func TestFaviconUseCase_CloseCancelsAndDrains(t *testing.T) {
+	background, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sawCancel := make(chan struct{}, 1)
+	fetcher := refreshFetcherMock(t, func(ctx context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		select {
+		case <-ctx.Done():
+			sawCancel <- struct{}{}
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Second):
+			return fetchedIcon(req.IconURL), nil
+		}
+	})
+	uc := refreshTestUC(t, fetcher, nil, background)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- uc.RefreshFromIconURLs(context.Background(), "https://example.com/a", []string{"https://example.com/favicon.ico"})
+	}()
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		return len(uc.shared.active) == 1
+	}, 10*time.Second, 5*time.Millisecond)
+
+	closed := make(chan struct{})
+	go func() {
+		uc.Close()
+		close(closed)
+	}()
+	select {
+	case <-sawCancel:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not cancel background work")
+	}
+	select {
+	case <-closed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not drain")
+	}
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("refresh caller did not return after Close")
+	}
+	// Repeat Close must be safe (idempotent, no error to report).
+	uc.Close()
+}
+
+// TestRefreshMissClassification_HTTPClasses proves only genuine absence
+// (404/410) is negatively cached: auth/transient failures refetch, and a
+// repeated miss within TTL issues no fetch.
+func TestRefreshMissClassification_HTTPClasses(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	statusByURL := map[string]int{
+		"https://example.com/gone.ico":       404,
+		"https://example.com/removed.ico":    410,
+		"https://example.com/denied.ico":     403,
+		"https://example.com/login.ico":      401,
+		"https://example.com/broken.ico":     500,
+		"https://example.com/unstable.ico":   503,
+		"https://example.com/validation.ico": 0,
+	}
+	var calls atomic.Int64
+	var candidateCalls atomic.Int64
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		calls.Add(1)
+		// The all-miss fallback runs a candidate-less discovery fetch;
+		// assertions below count candidate batches only.
+		if req.IconURL != "" {
+			candidateCalls.Add(1)
+		}
+		status := statusByURL[req.IconURL]
+		if status == 0 {
+			return nil, appport.ErrFaviconMiss
+		}
+		return nil, &appport.FaviconFetchError{StatusCode: status}
+	})
+	uc := refreshTestUC(t, fetcher, &now, nil)
+	page := "https://example.com/a"
+
+	refresh := func(icon string) error {
+		return uc.RefreshFromIconURLs(context.Background(), page, []string{icon})
+	}
+	for icon := range statusByURL {
+		err := refresh(icon)
+		require.ErrorIs(t, err, ErrFaviconMiss, "every class must preserve miss matching for %s", icon)
+	}
+	firstCalls := candidateCalls.Load()
+	require.EqualValues(t, len(statusByURL), firstCalls)
+
+	// Genuine absence is cached: 404/410 refetch nothing within TTL.
+	require.ErrorIs(t, refresh("https://example.com/gone.ico"), ErrFaviconMiss)
+	require.ErrorIs(t, refresh("https://example.com/removed.ico"), ErrFaviconMiss)
+	require.Equal(t, firstCalls, candidateCalls.Load(), "cached genuine absence must not refetch")
+
+	// Auth/transient/validation failures are never cached: they refetch.
+	require.ErrorIs(t, refresh("https://example.com/denied.ico"), ErrFaviconMiss)
+	require.ErrorIs(t, refresh("https://example.com/broken.ico"), ErrFaviconMiss)
+	require.ErrorIs(t, refresh("https://example.com/validation.ico"), ErrFaviconMiss)
+	require.Equal(t, firstCalls+3, candidateCalls.Load())
+
+	// After TTL expiry the genuine absence is eligible again.
+	now = now.Add(faviconMissTTL + time.Second)
+	require.ErrorIs(t, refresh("https://example.com/gone.ico"), ErrFaviconMiss)
+	require.Equal(t, firstCalls+4, candidateCalls.Load())
+}
+
+// TestRefreshInvalidate_DropsStaleCompletion proves the epoch rule: an
+// invalidation racing an in-flight fetch prevents the stale bytes from
+// being stored.
+func TestRefreshInvalidate_DropsStaleCompletion(t *testing.T) {
+	release := make(chan struct{})
+	fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+		<-release
+		return fetchedIcon(req.IconURL), nil
+	})
+	repo := newFaviconRepoState()
+	uc := NewFaviconUseCase(FaviconDeps{
+		Repository:   mockFaviconRepository(t, repo),
+		BlobStore:    mockFaviconBlobStore(t, newFaviconBlobStoreState()),
+		Converter:    mockFaviconConverter(t, &faviconConverterState{}),
+		Scheduler:    mockFaviconScheduler(t, &faviconSchedulerState{seen: map[favicon.Key]bool{}}),
+		Invalidators: mockFaviconInvalidators(t, &faviconInvalidatorsState{}),
+		Fetcher:      fetcher,
+		Now:          time.Now,
+		Background:   context.Background(),
+	})
+
+	page := "https://example.com/a"
+	done := make(chan error, 1)
+	go func() {
+		done <- uc.RefreshFromIconURLs(context.Background(), page, []string{"https://example.com/favicon.ico"})
+	}()
+	require.Eventually(t, func() bool {
+		uc.shared.mu.Lock()
+		defer uc.shared.mu.Unlock()
+		return len(uc.shared.active) == 1
+	}, 10*time.Second, 5*time.Millisecond)
+
+	key, ok := favicon.CanonicalKey(page)
+	require.True(t, ok)
+	require.NoError(t, uc.Invalidate(context.Background(), key))
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("refresh did not complete after release")
+	}
+	require.Empty(t, repo.byKey, "stale completion must not repopulate invalidated entries")
+}
+
+// TestRefreshSharing_ScopedToUseCaseInstance proves profile isolation:
+// identical requests on different use-case instances never share fetches.
+func TestRefreshSharing_ScopedToUseCaseInstance(t *testing.T) {
+	var calls atomic.Int64
+	newUC := func() *FaviconUseCase {
+		fetcher := refreshFetcherMock(t, func(_ context.Context, req appport.FaviconFetchRequest) (*appport.FaviconFetchedIcon, error) {
+			calls.Add(1)
+			return fetchedIcon(req.IconURL), nil
+		})
+		return refreshTestUC(t, fetcher, nil, nil)
+	}
+	first, second := newUC(), newUC()
+	page := "https://example.com/a"
+	candidates := []string{"https://example.com/favicon.ico"}
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, uc := range []*FaviconUseCase{first, second} {
+		wg.Add(1)
+		go func(uc *FaviconUseCase) {
+			defer wg.Done()
+			errs <- uc.RefreshFromIconURLs(context.Background(), page, candidates)
+		}(uc)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 2, calls.Load(), "sharing must not cross use-case instances")
+}

--- a/internal/infrastructure/cef/content_injector.go
+++ b/internal/infrastructure/cef/content_injector.go
@@ -249,6 +249,30 @@ func (ci *contentInjector) RefreshScripts(ctx context.Context, wv port.WebView) 
 	return nil
 }
 
+// onLoadEndForEvent installs scripts for a captured load-end event after
+// revalidating it on the GTK thread. Events that are provably stale are
+// skipped: a replaced browser instance (old main frame during process
+// swap) or a superseded intent ID (a newer navigation committed while the
+// callback was queued). Ambiguous cases fall back to legacy installation:
+// a nil captured browser cannot prove staleness, and matching identity
+// installs exactly as before. Repeated same-document load-ends still
+// install; the injected scripts are idempotent by element ID.
+func (ci *contentInjector) onLoadEndForEvent(wv *WebView, event injectionEvent) {
+	if wv == nil || ci == nil {
+		return
+	}
+	wv.mu.RLock()
+	currentBrowser, currentIntent := wv.browser, wv.pendingIntentID
+	wv.mu.RUnlock()
+	if event.browser != nil && currentBrowser != event.browser {
+		return
+	}
+	if event.intentID != currentIntent {
+		return
+	}
+	ci.onLoadEnd(wv)
+}
+
 // onLoadEnd is called from the load handler after a page finishes loading.
 // It injects the appropriate scripts based on whether the page is internal.
 func (ci *contentInjector) onLoadEnd(wv *WebView) {

--- a/internal/infrastructure/cef/content_injector.go
+++ b/internal/infrastructure/cef/content_injector.go
@@ -250,10 +250,11 @@ func (ci *contentInjector) RefreshScripts(ctx context.Context, wv port.WebView) 
 }
 
 // onLoadEndForEvent installs scripts for a captured load-end event after
-// revalidating it on the GTK thread. Events that are provably stale are
-// skipped: a replaced browser identifier (old main frame during process
-// swap) or a superseded intent ID (a newer navigation committed while the
-// callback was queued). Ambiguous cases fall back to skipping rather than
+// revalidating it on the GTK thread. The event identity comes from the
+// OnLoadEnd callback's browser (not mutable WebView state), so events that
+// are provably stale are skipped: a replaced browser identifier (old main
+// frame during process swap) or a superseded intent ID (a newer navigation
+// committed while the callback was queued). Ambiguous cases fall back to skipping rather than
 // installing blind: an event captured without a browser cannot prove
 // identity, and the current browser gets its own load-end installation.
 // The single snapshot bounds the residual check-then-install window to

--- a/internal/infrastructure/cef/content_injector.go
+++ b/internal/infrastructure/cef/content_injector.go
@@ -251,23 +251,28 @@ func (ci *contentInjector) RefreshScripts(ctx context.Context, wv port.WebView) 
 
 // onLoadEndForEvent installs scripts for a captured load-end event after
 // revalidating it on the GTK thread. Events that are provably stale are
-// skipped: a replaced browser instance (old main frame during process
+// skipped: a replaced browser identifier (old main frame during process
 // swap) or a superseded intent ID (a newer navigation committed while the
-// callback was queued). Ambiguous cases fall back to legacy installation:
-// a nil captured browser cannot prove staleness, and matching identity
-// installs exactly as before. Repeated same-document load-ends still
-// install; the injected scripts are idempotent by element ID.
+// callback was queued). Ambiguous cases fall back to skipping rather than
+// installing blind: an event captured without a browser cannot prove
+// identity, and the current browser gets its own load-end installation.
+// The single snapshot bounds the residual check-then-install window to
+// nanoseconds, and any race there can only repeat idempotent scripts.
+// Repeated same-document load-ends still install.
 func (ci *contentInjector) onLoadEndForEvent(wv *WebView, event injectionEvent) {
-	if wv == nil || ci == nil {
+	if wv == nil || ci == nil || event.browserID == noBrowserID {
 		return
 	}
 	wv.mu.RLock()
-	currentBrowser, currentIntent := wv.browser, wv.pendingIntentID
+	browser, currentIntent := wv.browser, wv.pendingIntentID
 	wv.mu.RUnlock()
-	if event.browser != nil && currentBrowser != event.browser {
+	if browser == nil {
 		return
 	}
-	if event.intentID != currentIntent {
+	if browser.GetIdentifier() != event.browserID {
+		return
+	}
+	if currentIntent != event.intentID {
 		return
 	}
 	ci.onLoadEnd(wv)

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -323,6 +323,7 @@ func (e *Engine) destroyClosedWebViewBridges(webViews []*WebView) {
 		if wv != nil && wv.destroyed.Load() {
 			// Completion accounting lands in destroyViewBridgeOnGTKThread.
 			wv.destroyViewBridgeOnGTKSync()
+			e.activity.NoteCleanupCompleted()
 		}
 	}
 }

--- a/internal/infrastructure/cef/engine.go
+++ b/internal/infrastructure/cef/engine.go
@@ -323,7 +323,6 @@ func (e *Engine) destroyClosedWebViewBridges(webViews []*WebView) {
 		if wv != nil && wv.destroyed.Load() {
 			// Completion accounting lands in destroyViewBridgeOnGTKThread.
 			wv.destroyViewBridgeOnGTKSync()
-			e.activity.NoteCleanupCompleted()
 		}
 	}
 }

--- a/internal/infrastructure/cef/engine_init_test.go
+++ b/internal/infrastructure/cef/engine_init_test.go
@@ -62,6 +62,20 @@ func TestPrepareCEFSettings_UsesResolvedProfilePaths(t *testing.T) {
 	require.Empty(t, settings.BrowserSubprocessPath)
 }
 
+// TestPrepareCEFSettings_LeavesCachePathToCEFDefault locks the P3 cache
+// contract: only RootCachePath is configured and the global request
+// context derives its cache location from it. Setting an explicit
+// CachePath requires the P3.3 compatibility decision with
+// data-preservation tests; see docs/cef-cache-contract.md.
+func TestPrepareCEFSettings_LeavesCachePathToCEFDefault(t *testing.T) {
+	logger := zerolog.Nop()
+	profile := testCEFDevProfile(t)
+	settings, err := prepareCEFSettings(port.EngineOptions{}, RuntimePaths{StateRoot: profile.CEFUserDataDir(), LogFile: profile.CEFLogFile()}, RuntimeConfig{}, &logger)
+	require.NoError(t, err)
+	require.NotEmpty(t, settings.RootCachePath)
+	require.Empty(t, settings.CachePath, "explicit CachePath needs the P3.3 decision; the global context derives it from RootCachePath")
+}
+
 func TestParseLoadedLibCEFPath(t *testing.T) {
 	maps := "7f5fd4000000-7f5fd4200000 r--p 00000000 00:00 0 /usr/lib/libvulkan.so.1\n" +
 		"7f5fe0000000-7f5fe8200000 r-xp 00000000 00:00 0 /opt/cef-vaapi-runtime/usr/lib/cef/libcef.so\n" +

--- a/internal/infrastructure/cef/engine_init_test.go
+++ b/internal/infrastructure/cef/engine_init_test.go
@@ -63,17 +63,19 @@ func TestPrepareCEFSettings_UsesResolvedProfilePaths(t *testing.T) {
 }
 
 // TestPrepareCEFSettings_LeavesCachePathToCEFDefault locks the P3 cache
-// contract: only RootCachePath is configured and the global request
-// context derives its cache location from it. Setting an explicit
-// CachePath requires the P3.3 compatibility decision with
-// data-preservation tests; see docs/cef-cache-contract.md.
+// contract: only RootCachePath is configured and CachePath stays empty, so
+// the global request context runs incognito-style with in-memory storage.
+// RootCachePath does not supply CachePath and grants no persistent
+// localStorage. Setting an explicit CachePath requires the P3.3
+// compatibility decision with data-preservation tests; see
+// docs/cef-cache-contract.md.
 func TestPrepareCEFSettings_LeavesCachePathToCEFDefault(t *testing.T) {
 	logger := zerolog.Nop()
 	profile := testCEFDevProfile(t)
 	settings, err := prepareCEFSettings(port.EngineOptions{}, RuntimePaths{StateRoot: profile.CEFUserDataDir(), LogFile: profile.CEFLogFile()}, RuntimeConfig{}, &logger)
 	require.NoError(t, err)
 	require.NotEmpty(t, settings.RootCachePath)
-	require.Empty(t, settings.CachePath, "explicit CachePath needs the P3.3 decision; the global context derives it from RootCachePath")
+	require.Empty(t, settings.CachePath, "explicit CachePath needs the P3.3 decision; empty CachePath means in-memory global context")
 }
 
 func TestParseLoadedLibCEFPath(t *testing.T) {

--- a/internal/infrastructure/cef/experiment_surface_test.go
+++ b/internal/infrastructure/cef/experiment_surface_test.go
@@ -1,0 +1,23 @@
+package cef
+
+import (
+	purecef "github.com/bnema/purego-cef/cef"
+)
+
+// Compile-time pins for the Plan 04 experiment surfaces. These assert the
+// selected binding exposes the exact API shape the display-side probes were
+// designed against, without initializing CEF. Evaluating a method
+// expression performs no call.
+//
+// P3 cache probe: RequestContextGetGlobalContext,
+// BrowserHost.GetRequestContext, RequestContext.GetCachePath.
+// P5 DNS experiment: RequestContext.ResolveHost. Note the fire-and-forget
+// signature: ResolveHost carries no cancellation handle, so the experiment
+// design must recheck selection eligibility before issuance and only ignore
+// stale completions afterwards.
+var (
+	_ func() purecef.RequestContext                                 = purecef.RequestContextGetGlobalContext
+	_ func(purecef.BrowserHost) purecef.RequestContext              = purecef.BrowserHost.GetRequestContext
+	_ func(purecef.RequestContext) string                           = purecef.RequestContext.GetCachePath
+	_ func(purecef.RequestContext, string, purecef.ResolveCallback) = purecef.RequestContext.ResolveHost
+)

--- a/internal/infrastructure/cef/filter_request_handler.go
+++ b/internal/infrastructure/cef/filter_request_handler.go
@@ -1,0 +1,65 @@
+package cef
+
+import (
+	"sync/atomic"
+
+	purecef "github.com/bnema/purego-cef/cef"
+
+	"github.com/bnema/dumber/internal/application/port"
+)
+
+// filterRequestHandler adapts a port.ContentFilter to CEF resource loading.
+// This is the test-only feasibility seam for the filtering gate: it is
+// deliberately NOT wired into client/handler creation, so it has no
+// production effect. Decisions are synchronous; asynchronous rule loading,
+// atomic updates, and corruption recovery belong to the separately approved
+// production design.
+type filterRequestHandler struct {
+	filter port.ContentFilter
+	closed atomic.Bool
+}
+
+// newFilterRequestHandler builds the seam adapter around matcher. A nil
+// matcher allows everything.
+func newFilterRequestHandler(matcher port.ContentFilter) *filterRequestHandler {
+	return &filterRequestHandler{filter: matcher}
+}
+
+// Close retires the seam: later requests are allowed without consulting the
+// matcher (fail-open is correct for a test seam; production UX for a
+// missing/errored policy belongs to the follow-up design).
+func (h *filterRequestHandler) Close() {
+	if h == nil {
+		return
+	}
+	h.closed.Store(true)
+}
+
+// OnBeforeResourceLoad maps one filter decision onto CEF's synchronous
+// return value. Unclassifiable requests (nil request/empty URL) and a
+// retired/nil matcher allow the request. The CEF continuation callback is
+// untouched: this seam never defers decisions asynchronously.
+func (h *filterRequestHandler) OnBeforeResourceLoad(
+	browser purecef.Browser, frame purecef.Frame, request purecef.Request, _ purecef.Callback,
+) purecef.ReturnValue {
+	if h == nil || h.closed.Load() || h.filter == nil || request == nil {
+		return purecef.ReturnValueRvContinue
+	}
+	var isMain bool
+	if frame != nil {
+		isMain = frame.IsMain()
+	}
+	url := request.GetURL()
+	if url == "" {
+		return purecef.ReturnValueRvContinue
+	}
+	// Document loads are main/sub-frame resource types; everything else
+	// is a subresource of the current document.
+	resourceType := request.GetResourceType()
+	isNavigation := resourceType == purecef.ResourceTypeRtMainFrame || resourceType == purecef.ResourceTypeRtSubFrame
+	_ = browser
+	if h.filter.Decide(port.FilterRequest{URL: url, IsMainFrame: isMain, IsNavigation: isNavigation}) == port.FilterBlock {
+		return purecef.ReturnValueRvCancel
+	}
+	return purecef.ReturnValueRvContinue
+}

--- a/internal/infrastructure/cef/filter_request_handler_test.go
+++ b/internal/infrastructure/cef/filter_request_handler_test.go
@@ -1,0 +1,172 @@
+package cef
+
+import (
+	"sync"
+	"testing"
+
+	purecef "github.com/bnema/purego-cef/cef"
+	cefmocks "github.com/bnema/purego-cef/cef/mocks"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/dumber/internal/application/port"
+)
+
+// listMatcher is the P4.2 fake matcher: synthetic block-list decisions over
+// loopback fixtures, recording every offered request.
+type listMatcher struct {
+	mu      sync.Mutex
+	blocked map[string]bool
+	seen    []port.FilterRequest
+}
+
+func (m *listMatcher) Decide(req port.FilterRequest) port.FilterAction {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.seen = append(m.seen, req)
+	if m.blocked[req.URL] {
+		return port.FilterBlock
+	}
+	return port.FilterAllow
+}
+
+func (m *listMatcher) seenCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.seen)
+}
+
+func filterRequest(t *testing.T, url string, resourceType purecef.ResourceType, isMain bool) (purecef.Frame, purecef.Request) {
+	t.Helper()
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().IsMain().Return(isMain).Maybe()
+	request := cefmocks.NewMockRequest(t)
+	request.EXPECT().GetURL().Return(url).Maybe()
+	request.EXPECT().GetResourceType().Return(resourceType).Maybe()
+	return frame, request
+}
+
+// TestFilterSeam_AllowsMainDocument verifies the baseline: an unlisted main
+// document proceeds.
+func TestFilterSeam_AllowsMainDocument(t *testing.T) {
+	matcher := &listMatcher{blocked: map[string]bool{}}
+	handler := newFilterRequestHandler(matcher)
+
+	frame, request := filterRequest(t, "http://127.0.0.1:8471/page", purecef.ResourceTypeRtMainFrame, true)
+	rv := handler.OnBeforeResourceLoad(nil, frame, request, nil)
+	require.Equal(t, purecef.ReturnValueRvContinue, rv)
+	require.Equal(t, 1, matcher.seenCount())
+}
+
+// TestFilterSeam_BlocksListedSubresource verifies subresource blocking while
+// the document itself stays allowed.
+func TestFilterSeam_BlocksListedSubresource(t *testing.T) {
+	matcher := &listMatcher{blocked: map[string]bool{"http://127.0.0.1:8471/tracker.js": true}}
+	handler := newFilterRequestHandler(matcher)
+
+	frame, _ := filterRequest(t, "http://127.0.0.1:8471/page", purecef.ResourceTypeRtMainFrame, true)
+	require.Equal(t, purecef.ReturnValueRvContinue,
+		handler.OnBeforeResourceLoad(nil, frame, mustFilterRequest(t, "http://127.0.0.1:8471/app.js", purecef.ResourceTypeRtScript), nil))
+
+	_, blocked := filterRequest(t, "http://127.0.0.1:8471/tracker.js", purecef.ResourceTypeRtScript, false)
+	require.Equal(t, purecef.ReturnValueRvCancel,
+		handler.OnBeforeResourceLoad(nil, frame, blocked, nil))
+}
+
+func mustFilterRequest(t *testing.T, url string, resourceType purecef.ResourceType) purecef.Request {
+	t.Helper()
+	_, request := filterRequest(t, url, resourceType, false)
+	return request
+}
+
+// TestFilterSeam_ClassifiesNavigationVsSubresource proves main/sub-frame
+// document loads arrive as navigations and scripts as subresources.
+func TestFilterSeam_ClassifiesNavigationVsSubresource(t *testing.T) {
+	var got []port.FilterRequest
+	matcher := &listMatcher{blocked: map[string]bool{}}
+	handler := newFilterRequestHandler(recordingMatcher(matcher, &got))
+
+	frame, mainReq := filterRequest(t, "http://127.0.0.1:8471/page", purecef.ResourceTypeRtMainFrame, true)
+	handler.OnBeforeResourceLoad(nil, frame, mainReq, nil)
+	// Page scripts belong to the main frame yet are subresources: frame
+	// identity and navigation classification are independent axes.
+	handler.OnBeforeResourceLoad(nil, frame, mustFilterRequest(t, "http://127.0.0.1:8471/app.js", purecef.ResourceTypeRtScript), nil)
+	subFrame, _ := filterRequest(t, "http://127.0.0.1:8471/frame", purecef.ResourceTypeRtSubFrame, false)
+	_, frameReq := filterRequest(t, "http://127.0.0.1:8471/frame", purecef.ResourceTypeRtSubFrame, false)
+	handler.OnBeforeResourceLoad(nil, subFrame, frameReq, nil)
+
+	require.Len(t, got, 3)
+	require.True(t, got[0].IsMainFrame && got[0].IsNavigation, "main document must be a main-frame navigation")
+	require.True(t, got[1].IsMainFrame, "page scripts belong to the main frame")
+	require.False(t, got[1].IsNavigation, "scripts must be subresources")
+	require.True(t, got[2].IsNavigation, "sub-frame documents are navigations")
+	require.False(t, got[2].IsMainFrame)
+}
+
+func recordingMatcher(inner *listMatcher, out *[]port.FilterRequest) port.ContentFilter {
+	return filterFunc(func(req port.FilterRequest) port.FilterAction {
+		*out = append(*out, req)
+		return inner.Decide(req)
+	})
+}
+
+type filterFunc func(port.FilterRequest) port.FilterAction
+
+func (f filterFunc) Decide(req port.FilterRequest) port.FilterAction { return f(req) }
+
+// TestFilterSeam_RedirectTargetEvaluatedIndependently verifies each request
+// in a redirect chain is offered separately: blocking the redirect target
+// cancels it without retroactively affecting the source decision.
+func TestFilterSeam_RedirectTargetEvaluatedIndependently(t *testing.T) {
+	matcher := &listMatcher{blocked: map[string]bool{"http://127.0.0.1:8471/target": true}}
+	handler := newFilterRequestHandler(matcher)
+
+	frame, source := filterRequest(t, "http://127.0.0.1:8471/redirect", purecef.ResourceTypeRtMainFrame, true)
+	require.Equal(t, purecef.ReturnValueRvContinue,
+		handler.OnBeforeResourceLoad(nil, frame, source, nil))
+	_, target := filterRequest(t, "http://127.0.0.1:8471/target", purecef.ResourceTypeRtMainFrame, true)
+	require.Equal(t, purecef.ReturnValueRvCancel,
+		handler.OnBeforeResourceLoad(nil, frame, target, nil))
+	require.Equal(t, 2, matcher.seenCount())
+}
+
+// TestFilterSeam_UnclassifiableAllows verifies fail-open guards: nil
+// request, empty URL, nil frame, and nil matcher never cancel.
+func TestFilterSeam_UnclassifiableAllows(t *testing.T) {
+	matcher := &listMatcher{blocked: map[string]bool{"http://127.0.0.1:8471/x": true}}
+	handler := newFilterRequestHandler(matcher)
+
+	require.Equal(t, purecef.ReturnValueRvContinue, handler.OnBeforeResourceLoad(nil, nil, nil, nil))
+
+	// A nil frame does not make a listed URL unclassifiable: the URL
+	// decision still applies.
+	require.Equal(t, purecef.ReturnValueRvCancel, handler.OnBeforeResourceLoad(nil, nil, mustFilterRequest(t, "http://127.0.0.1:8471/x", purecef.ResourceTypeRtScript), nil))
+
+	frame, _ := filterRequest(t, "http://127.0.0.1:8471/x", purecef.ResourceTypeRtScript, false)
+	require.Equal(t, purecef.ReturnValueRvContinue, handler.OnBeforeResourceLoad(nil, frame, nil, nil))
+
+	emptyURL := cefmocks.NewMockRequest(t)
+	emptyURL.EXPECT().GetURL().Return("").Once()
+	require.Equal(t, purecef.ReturnValueRvContinue, handler.OnBeforeResourceLoad(nil, frame, emptyURL, nil))
+
+	allowAll := newFilterRequestHandler(nil)
+	_, blocked := filterRequest(t, "http://127.0.0.1:8471/x", purecef.ResourceTypeRtScript, false)
+	require.Equal(t, purecef.ReturnValueRvContinue, allowAll.OnBeforeResourceLoad(nil, frame, blocked, nil))
+	require.Equal(t, purecef.ReturnValueRvContinue, (*filterRequestHandler)(nil).OnBeforeResourceLoad(nil, frame, blocked, nil))
+}
+
+// TestFilterSeam_CloseRetiresMatcher verifies shutdown semantics: after
+// Close the matcher is no longer consulted and everything is allowed.
+func TestFilterSeam_CloseRetiresMatcher(t *testing.T) {
+	matcher := &listMatcher{blocked: map[string]bool{"http://127.0.0.1:8471/tracker.js": true}}
+	handler := newFilterRequestHandler(matcher)
+
+	_, blocked := filterRequest(t, "http://127.0.0.1:8471/tracker.js", purecef.ResourceTypeRtScript, false)
+	frame, _ := filterRequest(t, "http://127.0.0.1:8471/page", purecef.ResourceTypeRtMainFrame, true)
+	require.Equal(t, purecef.ReturnValueRvCancel, handler.OnBeforeResourceLoad(nil, frame, blocked, nil))
+	before := matcher.seenCount()
+
+	handler.Close()
+	require.Equal(t, purecef.ReturnValueRvContinue, handler.OnBeforeResourceLoad(nil, frame, blocked, nil))
+	require.Equal(t, before, matcher.seenCount(), "retired matcher must not be consulted")
+	handler.Close()
+}

--- a/internal/infrastructure/cef/injection_event_test.go
+++ b/internal/infrastructure/cef/injection_event_test.go
@@ -1,0 +1,130 @@
+package cef
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	cefmocks "github.com/bnema/purego-cef/cef/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// injectionHarness builds a WebView with a recording main frame. Engine is
+// nil so RunJavaScript executes synchronously without GTK dispatch.
+type injectionHarness struct {
+	wv      *WebView
+	browser *cefmocks.MockBrowser
+	mu      sync.Mutex
+	scripts []string
+}
+
+func newInjectionHarness(t *testing.T, uri string) *injectionHarness {
+	t.Helper()
+	h := &injectionHarness{}
+	frame := cefmocks.NewMockFrame(t)
+	frame.EXPECT().ExecuteJavaScript(mock.Anything, "", int32(0)).Run(func(script string, _ string, _ int32) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		h.scripts = append(h.scripts, script)
+	}).Maybe()
+	h.browser = cefmocks.NewMockBrowser(t)
+	h.browser.EXPECT().GetMainFrame().Return(frame).Maybe()
+	h.wv = &WebView{ctx: context.Background(), browser: h.browser}
+	h.wv.uri = uri
+	return h
+}
+
+func (h *injectionHarness) scriptCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.scripts)
+}
+
+func testInjector() *contentInjector {
+	return &contentInjector{themeCSS: ":root{--t:1}", findHighlightCSS: ".find{--f:1}"}
+}
+
+// TestInjectionEvent_ExternalPageScriptSet counts the installation for an
+// external document: scrollbar styling, its auto-hide behavior, the
+// clipboard bridge, plus configured find CSS. No dark-mode or message
+// bridge shim belongs to external pages.
+func TestInjectionEvent_ExternalPageScriptSet(t *testing.T) {
+	h := newInjectionHarness(t, "https://example.com/page")
+	testInjector().onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+
+	require.Equal(t, 4, h.scriptCount(), "external install must stay a fixed small script set")
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	joined := ""
+	for _, script := range h.scripts {
+		joined += script
+	}
+	require.Contains(t, joined, "dumber-scrollbar")
+	require.Contains(t, joined, "dumber-find-highlight")
+	require.NotContains(t, joined, "dumber-theme-vars")
+	require.NotContains(t, joined, "__dumber_cef_prefers_dark")
+}
+
+// TestInjectionEvent_InternalPageScriptSet counts the installation for an
+// internal document, including dark-mode handling and the message bridge.
+func TestInjectionEvent_InternalPageScriptSet(t *testing.T) {
+	h := newInjectionHarness(t, "dumb://home")
+	testInjector().onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+
+	require.Equal(t, 7, h.scriptCount(), "internal install must stay a fixed small script set")
+}
+
+// TestInjectionEvent_StaleBrowserSkipped reproduces an old main frame firing
+// during process swap: the GTK-dispatched callback must install nothing.
+func TestInjectionEvent_StaleBrowserSkipped(t *testing.T) {
+	h := newInjectionHarness(t, "https://example.com/a")
+	event := h.wv.captureInjectionEvent()
+
+	replacement := cefmocks.NewMockBrowser(t)
+	h.wv.mu.Lock()
+	h.wv.browser = replacement
+	h.wv.mu.Unlock()
+
+	testInjector().onLoadEndForEvent(h.wv, event)
+	require.Zero(t, h.scriptCount(), "old-frame event must not install against the replacement browser")
+}
+
+// TestInjectionEvent_StaleIntentSkipped reproduces a queued callback
+// outlived by a newer navigation: installation must not run for the
+// superseded intent.
+func TestInjectionEvent_StaleIntentSkipped(t *testing.T) {
+	h := newInjectionHarness(t, "https://example.com/a")
+	event := h.wv.captureInjectionEvent()
+
+	h.wv.mu.Lock()
+	h.wv.pendingIntentID++
+	h.wv.mu.Unlock()
+
+	testInjector().onLoadEndForEvent(h.wv, event)
+	require.Zero(t, h.scriptCount(), "superseded intent must not install")
+}
+
+// TestInjectionEvent_CurrentInstalls verifies matching identity installs
+// exactly as the legacy path, including repeated same-document load-ends
+// whose scripts are idempotent by element ID.
+func TestInjectionEvent_CurrentInstalls(t *testing.T) {
+	h := newInjectionHarness(t, "https://example.com/a")
+	ci := testInjector()
+
+	ci.onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+	first := h.scriptCount()
+	require.Positive(t, first)
+
+	ci.onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+	require.Equal(t, 2*first, h.scriptCount(), "repeated same-document events reinstall idempotent scripts")
+}
+
+// TestInjectionEvent_NilCaptureFallsBackToLegacy verifies the conservative
+// fallback: a capture without a browser cannot prove staleness and installs
+// as before.
+func TestInjectionEvent_NilCaptureFallsBackToLegacy(t *testing.T) {
+	h := newInjectionHarness(t, "https://example.com/a")
+	testInjector().onLoadEndForEvent(h.wv, injectionEvent{})
+	require.Positive(t, h.scriptCount())
+}

--- a/internal/infrastructure/cef/injection_event_test.go
+++ b/internal/infrastructure/cef/injection_event_test.go
@@ -57,7 +57,7 @@ func testInjector() *contentInjector {
 // bridge shim belongs to external pages.
 func TestInjectionEvent_ExternalPageScriptSet(t *testing.T) {
 	h := newInjectionHarness(t, "https://example.com/page")
-	testInjector().onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+	testInjector().onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent(h.browser))
 
 	require.Equal(t, 4, h.scriptCount(), "external install must stay a fixed small script set")
 	h.mu.Lock()
@@ -76,7 +76,7 @@ func TestInjectionEvent_ExternalPageScriptSet(t *testing.T) {
 // internal document, including dark-mode handling and the message bridge.
 func TestInjectionEvent_InternalPageScriptSet(t *testing.T) {
 	h := newInjectionHarness(t, "dumb://home")
-	testInjector().onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+	testInjector().onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent(h.browser))
 
 	require.Equal(t, 7, h.scriptCount(), "internal install must stay a fixed small script set")
 }
@@ -85,7 +85,7 @@ func TestInjectionEvent_InternalPageScriptSet(t *testing.T) {
 // during process swap: the GTK-dispatched callback must install nothing.
 func TestInjectionEvent_StaleBrowserSkipped(t *testing.T) {
 	h := newInjectionHarnessWithID(t, "https://example.com/a", 7)
-	event := h.wv.captureInjectionEvent()
+	event := h.wv.captureInjectionEvent(h.browser)
 
 	replacement := cefmocks.NewMockBrowser(t)
 	replacement.EXPECT().GetIdentifier().Return(int32(8)).Maybe()
@@ -102,7 +102,7 @@ func TestInjectionEvent_StaleBrowserSkipped(t *testing.T) {
 // superseded intent.
 func TestInjectionEvent_StaleIntentSkipped(t *testing.T) {
 	h := newInjectionHarness(t, "https://example.com/a")
-	event := h.wv.captureInjectionEvent()
+	event := h.wv.captureInjectionEvent(h.browser)
 
 	h.wv.mu.Lock()
 	h.wv.pendingIntentID++
@@ -119,28 +119,22 @@ func TestInjectionEvent_CurrentInstalls(t *testing.T) {
 	h := newInjectionHarness(t, "https://example.com/a")
 	ci := testInjector()
 
-	ci.onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+	ci.onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent(h.browser))
 	first := h.scriptCount()
 	require.Positive(t, first)
 
-	ci.onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent())
+	ci.onLoadEndForEvent(h.wv, h.wv.captureInjectionEvent(h.browser))
 	require.Equal(t, 2*first, h.scriptCount(), "repeated same-document events reinstall idempotent scripts")
 }
 
 // TestInjectionEvent_NilCaptureSkips verifies the conservative fallback: a
-// capture taken while no browser was attached cannot prove identity, so it
-// installs nothing; the current browser gets its own load-end installation.
+// capture from a nil callback browser cannot prove identity, so it installs
+// nothing; the current browser gets its own load-end installation.
 func TestInjectionEvent_NilCaptureSkips(t *testing.T) {
 	h := newInjectionHarness(t, "https://example.com/a")
-	h.wv.mu.Lock()
-	h.wv.browser = nil
-	h.wv.mu.Unlock()
-	event := h.wv.captureInjectionEvent()
+	event := h.wv.captureInjectionEvent(nil)
 	require.Equal(t, noBrowserID, event.browserID)
 
-	h.wv.mu.Lock()
-	h.wv.browser = h.browser
-	h.wv.mu.Unlock()
 	testInjector().onLoadEndForEvent(h.wv, event)
 	require.Zero(t, h.scriptCount(), "identity-less capture must not install blind")
 }
@@ -149,11 +143,32 @@ func TestInjectionEvent_NilCaptureSkips(t *testing.T) {
 // destroyed browser installs nothing instead of dereferencing it.
 func TestInjectionEvent_NilCurrentBrowserSkips(t *testing.T) {
 	h := newInjectionHarness(t, "https://example.com/a")
-	event := h.wv.captureInjectionEvent()
+	event := h.wv.captureInjectionEvent(h.browser)
 
 	h.wv.mu.Lock()
 	h.wv.browser = nil
 	h.wv.mu.Unlock()
 	testInjector().onLoadEndForEvent(h.wv, event)
 	require.Zero(t, h.scriptCount())
+}
+
+// TestInjectionEvent_StaleCallbackBrowserSkipped reproduces the exact
+// reviewer scenario: WebView state advances to a replacement browser, then
+// the OLD callback browser fires. Identity must come from the callback, so
+// the event keeps the old identifier and is rejected. Stamping the current
+// wv.browser instead would bless it with the replacement identity.
+func TestInjectionEvent_StaleCallbackBrowserSkipped(t *testing.T) {
+	h := newInjectionHarnessWithID(t, "https://example.com/a", 7)
+	oldCallbackBrowser := h.browser
+
+	replacement := cefmocks.NewMockBrowser(t)
+	replacement.EXPECT().GetIdentifier().Return(int32(8)).Maybe()
+	h.wv.mu.Lock()
+	h.wv.browser = replacement
+	h.wv.mu.Unlock()
+
+	event := h.wv.captureInjectionEvent(oldCallbackBrowser)
+	require.Equal(t, int32(7), event.browserID, "callback-sourced capture must keep the old identity")
+	testInjector().onLoadEndForEvent(h.wv, event)
+	require.Zero(t, h.scriptCount(), "old-callback event must not install against the replacement browser")
 }

--- a/internal/infrastructure/cef/injection_event_test.go
+++ b/internal/infrastructure/cef/injection_event_test.go
@@ -21,6 +21,11 @@ type injectionHarness struct {
 
 func newInjectionHarness(t *testing.T, uri string) *injectionHarness {
 	t.Helper()
+	return newInjectionHarnessWithID(t, uri, 7)
+}
+
+func newInjectionHarnessWithID(t *testing.T, uri string, browserID int32) *injectionHarness {
+	t.Helper()
 	h := &injectionHarness{}
 	frame := cefmocks.NewMockFrame(t)
 	frame.EXPECT().ExecuteJavaScript(mock.Anything, "", int32(0)).Run(func(script string, _ string, _ int32) {
@@ -30,6 +35,7 @@ func newInjectionHarness(t *testing.T, uri string) *injectionHarness {
 	}).Maybe()
 	h.browser = cefmocks.NewMockBrowser(t)
 	h.browser.EXPECT().GetMainFrame().Return(frame).Maybe()
+	h.browser.EXPECT().GetIdentifier().Return(browserID).Maybe()
 	h.wv = &WebView{ctx: context.Background(), browser: h.browser}
 	h.wv.uri = uri
 	return h
@@ -78,10 +84,11 @@ func TestInjectionEvent_InternalPageScriptSet(t *testing.T) {
 // TestInjectionEvent_StaleBrowserSkipped reproduces an old main frame firing
 // during process swap: the GTK-dispatched callback must install nothing.
 func TestInjectionEvent_StaleBrowserSkipped(t *testing.T) {
-	h := newInjectionHarness(t, "https://example.com/a")
+	h := newInjectionHarnessWithID(t, "https://example.com/a", 7)
 	event := h.wv.captureInjectionEvent()
 
 	replacement := cefmocks.NewMockBrowser(t)
+	replacement.EXPECT().GetIdentifier().Return(int32(8)).Maybe()
 	h.wv.mu.Lock()
 	h.wv.browser = replacement
 	h.wv.mu.Unlock()
@@ -120,11 +127,33 @@ func TestInjectionEvent_CurrentInstalls(t *testing.T) {
 	require.Equal(t, 2*first, h.scriptCount(), "repeated same-document events reinstall idempotent scripts")
 }
 
-// TestInjectionEvent_NilCaptureFallsBackToLegacy verifies the conservative
-// fallback: a capture without a browser cannot prove staleness and installs
-// as before.
-func TestInjectionEvent_NilCaptureFallsBackToLegacy(t *testing.T) {
+// TestInjectionEvent_NilCaptureSkips verifies the conservative fallback: a
+// capture taken while no browser was attached cannot prove identity, so it
+// installs nothing; the current browser gets its own load-end installation.
+func TestInjectionEvent_NilCaptureSkips(t *testing.T) {
 	h := newInjectionHarness(t, "https://example.com/a")
-	testInjector().onLoadEndForEvent(h.wv, injectionEvent{})
-	require.Positive(t, h.scriptCount())
+	h.wv.mu.Lock()
+	h.wv.browser = nil
+	h.wv.mu.Unlock()
+	event := h.wv.captureInjectionEvent()
+	require.Equal(t, noBrowserID, event.browserID)
+
+	h.wv.mu.Lock()
+	h.wv.browser = h.browser
+	h.wv.mu.Unlock()
+	testInjector().onLoadEndForEvent(h.wv, event)
+	require.Zero(t, h.scriptCount(), "identity-less capture must not install blind")
+}
+
+// TestInjectionEvent_NilCurrentBrowserSkips verifies dispatch against a
+// destroyed browser installs nothing instead of dereferencing it.
+func TestInjectionEvent_NilCurrentBrowserSkips(t *testing.T) {
+	h := newInjectionHarness(t, "https://example.com/a")
+	event := h.wv.captureInjectionEvent()
+
+	h.wv.mu.Lock()
+	h.wv.browser = nil
+	h.wv.mu.Unlock()
+	testInjector().onLoadEndForEvent(h.wv, event)
+	require.Zero(t, h.scriptCount())
 }

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -1268,6 +1268,11 @@ func (wv *WebView) Destroy() {
 	if !wv.destroyed.CompareAndSwap(false, true) {
 		return
 	}
+	// Native close begins here: the view leaves the active set and enters
+	// GTK-teardown outstanding for the quiescence boundary.
+	if wv.engine != nil {
+		wv.engine.activity.NoteViewCloseStarted()
+	}
 	// Retire scroll motion the moment destruction begins, regardless of
 	// calling thread; GTK-only cleanup follows through the owning
 	// dispatcher without waiting for the deferred native browser close.

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2209,20 +2209,27 @@ type injectionEvent struct {
 // attached; such events cannot prove identity and are skipped.
 const noBrowserID = int32(-1)
 
-// captureInjectionEvent snapshots the current browser identifier and pending
-// navigation intent for a load-end event. Called on the CEF thread; the
-// identifier read is a foreign call made outside any state lock.
-func (wv *WebView) captureInjectionEvent() injectionEvent {
+// captureInjectionEvent snapshots the navigation identity for a load-end
+// event from the callback's browser, not from mutable WebView state. Called
+// on the CEF thread; the identifier read is a foreign call made outside any
+// state lock. Sourcing identity from the callback is what makes staleness
+// detection work: a queued event from a replaced browser keeps the OLD
+// identifier and fails revalidation, while stamping the current wv.browser
+// would bless it. Same-browser navigations are distinguished by the pending
+// intent generation; repeated same-document load-ends share it and still
+// install (their scripts are idempotent).
+func (wv *WebView) captureInjectionEvent(browser purecef.Browser) injectionEvent {
 	if wv == nil {
 		return injectionEvent{browserID: noBrowserID}
 	}
-	wv.mu.RLock()
-	browser, intentID := wv.browser, wv.pendingIntentID
-	wv.mu.RUnlock()
 	if browser == nil {
-		return injectionEvent{browserID: noBrowserID, intentID: intentID}
+		return injectionEvent{browserID: noBrowserID}
 	}
-	return injectionEvent{browserID: browser.GetIdentifier(), intentID: intentID}
+	browserID := browser.GetIdentifier()
+	wv.mu.RLock()
+	intentID := wv.pendingIntentID
+	wv.mu.RUnlock()
+	return injectionEvent{browserID: browserID, intentID: intentID}
 }
 
 func pendingURIEquivalent(a, b string) bool {

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2195,22 +2195,34 @@ func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID i
 // injectionEvent captures the navigation identity observed at main-frame
 // load-end so the GTK-dispatched installation can drop stale events: an
 // old main frame firing during process swap, or a queued callback outlived
-// by a newer navigation. Browser instance and intent ID are both required;
-// the current URL alone never proves document identity.
+// by a newer navigation. The browser is identified by its CEF identifier
+// (matching codebase convention) rather than interface identity, which is
+// neither panic-safe for arbitrary dynamic types nor proof of CEF object
+// identity. noBrowserID marks captures taken while no browser was
+// attached. The current URL alone never proves document identity.
 type injectionEvent struct {
-	browser  purecef.Browser
-	intentID uint64
+	browserID int32
+	intentID  uint64
 }
 
-// captureInjectionEvent snapshots the current browser instance and pending
-// navigation intent for a load-end event. Called on the CEF thread.
+// noBrowserID marks an injection event captured while no browser was
+// attached; such events cannot prove identity and are skipped.
+const noBrowserID = int32(-1)
+
+// captureInjectionEvent snapshots the current browser identifier and pending
+// navigation intent for a load-end event. Called on the CEF thread; the
+// identifier read is a foreign call made outside any state lock.
 func (wv *WebView) captureInjectionEvent() injectionEvent {
 	if wv == nil {
-		return injectionEvent{}
+		return injectionEvent{browserID: noBrowserID}
 	}
 	wv.mu.RLock()
-	defer wv.mu.RUnlock()
-	return injectionEvent{browser: wv.browser, intentID: wv.pendingIntentID}
+	browser, intentID := wv.browser, wv.pendingIntentID
+	wv.mu.RUnlock()
+	if browser == nil {
+		return injectionEvent{browserID: noBrowserID, intentID: intentID}
+	}
+	return injectionEvent{browserID: browser.GetIdentifier(), intentID: intentID}
 }
 
 func pendingURIEquivalent(a, b string) bool {

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -2192,6 +2192,27 @@ func (wv *WebView) claimPendingNavigationSubmission(intentID uint64, browserID i
 	return uri, pendingClaimReady
 }
 
+// injectionEvent captures the navigation identity observed at main-frame
+// load-end so the GTK-dispatched installation can drop stale events: an
+// old main frame firing during process swap, or a queued callback outlived
+// by a newer navigation. Browser instance and intent ID are both required;
+// the current URL alone never proves document identity.
+type injectionEvent struct {
+	browser  purecef.Browser
+	intentID uint64
+}
+
+// captureInjectionEvent snapshots the current browser instance and pending
+// navigation intent for a load-end event. Called on the CEF thread.
+func (wv *WebView) captureInjectionEvent() injectionEvent {
+	if wv == nil {
+		return injectionEvent{}
+	}
+	wv.mu.RLock()
+	defer wv.mu.RUnlock()
+	return injectionEvent{browser: wv.browser, intentID: wv.pendingIntentID}
+}
+
 func pendingURIEquivalent(a, b string) bool {
 	if a == "" || b == "" {
 		return false

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -532,8 +532,11 @@ func (h *handlerSet) OnLoadEnd(_ purecef.Browser, frame purecef.Frame, httpStatu
 		})
 	}
 	if h.wv.engine != nil && h.wv.engine.contentInj != nil {
+		// Capture navigation identity for the GTK hop: a process swap or a
+		// newer navigation can stale this event before it runs.
+		event := h.wv.captureInjectionEvent()
 		h.wv.runOnGTK(func() {
-			h.wv.engine.contentInj.onLoadEnd(h.wv)
+			h.wv.engine.contentInj.onLoadEndForEvent(h.wv, event)
 		})
 	}
 

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -490,7 +490,7 @@ func (h *handlerSet) OnLoadStart(_ purecef.Browser, frame purecef.Frame, _ purec
 }
 
 // OnLoadEnd resets crash count and injects content scripts for the main frame.
-func (h *handlerSet) OnLoadEnd(_ purecef.Browser, frame purecef.Frame, httpStatusCode int32) {
+func (h *handlerSet) OnLoadEnd(browser purecef.Browser, frame purecef.Frame, httpStatusCode int32) {
 	log := logging.FromContext(h.wv.ctx)
 	log.Debug().
 		Bool("frame_nil", frame == nil).
@@ -532,9 +532,10 @@ func (h *handlerSet) OnLoadEnd(_ purecef.Browser, frame purecef.Frame, httpStatu
 		})
 	}
 	if h.wv.engine != nil && h.wv.engine.contentInj != nil {
-		// Capture navigation identity for the GTK hop: a process swap or a
-		// newer navigation can stale this event before it runs.
-		event := h.wv.captureInjectionEvent()
+		// Capture navigation identity for the GTK hop from the callback's
+		// browser: a process swap or a newer navigation can stale this
+		// event before it runs.
+		event := h.wv.captureInjectionEvent(browser)
 		h.wv.runOnGTK(func() {
 			h.wv.engine.contentInj.onLoadEndForEvent(h.wv, event)
 		})

--- a/internal/infrastructure/favicon/fetcher.go
+++ b/internal/infrastructure/favicon/fetcher.go
@@ -131,7 +131,10 @@ func (f *Fetcher) fetchURL(ctx context.Context, raw, pageURL string) ([]byte, st
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", appport.ErrFaviconMiss
+		// Classified miss: callers keep ErrFaviconMiss matching via Is,
+		// while the use case can distinguish genuine absence (404/410)
+		// from auth/transient failures for negative caching.
+		return nil, "", &appport.FaviconFetchError{StatusCode: resp.StatusCode}
 	}
 	limit := f.maxBytes
 	if limit <= 0 {


### PR DESCRIPTION
Stacked on #412 (perf/cef-startup-03). Implements Plan 04: adopted corrections plus explicit feasibility reports; no production network speculation is enabled.

## Adopted corrections (issues #400, #403 favicon; P2 injection)

- **Shared favicon refresh (#400):** direct candidate refreshes join shared in-flight operations keyed by validated request identity (page origin plus ordered normalized candidates). Caps: 16 candidates, 8 KiB per URL, 8 active operations, 5 s whole-operation deadline. Waiters cancel independently; the last waiter cancels atomically under lock and late joiners start fresh. Overload reports ErrFaviconBusy, shutdown ErrFaviconShutdown, never false success or miss.
- **Miss classification (#403):** the fetcher returns typed HTTP statuses preserving ErrFaviconMiss matching; only verified 404/410 populate the 30 s / 256-entry negative cache (success clears it, full-miss only). 401/403, 5xx, transport, validation, and canceled work always refetch. Invalidation advances an epoch (owned by op creation) that drops stale completions. Background work runs on an owned cancelable scope, sealed/canceled/drained by Close on shutdown.
- **Stale load-end suppression (P2):** main-frame load-end captures CEF browser identifier plus navigation intent for the GTK hop; provably stale events (old frame during process swap, superseded intent, identity-less captures) are skipped. Repeated same-document load-ends still install idempotent scripts. URL equality is never claimed as document identity.

## Gated follow-ups (no change shipped)

- **P1.4** (source-discovery suppression): still blocked on verified committed-document correlation; the P2 gate covers browser/instance plus intent only.
- **P2.3 measurement / P3.2 probes / P5 live experiment:** need display/GPU; listed below.

## P3 cache decision (no config change)

Only RootCachePath is configured; CachePath stays at the CEF default (locked by TestPrepareCEFSettings_LeavesCachePathToCEFDefault). Browsers share the global request context (nil context in factory). docs/cef-cache-contract.md records semantics plus the display-side probe plan (GetCachePath equality, seed/read-before-write, no-store control, egress control, graceful shutdown only).

## P4.3 filtering feasibility report

- Inventory: the downloader fetches manifest plus filter files from GitHub releases; the store compiles through webkit.UserContentFilterStore into WebKit bytecode, which cannot transfer to CEF. No reusable CEF rule engine exists in-tree.
- Verified in binding: GetResourceRequestHandler plus ResourceRequestHandler.OnBeforeResourceLoad returning RvCancel/RvContinue/RvContinueAsync, main/sub-frame resource types for navigation classification.
- Seam added (test-only, deliberately unwired): port.ContentFilter decision interface plus a CEF adapter with allow/block, redirect-chain, fail-open, and shutdown coverage against synthetic loopback fixtures.
- Conclusion: feasible, but NO-GO for production without a separately approved design naming a matcher candidate (rule syntax, license, compiled-cache format, readiness, atomic updates, corruption recovery, missing-cache UX, and interception overhead measurement).

## P5.3 DNS report: no-go (inconclusive)

- Preflight verified at compile time (experiment_surface_test.go, no CEF init): RequestContext.ResolveHost(origin, callback) exists and is fire-and-forget with no cancellation handle, confirming the queued-cancellation design constraint.
- Live measurement is inconclusive without a display host, a disposable controlled delayed-DNS setup, and the retained runtime from the deferred Plan 02 prewarm gate. No host resolver changes were made, nothing prefetches, omnibox behavior is unchanged.

## Checks

- V1 (usecase, infra/favicon, ui/adapter favicon): green, incl. 15 new refresh tests (5 x count stable)
- V2 (infra/cef, coordinator/content): green, incl. injection-event and filter-seam suites
- V6 (usecase, dispatcher): green
- git diff --check, make lint: clean
- make test: green except pre-existing internal/ui/input SIGSEGV, reproduced on clean main
- Go review: 1 GO plus 7 NO-GO findings across 2 commits, all addressed (atomic last-waiter cancel with fresh-join, creator-owned epoch, full-miss-only negative cache, close-sealed admission, identifier-based injection events, order compaction) with regression tests

## Display/GPU validation needed (cannot run headless)

- Favicon: concurrent same-page loads share one fetch; 404 icons stop refetching within 30 s; invalidation during load drops stale bytes
- Injection: cross-site process-swap load-end installs nothing stale; redirect target still installs
- P3 probes per docs/cef-cache-contract.md; P5 experiment needs controlled delayed-DNS host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved favicon refreshing by sharing duplicate requests, limiting overload, caching confirmed missing icons, and preventing stale results after invalidation.
  - Favicon refresh activity now shuts down cleanly without leaving background work running.
  - Prevented outdated page-load events from injecting scripts into replaced or superseded browser views.
  - Improved handling of favicon fetch failures by distinguishing missing icons from authorization and temporary server errors.

- **Documentation**
  - Added documentation describing browser cache behavior and persistence across orderly restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->