### PR TITLE
fix(cef): update bridge with safe offload default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/bnema/purego v0.11.0-bnema.4
 	github.com/bnema/purego-cef v0.14.2
-	github.com/bnema/purego-cef2gtk v0.11.0
+	github.com/bnema/purego-cef2gtk v0.11.1
 	github.com/bnema/purego-pipewire v0.1.6
 	github.com/bnema/purego-sqlite v0.1.5
 	github.com/bnema/purego-webp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bnema/purego v0.11.0-bnema.4 h1:uQjx9QtM945rD6HkwYzPGuVN7wKr5HrFKIWE3
 github.com/bnema/purego v0.11.0-bnema.4/go.mod h1:LHW8Sb4QO18dQaLVRU8tZCGM0SjsC+agFW/3M3nCUtg=
 github.com/bnema/purego-cef v0.14.2 h1:0tKXT00gFvWUsL3A4sX4kzD+3XRmPOif0ccwO9iokqU=
 github.com/bnema/purego-cef v0.14.2/go.mod h1:r+qCMwzuI+wq3xo189x3NAWWpALWoWwjtk+8wVCK1Eg=
-github.com/bnema/purego-cef2gtk v0.11.0 h1:imn2AzfqXijtWw1NXE4E7niIja7itKQATDS/JPAEGPw=
-github.com/bnema/purego-cef2gtk v0.11.0/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
+github.com/bnema/purego-cef2gtk v0.11.1 h1:EPDHn1QrGGGwdtWZbgWOw4dRjJq9Dz4iLzOnH+eeGMo=
+github.com/bnema/purego-cef2gtk v0.11.1/go.mod h1:1tIL/HpDXXwNSIgtLVgumjApAEP7noO0DcHPhmEcgcU=
 github.com/bnema/purego-pipewire v0.1.6 h1:olbxeiqIJZXil0pus5Uzh9psH/KTI9GovqTCuPXTquU=
 github.com/bnema/purego-pipewire v0.1.6/go.mod h1:57aFYl3Wll3XbrwblQjmX8R1k7RkcZQwfQTGQWcKbdc=
 github.com/bnema/purego-sqlite v0.1.5 h1:L4KtDQR0++TZqHVnuzCPsrw55s1ww/nXGEpdrkHsM4Y=


### PR DESCRIPTION
## Summary

- update `purego-cef2gtk` to v0.11.1
- use the safe default that keeps GDK DMA-BUF rendering while making GtkGraphicsOffload opt-in
- retain explicit offload testing through `PUREGO_CEF2GTK_GDK_GRAPHICS_OFFLOAD=1`

## Verification

- `go test ./internal/infrastructure/cef`
- `git diff --check`

## Manual validation

The previous offload default corrupted split-pane presentation on an affected Wayland ultrawide setup. Disabling only the offload wrapper restored both webviews and the omnibox.