### PR TITLE
chore(build): require go 1.27

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -51,7 +51,7 @@ jobs:
             "arch=('x86_64')" \
             'url="https://github.com/bnema/dumber"' \
             "license=('MIT')" \
-            "makedepends=('go>=1.26' 'git' 'brotli')" \
+            "makedepends=('go>=1.27' 'git' 'brotli')" \
             "depends=('gtk4' 'cef' 'webkitgtk-6.0')" \
             'optdepends=(' \
             "    'gst-plugins-base: Base media codecs'" \

--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,10 @@ WASM_GOFLAGS?=$(GOFLAGS)
 # Linker flags
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildDate=$(BUILD_DATE)"
 
-# Blessed toolchain for systemview artifacts, read from go.mod so there is
-# exactly one version to bump. The verify-generated CI gate rebuilds these
-# artifacts with setup-go's pinned toolchain: recipe-level GOTOOLCHAIN
-# (not ambient environment) plus GOENV=off (ignore the developer's go env
-# file — e.g. a local GOEXPERIMENT changes runtime codegen) is what makes
-# local builds byte-identical to CI's.
-SYSTEMVIEWS_GOTOOLCHAIN?=$(shell grep '^toolchain ' go.mod | awk '{print $$2}')
+# Systemview artifacts are built with the toolchain that satisfies go.mod's
+# go directive: setup-go's toolchain in CI, the local Go elsewhere. GOENV=off
+# keeps the developer's go env file out of the build (e.g. a local GOEXPERIMENT
+# changes runtime codegen), so one toolchain always yields the same WASM bytes.
 
 # Disable optimizations and inlining for ALL packages. purego callbacks
 # create mixed Go/C stack frames; the Go runtime (stack growth, GC,
@@ -70,15 +67,15 @@ build: build-systemviews verify-systemviews-assets ## Build the application (pur
 
 generate-systemviews: ## Generate Go code from systemviews templ components
 	@echo "Generating systemviews templ components..."
-	GOTOOLCHAIN="$(SYSTEMVIEWS_GOTOOLCHAIN)" GOENV=off go tool templ generate -path internal/ui/systemviews -include-version=false
+	GOENV=off go tool templ generate -path internal/ui/systemviews -include-version=false
 	@echo "Systemviews templ generation complete"
 
 build-systemviews: generate-systemviews ## Build the WASM systemviews runtime
 	@echo "Building systemviews wasm assets..."
 	@command -v brotli >/dev/null 2>&1 || { echo "Error: brotli is required to build compressed systemviews assets. Install brotli and retry."; exit 1; }
 	@mkdir -p assets/systemviews
-	@cp -f "$$(GOTOOLCHAIN="$(SYSTEMVIEWS_GOTOOLCHAIN)" go env GOROOT)/lib/wasm/wasm_exec.js" assets/systemviews/wasm_exec.js
-	GOFLAGS="$(WASM_GOFLAGS)" GOTOOLCHAIN="$(SYSTEMVIEWS_GOTOOLCHAIN)" GOENV=off GOOS=js GOARCH=wasm go build -trimpath -buildvcs=false -ldflags="-s -w" -o assets/systemviews/systemviews.wasm ./cmd/systemviews
+	@cp -f "$$(go env GOROOT)/lib/wasm/wasm_exec.js" assets/systemviews/wasm_exec.js
+	GOFLAGS="$(WASM_GOFLAGS)" GOENV=off GOOS=js GOARCH=wasm go build -trimpath -buildvcs=false -ldflags="-s -w" -o assets/systemviews/systemviews.wasm ./cmd/systemviews
 	brotli -f -o assets/systemviews/systemviews.wasm.br assets/systemviews/systemviews.wasm
 	go run ./cmd/systemviews-assets -dir assets/systemviews
 	@echo "Systemviews build complete"

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Set `ENV=dev` to isolate the development process under `.dev/dumber/`. Dumber se
 
 **Prerequisites:**
 
-- Go 1.26+
+- Go 1.27+
 - GTK4 development packages
 - CEF runtime (default backend)
 - WebKitGTK 6.0 development/runtime packages (fallback backend and runtime checks)

--- a/aur/dumber-browser-git/.SRCINFO
+++ b/aur/dumber-browser-git/.SRCINFO
@@ -5,7 +5,7 @@ pkgbase = dumber-browser-git
 	url = https://github.com/bnema/dumber
 	arch = x86_64
 	license = MIT
-	makedepends = go>=1.26
+	makedepends = go>=1.27
 	makedepends = git
 	makedepends = brotli
 	depends = gtk4

--- a/aur/dumber-browser-git/PKGBUILD
+++ b/aur/dumber-browser-git/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="A minimal keyboard-driven browser for tiling WMs (git version)"
 arch=('x86_64')
 url="https://github.com/bnema/dumber"
 license=('MIT')
-makedepends=('go>=1.26' 'git' 'brotli')
+makedepends=('go>=1.27' 'git' 'brotli')
 depends=('gtk4' 'cef' 'webkitgtk-6.0' 'libwebp')
 optdepends=(
     'gst-plugins-base: Base media codecs'

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,7 +49,7 @@ make build
 
 ### Build Dependencies
 
-- Go 1.26+
+- Go 1.27+
 - GTK4 development libraries
 - CEF runtime for the default backend
 - WebKitGTK 6.0 development/runtime libraries for the fallback backend and runtime checks

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/bnema/dumber
 
-go 1.26.0
-
-toolchain go1.26.7
+go 1.27
 
 require (
 	github.com/a-h/templ v0.3.1020

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,6 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e h1:5gvWSQlaKCI3JALXP/BiDjJftZgMg63cwRew5N+y6kc=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911040156-b806b4fd912e/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1 h1:MBsbM9JuYvGmGyGfF8YQaPsmggnrIJlKdnQDDNOck3Y=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042054-6d0a75439db1/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8 h1:9BtmuhH5raXQKXwI0+owr/iD1oT0hkjCHhS/WUPUiXk=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=


### PR DESCRIPTION
## What

- `go.mod` requires Go 1.27 (`go 1.27`) and no longer pins a `toolchain` patch release, so there is no patch version to bump every couple of months. Systemview WASM artifacts are built with whatever toolchain satisfies that directive: setup-go's toolchain in CI, the local Go elsewhere.
- `go.sum` re-tidied with Go 1.27, which drops four stale `purego-cef2gtk` pseudo-version lines.
- Build requirements state Go 1.27 in `README.md`, `docs/installation.md`, and the AUR metadata (`PKGBUILD`, `.SRCINFO`, AUR publish workflow).
- `Makefile`: removed `SYSTEMVIEWS_GOTOOLCHAIN` and the recipe-level `GOTOOLCHAIN` overrides. `GOENV=off` and `-trimpath` stay, so a given toolchain still yields stable WASM bytes.

## Verification

- `make build-systemviews`, `make build-quick`, `make verify-generated`, `make verify-systemviews-assets` (manifest matches the built artifacts and the compressed WASM agrees)
- `make verify-purego`, `CGO_ENABLED=0 go build ./cmd/dumber`
- `go test ./...` green, plus `go test -count=1` on the assets, cmd, systemviews and usecase packages
- `golangci-lint run` (v2.13.2, built with Go 1.27): 0 issues

## Note

Dropping the `toolchain` line trades byte-identical WASM across Go 1.27.x patches for not tracking a patch version. The `go 1.27` directive still enforces the minimum toolchain.
