### PR TITLE
fix(cef): apply the bridge page-zoom compensation once

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -299,7 +299,7 @@ CEF is the default browser engine. WebKitGTK remains available as a fallback via
 
 `engine.cef.input.scroll_precise_multiplier` controls touchpad/high-resolution wheel scroll speed, and `engine.cef.input.scroll_vertical_multiplier` applies an additional vertical-only scale. `engine.cef.input.touchpad_navigation_max_vertical_ratio` only filters horizontal back/forward swipe recognition; it does not tune vertical scroll speed.
 
-`default_ui_scale` sizes Dumber's own interface: toolbars, modals, and the density the CEF off-screen bridge renders at. It does not resize web content, so the page keeps one CSS pixel per GTK logical pixel on every output scale. Use `default_webpage_zoom` or per-site zoom to make pages larger or smaller.
+With the CEF engine, `default_ui_scale` sizes Dumber's own interface—toolbars and modals—and controls the density at which the off-screen bridge renders. It does not resize web content, so the page keeps one CSS pixel per GTK logical pixel on every output scale. Use `default_webpage_zoom` or per-site zoom to make pages larger or smaller.
 
 `engine.cef.input.touchpad_navigation_min_delta` uses raw GTK touchpad surface units for back/forward gestures. The default `320.0` matches WebKit-style commit distance to reduce accidental navigation; raise or lower it in `config.toml` to tune gesture sensitivity.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -299,6 +299,8 @@ CEF is the default browser engine. WebKitGTK remains available as a fallback via
 
 `engine.cef.input.scroll_precise_multiplier` controls touchpad/high-resolution wheel scroll speed, and `engine.cef.input.scroll_vertical_multiplier` applies an additional vertical-only scale. `engine.cef.input.touchpad_navigation_max_vertical_ratio` only filters horizontal back/forward swipe recognition; it does not tune vertical scroll speed.
 
+`default_ui_scale` sizes Dumber's own interface: toolbars, modals, and the density the CEF off-screen bridge renders at. It does not resize web content, so the page keeps one CSS pixel per GTK logical pixel on every output scale. Use `default_webpage_zoom` or per-site zoom to make pages larger or smaller.
+
 `engine.cef.input.touchpad_navigation_min_delta` uses raw GTK touchpad surface units for back/forward gestures. The default `320.0` matches WebKit-style commit distance to reduce accidental navigation; raise or lower it in `config.toml` to tune gesture sensitivity.
 
 ### Legacy key migration

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.10.1
+	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1
+	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e
+	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e h1:5gvWSQl
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1 h1:MBsbM9JuYvGmGyGfF8YQaPsmggnrIJlKdnQDDNOck3Y=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8 h1:9BtmuhH5raXQKXwI0+owr/iD1oT0hkjCHhS/WUPUiXk=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iok
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e h1:5gvWSQlaKCI3JALXP/BiDjJftZgMg63cwRew5N+y6kc=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1 h1:MBsbM9JuYvGmGyGfF8YQaPsmggnrIJlKdnQDDNOck3Y=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.10.1 h1:Zo5cyBsPEATcK90cYuDpgxfCIkAhYw0by/z2p/9PHpQ=
-github.com/bnema/purego-cef2gtk v0.10.1/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e h1:5gvWSQlaKCI3JALXP/BiDjJftZgMg63cwRew5N+y6kc=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/internal/domain/entity/zoom.go
+++ b/internal/domain/entity/zoom.go
@@ -1,6 +1,9 @@
 package entity
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // ZoomLevel represents the zoom factor for a specific domain.
 // Allows users to set persistent zoom levels per-site.
@@ -53,9 +56,11 @@ func (z *ZoomLevel) IsDefault() bool {
 	return z.ZoomFactor == ZoomDefault
 }
 
-// Percentage returns the zoom factor as a percentage (e.g., 150 for 1.5).
+// Percentage returns the zoom factor as a whole percentage (e.g., 150 for 1.5).
+// Accumulated floating-point error is rounded away so a factor that equals the
+// default zoom in intent (0.9999999999999997) displays as 100, not 99.
 func (z *ZoomLevel) Percentage() int {
-	return int(z.ZoomFactor * 100)
+	return int(math.Round(z.ZoomFactor * 100))
 }
 
 // clampZoom constrains a zoom factor to the valid range.

--- a/internal/domain/entity/zoom.go
+++ b/internal/domain/entity/zoom.go
@@ -56,11 +56,16 @@ func (z *ZoomLevel) IsDefault() bool {
 	return z.ZoomFactor == ZoomDefault
 }
 
-// Percentage returns the zoom factor as a whole percentage (e.g., 150 for 1.5).
-// Accumulated floating-point error is rounded away so a factor that equals the
-// default zoom in intent (0.9999999999999997) displays as 100, not 99.
+// ZoomPercentage returns a zoom factor as a whole percentage (e.g., 150 for
+// 1.5). Accumulated floating-point error is rounded away so a factor that equals
+// the default zoom in intent (0.9999999999999997) displays as 100, not 99.
+func ZoomPercentage(factor float64) int {
+	return int(math.Round(factor * 100))
+}
+
+// Percentage returns the zoom factor as a whole percentage.
 func (z *ZoomLevel) Percentage() int {
-	return int(math.Round(z.ZoomFactor * 100))
+	return ZoomPercentage(z.ZoomFactor)
 }
 
 // clampZoom constrains a zoom factor to the valid range.

--- a/internal/domain/entity/zoom_test.go
+++ b/internal/domain/entity/zoom_test.go
@@ -1,0 +1,57 @@
+package entity
+
+import (
+	"math"
+	"testing"
+)
+
+func TestZoomPercentageRoundsDisplayedValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		factor float64
+		want   int
+	}{
+		{name: "default_zoom", factor: 1.0, want: 100},
+		{name: "accumulated_default_error", factor: 0.9999999999999997, want: 100},
+		{name: "accumulated_above_default", factor: 1.0000000000000002, want: 100},
+		{name: "ordinary_percent", factor: 1.5, want: 150},
+		{name: "minimum_zoom", factor: ZoomMin, want: 25},
+		{name: "maximum_zoom", factor: ZoomMax, want: 500},
+		{name: "rounds_up", factor: 1.006, want: 101},
+		{name: "rounds_down", factor: 1.004, want: 100},
+		{name: "three_digit_percent_below_half", factor: 2.344, want: 234},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zoom := NewZoomLevel("example.com", tt.factor)
+			if got := zoom.Percentage(); got != tt.want {
+				t.Fatalf("Percentage()=%d, want %d for factor %.16f", got, tt.want, tt.factor)
+			}
+		})
+	}
+}
+
+func TestZoomPercentageSurvivesRepeatedSteps(t *testing.T) {
+	zoom := NewZoomLevel("example.com", ZoomDefault)
+
+	for range 10 {
+		zoom.ZoomIn()
+	}
+	if got := zoom.Percentage(); got != 200 {
+		t.Fatalf("after 10 zoom-in steps Percentage()=%d, want 200", got)
+	}
+
+	for range 10 {
+		zoom.ZoomOut()
+	}
+	if got := zoom.Percentage(); got != 100 {
+		t.Fatalf("after 10 zoom-out steps Percentage()=%d, want 100", got)
+	}
+	if math.Abs(zoom.ZoomFactor-ZoomDefault) > 1e-9 {
+		t.Fatalf("persisted factor drifted to %.16f, want default", zoom.ZoomFactor)
+	}
+	if !zoom.IsDefault() {
+		t.Fatal("factor behind a 100%% display must still compare equal to the default zoom")
+	}
+}

