### PR TITLE
fix(cef): honor invisible cursor requests from web content

### DIFF
--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -1392,6 +1392,7 @@ var cefCursorNames = map[purecef.CursorType]string{
 	purecef.CursorTypeCtGrabbing:                 "grabbing",
 	purecef.CursorTypeCtZoomin:                   "zoom-in",
 	purecef.CursorTypeCtZoomout:                  "zoom-out",
+	purecef.CursorTypeCtNone:                     "none",
 }
 
 // cefCursorToGDKName maps a CEF cursor type to a GDK/CSS cursor name.

--- a/internal/infrastructure/cef/webview_handlers_test.go
+++ b/internal/infrastructure/cef/webview_handlers_test.go
@@ -679,3 +679,23 @@ type selectionRenderHandlerForTest struct{ wv *WebView }
 func (h *selectionRenderHandlerForTest) OnTextSelectionChanged(_ purecef.Browser, selectedText string, _ *purecef.Range) {
 	handleRenderTextSelectionChanged(h.wv, selectedText)
 }
+
+func TestCEFCursorToGDKName(t *testing.T) {
+	tests := []struct {
+		name     string
+		cursor   purecef.CursorType
+		expected string
+	}{
+		{name: "none maps to invisible cursor", cursor: purecef.CursorTypeCtNone, expected: "none"},
+		{name: "pointer maps to default", cursor: purecef.CursorTypeCtPointer, expected: "default"},
+		{name: "hand maps to pointer", cursor: purecef.CursorTypeCtHand, expected: "pointer"},
+		{name: "ibeam maps to text", cursor: purecef.CursorTypeCtIbeam, expected: "text"},
+		{name: "unknown falls back to default", cursor: purecef.CursorType(-1), expected: "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, cefCursorToGDKName(tt.cursor))
+		})
+	}
+}


### PR DESCRIPTION
Replaces #423 (merged into `next` by mistake); this targets `main` directly.

Sites that request an invisible cursor (e.g. video players hiding the cursor when idle) previously fell back to `"default"` because `cefCursorNames` lacked `CursorTypeCtNone`. This maps it to `"none"`, which forwards unchanged through `Cef2gtkAdapter.SetCursorFromName` to `gtk_widget_set_cursor_from_name`.

The site keeps owning hide/restore timing; no browser timers, compositor changes, or bridge refactoring.

## Verification

- `TestCEFCursorToGDKName`: red before the fix (none -> `"default"`), green after; covers pointer, hand, ibeam, and unknown-type fallback.
- Full `internal/infrastructure/cef` package: green on this branch.
- `make lint`: 0 issues.
- Manual Wayland smoke test: not run; needs eyes on a real Niri session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the handling of “no cursor” states so they display no cursor instead of falling back to the default cursor.
- **Tests**
  - Added coverage for cursor mappings, including pointer, hand, text, no-cursor, and unknown cursor types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->