### PR TITLE
perf(cef): opt-in BeginFrame from the frame clock and pin the OSR rate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063
+	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911091542-e188b7bfb58d
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911091542-e188b7bfb58d
+	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911095014-8dac8e1fea73
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8
+	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.10.2-0.20260911095014-8dac8e1fea73
+	github.com/bnema/purego-cef2gtk v0.11.0
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iok
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8 h1:9BtmuhH5raXQKXwI0+owr/iD1oT0hkjCHhS/WUPUiXk=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063 h1:zum1q64UkobNeTo11uNErL0FcfBJ6HEEVpi8kU2SpJo=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/go.sum
+++ b/go.sum
@@ -14,12 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8 h1:9BtmuhH5raXQKXwI0+owr/iD1oT0hkjCHhS/WUPUiXk=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063 h1:zum1q64UkobNeTo11uNErL0FcfBJ6HEEVpi8kU2SpJo=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911091542-e188b7bfb58d h1:zKRn+VsS+lI0CbKlAC5uviyVQsw4hdKBOueJ7qiy+O0=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911091542-e188b7bfb58d/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911095014-8dac8e1fea73 h1:0dC27qHOb8avbXpmQLqUEQ1QOC9U3wy5q7OTv+sVZtU=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911095014-8dac8e1fea73/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911095014-8dac8e1fea73 h1:0dC27qHOb8avbXpmQLqUEQ1QOC9U3wy5q7OTv+sVZtU=
-github.com/bnema/purego-cef2gtk v0.10.2-0.20260911095014-8dac8e1fea73/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.11.0 h1:imn2AzfqXijtWw1NXE4E7niIja7itKQATDS/JPAEGPw=
+github.com/bnema/purego-cef2gtk v0.11.0/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8 h1:9BtmuhH
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911042437-e9e81371d3b8/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063 h1:zum1q64UkobNeTo11uNErL0FcfBJ6HEEVpi8kU2SpJo=
 github.com/bnema/purego-cef2gtk v0.10.2-0.20260911065409-4c5c8b591063/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911091542-e188b7bfb58d h1:zKRn+VsS+lI0CbKlAC5uviyVQsw4hdKBOueJ7qiy+O0=
+github.com/bnema/purego-cef2gtk v0.10.2-0.20260911091542-e188b7bfb58d/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=

--- a/internal/infrastructure/cef/adaptive_frame_rate.go
+++ b/internal/infrastructure/cef/adaptive_frame_rate.go
@@ -23,6 +23,16 @@ func adaptiveFrameRateForRefresh(refreshRateMilliHz int, fallbackFPS, maxFPS int
 	})
 }
 