--- a/internal/infrastructure/cef/cef2gtk_adapter.go
+++ b/internal/infrastructure/cef/cef2gtk_adapter.go
@@ -123,6 +123,23 @@ func (a *Cef2gtkAdapter) OSRBackingScaleFactor() float64 {
 	return cef2gtk.OSRBackingScaleFactorForScale(float64(a.view.DeviceScaleFactor()))
 }
 
+// PageZoomCompensation returns the factor Dumber must multiply user page zoom by
+// before applying it through CEF, so the page's CSS viewport keeps matching the
+// GTK logical view size under the bridge's active OSR geometry contract. It
+// returns 1 for a nil or destroyed adapter and whenever CEF's normal logical OSR
+// contract is in effect.
+func (a *Cef2gtkAdapter) PageZoomCompensation() float64 {
+	if a == nil || a.destroyed.Load() {
+		return 1
+	}
+	a.viewMu.RLock()
+	defer a.viewMu.RUnlock()
+	if a.view == nil {
+		return 1
+	}
+	return a.view.PageZoomCompensation()
+}
+
 // AddSizeObserver registers a positive-size change callback. Register and
 // unregister from the GTK main thread; callbacks are invoked by the bridge from
 // GTK size notifications.

--- a/internal/infrastructure/cef/factory.go
+++ b/internal/infrastructure/cef/factory.go
@@ -127,6 +127,7 @@ func (f *WebViewFactory) newWebView(ctx context.Context) (*WebView, error) {
 		engine:                      f.engine,
 		factory:                     f,
 		viewBridge:                  viewBridge,
+		zoomCompensation:            viewBridge,
 		audioOutputFactory:          f.audioOutputFactory,
 		adaptiveWindowlessFrameRate: f.adaptiveWindowlessFrameRate,
 		windowlessFrameRate:         f.windowlessFrameRate,

--- a/internal/infrastructure/cef/scale_probe.go
+++ b/internal/infrastructure/cef/scale_probe.go
@@ -8,12 +8,12 @@ import (
 const scaleProbeRoundFactor = 1_000_000
 
 type cefScaleProbeMetrics struct {
-	SurfaceWidth      int32
-	SurfaceHeight     int32
-	SurfaceScale      float64
-	OSRBackingScale   float64
-	UserZoom          float64
-	InternalCEFFactor float64
+	SurfaceWidth         int32
+	SurfaceHeight        int32
+	SurfaceScale         float64
+	PageZoomCompensation float64
+	UserZoom             float64
+	InternalCEFFactor    float64
 }
 
 func shouldRunCEFScaleProbe(frameURL string, httpStatusCode int32) bool {
@@ -29,20 +29,20 @@ func shouldRunCEFScaleProbe(frameURL string, httpStatusCode int32) bool {
 
 func cefScaleProbeSnapshot(wv *WebView) cefScaleProbeMetrics {
 	m := cefScaleProbeMetrics{
-		SurfaceWidth:      1,
-		SurfaceHeight:     1,
-		SurfaceScale:      1,
-		OSRBackingScale:   1,
-		UserZoom:          1,
-		InternalCEFFactor: 1,
+		SurfaceWidth:         1,
+		SurfaceHeight:        1,
+		SurfaceScale:         1,
+		PageZoomCompensation: 1,
+		UserZoom:             1,
+		InternalCEFFactor:    1,
 	}
 	if wv == nil {
 		return m
 	}
 	m.UserZoom = normalizeScale(wv.GetZoomLevel())
-	m.OSRBackingScale = normalizeScale(wv.osrBackingScaleFactor())
+	m.PageZoomCompensation = wv.pageZoomCompensation()
 	m.SurfaceScale = normalizeScale(wv.viewBridgeScale())
-	m.InternalCEFFactor = m.UserZoom * zoomScaleRatio(m.SurfaceScale, m.OSRBackingScale)
+	m.InternalCEFFactor = m.UserZoom * m.PageZoomCompensation
 	if wv.viewBridge != nil {
 		m.SurfaceWidth, m.SurfaceHeight = wv.viewBridge.Size()
 	}
@@ -51,12 +51,12 @@ func cefScaleProbeSnapshot(wv *WebView) cefScaleProbeMetrics {
 
 func (m cefScaleProbeMetrics) logFields() map[string]any {
 	return map[string]any{
-		"surface_width":       m.SurfaceWidth,
-		"surface_height":      m.SurfaceHeight,
-		"surface_scale":       roundedScale(m.SurfaceScale),
-		"osr_backing_scale":   roundedScale(m.OSRBackingScale),
-		"user_zoom":           roundedScale(m.UserZoom),
-		"internal_cef_factor": roundedScale(m.InternalCEFFactor),
+		"surface_width":          m.SurfaceWidth,
+		"surface_height":         m.SurfaceHeight,
+		"surface_scale":          roundedScale(m.SurfaceScale),
+		"page_zoom_compensation": roundedScale(m.PageZoomCompensation),
+		"user_zoom":              roundedScale(m.UserZoom),
+		"internal_cef_factor":    roundedScale(m.InternalCEFFactor),
 	}
 }
 

--- a/internal/infrastructure/cef/scale_probe_test.go
+++ b/internal/infrastructure/cef/scale_probe_test.go
@@ -40,10 +40,34 @@ func TestCEFScaleProbeSnapshotNormalizesMissingBridge(t *testing.T) {
 	if s.SurfaceWidth != 1 || s.SurfaceHeight != 1 {
 		t.Fatalf("surface size = %dx%d, want 1x1", s.SurfaceWidth, s.SurfaceHeight)
 	}
-	if s.SurfaceScale != 1 || s.OSRBackingScale != 1 {
-		t.Fatalf("scales = surface %v backing %v, want 1/1", s.SurfaceScale, s.OSRBackingScale)
+	if s.SurfaceScale != 1 || s.PageZoomCompensation != 1 {
+		t.Fatalf("scales = surface %v compensation %v, want 1/1", s.SurfaceScale, s.PageZoomCompensation)
 	}
 	if s.UserZoom != 1 || s.InternalCEFFactor != 1 {
 		t.Fatalf("zoom = user %v internal %v, want 1/1", s.UserZoom, s.InternalCEFFactor)
+	}
+}
+
+func TestCEFScaleProbeSnapshotDerivesInternalFactorFromContract(t *testing.T) {
+	wv := &WebView{zoomCompensation: zoomCompensationStub{compensation: 1.75}}
+	wv.zoomFactor.Store(1.3)
+
+	s := cefScaleProbeSnapshot(wv)
+
+	if s.UserZoom != 1.3 {
+		t.Fatalf("user zoom = %v, want 1.3", s.UserZoom)
+	}
+	if s.PageZoomCompensation != 1.75 {
+		t.Fatalf("compensation = %v, want 1.75", s.PageZoomCompensation)
+	}
+	if s.InternalCEFFactor != 2.275 {
+		t.Fatalf("internal CEF factor = %v, want user zoom x compensation = 2.275", s.InternalCEFFactor)
+	}
+	fields := s.logFields()
+	if _, ok := fields["page_zoom_compensation"]; !ok {
+		t.Fatalf("probe fields %v missing page_zoom_compensation", fields)
+	}
+	if _, ok := fields["osr_backing_scale"]; ok {
+		t.Fatalf("probe fields %v must not carry a separate backing-scale formula", fields)
 	}
 }

--- a/internal/infrastructure/cef/testutil_test.go
+++ b/internal/infrastructure/cef/testutil_test.go
@@ -94,3 +94,14 @@ func (stubMenuModel) GetColorAt(_ int32, _ purecef.MenuColorType, _ uintptr) int
 }
 func (stubMenuModel) SetFontList(_ int32, _ string) int32   { panic("unexpected call") }
 func (stubMenuModel) SetFontListAt(_ int32, _ string) int32 { panic("unexpected call") }
+
+// zoomCompensationStub supplies the OSR page-zoom compensation contract owned by
+// the render bridge, so tests can exercise zoom conversion, reapplication, and
+// diagnostics without a live GTK/CEF view.
+type zoomCompensationStub struct {
+	compensation float64
+}
+
+func (s zoomCompensationStub) PageZoomCompensation() float64 {
+	return s.compensation
+}

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -99,6 +99,14 @@ var (
 	cefScheduleAfter    = func(delay time.Duration, fn func()) { time.AfterFunc(delay, fn) }
 )
 
+// pageZoomCompensationBridge is the narrow bridge surface Dumber reads the OSR
+// page-zoom compensation from. The compensation is owned by purego-cef2gtk's OSR
+// geometry contract, so Dumber must never derive it from GTK surface or backing
+// geometry itself.
+type pageZoomCompensationBridge interface {
+	PageZoomCompensation() float64
+}
+
 // WebView implements port.WebView using a CEF off-screen browser rendered and
 // driven through purego-cef2gtk. Dumber owns browser state and callbacks; the
 // bridge owns GTK rendering and input forwarding.
@@ -111,6 +119,7 @@ type WebView struct {
 	host                      purecef.BrowserHost
 	client                    purecef.RawClient // prevent GC from collecting the client before CEF AddRef's it
 	viewBridge                *Cef2gtkAdapter
+	zoomCompensation          pageZoomCompensationBridge
 	popupSurface              *popupBridgeSurface
 	nativeWidget              *gtk.Widget
 	handlers                  *handlerSet
@@ -283,11 +292,11 @@ type WebView struct {
 	// bridgeTeardownNoted gates quiescence accounting exactly once per
 	// view: every bridge teardown is scheduled through the Sync/Async
 	// wrappers below and completes in destroyViewBridgeOnGTKThread.
-	bridgeTeardownNoted           atomic.Bool
-	generation                    atomic.Uint64
-	audioPlaying                  atomic.Bool
-	zoomFactor                    atomic.Value // float64, initialized to 1.0
-	lastAppliedZoomScaleRatioBits atomic.Uint64
+	bridgeTeardownNoted             atomic.Bool
+	generation                      atomic.Uint64
+	audioPlaying                    atomic.Bool
+	zoomFactor                      atomic.Value // float64, initialized to 1.0
+	lastAppliedZoomCompensationBits atomic.Uint64
 
 	// Browser creation defaults copied from the factory so native popup shells
 	// can apply the same settings in OnBeforePopup.
@@ -592,23 +601,25 @@ func cefZoomFromFactor(factor float64) float64 {
 	return math.Log(factor) / math.Log(chromiumZoomBase)
 }
 
-func zoomScaleRatio(surfaceScale, backingScale float64) float64 {
-	backingScale = normalizeScale(backingScale)
-	if backingScale <= 1 {
-		return 1
-	}
-	return normalizeScale(surfaceScale) / backingScale
+// cefZoomFromPageZoom converts user page zoom to CEF's logarithmic zoom level by
+// folding in the bridge's OSR page-zoom compensation, so one CSS pixel keeps
+// matching one GTK logical pixel on every output scale.
+func cefZoomFromPageZoom(pageZoom, compensation float64) float64 {
+	return cefZoomFromFactor(normalizeScale(pageZoom) * normalizeScale(compensation))
 }
 
-func cefZoomFromPageAndScaleFactors(pageZoom, surfaceScale, backingScale float64) float64 {
-	return cefZoomFromFactor(pageZoom * zoomScaleRatio(surfaceScale, backingScale))
+// pageZoomFromCEFLevel is the inverse of cefZoomFromPageZoom: it reports the
+// user-facing page zoom for a CEF zoom level observed under compensation.
+func pageZoomFromCEFLevel(level, compensation float64) float64 {
+	return factorFromCEFZoom(level) / normalizeScale(compensation)
 }
 
-func pageZoomFromCEFAndScaleLevel(level, surfaceScale, backingScale float64) float64 {
-	return factorFromCEFZoom(level) / zoomScaleRatio(surfaceScale, backingScale)
-}
-
-func (wv *WebView) applyCEFZoomLevel(host purecef.BrowserHost, factor, cefLevel, surfaceScale, backingScale float64) {
+// applyZoomForCompensation applies one user page zoom through CEF using the
+// compensation of the OSR contract that is active in the bridge. Every zoom
+// application goes through this path so the applied compensation is recorded once.
+func (wv *WebView) applyZoomForCompensation(host purecef.BrowserHost, pageZoom, compensation float64) {
+	compensation = normalizeScale(compensation)
+	cefLevel := cefZoomFromPageZoom(pageZoom, compensation)
 	host.SetZoomLevel(cefLevel)
 	// Force CEF to produce a new frame at the new zoom level. In OSR mode,
 	// SetZoomLevel changes the Blink layout zoom but doesn't guarantee a
@@ -617,12 +628,12 @@ func (wv *WebView) applyCEFZoomLevel(host purecef.BrowserHost, factor, cefLevel,
 	// SynchronizeVisualProperties cycle, which makes the renderer produce
 	// a new compositor frame at the new zoom level.
 	host.NotifyScreenInfoChanged()
-	wv.recordAppliedZoomScaleRatio(surfaceScale, backingScale)
+	wv.recordAppliedZoomCompensation(compensation)
 	// Zoom is applied asynchronously in the renderer process. Request a couple
 	// of follow-up refreshes on the CEF UI thread so OSR captures the updated
 	// compositor frame after the zoom IPC has been processed.
 	wv.scheduleZoomRefresh()
-	wv.scheduleZoomReadback(factor, cefLevel)
+	wv.scheduleZoomReadback(pageZoom, cefLevel, compensation)
 }
 
 // factorFromCEFZoom converts a Chromium/CEF logarithmic zoom level back to a
@@ -651,15 +662,15 @@ func (wv *WebView) SetZoomLevel(_ context.Context, factor float64) error {
 		return errNoBrowser
 	}
 	surfaceScale := wv.viewBridgeScale()
-	backingScale := wv.osrBackingScaleFactor()
-	cefLevel := cefZoomFromPageAndScaleFactors(factor, surfaceScale, backingScale)
+	compensation := wv.pageZoomCompensation()
+	cefLevel := cefZoomFromPageZoom(factor, compensation)
 	logging.FromContext(wv.ctx).Debug().
 		Float64("factor", factor).
 		Float64("cef_level", cefLevel).
-		Float64("osr_backing_scale", backingScale).
+		Float64("page_zoom_compensation", compensation).
 		Float64("surface_scale", surfaceScale).
 		Msg("cef: SetZoomLevel")
-	wv.applyCEFZoomLevel(host, factor, cefLevel, surfaceScale, backingScale)
+	wv.applyZoomForCompensation(host, factor, compensation)
 	wv.zoomFactor.Store(factor)
 	return nil
 }
@@ -1377,6 +1388,7 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 	_ = wv.viewBridge.DetachInput()
 	_ = wv.viewBridge.Destroy()
 	wv.viewBridge = nil
+	wv.zoomCompensation = nil
 	wv.nativeWidget = nil
 	// The bridge actually tore down here (second arrivals return early on
 	// the nil guard above), completing the outstanding teardown exactly once.
@@ -1822,6 +1834,9 @@ func (wv *WebView) viewBridgeScale() float64 {
 	return normalizeScale(float64(wv.viewBridge.DeviceScaleFactor()))
 }
 
+// osrBackingScaleFactor reports the bridge's OSR backing scale used for view,
+// popup, and input geometry. It is 1 when the bridge uses CEF's normal logical
+// OSR contract.
 func (wv *WebView) osrBackingScaleFactor() float64 {
 	if wv == nil || wv.viewBridge == nil {
 		return 1
@@ -1829,23 +1844,50 @@ func (wv *WebView) osrBackingScaleFactor() float64 {
 	return normalizeScale(wv.viewBridge.OSRBackingScaleFactor())
 }
 
-func (wv *WebView) recordAppliedZoomScaleRatio(surfaceScale, backingScale float64) {
+// pageZoomCompensation reports the compensation of the OSR geometry contract
+// currently active in the render bridge. It is 1 when the bridge is missing or
+// uses CEF's normal logical OSR contract, and it must never be persisted: user
+// page zoom stays a user-facing value that survives output and density changes.
+func (wv *WebView) pageZoomCompensation() float64 {
+	if wv == nil || wv.zoomCompensation == nil {
+		return 1
+	}
+	return normalizeScale(wv.zoomCompensation.PageZoomCompensation())
+}
+
+func (wv *WebView) recordAppliedZoomCompensation(compensation float64) {
 	if wv == nil {
 		return
 	}
-	wv.lastAppliedZoomScaleRatioBits.Store(math.Float64bits(zoomScaleRatio(surfaceScale, backingScale)))
+	wv.lastAppliedZoomCompensationBits.Store(math.Float64bits(normalizeScale(compensation)))
 }
 
-func (wv *WebView) shouldReapplyZoomForScaleRatio(surfaceScale, backingScale float64) bool {
+// appliedZoomCompensation returns the compensation of the most recent zoom
+// application, or 0 when no zoom has been applied to the current host.
+func (wv *WebView) appliedZoomCompensation() float64 {
+	if wv == nil {
+		return 0
+	}
+	bits := wv.lastAppliedZoomCompensationBits.Load()
+	if bits == 0 {
+		return 0
+	}
+	return math.Float64frombits(bits)
+}
+
+// shouldReapplyZoomForCompensation reports whether page zoom must be applied
+// again for compensation. An unknown applied compensation always reapplies; an
+// unchanged one never does, so an output transition that keeps the same OSR
+// contract causes no redundant reapplication.
+func (wv *WebView) shouldReapplyZoomForCompensation(compensation float64) bool {
 	if wv == nil {
 		return false
 	}
-	ratio := zoomScaleRatio(surfaceScale, backingScale)
-	bits := wv.lastAppliedZoomScaleRatioBits.Load()
-	if bits == 0 {
+	applied := wv.appliedZoomCompensation()
+	if applied == 0 {
 		return true
 	}
-	return math.Float64frombits(bits) != ratio
+	return applied != normalizeScale(compensation)
 }
 
 func (wv *WebView) handleMiddleClickFromBridge() bool {
@@ -2287,10 +2329,18 @@ func (wv *WebView) scheduleZoomRefresh() {
 //     process the zoom IPC and reflect the new level back to the browser.
 //
 // These values are empirically tuned for CEF's async zoom application.
-func (wv *WebView) scheduleZoomReadback(expectedFactor, expectedLevel float64) {
+//
+// Both readbacks are decoded with the compensation of the application they
+// diagnose and are skipped when a newer application superseded it, so a stale
+// CEF zoom level is never relabelled with a newer compensation.
+func (wv *WebView) scheduleZoomReadback(expectedPageZoom, expectedLevel, compensation float64) {
+	compensation = normalizeScale(compensation)
 	for _, delayMs := range [...]int64{0, 64} {
 		task := cefNewTask(cefTaskFunc(func() {
 			if wv.destroyed.Load() {
+				return
+			}
+			if wv.appliedZoomCompensation() != compensation {
 				return
 			}
 			wv.mu.RLock()
@@ -2300,16 +2350,15 @@ func (wv *WebView) scheduleZoomReadback(expectedFactor, expectedLevel float64) {
 				return
 			}
 			surfaceScale := wv.viewBridgeScale()
-			backingScale := wv.osrBackingScaleFactor()
 			actualLevel := host.GetZoomLevel()
 			logging.FromContext(wv.ctx).Debug().
 				Int64("delay_ms", delayMs).
-				Float64("expected_factor", expectedFactor).
+				Float64("expected_factor", expectedPageZoom).
 				Float64("expected_cef_level", expectedLevel).
-				Float64("actual_factor", pageZoomFromCEFAndScaleLevel(actualLevel, surfaceScale, backingScale)).
+				Float64("actual_factor", pageZoomFromCEFLevel(actualLevel, compensation)).
 				Float64("actual_cef_factor", factorFromCEFZoom(actualLevel)).
 				Float64("actual_cef_level", actualLevel).
-				Float64("osr_backing_scale", backingScale).
+				Float64("page_zoom_compensation", compensation).
 				Float64("surface_scale", surfaceScale).
 				Msg("cef: zoom level readback")
 		}))
@@ -2320,6 +2369,10 @@ func (wv *WebView) scheduleZoomReadback(expectedFactor, expectedLevel float64) {
 	}
 }
 
+// reapplyCurrentZoomForBackingScale reapplies the current user page zoom after
+// the bridge reported a different OSR page-zoom compensation, so the CSS
+// viewport keeps matching the GTK logical view size. User page zoom itself is
+// never mutated by an output transition.
 func (wv *WebView) reapplyCurrentZoomForBackingScale(reason string) {
 	if wv == nil || wv.destroyed.Load() {
 		return
@@ -2330,18 +2383,15 @@ func (wv *WebView) reapplyCurrentZoomForBackingScale(reason string) {
 	if host == nil {
 		return
 	}
-	factor := wv.GetZoomLevel()
-	surfaceScale := wv.viewBridgeScale()
-	backingScale := wv.osrBackingScaleFactor()
-	cefLevel := cefZoomFromPageAndScaleFactors(factor, surfaceScale, backingScale)
-	wv.applyCEFZoomLevel(host, factor, cefLevel, surfaceScale, backingScale)
+	pageZoom := wv.GetZoomLevel()
+	compensation := wv.pageZoomCompensation()
+	wv.applyZoomForCompensation(host, pageZoom, compensation)
 	logging.FromContext(wv.ctx).Debug().
 		Str("reason", reason).
-		Float64("factor", factor).
-		Float64("cef_level", cefLevel).
-		Float64("osr_backing_scale", backingScale).
-		Float64("surface_scale", surfaceScale).
-		Msg("cef: reapplied zoom after OSR backing scale change")
+		Float64("factor", pageZoom).
+		Float64("cef_level", cefZoomFromPageZoom(pageZoom, compensation)).
+		Float64("page_zoom_compensation", compensation).
+		Msg("cef: reapplied zoom after OSR page-zoom compensation change")
 }
 
 func (wv *WebView) scheduleStartBeginFrameLoop() {

--- a/internal/infrastructure/cef/webview.go
+++ b/internal/infrastructure/cef/webview.go
@@ -297,6 +297,7 @@ type WebView struct {
 	audioPlaying                    atomic.Bool
 	zoomFactor                      atomic.Value // float64, initialized to 1.0
 	lastAppliedZoomCompensationBits atomic.Uint64
+	zoomApplicationEpoch            atomic.Uint64
 
 	// Browser creation defaults copied from the factory so native popup shells
 	// can apply the same settings in OnBeforePopup.
@@ -629,11 +630,12 @@ func (wv *WebView) applyZoomForCompensation(host purecef.BrowserHost, pageZoom, 
 	// a new compositor frame at the new zoom level.
 	host.NotifyScreenInfoChanged()
 	wv.recordAppliedZoomCompensation(compensation)
+	epoch := wv.zoomApplicationEpoch.Add(1)
 	// Zoom is applied asynchronously in the renderer process. Request a couple
 	// of follow-up refreshes on the CEF UI thread so OSR captures the updated
 	// compositor frame after the zoom IPC has been processed.
 	wv.scheduleZoomRefresh()
-	wv.scheduleZoomReadback(pageZoom, cefLevel, compensation)
+	wv.scheduleZoomReadback(pageZoom, cefLevel, compensation, epoch)
 }
 
 // factorFromCEFZoom converts a Chromium/CEF logarithmic zoom level back to a
@@ -1387,9 +1389,11 @@ func (wv *WebView) destroyViewBridgeOnGTKThread() {
 	}
 	_ = wv.viewBridge.DetachInput()
 	_ = wv.viewBridge.Destroy()
+	wv.mu.Lock()
 	wv.viewBridge = nil
 	wv.zoomCompensation = nil
 	wv.nativeWidget = nil
+	wv.mu.Unlock()
 	// The bridge actually tore down here (second arrivals return early on
 	// the nil guard above), completing the outstanding teardown exactly once.
 	if wv.engine != nil {
@@ -1849,10 +1853,16 @@ func (wv *WebView) osrBackingScaleFactor() float64 {
 // uses CEF's normal logical OSR contract, and it must never be persisted: user
 // page zoom stays a user-facing value that survives output and density changes.
 func (wv *WebView) pageZoomCompensation() float64 {
-	if wv == nil || wv.zoomCompensation == nil {
+	if wv == nil {
 		return 1
 	}
-	return normalizeScale(wv.zoomCompensation.PageZoomCompensation())
+	wv.mu.RLock()
+	bridge := wv.zoomCompensation
+	wv.mu.RUnlock()
+	if bridge == nil {
+		return 1
+	}
+	return normalizeScale(bridge.PageZoomCompensation())
 }
 
 func (wv *WebView) recordAppliedZoomCompensation(compensation float64) {
@@ -1860,6 +1870,13 @@ func (wv *WebView) recordAppliedZoomCompensation(compensation float64) {
 		return
 	}
 	wv.lastAppliedZoomCompensationBits.Store(math.Float64bits(normalizeScale(compensation)))
+}
+
+func (wv *WebView) clearAppliedZoomCompensation() {
+	if wv == nil {
+		return
+	}
+	wv.lastAppliedZoomCompensationBits.Store(0)
 }
 
 // appliedZoomCompensation returns the compensation of the most recent zoom
@@ -2333,11 +2350,11 @@ func (wv *WebView) scheduleZoomRefresh() {
 // Both readbacks are decoded with the compensation of the application they
 // diagnose and are skipped when a newer application superseded it, so a stale
 // CEF zoom level is never relabelled with a newer compensation.
-func (wv *WebView) scheduleZoomReadback(expectedPageZoom, expectedLevel, compensation float64) {
+func (wv *WebView) scheduleZoomReadback(expectedPageZoom, expectedLevel, compensation float64, epoch uint64) {
 	compensation = normalizeScale(compensation)
 	for _, delayMs := range [...]int64{0, 64} {
 		task := cefNewTask(cefTaskFunc(func() {
-			if wv.destroyed.Load() {
+			if wv.destroyed.Load() || wv.zoomApplicationEpoch.Load() != epoch {
 				return
 			}
 			if wv.appliedZoomCompensation() != compensation {

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -889,7 +889,7 @@ func (h *handlerSet) attachAfterCreatedBrowser(
 
 	h.wv.browser = browser
 	h.wv.host = host
-	h.wv.lastAppliedZoomScaleRatioBits.Store(0)
+	h.wv.lastAppliedZoomCompensationBits.Store(0)
 	h.wv.pendingCreate = nil
 	bridge := h.wv.viewBridge
 	h.wv.inputAttached = bridge == nil
@@ -1007,7 +1007,7 @@ func (h *handlerSet) OnBeforeClose(browser purecef.Browser) {
 	h.wv.mu.Lock()
 	h.wv.browser = nil
 	h.wv.host = nil
-	h.wv.lastAppliedZoomScaleRatioBits.Store(0)
+	h.wv.lastAppliedZoomCompensationBits.Store(0)
 	h.wv.inputAttached = false
 	if h.wv.findCtrl != nil {
 		h.wv.findCtrl.setHost(nil)

--- a/internal/infrastructure/cef/webview_handlers.go
+++ b/internal/infrastructure/cef/webview_handlers.go
@@ -889,7 +889,7 @@ func (h *handlerSet) attachAfterCreatedBrowser(
 
 	h.wv.browser = browser
 	h.wv.host = host
-	h.wv.lastAppliedZoomCompensationBits.Store(0)
+	h.wv.clearAppliedZoomCompensation()
 	h.wv.pendingCreate = nil
 	bridge := h.wv.viewBridge
 	h.wv.inputAttached = bridge == nil
@@ -1007,7 +1007,7 @@ func (h *handlerSet) OnBeforeClose(browser purecef.Browser) {
 	h.wv.mu.Lock()
 	h.wv.browser = nil
 	h.wv.host = nil
-	h.wv.lastAppliedZoomCompensationBits.Store(0)
+	h.wv.clearAppliedZoomCompensation()
 	h.wv.inputAttached = false
 	if h.wv.findCtrl != nil {
 		h.wv.findCtrl.setHost(nil)

--- a/internal/infrastructure/cef/webview_lifecycle_test.go
+++ b/internal/infrastructure/cef/webview_lifecycle_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCef2gtkAdapterPageZoomCompensationDefaultsToOne(t *testing.T) {
+	var nilAdapter *Cef2gtkAdapter
+	require.Equal(t, 1.0, nilAdapter.PageZoomCompensation())
+
+	adapter := &Cef2gtkAdapter{}
+	require.Equal(t, 1.0, adapter.PageZoomCompensation())
+	adapter.destroyed.Store(true)
+	require.Equal(t, 1.0, adapter.PageZoomCompensation())
+}
+
 func TestDestroy_WithHostDefersBridgeDestroyUntilBeforeClose(t *testing.T) {
 	bridge := &Cef2gtkAdapter{}
 	host := &stubBrowserHost{}

--- a/internal/infrastructure/cef/webview_lifecycle_test.go
+++ b/internal/infrastructure/cef/webview_lifecycle_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestCef2gtkAdapterPageZoomCompensationDefaultsToOne(t *testing.T) {
 	var nilAdapter *Cef2gtkAdapter
-	require.Equal(t, 1.0, nilAdapter.PageZoomCompensation())
+	require.InDelta(t, 1.0, nilAdapter.PageZoomCompensation(), 1e-9)
 
 	adapter := &Cef2gtkAdapter{}
-	require.Equal(t, 1.0, adapter.PageZoomCompensation())
+	require.InDelta(t, 1.0, adapter.PageZoomCompensation(), 1e-9)
 	adapter.destroyed.Store(true)
-	require.Equal(t, 1.0, adapter.PageZoomCompensation())
+	require.InDelta(t, 1.0, adapter.PageZoomCompensation(), 1e-9)
 }
 
 func TestDestroy_WithHostDefersBridgeDestroyUntilBeforeClose(t *testing.T) {

--- a/internal/infrastructure/cef/webview_viewport.go
+++ b/internal/infrastructure/cef/webview_viewport.go
@@ -551,7 +551,8 @@ func (wv *WebView) syncZoomForBackingScaleOnCEFUIThread(host purecef.BrowserHost
 	if host == nil || wv == nil {
 		return
 	}
-	if !wv.shouldReapplyZoomForScaleRatio(wv.viewBridgeScale(), wv.osrBackingScaleFactor()) {
+	compensation := wv.pageZoomCompensation()
+	if !wv.shouldReapplyZoomForCompensation(compensation) {
 		return
 	}
 	task := cefNewTask(cefTaskFunc(func() {
@@ -564,9 +565,9 @@ func (wv *WebView) syncZoomForBackingScaleOnCEFUIThread(host purecef.BrowserHost
 		if currentHost != host {
 			return
 		}
-		surfaceScale := wv.viewBridgeScale()
-		backingScale := wv.osrBackingScaleFactor()
-		if !wv.shouldReapplyZoomForScaleRatio(surfaceScale, backingScale) {
+		// Re-check on execution: a newer output scale may have superseded the
+		// compensation captured when this task was scheduled.
+		if !wv.shouldReapplyZoomForCompensation(wv.pageZoomCompensation()) {
 			return
 		}
 		wv.reapplyCurrentZoomForBackingScale(reason)

--- a/internal/infrastructure/cef/webview_viewport_test.go
+++ b/internal/infrastructure/cef/webview_viewport_test.go
@@ -11,8 +11,9 @@ import (
 
 type viewportSyncOrderHost struct {
 	purecef.BrowserHost
-	calls     []string
-	zoomLevel float64
+	calls             []string
+	zoomLevel         float64
+	getZoomLevelCalls int
 }
 
 type pendingBrowserCreateObservedSizeBridgeStub struct {
@@ -61,6 +62,7 @@ func (h *viewportSyncOrderHost) SetZoomLevel(level float64) {
 }
 
 func (h *viewportSyncOrderHost) GetZoomLevel() float64 {
+	h.getZoomLevelCalls++
 	return h.zoomLevel
 }
 
@@ -208,7 +210,7 @@ func TestSyncZoomForBackingScaleOnCEFUIThread_SkipsRedundantReapplyWhenBackingSc
 	}
 
 	host := &viewportSyncOrderHost{}
-	wv := &WebView{ctx: context.Background(), host: host}
+	wv := &WebView{ctx: context.Background(), host: host, zoomCompensation: zoomCompensationStub{compensation: 1.25}}
 
 	wv.syncZoomForBackingScaleOnCEFUIThread(host, "gtk-size-observer")
 	require.NotNil(t, scheduled)
@@ -220,6 +222,89 @@ func TestSyncZoomForBackingScaleOnCEFUIThread_SkipsRedundantReapplyWhenBackingSc
 	wv.syncZoomForBackingScaleOnCEFUIThread(host, "gtk-size-observer")
 	require.Nil(t, scheduled)
 	require.Empty(t, host.calls)
+}
+
+func TestSyncZoomForBackingScaleOnCEFUIThread_ReappliesWhenCompensationChangesWithoutTouchingUserZoom(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled []purecef.Task
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, delayMs int64) int32 {
+		require.Equal(t, purecef.ThreadIDTidUi, threadID)
+		if delayMs == 0 {
+			scheduled = append(scheduled, task)
+		}
+		return 1
+	}
+
+	host := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: host, zoomCompensation: zoomCompensationStub{compensation: 1.25}}
+	wv.zoomFactor.Store(1.3)
+
+	wv.syncZoomForBackingScaleOnCEFUIThread(host, "gtk-size-observer")
+	require.Len(t, scheduled, 1)
+	scheduled[0].Execute()
+	require.InDelta(t, cefZoomFromFactor(1.625), host.zoomLevel, 1e-9)
+
+	// Moving to a different output scale must reapply the same user zoom under the
+	// new compensation and must not mutate the persisted user zoom.
+	host.calls = nil
+	scheduled = nil
+	wv.zoomCompensation = zoomCompensationStub{compensation: 2.0}
+
+	wv.syncZoomForBackingScaleOnCEFUIThread(host, "gtk-size-observer")
+	require.Len(t, scheduled, 1)
+	scheduled[0].Execute()
+	require.InDelta(t, cefZoomFromFactor(2.6), host.zoomLevel, 1e-9)
+	require.InDelta(t, 1.3, wv.GetZoomLevel(), 1e-9, "user zoom must survive an output transition")
+	require.Equal(t, []string{"SetZoomLevel", "NotifyScreenInfoChanged"}, host.calls)
+}
+
+func TestSyncZoomForBackingScaleOnCEFUIThread_SkipsStaleHostAndDestroyedView(t *testing.T) {
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	defer func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	}()
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+
+	var scheduled []purecef.Task
+	cefPostDelayedTask = func(_ purecef.ThreadID, task purecef.Task, _ int64) int32 {
+		scheduled = append(scheduled, task)
+		return 1
+	}
+
+	capturedHost := &viewportSyncOrderHost{}
+	currentHost := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: currentHost, zoomCompensation: zoomCompensationStub{compensation: 1.25}}
+
+	wv.syncZoomForBackingScaleOnCEFUIThread(capturedHost, "host-replaced")
+	require.Len(t, scheduled, 1)
+	scheduled[0].Execute()
+	require.Empty(t, capturedHost.calls)
+	require.Empty(t, currentHost.calls)
+
+	destroyed := &WebView{ctx: context.Background(), host: currentHost, zoomCompensation: zoomCompensationStub{compensation: 1.25}}
+	destroyed.destroyed.Store(true)
+	scheduled = nil
+	destroyed.syncZoomForBackingScaleOnCEFUIThread(currentHost, "destroyed")
+	require.Len(t, scheduled, 1)
+	scheduled[0].Execute()
+	require.Empty(t, currentHost.calls)
+}
+
+func TestSyncZoomForBackingScaleOnCEFUIThread_SkipsMissingHost(t *testing.T) {
+	wv := &WebView{ctx: context.Background(), zoomCompensation: zoomCompensationStub{compensation: 1.25}}
+	wv.syncZoomForBackingScaleOnCEFUIThread(nil, "missing-host")
+	require.Zero(t, wv.appliedZoomCompensation())
 }
 
 func TestNotifyViewportSyncOnCEFUIThread_SkipsStaleHost(t *testing.T) {

--- a/internal/infrastructure/cef/webview_zoom_test.go
+++ b/internal/infrastructure/cef/webview_zoom_test.go
@@ -112,6 +112,10 @@ func TestPageZoomCompensationDefaultsToOneWithoutBridge(t *testing.T) {
 
 	wv.zoomCompensation = zoomCompensationStub{compensation: math.NaN()}
 	assert.InDelta(t, 1.0, wv.pageZoomCompensation(), 1e-9)
+
+	var typedNil *Cef2gtkAdapter
+	wv.zoomCompensation = typedNil
+	assert.InDelta(t, 1.0, wv.pageZoomCompensation(), 1e-9)
 }
 
 // withSynchronousCEFTasks replaces delayed task posting with a recorder so tests
@@ -148,6 +152,7 @@ func TestSetZoomLevelAppliesUserZoomThroughCompensation(t *testing.T) {
 
 	require.NoError(t, wv.SetZoomLevel(context.Background(), 1.3))
 
+	assert.Equal(t, []string{"SetZoomLevel", "NotifyScreenInfoChanged"}, host.calls)
 	assert.InDelta(t, cefZoomFromFactor(1.625), host.zoomLevel, 1e-9, "internal CEF level must include user zoom x compensation")
 	assert.InDelta(t, 1.3, wv.GetZoomLevel(), 1e-9, "user zoom must stay user-facing")
 	assert.InDelta(t, 1.25, wv.appliedZoomCompensation(), 1e-9)
@@ -176,17 +181,21 @@ func TestScheduleZoomReadbackSkipsSupersededApplication(t *testing.T) {
 	wv := &WebView{ctx: context.Background(), host: host}
 
 	wv.recordAppliedZoomCompensation(1.25)
-	wv.scheduleZoomReadback(1.3, cefZoomFromPageZoom(1.3, 1.25), 1.25)
+	firstEpoch := wv.zoomApplicationEpoch.Add(1)
+	wv.scheduleZoomReadback(1.3, cefZoomFromPageZoom(1.3, 1.25), 1.25, firstEpoch)
 	require.Len(t, *scheduled, 2)
 	stale := (*scheduled)[0]
 
 	// A newer application supersedes the pending readback: decoding the newer CEF
 	// level with the older compensation would report a wrong user zoom.
-	wv.recordAppliedZoomCompensation(2.0)
+	wv.recordAppliedZoomCompensation(1.25)
+	wv.zoomApplicationEpoch.Add(1)
 	stale.Execute()
 	assert.Zero(t, host.getZoomLevelCalls, "superseded application must not be diagnosed")
 
-	wv.scheduleZoomReadback(1.3, cefZoomFromPageZoom(1.3, 2.0), 2.0)
+	wv.recordAppliedZoomCompensation(2.0)
+	currentEpoch := wv.zoomApplicationEpoch.Add(1)
+	wv.scheduleZoomReadback(1.3, cefZoomFromPageZoom(1.3, 2.0), 2.0, currentEpoch)
 	require.Len(t, *scheduled, 4)
 	(*scheduled)[2].Execute()
 	assert.Equal(t, 1, host.getZoomLevelCalls, "current application must be diagnosed")

--- a/internal/infrastructure/cef/webview_zoom_test.go
+++ b/internal/infrastructure/cef/webview_zoom_test.go
@@ -1,10 +1,14 @@
 package cef
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"testing"
 
+	purecef "github.com/bnema/purego-cef/cef"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestZoomConversionsRoundTrip(t *testing.T) {
@@ -18,58 +22,172 @@ func TestZoomConversionsRoundTrip(t *testing.T) {
 	}
 }
 
-func TestZoomConversionsCompensateDeviceSizedOSRBackingAndSurfaceScale(t *testing.T) {
+func TestZoomConversionsApplyUserZoomAndCompensation(t *testing.T) {
 	tests := []struct {
 		name         string
-		surfaceScale float64
-		backingScale float64
-		pageZoom     float64
+		userZoom     float64
+		compensation float64
 		wantInternal float64
 	}{
 		{
-			name:         "fractional_hidpi_keeps_100_percent_internal_zoom",
-			surfaceScale: 1.2,
-			backingScale: 1.2,
-			pageZoom:     1.0,
+			name:         "unit_output_needs_no_compensation",
+			userZoom:     1.0,
+			compensation: 1.0,
 			wantInternal: 1.0,
 		},
 		{
-			name:         "integer_hidpi_keeps_requested_user_zoom",
-			surfaceScale: 2.0,
-			backingScale: 2.0,
-			pageZoom:     1.2,
-			wantInternal: 1.2,
+			name:         "user_zoom_on_unit_output",
+			userZoom:     1.3,
+			compensation: 1.0,
+			wantInternal: 1.3,
 		},
 		{
-			name:         "normal_osr_hidpi_keeps_requested_user_zoom",
-			surfaceScale: 1.2,
-			backingScale: 1.0,
-			pageZoom:     1.0,
-			wantInternal: 1.0,
+			name:         "fractional_output_compensates_100_percent",
+			userZoom:     1.0,
+			compensation: 1.25,
+			wantInternal: 1.25,
 		},
 		{
-			name:         "device_sized_backing_remains_compensated",
-			surfaceScale: 1.25,
-			backingScale: 2.0,
-			pageZoom:     1.2,
-			wantInternal: 0.75,
+			name:         "user_zoom_times_fractional_output",
+			userZoom:     1.3,
+			compensation: 1.25,
+			wantInternal: 1.625,
+		},
+		{
+			name:         "application_scale_composed_compensation",
+			userZoom:     1.0,
+			compensation: 1.75,
+			wantInternal: 1.75,
+		},
+		{
+			name:         "integer_output_doubles_internal_factor",
+			userZoom:     2.0,
+			compensation: 2.0,
+			wantInternal: 4.0,
+		},
+		{
+			name:         "half_user_zoom_stays_compensated",
+			userZoom:     0.5,
+			compensation: 1.25,
+			wantInternal: 0.625,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			level := cefZoomFromPageAndScaleFactors(tt.pageZoom, tt.surfaceScale, tt.backingScale)
-			assert.InDelta(t, tt.wantInternal, factorFromCEFZoom(level), 1e-9)
-			assert.InDelta(t, tt.pageZoom, pageZoomFromCEFAndScaleLevel(level, tt.surfaceScale, tt.backingScale), 1e-9)
+			level := cefZoomFromPageZoom(tt.userZoom, tt.compensation)
+			assert.InDelta(t, tt.wantInternal, factorFromCEFZoom(level), 1e-9, "internal CEF factor")
+			assert.InDelta(t, tt.userZoom, pageZoomFromCEFLevel(level, tt.compensation), 1e-9, "inverse must return user zoom")
 		})
 	}
 }
 
-func TestZoomReapplyGuardTracksEffectiveScaleRatio(t *testing.T) {
+func TestZoomConversionsNormalizeInvalidCompensation(t *testing.T) {
+	for _, compensation := range []float64{0, -1.5, math.NaN(), math.Inf(1)} {
+		level := cefZoomFromPageZoom(1.3, compensation)
+		assert.InDelta(t, 1.3, factorFromCEFZoom(level), 1e-9, "invalid compensation %v must behave as 1", compensation)
+		assert.InDelta(t, 1.3, pageZoomFromCEFLevel(level, compensation), 1e-9)
+	}
+}
+
+func TestZoomReapplyGuardTracksAppliedCompensation(t *testing.T) {
 	wv := &WebView{}
 
-	wv.recordAppliedZoomScaleRatio(1.2, 1.2)
+	assert.True(t, wv.shouldReapplyZoomForCompensation(1.25), "unknown applied compensation must reapply")
+	assert.Zero(t, wv.appliedZoomCompensation())
 
-	assert.False(t, wv.shouldReapplyZoomForScaleRatio(2.0, 2.0), "same effective ratio should not reapply")
-	assert.True(t, wv.shouldReapplyZoomForScaleRatio(1.2, 2.0), "changed active-backing ratio should reapply")
+	wv.recordAppliedZoomCompensation(1.25)
+
+	assert.False(t, wv.shouldReapplyZoomForCompensation(1.25), "unchanged compensation must not reapply")
+	assert.True(t, wv.shouldReapplyZoomForCompensation(2.0), "compensation change 1.25 -> 2 must reapply")
+	assert.InDelta(t, 1.25, wv.appliedZoomCompensation(), 1e-9)
+}
+
+func TestPageZoomCompensationDefaultsToOneWithoutBridge(t *testing.T) {
+	wv := &WebView{}
+	assert.InDelta(t, 1.0, wv.pageZoomCompensation(), 1e-9)
+
+	wv.zoomCompensation = zoomCompensationStub{compensation: 1.75}
+	assert.InDelta(t, 1.75, wv.pageZoomCompensation(), 1e-9)
+
+	wv.zoomCompensation = zoomCompensationStub{compensation: math.NaN()}
+	assert.InDelta(t, 1.0, wv.pageZoomCompensation(), 1e-9)
+}
+
+// withSynchronousCEFTasks replaces delayed task posting with a recorder so tests
+// can inspect and run zoom tasks without a CEF message loop.
+func withSynchronousCEFTasks(t *testing.T) *[]purecef.Task {
+	t.Helper()
+	oldNewTask := cefNewTask
+	oldPostDelayedTask := cefPostDelayedTask
+	t.Cleanup(func() {
+		cefNewTask = oldNewTask
+		cefPostDelayedTask = oldPostDelayedTask
+	})
+
+	cefNewTask = func(task purecef.Task) purecef.Task { return task }
+	scheduled := &[]purecef.Task{}
+	cefPostDelayedTask = func(threadID purecef.ThreadID, task purecef.Task, _ int64) int32 {
+		require.Equal(t, purecef.ThreadIDTidUi, threadID)
+		require.NotNil(t, task)
+		*scheduled = append(*scheduled, task)
+		return 1
+	}
+	return scheduled
+}
+
+func TestSetZoomLevelAppliesUserZoomThroughCompensation(t *testing.T) {
+	scheduled := withSynchronousCEFTasks(t)
+
+	host := &viewportSyncOrderHost{}
+	wv := &WebView{
+		ctx:              context.Background(),
+		host:             host,
+		zoomCompensation: zoomCompensationStub{compensation: 1.25},
+	}
+
+	require.NoError(t, wv.SetZoomLevel(context.Background(), 1.3))
+
+	assert.InDelta(t, cefZoomFromFactor(1.625), host.zoomLevel, 1e-9, "internal CEF level must include user zoom x compensation")
+	assert.InDelta(t, 1.3, wv.GetZoomLevel(), 1e-9, "user zoom must stay user-facing")
+	assert.InDelta(t, 1.25, wv.appliedZoomCompensation(), 1e-9)
+	assert.False(t, wv.shouldReapplyZoomForCompensation(1.25))
+	assert.NotEmpty(t, *scheduled)
+
+	// The diagnostic readback decodes the same CEF level back to user zoom with
+	// the compensation of its own application.
+	for _, task := range *scheduled {
+		task.Execute()
+	}
+	assert.InDelta(t, 1.3, pageZoomFromCEFLevel(host.zoomLevel, 1.25), 1e-9)
+}
+
+func TestSetZoomLevelRejectsDestroyedViewAndMissingHost(t *testing.T) {
+	destroyed := &WebView{ctx: context.Background()}
+	destroyed.destroyed.Store(true)
+	require.ErrorIs(t, destroyed.SetZoomLevel(context.Background(), 1.2), errDestroyed)
+
+	require.ErrorIs(t, (&WebView{ctx: context.Background()}).SetZoomLevel(context.Background(), 1.2), errNoBrowser)
+}
+
+func TestScheduleZoomReadbackSkipsSupersededApplication(t *testing.T) {
+	scheduled := withSynchronousCEFTasks(t)
+	host := &viewportSyncOrderHost{}
+	wv := &WebView{ctx: context.Background(), host: host}
+
+	wv.recordAppliedZoomCompensation(1.25)
+	wv.scheduleZoomReadback(1.3, cefZoomFromPageZoom(1.3, 1.25), 1.25)
+	require.Len(t, *scheduled, 2)
+	stale := (*scheduled)[0]
+
+	// A newer application supersedes the pending readback: decoding the newer CEF
+	// level with the older compensation would report a wrong user zoom.
+	wv.recordAppliedZoomCompensation(2.0)
+	stale.Execute()
+	assert.Zero(t, host.getZoomLevelCalls, "superseded application must not be diagnosed")
+
+	wv.scheduleZoomReadback(1.3, cefZoomFromPageZoom(1.3, 2.0), 2.0)
+	require.Len(t, *scheduled, 4)
+	(*scheduled)[2].Execute()
+	assert.Equal(t, 1, host.getZoomLevelCalls, "current application must be diagnosed")
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2452,7 +2452,7 @@ func (a *App) zoomBrowserWindow(ctx context.Context, bw *browserWindow, action s
 	}
 	if wsView := a.activeWorkspaceViewForBrowserWindow(bw); wsView != nil {
 		if paneView := wsView.GetPaneView(paneID); paneView != nil {
-			paneView.ShowZoomToast(ctx, int(newZoom.ZoomFactor*100))
+			paneView.ShowZoomToast(ctx, entity.ZoomPercentage(newZoom.ZoomFactor))
 		}
 	}
 	return nil

--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -2939,10 +2939,10 @@ func (o *Omnibox) UpdateZoomIndicator(factor float64) {
 		if o.zoomLabel == nil {
 			return false
 		}
-		if factor == 1.0 {
+		percentage := entity.ZoomPercentage(factor)
+		if percentage == 100 {
 			o.zoomLabel.SetVisible(false)
 		} else {
-			percentage := int(factor * 100)
 			o.zoomLabel.SetText(fmt.Sprintf("%d%%", percentage))
 			o.zoomLabel.SetVisible(true)
 		}

--- a/internal/ui/dispatcher/keyboard.go
+++ b/internal/ui/dispatcher/keyboard.go
@@ -612,7 +612,7 @@ func (d *KeyboardDispatcher) handleZoom(ctx context.Context, action string) erro
 		d.navCoord.NotifyZoomChanged(ctx, newZoom.ZoomFactor)
 
 		// Show zoom toast on the active pane
-		zoomPercent := int(newZoom.ZoomFactor * 100)
+		zoomPercent := entity.ZoomPercentage(newZoom.ZoomFactor)
 		d.wsCoord.ShowZoomToast(ctx, zoomPercent)
 
 		log.Debug().


### PR DESCRIPTION
## Problem

Dumber derived its internal CEF zoom factor from `surfaceScale / osrBackingScale`. Under the bridge's device-sized OSR backing contract that ratio is always 1, because the same effective scale feeds both terms, so no compensation was ever applied.

Measured on a 3840x2160 output at compositor scale 1.25 (logical 3072x1728), UI scale 1.4, page zoom 100%:

| build | compensation | internal CEF factor | 100 CSS px square, logical |
| --- | --- | --- | --- |
| before | 1.75 | 1.0 | 56.8 px (predicted 57.14) |
| after | 1.75 | 1.75 | 100.0 px |

At UI scale 1.0 the same square rendered 79.2 logical px before the change.

## Change

- Consume the compensation the render bridge owns (`View.PageZoomCompensation`, purego-cef2gtk `feat/page-zoom-compensation`) through a narrow bridge interface instead of deriving it from GTK surface/backing geometry.
- Route `SetZoomLevel` and output-scale reapplication through one calculation/application path, and record the compensation that was actually applied for the reapply guard.
- Decode CEF zoom readback with the compensation of the application it diagnoses, and skip the readback once a newer application supersedes it.
- Derive the scale probe's internal CEF factor from the same contract.
- Round the displayed zoom percentage before integer conversion, so the default zoom no longer displays as 99%.

User page zoom remains a user-facing value: no output transition, density change, or reapplication mutates or persists it. No application port, persistence migration, default zoom change, or compositor/WebKit change is included.

## Dependency

`go.mod` pins `github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e`, the commit that publishes `PageZoomCompensation`. The released version replaces this pre-release pin at the release gate.

## Verification

- `go test ./internal/infrastructure/cef -run 'TestZoomConversions|TestZoomReapplyGuard|TestCEFScaleProbe' -count=1`
- `go test ./internal/domain/entity ./internal/application/usecase ./internal/infrastructure/cef -count=1`
- `make lint`, `make test`, `make check` (standalone, without a Go workspace)
- Runtime matrix: OSR backing auto at UI scale 1.0/1.4 and page zoom 100/130/200%, first presentation only, with a 100x100 CSS-pixel probe page and the bridge scale traces. Measured square sizes match one CSS pixel per GTK logical pixel within one logical pixel of raster rounding.
- Not exercised: moving a window between outputs of different scale at runtime, pointer/menu-anchor interaction, and text selection (input geometry paths are unchanged; they are covered by cef2gtk input tests). Output-scale changes are covered by unit tests using the host seam.

## Rollout

No saved per-site zoom is reset: users may have enlarged pages to compensate for the previous size and may need to adjust it manually. The previous binary and profile stay usable if visual size or input alignment regresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zoom percentages now round correctly, preventing values such as 99% from appearing when zoom is effectively 100%.
  * Zoom levels remain consistent when display scaling changes, while preserving the selected page zoom.
  * Zoom indicators now hide reliably at the default 100% level.

* **Documentation**
  * Clarified how interface scale and webpage zoom settings affect the application and displayed pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->