### PR TITLE
fix(input): release unrealized shortcut test window without destroy

### DIFF
--- a/internal/ui/input/global_shortcuts_test.go
+++ b/internal/ui/input/global_shortcuts_test.go
@@ -82,7 +82,12 @@ func TestGlobalShortcutHandlerUsesDistinctNamedActionsAcrossReloads(t *testing.T
 	}
 	t.Cleanup(func() {
 		h.Detach()
-		window.Destroy()
+		// The test window is never presented, so it has no Wayland surface.
+		// gtk_window_destroy on such an unrealized window segfaults on the
+		// Wayland backend (gdk_surface_get_display assertion). Release the
+		// initial reference instead, matching the unrealized-window paths in
+		// window.New/PopupWindow. Destroy remains correct for shown windows.
+		window.Unref()
 		app.Unref()
 	})
 


### PR DESCRIPTION
Closes #418.

## Root cause

Reduced to a minimal reproducer: creating a `GtkApplication`, registering it, creating a `GtkApplicationWindow`, and calling `gtk_window_destroy` without ever presenting the window segfaults on the Wayland backend (`gdk_surface_get_display: assertion 'GDK_IS_SURFACE (surface)' failed` followed by SIGSEGV). The handler, `Detach()`, and controller reloads are not involved; the crash reproduces with app + window + `Destroy()` alone.

Two hypotheses from the issue are ruled out by the reproducer:
- Thread affinity: the minimal case still crashes with `runtime.LockOSThread`.
- Backend-independent teardown: the same sequence passes under Xvfb/X11 and passes on Wayland once the window is presented, or when teardown uses `Close`/`Unref` instead of `Destroy`.

So this is a teardown-lifecycle mismatch in the test, not a production shutdown bug: production windows are always presented before `Destroy()`, while the test destroyed a never-realized window with no Wayland surface.

## Fix

Test cleanup now calls `window.Unref()` instead of `window.Destroy()`, matching the existing unrealized-window paths in `window.New`/`PopupWindow` init failures. Assertions, reload coverage, and `h.Detach()` are unchanged. `Destroy` remains correct for shown windows.

## Verification

- `go test ./internal/ui/input -run TestGlobalShortcutHandlerUsesDistinctNamedActionsAcrossReloads -count=1` passes natively on Wayland (previously SIGSEGV).
- `go test ./internal/ui/input -count=1` passes natively.
- `make lint` clean; `gofmt`/`go vet` clean on the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cleanup in the GTK shortcut reload test to ensure test windows are released correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->