+// resolveWindowlessFrameRate applies a pinned rate on top of the configured OSR
+// frame rate. A pinned rate wins over both the configured value and the adaptive
+// monitor polling, which is suspended so the pinned cadence is what CEF keeps.
+func resolveWindowlessFrameRate(configRate int32, adaptive bool) (int32, bool) {
+	if pinned, ok := windowlessFrameRateOverride(); ok {
+		return pinned, false
+	}
+	return normalizedWindowlessFrameRate(configRate), adaptive
+}
+
 func (wv *WebView) scheduleStartAdaptiveFrameRatePolling() {
 	if wv == nil || !wv.adaptiveWindowlessFrameRate {
 		return

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -50,7 +50,7 @@ func NewEngine(
 		logger.Warn().Str("state_root", stateRoot).Msg("cef: applying next-start GPU safety recovery")
 	}
 	cleanStaleSingletonLocks(logger, stateRoot)
-	windowlessFrameRate := normalizedWindowlessFrameRate(cfg.WindowlessFrameRate)
+	windowlessFrameRate, adaptiveWindowlessFrameRate := resolveWindowlessFrameRate(cfg.WindowlessFrameRate, cfg.AdaptiveWindowlessFrameRate)
 	renderStackPlan, err := resolveCEFRenderStackPlan(cfg.RenderStack)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func NewEngine(
 		ctx,
 		eng,
 		webViewFactoryOptions{
-			adaptiveWindowlessFrameRate: cfg.AdaptiveWindowlessFrameRate,
+			adaptiveWindowlessFrameRate: adaptiveWindowlessFrameRate,
 			windowlessFrameRate:         windowlessFrameRate,
 			windowlessFrameRateMax:      cfg.WindowlessFrameRateMax,
 			inputConfig:                 cfg.Input,

--- a/internal/infrastructure/cef/engine_init.go
+++ b/internal/infrastructure/cef/engine_init.go
@@ -89,6 +89,7 @@ func NewEngine(
 
 	logger.Info().
 		Int32("windowless_frame_rate", windowlessFrameRate).
+		Bool("windowless_frame_rate_pinned", windowlessFrameRatePinned()).
 		Str("render_stack", string(renderStackPlan.Stack)).
 		Str("render_backend", renderStackPlan.Backend.String()).
 		Str("angle_backend", renderStackPlan.ANGLEBackend).

--- a/internal/infrastructure/cef/env.go
+++ b/internal/infrastructure/cef/env.go
@@ -2,11 +2,13 @@ package cef
 
 import (
 	"os"
+	"strconv"
 	"strings"
 )
 
 const (
 	cefExternalBeginFrameEnvVar   = "DUMBER_CEF_EXTERNAL_BEGIN_FRAME"
+	cefWindowlessFrameRateEnvVar  = "DUMBER_CEF_WINDOWLESS_FRAME_RATE"
 	cefEnableWebAuthnUnsafeEnvVar = "DUMBER_CEF_ENABLE_WEBAUTHN_UNSAFE"
 	cefChromiumFlagsEnvVar        = "DUMBER_CEF_CHROMIUM_FLAGS"
 	cefEnableVAAPIEnvVar          = "DUMBER_CEF_ENABLE_VAAPI"
@@ -28,8 +30,31 @@ func envBoolEnabled(envVar string) bool {
 	}
 }
 
+// externalBeginFrameEnabled reports whether CEF produces frames on BeginFrame
+// ticks driven by the GTK frame clock instead of its own timer. It is enabled by
+// default; a falsy value restores CEF's internal cadence.
 func externalBeginFrameEnabled() bool {
-	return envBoolEnabled(cefExternalBeginFrameEnvVar)
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(cefExternalBeginFrameEnvVar))) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// windowlessFrameRateOverride returns an explicitly pinned OSR frame rate. A
+// pinned rate takes precedence over the configured value and disables adaptive
+// monitor-refresh polling, so a run can be compared at a single cadence.
+func windowlessFrameRateOverride() (int32, bool) {
+	raw := strings.TrimSpace(os.Getenv(cefWindowlessFrameRateEnvVar))
+	if raw == "" {
+		return 0, false
+	}
+	rate, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || rate <= 0 {
+		return 0, false
+	}
+	return int32(rate), true
 }
 
 func cefWebAuthnUnsafeEnabled() bool {

--- a/internal/infrastructure/cef/env.go
+++ b/internal/infrastructure/cef/env.go
@@ -53,6 +53,13 @@ func windowlessFrameRateOverride() (int32, bool) {
 	return int32(rate), true
 }
 
+// windowlessFrameRatePinned reports whether the environment pins the OSR frame
+// rate, which also suspends adaptive monitor-refresh polling.
+func windowlessFrameRatePinned() bool {
+	_, pinned := windowlessFrameRateOverride()
+	return pinned
+}
+
 func cefWebAuthnUnsafeEnabled() bool {
 	return envBoolEnabled(cefEnableWebAuthnUnsafeEnvVar)
 }

--- a/internal/infrastructure/cef/env.go
+++ b/internal/infrastructure/cef/env.go
@@ -31,15 +31,11 @@ func envBoolEnabled(envVar string) bool {
 }
 
 // externalBeginFrameEnabled reports whether CEF produces frames on BeginFrame
-// ticks driven by the GTK frame clock instead of its own timer. It is enabled by
-// default; a falsy value restores CEF's internal cadence.
+// ticks driven by the GTK frame clock instead of its own timer. It is opt-in:
+// only an explicit true value enables it, and unset, empty or invalid values
+// leave CEF's internal cadence in place.
 func externalBeginFrameEnabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(cefExternalBeginFrameEnvVar))) {
-	case "0", "false", "no", "off":
-		return false
-	default:
-		return true
-	}
+	return envBoolEnabled(cefExternalBeginFrameEnvVar)
 }
 
 // windowlessFrameRateOverride returns an explicitly pinned OSR frame rate. A

--- a/internal/infrastructure/cef/env.go
+++ b/internal/infrastructure/cef/env.go
@@ -31,11 +31,21 @@ func envBoolEnabled(envVar string) bool {
 }
 
 // externalBeginFrameEnabled reports whether CEF produces frames on BeginFrame
-// ticks driven by the GTK frame clock instead of its own timer. It is opt-in:
-// only an explicit true value enables it, and unset, empty or invalid values
-// leave CEF's internal cadence in place.
+// ticks driven by the GTK frame clock instead of its own timer. It is enabled by
+// default: the embedder's frame clock is the cadence the compositor samples, so
+// asking CEF for a frame on each tick aligns production with presentation. A
+// falsy value restores CEF's internal cadence.
+//
+// This is an experimental default under observation: the tick loop requests a
+// frame on every tick regardless of the configured capture rate, and no
+// frame-timing measurement yet shows an improvement over CEF's own timer.
 func externalBeginFrameEnabled() bool {
-	return envBoolEnabled(cefExternalBeginFrameEnvVar)
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(cefExternalBeginFrameEnvVar))) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
 }
 
 // windowlessFrameRateOverride returns an explicitly pinned OSR frame rate. A

