### PR TITLE
fix(omnibox): preserve submit during async paste

### DIFF
--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -1202,21 +1202,22 @@ func (o *Omnibox) onEntryChanged() {
 
 	entryText := o.entry.GetText()
 
-	// Detect debounced echo from our own SetText in setGhostText.
-	// search-changed is debounced by GtkSearchEntry, so it fires AFTER
-	// the isSettingGhost guard is already off. Such self-inflicted
-	// notifications must not consume a paste deferred while GTK is still
-	// reading the clipboard.
-	o.mu.RLock()
-	ghostEcho := o.ghostSuffix != "" && entryText == o.realInput+o.ghostSuffix
-	o.mu.RUnlock()
-	if ghostEcho {
-		return
-	}
-
 	o.mu.Lock()
 	deferredSubmit := o.pasteSubmit.textChanged()
 	o.mu.Unlock()
+
+	// Detect debounced echo from our own SetText in setGhostText.
+	// search-changed is debounced by GtkSearchEntry, so it fires AFTER
+	// the isSettingGhost guard is already off. A self-inflicted notification
+	// must leave the ghost state untouched, but it cannot be told apart from a
+	// paste that replaced the selected ghost suffix with the same text, so a
+	// deferred Enter always wins and the ghost state is rebuilt from the paste.
+	o.mu.RLock()
+	ghostEcho := o.ghostSuffix != "" && entryText == o.realInput+o.ghostSuffix
+	o.mu.RUnlock()
+	if ghostEcho && !deferredSubmit {
+		return
+	}
 
 	log := logging.FromContext(o.ctx)
 	if trimmed := url.TrimLeadingSpacesIfURL(entryText); trimmed != entryText {

--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -52,6 +52,44 @@ type favoriteToggleResultUpdate struct {
 	IsFavorite bool
 }
 
+type pasteSubmissionState struct {
+	active        bool
+	initialText   string
+	deferredEnter bool
+}
+
+func (s *pasteSubmissionState) beginPaste(text string) {
+	s.active = true
+	s.initialText = text
+	s.deferredEnter = false
+}
+
+func (s *pasteSubmissionState) requestSubmit(text string) (submit, pastedTextReady bool) {
+	if !s.active {
+		return true, false
+	}
+	if text == s.initialText {
+		s.deferredEnter = true
+		return false, false
+	}
+	s.active = false
+	return true, true
+}
+
+func (s *pasteSubmissionState) textChanged(text string) bool {
+	if !s.active || text == s.initialText {
+		return false
+	}
+	s.active = false
+	deferred := s.deferredEnter
+	s.deferredEnter = false
+	return deferred
+}
+
+func (s *pasteSubmissionState) reset() {
+	*s = pasteSubmissionState{}
+}
+
 // ViewMode distinguishes history search from favorites display.
 type ViewMode string
 
@@ -119,6 +157,7 @@ type Omnibox struct {
 	ghostSuffix      string // Completion suffix currently displayed
 	insertCompletion bool   // True on character insert, false on delete — gates ghost completion
 	isSettingGhost   bool   // Guard flag: skip onEntryChanged during programmatic SetText
+	pasteSubmit      pasteSubmissionState
 
 	// Dependencies
 	historyUC              *usecase.SearchHistoryUseCase
@@ -648,6 +687,16 @@ func (o *Omnibox) setupKeyboardHandling() {
 	controller.SetPropagationPhase(gtk.PhaseCaptureValue)
 
 	keyPressedCb := func(_ gtk.EventControllerKey, keyval, keycode uint, state gdk.ModifierType) bool {
+		if isPasteShortcut(keyval, state) && o.entry != nil {
+			entryText := o.entry.GetText()
+			o.mu.Lock()
+			o.pasteSubmit.beginPaste(entryText)
+			o.mu.Unlock()
+		} else if keyval != uint(gdk.KEY_Return) && keyval != uint(gdk.KEY_KP_Enter) {
+			o.mu.Lock()
+			o.pasteSubmit.reset()
+			o.mu.Unlock()
+		}
 		if o.handleKeyPress(keyval, keycode, state) {
 			return true
 		}
@@ -985,7 +1034,7 @@ func (o *Omnibox) handleKeyPress(keyval, keycode uint, state gdk.ModifierType) b
 		}
 
 	case uint(gdk.KEY_Return), uint(gdk.KEY_KP_Enter):
-		o.navigateToSelected()
+		o.handleSubmitKeyPress()
 		return true
 
 	case uint(gdk.KEY_Up):
@@ -1034,6 +1083,30 @@ func (o *Omnibox) handleKeyPress(keyval, keycode uint, state gdk.ModifierType) b
 	}
 
 	return false // Let entry handle the key
+}
+
+func (o *Omnibox) handleSubmitKeyPress() {
+	if o.entry == nil {
+		return
+	}
+	entryText := o.entry.GetText()
+	o.mu.Lock()
+	shouldSubmit, pastedTextReady := o.pasteSubmit.requestSubmit(entryText)
+	if pastedTextReady {
+		o.selectedIndex = -1
+		o.hasNavigated = false
+	}
+	o.mu.Unlock()
+	if shouldSubmit {
+		o.navigateToSelected()
+	}
+}
+
+func isPasteShortcut(keyval uint, state gdk.ModifierType) bool {
+	ctrl := state&gdk.ControlMaskValue != 0
+	shift := state&gdk.ShiftMaskValue != 0
+	return (ctrl && (keyval == uint(gdk.KEY_v) || keyval == uint(gdk.KEY_V))) ||
+		(shift && keyval == uint(gdk.KEY_Insert))
 }
 
 func isDeletionKey(keyval uint) bool {
@@ -1116,6 +1189,9 @@ func (o *Omnibox) onEntryChanged() {
 	}
 
 	entryText := o.entry.GetText()
+	o.mu.Lock()
+	deferredSubmit := o.pasteSubmit.textChanged(entryText)
+	o.mu.Unlock()
 
 	// Detect debounced echo from our own SetText in setGhostText.
 	// search-changed is debounced by GtkSearchEntry, so it fires AFTER
@@ -1145,6 +1221,11 @@ func (o *Omnibox) onEntryChanged() {
 	o.realInput = entryText
 	shouldComplete := o.insertCompletion
 	o.mu.Unlock()
+
+	if deferredSubmit {
+		o.navigateToSelected()
+		return
+	}
 
 	log.Debug().
 		Str("entryText", entryText).
@@ -2803,6 +2884,7 @@ func (o *Omnibox) Show(ctx context.Context, query string) {
 	o.ghostSuffix = ""
 
 	o.insertCompletion = false
+	o.pasteSubmit.reset()
 	o.mu.Unlock()
 
 	// Set initial query
@@ -2888,6 +2970,7 @@ func (o *Omnibox) Hide(ctx context.Context) {
 	o.mu.Lock()
 	o.realInput = ""
 	o.insertCompletion = false
+	o.pasteSubmit.reset()
 	o.mu.Unlock()
 	o.resetSearchSessionState()
 

--- a/internal/ui/component/omnibox.go
+++ b/internal/ui/component/omnibox.go
@@ -52,18 +52,25 @@ type favoriteToggleResultUpdate struct {
 	IsFavorite bool
 }
 
+// pasteSubmissionState tracks a paste whose clipboard read is still in flight so
+// that an Enter pressed in the meantime is replayed once the text lands.
 type pasteSubmissionState struct {
 	active        bool
 	initialText   string
 	deferredEnter bool
 }
 
+// beginPaste arms the state with the entry text seen when the user pressed the
+// paste shortcut.
 func (s *pasteSubmissionState) beginPaste(text string) {
 	s.active = true
 	s.initialText = text
 	s.deferredEnter = false
 }
 
+// requestSubmit reports whether Enter submits now and whether the pasted text is
+// already in the entry. Enter pressed while the entry still holds the pre-paste
+// text is deferred instead.
 func (s *pasteSubmissionState) requestSubmit(text string) (submit, pastedTextReady bool) {
 	if !s.active {
 		return true, false
@@ -76,8 +83,12 @@ func (s *pasteSubmissionState) requestSubmit(text string) (submit, pastedTextRea
 	return true, true
 }
 
-func (s *pasteSubmissionState) textChanged(text string) bool {
-	if !s.active || text == s.initialText {
+// textChanged reports whether an Enter pressed during the paste must be replayed.
+// The first entry change after a paste shortcut completes the paste operation,
+// even when the pasted text matches what the entry already contained, so
+// completion is never inferred from the text itself.
+func (s *pasteSubmissionState) textChanged() bool {
+	if !s.active {
 		return false
 	}
 	s.active = false
@@ -86,6 +97,7 @@ func (s *pasteSubmissionState) textChanged(text string) bool {
 	return deferred
 }
 
+// reset drops any paste state, discarding a deferred submission.
 func (s *pasteSubmissionState) reset() {
 	*s = pasteSubmissionState{}
 }
@@ -1189,19 +1201,22 @@ func (o *Omnibox) onEntryChanged() {
 	}
 
 	entryText := o.entry.GetText()
-	o.mu.Lock()
-	deferredSubmit := o.pasteSubmit.textChanged(entryText)
-	o.mu.Unlock()
 
 	// Detect debounced echo from our own SetText in setGhostText.
 	// search-changed is debounced by GtkSearchEntry, so it fires AFTER
-	// the isSettingGhost guard is already off.
+	// the isSettingGhost guard is already off. Such self-inflicted
+	// notifications must not consume a paste deferred while GTK is still
+	// reading the clipboard.
 	o.mu.RLock()
-	if o.ghostSuffix != "" && entryText == o.realInput+o.ghostSuffix {
-		o.mu.RUnlock()
+	ghostEcho := o.ghostSuffix != "" && entryText == o.realInput+o.ghostSuffix
+	o.mu.RUnlock()
+	if ghostEcho {
 		return
 	}
-	o.mu.RUnlock()
+
+	o.mu.Lock()
+	deferredSubmit := o.pasteSubmit.textChanged()
+	o.mu.Unlock()
 
 	log := logging.FromContext(o.ctx)
 	if trimmed := url.TrimLeadingSpacesIfURL(entryText); trimmed != entryText {

--- a/internal/ui/component/omnibox_navigation_state_test.go
+++ b/internal/ui/component/omnibox_navigation_state_test.go
@@ -33,6 +33,42 @@ func TestShouldPreferTypedURLNavigation(t *testing.T) {
 	}
 }
 
+func TestPasteSubmissionStateDefersEnterUntilTextArrives(t *testing.T) {
+	state := pasteSubmissionState{}
+	state.beginPaste("")
+
+	if submit, _ := state.requestSubmit(""); submit {
+		t.Fatal("Enter must not submit while the paste buffer is still empty")
+	}
+	if !state.textChanged("https://www.youtube.com/watch?v=LXb3EKWsInQ") {
+		t.Fatal("the completed paste must consume the deferred submission")
+	}
+	if state.textChanged("later edit") {
+		t.Fatal("the deferred submission must be consumed exactly once")
+	}
+}
+
+func TestPasteSubmissionStateRecognizesPasteThatArrivesBeforeEnter(t *testing.T) {
+	state := pasteSubmissionState{}
+	state.beginPaste("old")
+
+	submit, pastedTextReady := state.requestSubmit("new")
+	if !submit || !pastedTextReady {
+		t.Fatalf("completed paste should submit immediately, got submit=%v ready=%v", submit, pastedTextReady)
+	}
+}
+
+func TestPasteSubmissionStateResetCancelsDeferredEnter(t *testing.T) {
+	state := pasteSubmissionState{}
+	state.beginPaste("")
+	state.requestSubmit("")
+	state.reset()
+
+	if state.textChanged("later edit") {
+		t.Fatal("a later edit must not consume a canceled paste submission")
+	}
+}
+
 func TestResetSearchSessionState(t *testing.T) {
 	o := &Omnibox{}
 	o.lastQuery = "github"

--- a/internal/ui/component/omnibox_navigation_state_test.go
+++ b/internal/ui/component/omnibox_navigation_state_test.go
@@ -1,9 +1,11 @@
 package component
 
 import (
+	"context"
 	"testing"
 
 	"github.com/bnema/puregotk/v4/gdk"
+	"github.com/bnema/puregotk/v4/gtk"
 )
 
 func TestShouldPreferTypedURLNavigation(t *testing.T) {
@@ -81,6 +83,95 @@ func TestPasteSubmissionStateResetCancelsDeferredEnter(t *testing.T) {
 
 	if state.textChanged() {
 		t.Fatal("a later edit must not consume a canceled paste submission")
+	}
+}
+
+// omniboxPasteHarness drives the omnibox paste path against a real GTK entry.
+type omniboxPasteHarness struct {
+	omnibox   *Omnibox
+	navigated []string
+}
+
+func newOmniboxPasteHarness(t *testing.T) *omniboxPasteHarness {
+	t.Helper()
+	if !gtk.InitCheck() {
+		t.Skip("GTK native display prerequisite unavailable (gtk.InitCheck returned false)")
+	}
+	entry := gtk.NewSearchEntry()
+	if entry == nil {
+		t.Fatal("failed to create a GTK search entry")
+	}
+	harness := &omniboxPasteHarness{}
+	harness.omnibox = &Omnibox{
+		ctx:   context.Background(),
+		entry: entry,
+		onNavigate: func(_ context.Context, targetURL string) error {
+			harness.navigated = append(harness.navigated, targetURL)
+			return nil
+		},
+	}
+	return harness
+}
+
+// pasteShortcut reproduces what the capture-phase key controller does on Ctrl+V.
+func (h *omniboxPasteHarness) pasteShortcut() {
+	h.omnibox.mu.Lock()
+	defer h.omnibox.mu.Unlock()
+	h.omnibox.pasteSubmit.beginPaste(h.omnibox.entry.GetText())
+}
+
+// showGhostSuffix displays input+suffix with the suffix selected, as the ghost
+// completion does, without emitting entry notifications.
+func (h *omniboxPasteHarness) showGhostSuffix(input, suffix string) {
+	h.omnibox.entry.SetText(input + suffix)
+	h.omnibox.mu.Lock()
+	defer h.omnibox.mu.Unlock()
+	h.omnibox.realInput = input
+	h.omnibox.ghostSuffix = suffix
+	h.omnibox.selectedIndex = -1
+}
+
+func TestOmniboxReplaysDeferredEnterWhenPasteKeepsTheGhostSuffixText(t *testing.T) {
+	harness := newOmniboxPasteHarness(t)
+	harness.showGhostSuffix("https://example.com/gu", "ide")
+
+	// Ctrl+V with clipboard content equal to the whole entry text, then Enter
+	// before GTK delivers the pasted text.
+	harness.pasteShortcut()
+	harness.omnibox.handleSubmitKeyPress()
+	if len(harness.navigated) != 0 {
+		t.Fatalf("Enter must be deferred while the clipboard read is in flight, got %v", harness.navigated)
+	}
+
+	// GTK reports the replacement. The text is unchanged, so it also matches the
+	// ghost echo pattern; the pasted text still has to win.
+	harness.omnibox.onEntryChanged()
+
+	if len(harness.navigated) != 1 || harness.navigated[0] != "https://example.com/guide" {
+		t.Fatalf("the deferred Enter must navigate once the paste lands, got %v", harness.navigated)
+	}
+	if harness.omnibox.hasGhost() {
+		t.Fatal("the pasted text must replace the ghost suffix")
+	}
+}
+
+func TestOmniboxGhostEchoAloneKeepsItsBehavior(t *testing.T) {
+	harness := newOmniboxPasteHarness(t)
+	harness.showGhostSuffix("https://example.com/gu", "ide")
+
+	harness.omnibox.onEntryChanged()
+
+	if len(harness.navigated) != 0 {
+		t.Fatalf("a self-generated ghost echo must not navigate, got %v", harness.navigated)
+	}
+	harness.omnibox.mu.RLock()
+	defer harness.omnibox.mu.RUnlock()
+	if harness.omnibox.realInput != "https://example.com/gu" || harness.omnibox.ghostSuffix != "ide" {
+		t.Fatalf(
+			"a ghost echo must keep the ghost state, got input=%q suffix=%q",
+			harness.omnibox.realInput,
+			harness.omnibox.ghostSuffix,
+		)
 	}
 }
 

--- a/internal/ui/component/omnibox_navigation_state_test.go
+++ b/internal/ui/component/omnibox_navigation_state_test.go
@@ -40,10 +40,25 @@ func TestPasteSubmissionStateDefersEnterUntilTextArrives(t *testing.T) {
 	if submit, _ := state.requestSubmit(""); submit {
 		t.Fatal("Enter must not submit while the paste buffer is still empty")
 	}
-	if !state.textChanged("https://www.youtube.com/watch?v=LXb3EKWsInQ") {
+	if !state.textChanged() {
 		t.Fatal("the completed paste must consume the deferred submission")
 	}
-	if state.textChanged("later edit") {
+	if state.textChanged() {
+		t.Fatal("the deferred submission must be consumed exactly once")
+	}
+}
+
+func TestPasteSubmissionStateCompletesWhenPasteKeepsTheSameText(t *testing.T) {
+	state := pasteSubmissionState{}
+	state.beginPaste("https://example.com")
+
+	if submit, _ := state.requestSubmit("https://example.com"); submit {
+		t.Fatal("Enter must be deferred while the clipboard read is still in flight")
+	}
+	if !state.textChanged() {
+		t.Fatal("an identical replacement must consume the deferred submission")
+	}
+	if state.textChanged() {
 		t.Fatal("the deferred submission must be consumed exactly once")
 	}
 }
@@ -64,7 +79,7 @@ func TestPasteSubmissionStateResetCancelsDeferredEnter(t *testing.T) {
 	state.requestSubmit("")
 	state.reset()
 
-	if state.textChanged("later edit") {
+	if state.textChanged() {
 		t.Fatal("a later edit must not consume a canceled paste submission")
 	}
 }


### PR DESCRIPTION
## Summary

- preserve an Enter submission while GTK is still delivering pasted text
- clear stale result selection before submitting newly pasted input
- cancel pending paste submission state on later keyboard input or omnibox lifecycle changes

## Verification

- manually confirmed that immediately pasting the reported YouTube URL and pressing Enter opens it
- `make lint`
- `go test ./internal/ui/component ./internal/ui -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved omnibox behavior when submitting URLs pasted with keyboard shortcuts.
  * Enter now waits for pasted text to arrive before submitting, preventing premature submissions.
  * Pasted URLs are submitted immediately when the paste completes before Enter is pressed.
  * Pasted text identical to the existing entry is handled correctly without premature submission.
  * Deferred submissions are cleared when the omnibox is reset or no longer active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->