### PR TITLE
fix(ui): scale omnibox and session modal widths

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -5513,9 +5513,23 @@ func (a *App) applyRuntimeConfigChange(ctx context.Context, snapshot entity.Runt
 	sessionCfg := runtimeCfg.Session
 	a.syncExternalThemeWatcher(ctx)
 	a.applyAppearanceConfig(ctx)
+	a.omniboxCfg.UIScale = runtimeCfg.DefaultUIScale
+	for _, view := range a.workspaceViews {
+		if view != nil {
+			view.SetOmniboxUIScale(runtimeCfg.DefaultUIScale)
+		}
+	}
+	for _, session := range a.floatingSessions {
+		if session != nil && session.omnibox != nil {
+			session.omnibox.SetUIScale(runtimeCfg.DefaultUIScale)
+		}
+	}
 	for _, bw := range a.browserWindows {
 		if bw == nil {
 			continue
+		}
+		if bw.sessionManager != nil {
+			bw.sessionManager.SetUIScale(runtimeCfg.DefaultUIScale)
 		}
 		// Reapply sidebar width from live config (reloads after sidebar_width
 		// changes in the config file).

--- a/internal/ui/component/modal_scale_update_test.go
+++ b/internal/ui/component/modal_scale_update_test.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,4 +34,25 @@ func TestWorkspaceOmniboxUIScaleUpdatePreservesConfig(t *testing.T) {
 	wv.omnibox = nil
 	wv.SetOmniboxUIScale(2)
 	assert.InDelta(t, 2.0, wv.omniboxCfg.UIScale, 0.000001)
+}
+
+func TestModalUIScaleUpdateNormalizesNonFinite(t *testing.T) {
+	o := &Omnibox{uiScale: 1.5}
+	sm := &SessionManager{uiScale: 1.5}
+	for _, scale := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		o.SetUIScale(scale)
+		sm.SetUIScale(scale)
+		assert.InDelta(t, 1.0, o.uiScale, 0.000001)
+		assert.InDelta(t, 1.0, sm.uiScale, 0.000001)
+	}
+}
+
+func TestWorkspaceOmniboxUIScaleUpdateNormalizesBeforePersist(t *testing.T) {
+	o := &Omnibox{uiScale: 1}
+	wv := &WorkspaceView{omnibox: o, omniboxCfg: OmniboxConfig{UIScale: 1}}
+	for _, scale := range []float64{0, -2, math.NaN(), math.Inf(1)} {
+		wv.SetOmniboxUIScale(scale)
+		assert.InDelta(t, 1.0, wv.omniboxCfg.UIScale, 0.000001)
+		assert.InDelta(t, 1.0, o.uiScale, 0.000001)
+	}
 }

--- a/internal/ui/component/modal_scale_update_test.go
+++ b/internal/ui/component/modal_scale_update_test.go
@@ -1,0 +1,36 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModalUIScaleUpdate(t *testing.T) {
+	o := &Omnibox{uiScale: 1, sizeCfg: OmniboxSizeDefaults}
+	o.measuredHeights.valid = true
+	sm := &SessionManager{uiScale: 1}
+	sm.measuredHeights.valid = true
+	for _, scale := range []float64{1.5, 2, 1} {
+		o.SetUIScale(scale)
+		sm.SetUIScale(scale)
+		assert.InDelta(t, scale, o.uiScale, 0.000001)
+		assert.InDelta(t, scale, sm.uiScale, 0.000001)
+		assert.False(t, o.measuredHeights.valid)
+		assert.False(t, sm.measuredHeights.valid)
+		width, _ := o.requestedDimensions()
+		assert.Equal(t, int(640*scale), width)
+	}
+}
+
+func TestWorkspaceOmniboxUIScaleUpdatePreservesConfig(t *testing.T) {
+	o := &Omnibox{uiScale: 1}
+	wv := &WorkspaceView{omnibox: o, omniboxCfg: OmniboxConfig{UIScale: 1, SizeConfig: ModalSizeConfig{FixedWidth: 800}}}
+	wv.SetOmniboxUIScale(1.5)
+	assert.InDelta(t, 1.5, o.uiScale, 0.000001)
+	assert.InDelta(t, 1.5, wv.omniboxCfg.UIScale, 0.000001)
+	assert.Equal(t, 800, wv.omniboxCfg.SizeConfig.FixedWidth)
+	wv.omnibox = nil
+	wv.SetOmniboxUIScale(2)
+	assert.InDelta(t, 2.0, wv.omniboxCfg.UIScale, 0.000001)
+}

--- a/internal/ui/component/modal_sizing.go
+++ b/internal/ui/component/modal_sizing.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"math"
+
 	"github.com/bnema/dumber/internal/ui/layout"
 	"github.com/bnema/puregotk/v4/gtk"
 )