--- a/internal/infrastructure/cef/env_test.go
+++ b/internal/infrastructure/cef/env_test.go
@@ -2,24 +2,26 @@ package cef
 
 import "testing"
 
-func TestExternalBeginFrameEnabledIsOptIn(t *testing.T) {
+func TestExternalBeginFrameEnabledIsOnByDefault(t *testing.T) {
 	tests := []struct {
 		name  string
 		value string
 		want  bool
 	}{
+		{name: "unset", value: "", want: true},
+		{name: "blank", value: "  ", want: true},
 		{name: "1", value: "1", want: true},
 		{name: "true", value: "true", want: true},
 		{name: "yes", value: "yes", want: true},
 		{name: "on", value: "on", want: true},
 		{name: "TRUE", value: "TRUE", want: true},
 		{name: "  true  ", value: "  true  ", want: true},
-		{name: "", value: "", want: false},
-		{name: "false", value: "false", want: false},
+		{name: "random enables", value: "random", want: true},
 		{name: "0", value: "0", want: false},
+		{name: "false", value: "false", want: false},
 		{name: "no", value: "no", want: false},
 		{name: "off", value: "off", want: false},
-		{name: "random", value: "random", want: false},
+		{name: "OFF", value: "OFF", want: false},
 	}
 
 	for _, tt := range tests {

--- a/internal/infrastructure/cef/env_test.go
+++ b/internal/infrastructure/cef/env_test.go
@@ -26,8 +26,8 @@ func TestExternalBeginFrameEnabledIsOptIn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(cefExternalBeginFrameEnvVar, tt.value)
 
-			if got := envBoolEnabled(cefExternalBeginFrameEnvVar); got != tt.want {
-				t.Fatalf("envBoolEnabled(%q) = %v, want %v", tt.value, got, tt.want)
+			if got := externalBeginFrameEnabled(); got != tt.want {
+				t.Fatalf("externalBeginFrameEnabled(%q) = %v, want %v", tt.value, got, tt.want)
 			}
 		})
 	}

--- a/internal/infrastructure/cef/render_diagnostics.go
+++ b/internal/infrastructure/cef/render_diagnostics.go
@@ -102,6 +102,9 @@ func (wv *WebView) logRenderDiagnosticSnapshot(
 		Int("pending_reschedules", diag.PendingReschedules).
 		Int("pending_schedule_failures", diag.PendingScheduleFailures).
 		Int("pending_idle_callbacks", diag.PendingIdleCallbacks).
+		Bool("gdk_offload_requested", diag.OffloadRequested).
+		Int("gdk_import_priority", diag.ImportPriority).
+		Int("gdk_retire_limit", diag.RetireLimit).
 		Int32("surface_width", width).
 		Int32("surface_height", height).
 		Float32("surface_scale", scale).

--- a/internal/infrastructure/cef/render_diagnostics.go
+++ b/internal/infrastructure/cef/render_diagnostics.go
@@ -103,6 +103,7 @@ func (wv *WebView) logRenderDiagnosticSnapshot(
 		Int("pending_schedule_failures", diag.PendingScheduleFailures).
 		Int("pending_idle_callbacks", diag.PendingIdleCallbacks).
 		Bool("gdk_offload_requested", diag.OffloadRequested).
+		Bool("gdk_offload_installed", diag.OffloadInstalled).
 		Int("gdk_import_priority", diag.ImportPriority).
 		Int("gdk_retire_limit", diag.RetireLimit).
 		Int32("surface_width", width).

--- a/internal/infrastructure/cef/render_experiment_test.go
+++ b/internal/infrastructure/cef/render_experiment_test.go
@@ -1,0 +1,56 @@
+package cef
+
+import "testing"
+
+func TestResolveWindowlessFrameRatePrefersAPinnedRate(t *testing.T) {
+	t.Setenv(cefWindowlessFrameRateEnvVar, "")
+
+	rate, adaptive := resolveWindowlessFrameRate(0, true)
+	if rate != defaultCEFWindowlessFrameRate || !adaptive {
+		t.Fatalf("unpinned resolve = (%d, %v), want (%d, true)", rate, adaptive, defaultCEFWindowlessFrameRate)
+	}
+
+	rate, adaptive = resolveWindowlessFrameRate(90, true)
+	if rate != 90 || !adaptive {
+		t.Fatalf("configured resolve = (%d, %v), want (90, true)", rate, adaptive)
+	}
+
+	t.Setenv(cefWindowlessFrameRateEnvVar, "144")
+	rate, adaptive = resolveWindowlessFrameRate(0, true)
+	if rate != 144 || adaptive {
+		t.Fatalf("pinned resolve = (%d, %v), want (144, false)", rate, adaptive)
+	}
+
+	t.Setenv(cefWindowlessFrameRateEnvVar, "not-a-rate")
+	rate, adaptive = resolveWindowlessFrameRate(0, true)
+	if rate != defaultCEFWindowlessFrameRate || !adaptive {
+		t.Fatalf("unparsable pin resolve = (%d, %v), want the configured fallback", rate, adaptive)
+	}
+
+	t.Setenv(cefWindowlessFrameRateEnvVar, "0")
+	rate, adaptive = resolveWindowlessFrameRate(60, true)
+	if rate != 60 || !adaptive {
+		t.Fatalf("zero pin resolve = (%d, %v), want (60, true)", rate, adaptive)
+	}
+}
+
+func TestExternalBeginFrameIsEnabledByDefault(t *testing.T) {
+	t.Setenv(cefExternalBeginFrameEnvVar, "")
+	if !externalBeginFrameEnabled() {
+		t.Fatal("external begin frame should be enabled by default")
+	}
+
+	for _, value := range []string{"0", "false", "no", "off", "OFF"} {
+		t.Setenv(cefExternalBeginFrameEnvVar, value)
+		if externalBeginFrameEnabled() {
+			t.Fatalf("external begin frame enabled for %q, want disabled", value)
+		}
+	}
+
+	for _, value := range []string{"1", "true", "yes", "on"} {
+		t.Setenv(cefExternalBeginFrameEnvVar, value)
+		if !externalBeginFrameEnabled() {
+			t.Fatalf("external begin frame disabled for %q, want enabled", value)
+		}
+	}
+}

--- a/internal/infrastructure/cef/render_experiment_test.go
+++ b/internal/infrastructure/cef/render_experiment_test.go
@@ -3,7 +3,63 @@ package cef
 import (
 	"strconv"
 	"testing"
+
+	purecef "github.com/bnema/purego-cef/cef"
 )
+
+func TestWindowlessFrameRatePinnedFollowsTheOverride(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{value: "", want: false},
+		{value: "60", want: true},
+		{value: " 144 ", want: true},
+		{value: "0", want: false},
+		{value: "-60", want: false},
+		{value: "many", want: false},
+		{value: strconv.FormatInt(int64(1)<<40, 10), want: false},
+	}
+	for _, testCase := range cases {
+		t.Run("pin:"+testCase.value, func(t *testing.T) {
+			t.Setenv(cefWindowlessFrameRateEnvVar, testCase.value)
+			if got := windowlessFrameRatePinned(); got != testCase.want {
+				t.Fatalf("windowlessFrameRatePinned(%q) = %v, want %v", testCase.value, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestConfigureNativePopupWindowKeepsExternalBeginFrameOptIn(t *testing.T) {
+	// The pin is only worth asserting through a real call site: the inverted
+	// default shipped because only the boolean helper was covered.
+	cases := []struct {
+		value string
+		want  int32
+	}{
+		{value: "", want: 0},
+		{value: "0", want: 0},
+		{value: "false", want: 0},
+		{value: "random", want: 0},
+		{value: "1", want: 1},
+		{value: "true", want: 1},
+		{value: "on", want: 1},
+	}
+	for _, testCase := range cases {
+		t.Run("call-site:"+testCase.value, func(t *testing.T) {
+			t.Setenv(cefExternalBeginFrameEnvVar, testCase.value)
+			windowInfo := purecef.NewWindowInfo()
+			settings := purecef.NewBrowserSettings()
+
+			configureNativePopupWindow(&windowInfo, &settings, 60)
+
+			if windowInfo.ExternalBeginFrameEnabled != testCase.want {
+				t.Fatalf("ExternalBeginFrameEnabled with %q = %d, want %d",
+					testCase.value, windowInfo.ExternalBeginFrameEnabled, testCase.want)
+			}
+		})
+	}
+}
 
 func TestResolveWindowlessFrameRatePrefersAPinnedRate(t *testing.T) {
 	t.Setenv(cefWindowlessFrameRateEnvVar, "")

--- a/internal/infrastructure/cef/render_experiment_test.go
+++ b/internal/infrastructure/cef/render_experiment_test.go
@@ -1,6 +1,9 @@
 package cef
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func TestResolveWindowlessFrameRatePrefersAPinnedRate(t *testing.T) {
 	t.Setenv(cefWindowlessFrameRateEnvVar, "")
@@ -13,6 +16,11 @@ func TestResolveWindowlessFrameRatePrefersAPinnedRate(t *testing.T) {
 	rate, adaptive = resolveWindowlessFrameRate(90, true)
 	if rate != 90 || !adaptive {
 		t.Fatalf("configured resolve = (%d, %v), want (90, true)", rate, adaptive)
+	}
+
+	rate, adaptive = resolveWindowlessFrameRate(90, false)
+	if rate != 90 || adaptive {
+		t.Fatalf("non-adaptive resolve = (%d, %v), want (90, false)", rate, adaptive)
 	}
 
 	t.Setenv(cefWindowlessFrameRateEnvVar, "144")
@@ -32,25 +40,17 @@ func TestResolveWindowlessFrameRatePrefersAPinnedRate(t *testing.T) {
 	if rate != 60 || !adaptive {
 		t.Fatalf("zero pin resolve = (%d, %v), want (60, true)", rate, adaptive)
 	}
-}
 
-func TestExternalBeginFrameIsEnabledByDefault(t *testing.T) {
-	t.Setenv(cefExternalBeginFrameEnvVar, "")
-	if !externalBeginFrameEnabled() {
-		t.Fatal("external begin frame should be enabled by default")
+	t.Setenv(cefWindowlessFrameRateEnvVar, "-60")
+	rate, adaptive = resolveWindowlessFrameRate(60, true)
+	if rate != 60 || !adaptive {
+		t.Fatalf("negative pin resolve = (%d, %v), want (60, true)", rate, adaptive)
 	}
 
-	for _, value := range []string{"0", "false", "no", "off", "OFF"} {
-		t.Setenv(cefExternalBeginFrameEnvVar, value)
-		if externalBeginFrameEnabled() {
-			t.Fatalf("external begin frame enabled for %q, want disabled", value)
-		}
-	}
-
-	for _, value := range []string{"1", "true", "yes", "on"} {
-		t.Setenv(cefExternalBeginFrameEnvVar, value)
-		if !externalBeginFrameEnabled() {
-			t.Fatalf("external begin frame disabled for %q, want enabled", value)
-		}
+	overflow := strconv.FormatInt(int64(1)<<40, 10)
+	t.Setenv(cefWindowlessFrameRateEnvVar, overflow)
+	rate, adaptive = resolveWindowlessFrameRate(60, true)
+	if rate != 60 || !adaptive {
+		t.Fatalf("overflowing pin resolve = (%d, %v), want (60, true)", rate, adaptive)
 	}
 }

--- a/internal/infrastructure/cef/render_experiment_test.go
+++ b/internal/infrastructure/cef/render_experiment_test.go
@@ -30,20 +30,21 @@ func TestWindowlessFrameRatePinnedFollowsTheOverride(t *testing.T) {
 	}
 }
 
-func TestConfigureNativePopupWindowKeepsExternalBeginFrameOptIn(t *testing.T) {
-	// The pin is only worth asserting through a real call site: the inverted
-	// default shipped because only the boolean helper was covered.
+func TestConfigureNativePopupWindowEnablesExternalBeginFrameByDefault(t *testing.T) {
+	// The default is only worth asserting through a real call site: an inverted
+	// default shipped before because only the boolean helper was covered.
 	cases := []struct {
 		value string
 		want  int32
 	}{
-		{value: "", want: 0},
-		{value: "0", want: 0},
-		{value: "false", want: 0},
-		{value: "random", want: 0},
+		{value: "", want: 1},
 		{value: "1", want: 1},
 		{value: "true", want: 1},
 		{value: "on", want: 1},
+		{value: "random", want: 1},
+		{value: "0", want: 0},
+		{value: "false", want: 0},
+		{value: "off", want: 0},
 	}
 	for _, testCase := range cases {
 		t.Run("call-site:"+testCase.value, func(t *testing.T) {


### PR DESCRIPTION
## What this changes

Pins `purego-cef2gtk` v0.11.0, which carries the presenter and batching work,
and drives CEF BeginFrame from the GTK frame clock by default.

| Change | Default | Turn on/off with |
| --- | --- | --- |
| CEF produces frames on BeginFrame ticks driven by the GTK frame clock instead of its own timer | **on** (opt-out) | `DUMBER_CEF_EXTERNAL_BEGIN_FRAME=0` restores CEF's internal cadence |
| CEF's OSR frame rate can be pinned instead of following the monitor refresh | off (adaptive) | `DUMBER_CEF_WINDOWLESS_FRAME_RATE=<fps>` |

`externalBeginFrameEnabled` is enabled by default: the embedder's frame clock is
the cadence the compositor samples, so CEF is asked for a frame on each tick
instead of running its own timer in parallel. A falsy value (`0`, `false`, `no`,
`off`) restores CEF's internal cadence, and the call-site test asserts that
default through `configureNativePopupWindow` rather than only through the helper.

`DUMBER_CEF_WINDOWLESS_FRAME_RATE` takes precedence over the configured value and
over adaptive monitor polling, so a run can be held at one cadence without
editing the config file. A valid positive integer wins; unparsable, zero,
negative and overflowing values fall back to the configured behaviour, where a
configured `windowless_frame_rate` still disables adaptive polling on its own.
That pin selects how often CEF is asked to capture frames; it is independent of
the external BeginFrame request rate. Because a pin also suspends adaptive
polling, the `cef: configured engine` startup line now reports
`windowless_frame_rate_pinned` next to the rate it resolves to.

The render diagnostic snapshot reports the effective GDK render path: whether
offload was requested, whether the wrapper was installed, the import priority and
the retire limit.

## Not included, not verified

- No frame-timing evidence for the BeginFrame default. Driving frame production
  from the tick is enabled for observation, not because a measurement showed a
  win: the tick loop requests a frame on every tick regardless of the configured
  capture rate, so the default can be reverted to opt-in by changing one helper
  without touching the implementation.
- No ownership change. The bridge still presents a borrowed DMA-BUF that CEF
  releases to its pool when the callback returns.
- No pacing state machine and no demand-driven frame requests.
- No frame-timing or physical-FPS result.

## Operator validation

A manual session on the pinned build: continuous wheel scrolling on ordinary
pages no longer drives a single process past roughly 20-30% CPU, scrolling feels
fluid and no visual artefact was noticed.

A playback-only A/B against a build of the previous revision stayed in the same
envelope — about 26 to 29% of one core for the whole browser process tree and
about 1.6 to 1.7 GB PSS while the media engine decoded 4K at ~40% average — so
the playback comparison is inconclusive and no gain is claimed from it. The
scroll observation is a judgement plus process-level counters, not a frame-timing
measurement.

## Tests

- `go test ./internal/infrastructure/cef ./internal/infrastructure/config` clean;
  `make lint` reports 0 issues; `-race` clean on the CEF package.
- New coverage: the `configureNativePopupWindow` call site for the default and
  the opt-out of BeginFrame, the pinned-rate state used by the startup log
  (positive, padded, zero, negative, overflowing, unparsable), and
  windowless-rate resolution with the configured fallback.
- The bridge half of these changes is merged and released as
  `purego-cef2gtk` v0.11.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an environment setting to pin the windowless rendering frame rate.
  * Pinned frame rates disable adaptive polling; invalid values continue using the configured defaults.
  * Startup diagnostics now indicate whether the frame rate is pinned.

* **Diagnostics**
  * Expanded rendering diagnostics with additional graphics offload, import priority, and retirement limit details.

* **Tests**
  * Added coverage for frame-rate overrides and external frame-generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



