### PR TITLE
Update purego-cef2gtk to v0.10.1 with keyboard fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.9.4-0.20260907134332-33edf6236a95
+	github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.9.4-0.20260909155445-6255c5314f2b
+	github.com/bnema/purego-cef2gtk v0.10.1
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f
+	github.com/bnema/purego-cef2gtk v0.9.4-0.20260909155445-6255c5314f2b
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,10 @@ github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iok
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260907134332-33edf6236a95 h1:H+SC0HzS2H6IfRjdqYVzpE0pb9L5IZU7t+tRCQaDCjg=
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260907134332-33edf6236a95/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.9.4-0.20260909150906-2d2a98ba1044 h1:F6n/VkdhYEv9Ay9zi9A/zlSZx0Z1n3EFfhdKTjJkOLU=
+github.com/bnema/purego-cef2gtk v0.9.4-0.20260909150906-2d2a98ba1044/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f h1:EIylXdkLQ9Z+QU/7gLaEvmmmdcdOLPG8pukMsbWhIMQ=
+github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/bnema/purego-cef2gtk v0.9.4-0.20260909150906-2d2a98ba1044 h1:F6n/Vkdh
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260909150906-2d2a98ba1044/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f h1:EIylXdkLQ9Z+QU/7gLaEvmmmdcdOLPG8pukMsbWhIMQ=
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.9.4-0.20260909155445-6255c5314f2b h1:/Mic7Jw7m3p8SKRPc+GV9NbfIDfrnVnDhk/6qapExd0=
+github.com/bnema/purego-cef2gtk v0.9.4-0.20260909155445-6255c5314f2b/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,10 @@ github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f h1:EIylXdkL
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260909151926-35dee7685d6f/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260909155445-6255c5314f2b h1:/Mic7Jw7m3p8SKRPc+GV9NbfIDfrnVnDhk/6qapExd0=
 github.com/bnema/purego-cef2gtk v0.9.4-0.20260909155445-6255c5314f2b/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.0 h1:1/NJamPOalVu3xgmNixcA/x1dr9pXoiN46kH3NFUf2A=
+github.com/bnema/purego-cef2gtk v0.10.0/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.1 h1:Zo5cyBsPEATcK90cYuDpgxfCIkAhYw0by/z2p/9PHpQ=
+github.com/bnema/purego-cef2gtk v0.10.1/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=


### PR DESCRIPTION
This fix the pause on video who also made the viewport to scroll down.

Dependency updates:

* Upgraded `github.com/bnema/purego-cef2gtk` from version `v0.9.4-0.20260907134332-33edf6236a95` to `v0.10.1` to ensure the project uses the latest features and fixes from this library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to version 0.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->