@@ -146,6 +148,24 @@ func ResolveModalSizeConfig(cfg, defaults ModalSizeConfig) ModalSizeConfig {
 // CalculateModalDimensions computes width and top margin based on parent overlay.
 // Returns calculated width and top margin in pixels.
 func CalculateModalDimensions(parent layout.OverlayWidget, cfg ModalSizeConfig) (width, marginTop int) {
+	return CalculateModalDimensionsWithScale(parent, cfg, 1)
+}
+
+// normalizeUIScale maps nonpositive or nonfinite scale factors to 1.
+func normalizeUIScale(uiScale float64) float64 {
+	if math.IsNaN(uiScale) || math.IsInf(uiScale, 0) || uiScale <= 0 {
+		return 1.0
+	}
+	return uiScale
+}
+
+// CalculateModalDimensionsWithScale computes width and top margin based on
+// parent overlay, scaling the requested width by the UI scale factor while
+// preserving scale=1 geometry, top placement, and fallback height.
+// Returns calculated width and top margin in pixels.
+func CalculateModalDimensionsWithScale(parent layout.OverlayWidget, cfg ModalSizeConfig, uiScale float64) (width, marginTop int) {
+	scale := normalizeUIScale(uiScale)
+
 	var parentWidth, parentHeight int
 
 	if parent != nil {
@@ -156,16 +176,19 @@ func CalculateModalDimensions(parent layout.OverlayWidget, cfg ModalSizeConfig) 
 	// Use fallback if parent not allocated or too small to be useful
 	// A width < 100 is too small for any meaningful modal
 	if parentWidth < 100 {
-		parentWidth = cfg.FallbackWidth
+		parentWidth = ScaleValue(cfg.FallbackWidth, scale)
 	}
 	if parentHeight < 100 {
 		parentHeight = cfg.FallbackHeight
 	}
 
 	if cfg.FixedWidth > 0 {
-		width = cfg.FixedWidth
+		// Fixed widths (e.g. standalone omnibox) are content-sized requests:
+		// scale them directly without clamping to the host allocation, which
+		// is itself driven by the child and would prevent growth.
+		width = ScaleValue(cfg.FixedWidth, scale)
 	} else {
-		width = min(int(float64(parentWidth)*cfg.WidthPct), cfg.MaxWidth)
+		width = min(int(float64(parentWidth)*cfg.WidthPct), ScaleValue(cfg.MaxWidth, scale))
 	}
 
 	if cfg.UseFixedTopMargin {

--- a/internal/ui/component/modal_sizing_test.go
+++ b/internal/ui/component/modal_sizing_test.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"math"
 	"testing"
 
 	layoutmocks "github.com/bnema/dumber/internal/ui/layout/mocks"
@@ -283,3 +284,130 @@ func TestEffectiveMaxRows_NoAdaptation(t *testing.T) {
 	got := EffectiveMaxRows(500, 72, sizeCfg, defaults)
 	assert.Equal(t, 10, got)
 }
+
+func mockParent(t *testing.T, w, h int) *layoutmocks.MockOverlayWidget {
+	t.Helper()
+	parent := layoutmocks.NewMockOverlayWidget(t)
+	parent.EXPECT().GetAllocatedWidth().Return(w).Maybe()
+	parent.EXPECT().GetAllocatedHeight().Return(h).Maybe()
+	return parent
+}
+
+func TestCalculateModalDimensionsWithScale_ScaleOneUnchanged(t *testing.T) {
+	cfg := ModalSizeConfig{
+		WidthPct:       0.8,
+		MaxWidth:       800,
+		TopMarginPct:   0.2,
+		FallbackWidth:  800,
+		FallbackHeight: 600,
+	}
+	parent := mockParent(t, 1920, 1080)
+	w, m := CalculateModalDimensionsWithScale(parent, cfg, 1)
+	wLegacy, mLegacy := CalculateModalDimensions(parent, cfg)
+	assert.Equal(t, wLegacy, w)
+	assert.Equal(t, mLegacy, m)
+	assert.Equal(t, 800, w)
+	assert.Equal(t, 216, m)
+}
+
+func TestCalculateModalDimensionsWithScale_LargeParent(t *testing.T) {
+	cfg := OmniboxSizeDefaults
+	for _, tt := range []struct {
+		scale float64
+		want  int
+	}{
+		{1.25, 1000},
+		{1.5, 1200},
+		{2.0, 1600},
+	} {
+		parent := mockParent(t, 3000, 1200)
+		w, m := CalculateModalDimensionsWithScale(parent, cfg, tt.scale)
+		assert.Equal(t, tt.want, w, "scale %v", tt.scale)
+		assert.Equal(t, 240, m, "top margin unchanged")
+	}
+}
+
+func TestCalculateModalDimensionsWithScale_SmallParentPercentageBound(t *testing.T) {
+	cfg := SessionManagerSizeDefaults // 0.6 * w, max 600
+	parent := mockParent(t, 500, 800)
+	w, m := CalculateModalDimensionsWithScale(parent, cfg, 2.0)
+	// 0.6*500=300 < 600*2 → percentage bound wins
+	assert.Equal(t, 300, w)
+	assert.Equal(t, int(float64(800)*cfg.TopMarginPct), m)
+}
+
+func TestCalculateModalDimensionsWithScale_ScaleBelowOne(t *testing.T) {
+	cfg := OmniboxSizeDefaults
+	parent := mockParent(t, 3000, 1080)
+	w, _ := CalculateModalDimensionsWithScale(parent, cfg, 0.5)
+	assert.Equal(t, 400, w)
+}
+
+func TestCalculateModalDimensionsWithScale_NormalizesBadScale(t *testing.T) {
+	cfg := OmniboxSizeDefaults
+	for _, scale := range []float64{0, -1, -0.5, nan(), inf(1), inf(-1)} {
+		parent := mockParent(t, 3000, 1080)
+		w, m := CalculateModalDimensionsWithScale(parent, cfg, scale)
+		assert.Equal(t, 800, w, "scale %v", scale)
+		assert.Equal(t, 216, m, "scale %v", scale)
+	}
+}
+
+func TestCalculateModalDimensionsWithScale_FallbackScaled(t *testing.T) {
+	cfg := OmniboxSizeDefaults
+	parent := mockParent(t, 0, 0)
+	w, m := CalculateModalDimensionsWithScale(parent, cfg, 1.5)
+	// fallback 800*1.5=1200 → pct 0.8*1200=960 vs max 1200 → 960
+	assert.Equal(t, 960, w)
+	assert.Equal(t, int(float64(600)*cfg.TopMarginPct), m)
+}
+
+func TestCalculateModalDimensionsWithScale_FixedScalesOnceBeyondAllocation(t *testing.T) {
+	cfg := ResolveModalSizeConfig(ModalSizeConfig{
+		FixedWidth:        800,
+		FixedTopMargin:    0,
+		UseFixedTopMargin: true,
+	}, OmniboxSizeDefaults)
+	// Child-sized host allocation (small) must not clamp the fixed request.
+	parent := mockParent(t, 120, 200)
+	w, m := CalculateModalDimensionsWithScale(parent, cfg, 1.5)
+	assert.Equal(t, 1200, w)
+	assert.Equal(t, 0, m)
+	// Config must not be mutated by repeated calls.
+	assert.Equal(t, 800, cfg.FixedWidth)
+	w2, _ := CalculateModalDimensionsWithScale(parent, cfg, 1.5)
+	assert.Equal(t, w, w2)
+	assert.Equal(t, 800, cfg.FixedWidth)
+	assert.Equal(t, 800, OmniboxSizeDefaults.MaxWidth)
+}
+
+func TestCalculateModalDimensionsWithScale_NoDefaultMutation(t *testing.T) {
+	before := OmniboxSizeDefaults
+	parent := mockParent(t, 3000, 1200)
+	_, _ = CalculateModalDimensionsWithScale(parent, OmniboxSizeDefaults, 2.0)
+	assert.Equal(t, before, OmniboxSizeDefaults)
+}
+
+func TestOmniboxRequestedDimensions_UsesScale(t *testing.T) {
+	cfg := ResolveModalSizeConfig(ModalSizeConfig{
+		FixedWidth:        800,
+		FixedTopMargin:    0,
+		UseFixedTopMargin: true,
+	}, OmniboxSizeDefaults)
+	o := &Omnibox{parentOverlay: mockParent(t, 120, 200), sizeCfg: cfg, uiScale: 1.5}
+	w, m := o.requestedDimensions()
+	assert.Equal(t, 1200, w)
+	assert.Equal(t, 0, m)
+}
+
+func TestSessionManagerRequestedDimensions_UsesScale(t *testing.T) {
+	sm := &SessionManager{parentOverlay: mockParent(t, 3000, 1200), uiScale: 1.5}
+	w, m := sm.requestedDimensions()
+	// 0.6*3000=1800 vs 600*1.5=900 → 900
+	assert.Equal(t, 900, w)
+	assert.Equal(t, int(float64(1200)*SessionManagerSizeDefaults.TopMarginPct), m)
+}
+
+func nan() float64 { return math.NaN() }
+
+func inf(sign int) float64 { return math.Inf(sign) }

--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -347,6 +347,33 @@ func (o *Omnibox) WidgetAsLayout(factory layout.WidgetFactory) layout.Widget {
 	return factory.WrapWidget(&o.outerBox.Widget)
 }
 
+// SetUIScale updates modal geometry on the GTK main thread.
+func (o *Omnibox) SetUIScale(scale float64) {
+	scale = normalizeUIScale(scale)
+	if o.uiScale == scale {
+		return
+	}
+	o.uiScale = scale
+	o.measuredHeights.valid = false
+	if o.mainBox == nil {
+		return
+	}
+	width, _ := o.requestedDimensions()
+	o.mainBox.SetSizeRequest(width, -1)
+	if o.listBox != nil {
+		o.rebuildList()
+	}
+	o.mu.RLock()
+	count := len(o.favorites)
+	if o.bangMode {
+		count = len(o.bangSuggestions)
+	} else if o.viewMode == ViewModeHistory {
+		count = len(o.suggestions)
+	}
+	o.mu.RUnlock()
+	o.resizeAndCenter(count)
+}
+
 // estimateRowHeight returns the current best estimate for a single row height.
 func (o *Omnibox) estimateRowHeight() int {
 	if o.measuredHeights.valid && o.measuredHeights.singleRow > 0 {
@@ -494,6 +521,12 @@ func (o *Omnibox) effectiveMaxRows() int {
 	return EffectiveMaxRows(o.parentOverlay.GetAllocatedHeight(), o.estimateRowHeight(), o.sizeCfg, OmniboxListDefaults)
 }
 
+// requestedDimensions returns the scale-aware modal width and top margin for
+// the current parent overlay, size config, and UI scale.
+func (o *Omnibox) requestedDimensions() (width, marginTop int) {
+	return CalculateModalDimensionsWithScale(o.parentOverlay, o.sizeCfg, o.uiScale)
+}
+
 // resizeAndCenter adjusts the omnibox size based on content and centers it.
 // rowCount is the number of result rows to display (0 = no content, adapts to parent height).
 func (o *Omnibox) resizeAndCenter(rowCount int) {
@@ -508,7 +541,7 @@ func (o *Omnibox) resizeAndCenter(rowCount int) {
 
 	// Schedule measurement after GTK has laid out widgets
 	var cb glib.SourceFunc = func(uintptr) bool {
-		width, _ := CalculateModalDimensions(o.parentOverlay, o.sizeCfg)
+		width, _ := o.requestedDimensions()
 		o.measureAndResize(width, rowCount)
 		return false
 	}
@@ -1980,7 +2013,7 @@ func (o *Omnibox) rebuildList() {
 			if width <= 0 {
 				return false // Overlay not allocated yet, skip
 			}
-			forWidth, _ := CalculateModalDimensions(o.parentOverlay, o.sizeCfg)
+			forWidth, _ := o.requestedDimensions()
 			if o.measureComponentHeights(forWidth) {
 				// Re-trigger resize with accurate measurements
 				o.mu.RLock()
@@ -2784,7 +2817,7 @@ func (o *Omnibox) Show(ctx context.Context, query string) {
 		parentWidth = o.parentOverlay.GetAllocatedWidth()
 		parentHeight = o.parentOverlay.GetAllocatedHeight()
 	}
-	width, marginTop := CalculateModalDimensions(o.parentOverlay, o.sizeCfg)
+	width, marginTop := o.requestedDimensions()
 	log.Debug().
 		Int("parentWidth", parentWidth).
 		Int("parentHeight", parentHeight).

--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -197,10 +197,7 @@ type OmniboxConfig struct {
 func NewOmnibox(ctx context.Context, cfg OmniboxConfig) *Omnibox {
 	log := logging.FromContext(ctx)
 
-	uiScale := cfg.UIScale
-	if uiScale <= 0 {
-		uiScale = 1.0
-	}
+	uiScale := normalizeUIScale(cfg.UIScale)
 
 	sizeCfg := ResolveModalSizeConfig(cfg.SizeConfig, OmniboxSizeDefaults)
 
@@ -361,7 +358,17 @@ func (o *Omnibox) SetUIScale(scale float64) {
 	width, _ := o.requestedDimensions()
 	o.mainBox.SetSizeRequest(width, -1)
 	if o.listBox != nil {
+		// Rebuilding clears the selected GTK row, which resets
+		// selectedIndex to -1 via the row-selected callback. Snapshot
+		// and restore the selection so keyboard selection and ghost
+		// completion survive a scale change with identical content.
+		o.mu.RLock()
+		selected := o.selectedIndex
+		o.mu.RUnlock()
 		o.rebuildList()
+		if selected >= 0 && o.listBox.GetRowAtIndex(selected) != nil {
+			o.selectIndex(selected)
+		}
 	}
 	o.mu.RLock()
 	count := len(o.favorites)

--- a/internal/ui/component/session_manager.go
+++ b/internal/ui/component/session_manager.go
@@ -215,12 +215,32 @@ func (sm *SessionManager) Toggle(ctx context.Context) {
 	}
 }
 
+// SetUIScale updates modal geometry on the GTK main thread.
+func (sm *SessionManager) SetUIScale(scale float64) {
+	scale = normalizeUIScale(scale)
+	if sm.uiScale == scale {
+		return
+	}
+	sm.uiScale = scale
+	sm.measuredHeights.valid = false
+	sm.resizeAndCenter()
+	if sm.IsVisible() {
+		sm.populateList()
+	}
+}
+
+// requestedDimensions returns the scale-aware modal width and top margin for
+// the current parent overlay, session size defaults, and UI scale.
+func (sm *SessionManager) requestedDimensions() (width, marginTop int) {
+	return CalculateModalDimensionsWithScale(sm.parentOverlay, SessionManagerSizeDefaults, sm.uiScale)
+}
+
 func (sm *SessionManager) resizeAndCenter() {
 	if sm.outerBox == nil || sm.mainBox == nil {
 		return
 	}
 
-	width, marginTop := CalculateModalDimensions(sm.parentOverlay, SessionManagerSizeDefaults)
+	width, marginTop := sm.requestedDimensions()
 
 	sm.mainBox.SetSizeRequest(width, -1)
 	sm.outerBox.SetMarginTop(marginTop)
@@ -477,7 +497,7 @@ func (sm *SessionManager) populateList() {
 	sm.selectBySessionIndex(selectedIdx)
 
 	// Attempt to measure actual widget heights for accurate sizing
-	width, _ := CalculateModalDimensions(sm.parentOverlay, SessionManagerSizeDefaults)
+	width, _ := sm.requestedDimensions()
 	sm.measureWidgetHeights(width)
 
 	sm.resizeForContent(state.sessionRowCount, state.dividerCount, state.treeRowCount)

--- a/internal/ui/component/session_manager.go
+++ b/internal/ui/component/session_manager.go
@@ -90,10 +90,7 @@ type SessionManagerConfig struct {
 func NewSessionManager(ctx context.Context, cfg SessionManagerConfig) *SessionManager {
 	log := logging.FromContext(ctx)
 
-	uiScale := cfg.UIScale
-	if uiScale <= 0 {
-		uiScale = 1.0
-	}
+	uiScale := normalizeUIScale(cfg.UIScale)
 
 	sm := &SessionManager{
 		ctx:             ctx,

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -732,6 +732,17 @@ func (wv *WorkspaceView) SetOmniboxConfig(cfg OmniboxConfig) {
 	wv.omniboxCfg = cfg
 }
 
+// SetOmniboxUIScale updates current and future omniboxes on the GTK main thread.
+func (wv *WorkspaceView) SetOmniboxUIScale(scale float64) {
+	wv.mu.Lock()
+	wv.omniboxCfg.UIScale = scale
+	omnibox := wv.omnibox
+	wv.mu.Unlock()
+	if omnibox != nil {
+		omnibox.SetUIScale(scale)
+	}
+}
+
 // SetFindBarConfig stores the find bar configuration for later use.
 func (wv *WorkspaceView) SetFindBarConfig(cfg FindBarConfig) {
 	wv.mu.Lock()

--- a/internal/ui/component/workspace_view.go
+++ b/internal/ui/component/workspace_view.go
@@ -734,6 +734,7 @@ func (wv *WorkspaceView) SetOmniboxConfig(cfg OmniboxConfig) {
 
 // SetOmniboxUIScale updates current and future omniboxes on the GTK main thread.
 func (wv *WorkspaceView) SetOmniboxUIScale(scale float64) {
+	scale = normalizeUIScale(scale)
 	wv.mu.Lock()
 	wv.omniboxCfg.UIScale = scale
 	omnibox := wv.omnibox

--- a/internal/ui/theme/css.go
+++ b/internal/ui/theme/css.go
@@ -951,7 +951,8 @@ func generateSessionManagerCSS(p Palette) string {
 	border: 0.0625em solid var(--border);
 	border-radius: 0.1875em;
 	padding: 0;
-	min-width: 28em;
+	/* Width is owned by the Go sizing request so CSS must not force
+	   growth beyond the percentage viewport limit. */
 	/* Note: max-width not supported in GTK4 CSS, rely on container constraints */
 }
 

--- a/internal/ui/theme/css_test.go
+++ b/internal/ui/theme/css_test.go
@@ -311,3 +311,10 @@ func TestGenerateCSS_DoesNotEmitUnsupportedGTKProperties(t *testing.T) {
 	assert.NotContains(t, css, "pointer-events:")
 	assert.NotContains(t, css, "text-align:")
 }
+
+func TestGenerateCSS_SessionContainerHasNoMinWidth(t *testing.T) {
+	css := GenerateCSS(DefaultDarkPalette())
+	block := cssRuleBlock(t, css, ".session-manager-container")
+	assert.NotContains(t, block, "min-width:")
+	assert.Contains(t, block, "background-color: var(--surface-variant);")
+}


### PR DESCRIPTION
## Summary
- Scale browser and standalone omnibox width requests and session-manager width caps with the configured UI scale.
- Preserve percentage-based parent limits for embedded modals and remove the conflicting session CSS minimum.
- Update current and future browser omniboxes and session managers when runtime UI scale changes, invalidating cached measurements.
- Cover sizing, normalization, fixed-width standalone behavior, and component scale updates with regression tests.

## Validation
- `make lint` passes.
- Focused component, theme, and UI tests pass.
- `make build-systemviews` generates the ignored WASM prerequisites without tracked changes.
- `GDK_BACKEND=x11 xvfb-run -a make check` passes, including build, generated-artifact verification, full tests, and purego constraints.
- Native Wayland test execution hits a GTK teardown crash in `internal/ui/input`; the same crash reproduces on the unchanged base branch.

## Remaining validation
- Manual Wayland visual validation at different scales is still needed.
- Standalone fixed width scales naturally but is not explicitly capped to monitor width; high scales on small monitors can overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - UI scaling now updates omniboxes, session managers, workspace views, floating sessions, and browser windows when settings are reloaded.
  - Modal and session interfaces resize consistently according to the selected scale.
  - Improved handling of fractional and invalid scale values for more reliable sizing.
  - Session manager width now respects viewport sizing without unintended minimum-width expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->