### PR TITLE
fix(history): detach worker query context from shutdown cancellation

### DIFF
--- a/internal/application/usecase/history_recorder.go
+++ b/internal/application/usecase/history_recorder.go
@@ -355,6 +355,14 @@ func (uc *HistoryRecorderUseCase) historyWorker() {
 	ticker := time.NewTicker(historyWorkerFlushInterval)
 	defer ticker.Stop()
 	workerCtx := uc.workerContext()
+	// queryCtx carries the worker's values (logging) but is detached from
+	// worker cancellation. Every database/sql query derives per-query child
+	// contexts from its parent; deriving those children from workerCtx while
+	// Close cancels workerCtx intermittently crashed in
+	// context.propagateCancel (concurrent map writes, #408). Shutdown
+	// coordination stays on uc.done/workerCtx.Done() in the select below,
+	// and the shutdown drain uses its own bounded timeout context.
+	queryCtx := context.WithoutCancel(workerCtx)
 
 	pending := newPendingHistoryRecords()
 	for {
@@ -362,7 +370,7 @@ func (uc *HistoryRecorderUseCase) historyWorker() {
 		case record := <-uc.historyQueue:
 			pending.add(record)
 		case <-ticker.C:
-			_ = uc.flushPendingHistory(workerCtx, pending)
+			_ = uc.flushPendingHistory(queryCtx, pending)
 		case req := <-uc.controlQueue:
 			uc.handleHistoryControl(pending, req)
 		case <-uc.done:
@@ -598,7 +606,10 @@ func (uc *HistoryRecorderUseCase) publishHistoryChange(successfulVisits, success
 		reasons = append(reasons, dto.HistoryChangeReasonTitle)
 	}
 	sink := uc.historyChangeSink()
-	sink.OnHistoryChanged(uc.workerContext(), dto.HistoryChange{
+	// Detach the notification from worker cancellation: the sink runs on
+	// another goroutine (main-thread dispatch) and must never derive from
+	// or observe a parent that Close cancels concurrently (see #408).
+	sink.OnHistoryChanged(context.WithoutCancel(uc.workerContext()), dto.HistoryChange{
 		Reasons:    reasons,
 		VisitCount: successfulVisits,
 		TitleCount: successfulTitles,

--- a/internal/application/usecase/history_recorder_test.go
+++ b/internal/application/usecase/history_recorder_test.go
@@ -33,6 +33,29 @@ func (s *recordingHistoryChangeSink) snapshot() []dto.HistoryChange {
 	return out
 }
 
+// ctxCapturingHistoryChangeSink records the contexts delivered with each
+// change so tests can assert detachment from worker cancellation (#408).
+type ctxCapturingHistoryChangeSink struct {
+	recordingHistoryChangeSink
+	mu   sync.Mutex
+	ctxs []context.Context
+}
+
+func (s *ctxCapturingHistoryChangeSink) OnHistoryChanged(ctx context.Context, change dto.HistoryChange) {
+	s.mu.Lock()
+	s.ctxs = append(s.ctxs, ctx)
+	s.mu.Unlock()
+	s.recordingHistoryChangeSink.OnHistoryChanged(ctx, change)
+}
+
+func (s *ctxCapturingHistoryChangeSink) snapshotCtxs() []context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]context.Context, len(s.ctxs))
+	copy(out, s.ctxs)
+	return out
+}
+
 func TestNormalizeHistoryChangeSink_TreatsTypedNilAsNoop(t *testing.T) {
 	var sink *recordingHistoryChangeSink
 
@@ -204,26 +227,29 @@ func TestHistoryRecorder_CloseDrainsPendingAndPublishes(t *testing.T) {
 	require.Equal(t, 1, changes[0].VisitCount)
 }
 
-func TestHistoryRecorder_CloseCancelsInFlightWorkerFlushAndDrains(t *testing.T) {
+func TestHistoryRecorder_PeriodicFlushUsesDetachedQueryContext(t *testing.T) {
 	ctx := context.Background()
-	sink := &recordingHistoryChangeSink{}
+	sink := &ctxCapturingHistoryChangeSink{}
 	repo := repomocks.NewMockHistoryRepository(t)
-	const historyURL = "https://example.com/cancel-close"
+	const historyURL = "https://example.com/detached-flush"
 
 	findStarted := make(chan struct{})
+	releaseFind := make(chan struct{})
 	var findOnce sync.Once
+	var captureMu sync.Mutex
+	var captured context.Context
 	repo.EXPECT().FindByURL(mock.Anything, historyURL).RunAndReturn(
 		func(ctx context.Context, _ string) (*entity.HistoryEntry, error) {
-			first := false
-			findOnce.Do(func() { first = true })
-			if first {
-				close(findStarted)
-				<-ctx.Done()
-				return nil, ctx.Err()
+			findOnce.Do(func() { close(findStarted) })
+			captureMu.Lock()
+			if captured == nil {
+				captured = ctx
 			}
+			captureMu.Unlock()
+			<-releaseFind
 			return nil, nil
 		},
-	).Twice()
+	).Once()
 	repo.EXPECT().Save(mock.Anything, mock.MatchedBy(func(entry *entity.HistoryEntry) bool {
 		return entry.URL == historyURL && entry.VisitCount == 1
 	})).Return(nil).Once()
@@ -233,20 +259,35 @@ func TestHistoryRecorder_CloseCancelsInFlightWorkerFlushAndDrains(t *testing.T) 
 
 	select {
 	case <-findStarted:
-	case <-time.After(time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for periodic history flush to start")
 	}
 
+	// Close must not cancel the in-flight periodic flush: the flush runs to
+	// completion with a context detached from worker cancellation, and the
+	// shutdown drain then finds nothing left to persist.
 	closed := make(chan struct{})
 	go func() {
 		uc.Close()
 		close(closed)
 	}()
+	close(releaseFind)
 
 	select {
 	case <-closed:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for history recorder shutdown")
+	}
+
+	captureMu.Lock()
+	defer captureMu.Unlock()
+	require.NotNil(t, captured, "periodic flush must reach the repository")
+	require.Nil(t, captured.Done(),
+		"periodic flush query context must be detached from worker cancellation (#408)")
+	for _, sinkCtx := range sink.snapshotCtxs() {
+		require.NotNil(t, sinkCtx)
+		require.Nil(t, sinkCtx.Done(),
+			"history change notification must be detached from worker cancellation (#408)")
 	}
 
 	changes := sink.snapshot()


### PR DESCRIPTION
Fixes #408.

## Root cause

The history worker reused a single long-lived cancellable context (`workerCtx`) as the parent for every periodic `database/sql` flush, while `Close()` cancelled that same parent on another goroutine. Each query derives per-query child contexts from the parent (`Rows.initContextClose`), so the derive-vs-cancel contact on the shared parent intermittently crashed in `context.propagateCancel` with `fatal error: concurrent map writes` (stack: `QueryRowContext → GetHistoryByURL → FindByURL → persistTitleUpdate → flushPendingHistory → historyWorker`).

## Fix

Scope worker contexts so cancel and derive never share a parent:

- Periodic ticker flushes run under `context.WithoutCancel(workerCtx)`: values/logging preserved, `Done() == nil` so `database/sql` neither derives children from the shared parent nor spawns per-query watcher goroutines.
- The history-change sink notification is likewise detached before crossing to the main-thread dispatcher.
- Shutdown coordination stays on `uc.done`/`workerCtx.Done()` in the worker loop; the shutdown drain keeps its own bounded timeout context. Caller-driven control flushes (`BeginHistoryMutation`) intentionally keep the caller's context so caller cancellation still aborts.

Behavior change: `Close` no longer aborts an in-flight periodic flush mid-query; the flush runs to completion and the shutdown drain persists whatever remains. Previously this left entries pending for the shutdown re-flush anyway, so no writes are lost.

## Verification

- New regression test `TestHistoryRecorder_PeriodicFlushUsesDetachedQueryContext` asserts ticker-flush and sink contexts have a nil `Done` channel; it fails on the pre-fix code and passes with the fix (10x `-race` runs clean).
- `go test -race ./internal/application/usecase/ ./internal/infrastructure/persistence/sqlite/` passes; `make lint` reports 0 issues.
